### PR TITLE
[fix](vllm) Bound native output chunk cardinality

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_vllm.cpp
@@ -356,6 +356,56 @@ struct VLLMOperatorState : public OperatorState {
 	std::deque<unique_ptr<DataChunk>> pending_outputs;
 };
 
+static bool PopPendingOutput(VLLMOperatorState &state, DataChunk &chunk) {
+	if (state.pending_outputs.empty()) {
+		return false;
+	}
+
+	auto output = std::move(state.pending_outputs.front());
+	state.pending_outputs.pop_front();
+	if (output->size() > STANDARD_VECTOR_SIZE) {
+		throw InternalException("vllm output chunk has %d rows, maximum allowed is %d", output->size(),
+		                        STANDARD_VECTOR_SIZE);
+	}
+	chunk.Move(*output);
+	return true;
+}
+
+static void ConsumeReadyResult(ExecutionContext &context, VLLMGlobalOperatorState &gstate, VLLMOperatorState &state,
+                               VLLMResult &result) {
+	auto &rows = *result.rows;
+	if (rows.size() != result.outputs.size()) {
+		throw InvalidInputException("vllm output count (%d) does not match input rows (%d)", result.outputs.size(),
+		                            rows.size());
+	}
+	if (!result.outputs_validity.empty() && result.outputs_validity.size() != result.outputs.size()) {
+		throw InvalidInputException("vllm output validity count (%d) does not match input rows (%d)",
+		                            result.outputs_validity.size(), rows.size());
+	}
+	gstate.inflight_prompts.RecordCompletion(rows.size());
+
+	if (rows.size() <= STANDARD_VECTOR_SIZE) {
+		state.pending_outputs.push_back(BuildOutputChunk(context, rows, result.outputs, result.outputs_validity));
+		return;
+	}
+
+	for (idx_t offset = 0; offset < rows.size(); offset += STANDARD_VECTOR_SIZE) {
+		const auto count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, rows.size() - offset);
+		SelectionVector selection(count);
+		for (idx_t i = 0; i < count; i++) {
+			selection.set_index(i, offset + i);
+		}
+		auto chunk_rows = SliceChunk(context.client, rows, selection, count);
+		vector<string> chunk_outputs(result.outputs.begin() + offset, result.outputs.begin() + offset + count);
+		vector<bool> chunk_validity;
+		if (!result.outputs_validity.empty()) {
+			chunk_validity.insert(chunk_validity.end(), result.outputs_validity.begin() + offset,
+			                      result.outputs_validity.begin() + offset + count);
+		}
+		state.pending_outputs.push_back(BuildOutputChunk(context, *chunk_rows, chunk_outputs, chunk_validity));
+	}
+}
+
 static void TakeReadyResultOnce(ExecutionContext &context, VLLMGlobalOperatorState &gstate, VLLMOperatorState &state,
                                 idx_t input_column_count);
 
@@ -429,9 +479,7 @@ static void TakeReadyResultOnce(ExecutionContext &context, VLLMGlobalOperatorSta
 		throw InvalidInputException("vllm executor returned %d columns, expected %d", result.second.rows->ColumnCount(),
 		                            input_column_count);
 	}
-	gstate.inflight_prompts.RecordCompletion(result.second.rows->size());
-	auto output = BuildOutputChunk(context, *result.second.rows, result.second.outputs, result.second.outputs_validity);
-	state.pending_outputs.push_back(std::move(output));
+	ConsumeReadyResult(context, gstate, state, result.second);
 }
 
 static void PopAndSubmitTasks(ExecutionContext &context, VLLMGlobalOperatorState &gstate, VLLMOperatorState &state,
@@ -603,10 +651,7 @@ OperatorResultType PhysicalVLLM::Execute(ExecutionContext &context, DataChunk &i
 	auto &gstate = gstate_p.Cast<VLLMGlobalOperatorState>();
 	auto &state = state_p.Cast<VLLMOperatorState>();
 
-	if (!state.pending_outputs.empty()) {
-		auto output = std::move(state.pending_outputs.front());
-		state.pending_outputs.pop_front();
-		chunk.Move(*output);
+	if (PopPendingOutput(state, chunk)) {
 		return OperatorResultType::HAVE_MORE_OUTPUT;
 	}
 
@@ -640,11 +685,7 @@ OperatorResultType PhysicalVLLM::Execute(ExecutionContext &context, DataChunk &i
 
 		TakeReadyResultOnce(context, gstate, state, input.ColumnCount());
 	}
-	if (!state.pending_outputs.empty()) {
-		auto output = std::move(state.pending_outputs.front());
-		state.pending_outputs.pop_front();
-		chunk.Move(*output);
-	} else {
+	if (!PopPendingOutput(state, chunk)) {
 		chunk.SetCardinality(0);
 	}
 	return OperatorResultType::NEED_MORE_INPUT;
@@ -655,10 +696,7 @@ OperatorFinalizeResultType PhysicalVLLM::FinalExecute(ExecutionContext &context,
 	auto &gstate = gstate_p.Cast<VLLMGlobalOperatorState>();
 	auto &state = state_p.Cast<VLLMOperatorState>();
 
-	if (!state.pending_outputs.empty()) {
-		auto output = std::move(state.pending_outputs.front());
-		state.pending_outputs.pop_front();
-		chunk.Move(*output);
+	if (PopPendingOutput(state, chunk)) {
 		return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 	}
 
@@ -676,10 +714,7 @@ OperatorFinalizeResultType PhysicalVLLM::FinalExecute(ExecutionContext &context,
 	}
 
 	TakeReadyResultOnce(context, gstate, state, types.size() - 1);
-	if (!state.pending_outputs.empty()) {
-		auto output = std::move(state.pending_outputs.front());
-		state.pending_outputs.pop_front();
-		chunk.Move(*output);
+	if (PopPendingOutput(state, chunk)) {
 		return OperatorFinalizeResultType::HAVE_MORE_OUTPUT;
 	}
 

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -110,6 +110,24 @@ class _DeferredWakeupExecutor(_RecordingExecutor):
             callback()
 
 
+class _ChunkedBatchResultExecutor(_RecordingExecutor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.returned_arrow_batch_counts = []
+
+    def submit(self, prefix, prompts, rows) -> None:
+        prompt_values = tuple(prompts)
+        self.submissions.append((prefix, prompt_values))
+        outputs = []
+        for prompt in prompt_values:
+            row_id = int(prompt.rsplit("-", 1)[1])
+            outputs.append(None if row_id % 7 == 0 else f"generated:{prompt}")
+        batches = rows.to_batches(max_chunksize=511)
+        self.returned_arrow_batch_counts.append(len(batches))
+        self.ready.append((outputs, pa.Table.from_batches(batches)))
+        self._notify_wakeups()
+
+
 def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=1, query_suffix=""):
     import duckdb
     import duckdb.execution.vllm as vllm
@@ -411,6 +429,75 @@ def test_native_downstream_limit_retires_producer_when_final_execute_is_skipped(
     assert rows == [(0, "prompt-0", "generated:prompt-0")]
     assert sum(len(submitted) for _, submitted in executor.submissions) < len(prompts)
     assert executor.finished_count == 1
+
+
+@pytest.mark.parametrize("row_count", [2049, 6144])
+def test_native_vllm_splits_oversized_ready_results_before_downstream_operators(monkeypatch, row_count):
+    import duckdb
+    import duckdb.execution.vllm as vllm
+
+    executor = _ChunkedBatchResultExecutor()
+    observed_chunk_sizes = []
+
+    def observe_chunk(values):
+        observed_chunk_sizes.append(len(values))
+        return values
+
+    monkeypatch.setattr(vllm, "build_executor", lambda *_args, **_kwargs: executor)
+    prompts = [f"shared-prefix-{row_id:05d}" for row_id in range(row_count)]
+    con = duckdb.connect()
+    try:
+        con.execute("PRAGMA threads=1")
+        con.register(
+            "vllm_input",
+            pa.table(
+                {
+                    "id": pa.array(range(row_count), type=pa.int64()),
+                    "prompt": pa.array(prompts, type=pa.string()),
+                }
+            ),
+        )
+        con.create_function(
+            "observe_vllm_chunk",
+            observe_chunk,
+            ["VARCHAR"],
+            "VARCHAR",
+            type="arrow",
+            null_handling="special",
+            side_effects=True,
+        )
+        rows = con.execute(
+            """
+            SELECT id, observe_vllm_chunk(generated)
+            FROM (
+                SELECT id, vllm(prompt, 'recording-model', ?) AS generated
+                FROM vllm_input
+            )
+            """,
+            [
+                _packed_native_vllm_options(
+                    {
+                        "do_prefix_routing": True,
+                        "max_buffer_size": 5000,
+                        "min_bucket_size": 1,
+                        "batch_size": None,
+                        "inflight_limit": 0,
+                    }
+                )
+            ],
+        ).fetchall()
+    finally:
+        con.close()
+
+    vector_size = duckdb.__standard_vector_size__
+    assert observed_chunk_sizes
+    assert sum(observed_chunk_sizes) == row_count
+    assert max(observed_chunk_sizes) <= vector_size
+    assert [len(submitted) for _, submitted in executor.submissions] == [row_count]
+    assert executor.returned_arrow_batch_counts[0] > 1
+    assert dict(rows) == {
+        row_id: None if row_id % 7 == 0 else f"generated:{prompts[row_id]}" for row_id in range(row_count)
+    }
 
 
 def test_distributed_collection_keeps_explicit_pool_names_query_scoped():


### PR DESCRIPTION
## Summary

- Split native vLLM ready results larger than `STANDARD_VECTOR_SIZE` before emitting them into the DuckDB operator pipeline.
- Preserve `batch_size=NULL`, result ordering, NULL validity, and the existing fast path for standard-sized results.
- Fail closed if any pending vLLM output still exceeds the pipeline limit.
- Add regressions for 2049-row final flushes and 6144-row ordinary Execute results returned through multiple Arrow batches.

Compatibility impact: accepted vLLM options and SQL results are unchanged. Oversized internal results are now exposed downstream as multiple standard-sized chunks.

## Related issue

close: #477

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- Incremental Release install: `uv pip install . --no-build-isolation`
- `python -m pytest tests/fast/test_vllm_native_regressions.py` — 31 passed
- `python -m pytest tests/fast/test_vllm_runtime_fixes.py` — 66 passed
- `VCPKG_INSTALLED_DIR=/home/kaka/astrovela_vane/vcpkg_installed VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh "[vllm]"` — 4 test cases, 15 assertions
- `scripts/run_release_tests.sh` — 501 passed, 4 skipped, 15 deselected; real-Ray shard 11 passed, 509 deselected
- `scripts/format workspace --changed --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required. (No new dependencies or copied assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered. This change restores the standard output-cardinality boundary on a native operator path.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.