### PR TITLE
[fix](ray) Terminate unmatched scoped FTE waits

### DIFF
--- a/duckdb/runners/ray/fragment_worker_lifecycle.py
+++ b/duckdb/runners/ray/fragment_worker_lifecycle.py
@@ -447,6 +447,8 @@ class FteWorkerLifecycleMixin:
             status = fte_query_status(query_id)
             if bool(status.get("failed")):
                 raise RuntimeError(f"FTE query {query_id} failed: {status}")
+            if bool(status.get("canceled")):
+                raise RuntimeError(f"FTE query {query_id} canceled: {status}")
             if bool(status.get("finished")):
                 return status
             if deadline is not None and time.monotonic() >= deadline:

--- a/duckdb/runners/ray/fragment_worker_results.py
+++ b/duckdb/runners/ray/fragment_worker_results.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from typing import Any
 
 from duckdb.runners.ray.fragment_registry import (
+    _FTE_ACTIVE_OPERATIONS_BY_QUERY,
+    _FTE_CLOSING_QUERIES,
     _FTE_FRAGMENT_EXECUTIONS,
     _FTE_REGISTRY_LOCK,
     _FTE_RESULT_HANDLES_BY_QUERY,
@@ -75,6 +77,8 @@ def fte_query_status(
         if None in scoped_contexts:
             raise ValueError("task_context_filter contains an invalid task context")
     with _FTE_REGISTRY_LOCK:
+        registration_pending = _FTE_ACTIVE_OPERATIONS_BY_QUERY.get(query_id, 0) > 0
+        canceled = query_id in _FTE_CLOSING_QUERIES
         all_fragment_execution_items = [
             (fragment_id, fragment_execution)
             for (fragment_execution_query_id, fragment_id), fragment_execution in sorted(
@@ -156,6 +160,8 @@ def fte_query_status(
         "finished_count": finished_count,
         "failed": failed,
         "finished": finished,
+        "canceled": canceled,
+        "registration_pending": registration_pending,
         "selected_attempt_task_ids": selected_attempt_task_ids,
         "fragment_executions": fragment_executions,
         "failed_partitions": failed_partitions,

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -1207,6 +1207,7 @@ public:
 			bool finished = false;
 			bool canceled = false;
 			bool matched = true;
+			bool registration_pending = false;
 			string status_message;
 			try {
 				duckdb::PythonGILWrapper gil;
@@ -1236,6 +1237,7 @@ public:
 				canceled = OptionalStatusBool(status_obj, "canceled", false);
 				if (!task_contexts.empty()) {
 					matched = RequiredStatusBool(status_obj, "matched");
+					registration_pending = OptionalStatusBool(status_obj, "registration_pending", false);
 				}
 				selected_attempt_task_ids = SelectedAttemptTaskIds(status_obj);
 			} catch (const std::exception &e) {
@@ -1253,10 +1255,13 @@ public:
 				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
 				    DuckDBError::external_error("Python backend FTE query canceled: " + status_message));
 			}
-			// Submission and fragment registration are concurrent. A scoped
-			// status lookup may legitimately miss for a short interval after
-			// submit_fte_task_events returns.
-			if (matched && finished) {
+			if (!task_contexts.empty() && !matched) {
+				if (!registration_pending) {
+					return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
+					    DuckDBError::external_error(
+					        "Python backend FTE query scope did not match any registered fragment: " + status_message));
+				}
+			} else if (finished) {
 				break;
 			}
 			if (has_deadline && std::chrono::steady_clock::now() >= deadline) {

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -477,6 +477,20 @@ void register_ray_bindings(py::module_ &mod) {
 		        }
 	        },
 	        py::arg("query_id"), py::arg("timeout_s") = 0.0)
+	    .def(
+	        "_wait_fte_query_scoped_for_test",
+	        [](RayWorkerManager &self, const string &query_id, double timeout_s) {
+		        std::unordered_set<duckdb::distributed::TaskContext, duckdb::distributed::TaskContextHash>
+		            task_contexts {duckdb::distributed::TaskContext::from_node_context(1, 2, 3)};
+		        auto res = [&]() {
+			        py::gil_scoped_release release;
+			        return self.wait_fte_query(query_id, timeout_s, task_contexts, {});
+		        }();
+		        if (res.is_err()) {
+			        throw duckdb::InternalException(res.error().what());
+		        }
+	        },
+	        py::arg("query_id"), py::arg("timeout_s") = 0.0)
 	    .def("fragment_stats",
 	         [](RayWorkerManager &self) { return BuildFragmentStatsSummary(self.fragment_stats_by_worker()); })
 	    .def("try_autoscale", [](RayWorkerManager &self, py::object bundles_obj) {

--- a/src/duckdb_py/ray/worker.cpp
+++ b/src/duckdb_py/ray/worker.cpp
@@ -100,6 +100,18 @@ bool RequiredStatusBool(const py::dict &status, const char *field_name) {
 	return value.cast<bool>();
 }
 
+bool OptionalStatusBool(const py::dict &status, const char *field_name, bool default_value = false) {
+	auto key = py::str(field_name);
+	if (!status.contains(key)) {
+		return default_value;
+	}
+	auto value = py::reinterpret_borrow<py::object>(status[key]);
+	if (!py::isinstance<py::bool_>(value)) {
+		throw duckdb::InternalException("FTE query status field '%s' must be boolean", field_name);
+	}
+	return value.cast<bool>();
+}
+
 void FillSelectedAttemptTaskIds(const py::dict &status, RayWorkerRuntime::QueryStatus &result) {
 	auto key = py::str("selected_attempt_task_ids");
 	if (!status.contains(key)) {
@@ -129,6 +141,8 @@ RayWorkerRuntime::QueryStatus ParseFteQueryStatus(const py::object &status_obj, 
 	auto status = status_obj.cast<py::dict>();
 	result.failed = RequiredStatusBool(status, "failed");
 	result.finished = RequiredStatusBool(status, "finished");
+	result.canceled = OptionalStatusBool(status, "canceled");
+	result.registration_pending = OptionalStatusBool(status, "registration_pending");
 	if (scoped) {
 		result.matched = RequiredStatusBool(status, "matched");
 	}

--- a/src/duckdb_py/ray/worker.hpp
+++ b/src/duckdb_py/ray/worker.hpp
@@ -33,6 +33,8 @@ public:
 		bool failed = false;
 		bool finished = false;
 		bool matched = true;
+		bool canceled = false;
+		bool registration_pending = false;
 		std::string message;
 		std::unordered_set<string> selected_attempt_task_ids;
 	};

--- a/src/duckdb_py/ray/worker_manager.cpp
+++ b/src/duckdb_py/ray/worker_manager.cpp
@@ -73,6 +73,11 @@ void RayWorkerManager::EndOperation() const {
 	shutdown_cv_.notify_all();
 }
 
+bool RayWorkerManager::ShutdownStarted() const {
+	lock_guard<mutex> guard(mutex_);
+	return state_.shutdown_started;
+}
+
 bool RayWorkerManager::RetireWorkerForFailure(const string &worker_id, const std::shared_ptr<RayWorkerRuntime> &worker,
                                               const std::shared_ptr<std::atomic<bool>> &retired) const {
 	std::shared_ptr<RayWorkerRuntime> retired_worker;
@@ -1069,6 +1074,10 @@ DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>> RayWorkerMana
 
 	try {
 		while (true) {
+			if (ShutdownStarted()) {
+				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
+				    DuckDBError::invalid_state_error("Ray worker manager is shutting down"));
+			}
 			const auto *task_context_filter = task_contexts.empty() ? nullptr : &task_contexts;
 			auto status_res = FteQueryStatus(query_id, task_context_filter);
 			if (status_res.is_err()) {
@@ -1081,16 +1090,26 @@ DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>> RayWorkerMana
 				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
 				    DuckDBError::external_error("FTE query failed: " + status.message));
 			}
+			if (status.canceled) {
+				ClearFteResultHandles(query_id);
+				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
+				    DuckDBError::external_error("FTE query canceled: " + status.message));
+			}
 			auto collect_res = CollectFteResultHandles(query_id);
 			if (collect_res.is_err()) {
 				ClearFteResultHandles(query_id);
 				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(collect_res.error());
 			}
-			// A materializer can enter this wait immediately after submitting
-			// its events while another thread is still registering the matching
-			// fragment. Treat an unmatched scope as pending until it either
-			// appears, the query fails, or the ordinary wait deadline expires.
-			if ((!task_context_filter || status.matched) && status.finished) {
+			// Registry operations fence every ingress path that can publish a
+			// fragment. Once no such operation remains, an unmatched materializer
+			// scope cannot appear later and must not poll indefinitely.
+			if (task_context_filter && !status.matched) {
+				if (!status.registration_pending) {
+					return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
+					    DuckDBError::external_error("FTE query scope did not match any registered fragment: " +
+					                                status.message));
+				}
+			} else if (status.finished) {
 				finished_status = status;
 				has_finished_status = true;
 				break;

--- a/src/duckdb_py/ray/worker_manager.hpp
+++ b/src/duckdb_py/ray/worker_manager.hpp
@@ -111,6 +111,7 @@ private:
 
 	bool BeginOperation() const;
 	void EndOperation() const;
+	bool ShutdownStarted() const;
 	bool RetireWorkerForFailure(const string &worker_id, const std::shared_ptr<RayWorkerRuntime> &worker,
 	                            const std::shared_ptr<std::atomic<bool>> &retired) const;
 	WorkerSnapshotResult WorkerSnapshotsWithoutGIL() const;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -4236,6 +4236,165 @@ def test_ray_worker_manager_shutdown_waits_for_entered_result_collection(monkeyp
     assert shutdown_finished.is_set()
 
 
+def _ray_worker_manager_for_scoped_wait(monkeypatch, status_for_call):
+    import duckdb.runners.ray.worker_handle as ray_worker_handle
+
+    class DummyRayWorkerHandle:
+        def __init__(self):
+            self.status_calls = 0
+
+        def fte_query_status(self, _query_id, _task_contexts):
+            self.status_calls += 1
+            return status_for_call(self.status_calls)
+
+        def pop_fte_result_handles(self, _query_id):
+            return []
+
+        def prepare_shutdown(self):
+            return None
+
+        def finish_shutdown(self):
+            return None
+
+        def abort_shutdown(self):
+            raise AssertionError("successful shutdown must not abort")
+
+    worker_handle = DummyRayWorkerHandle()
+    monkeypatch.setattr(
+        ray_worker_handle,
+        "start_ray_workers",
+        lambda _existing_ids, _manager_instance_id: [
+            duckdb.ray_cxx.RayWorkerRuntime(
+                "worker-a",
+                worker_handle,
+                1.0,
+                0.0,
+                1024,
+            )
+        ],
+    )
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = duckdb.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 1
+    return manager, worker_handle
+
+
+def test_ray_worker_manager_scoped_wait_rejects_terminal_unmatched_scope(monkeypatch):
+    def status_for_call(status_calls):
+        if status_calls < 5:
+            return {
+                "failed": False,
+                "finished": False,
+                "matched": False,
+                "canceled": False,
+                "registration_pending": False,
+            }
+        return {
+            "failed": False,
+            "finished": True,
+            "matched": True,
+            "canceled": False,
+            "registration_pending": False,
+        }
+
+    manager, worker_handle = _ray_worker_manager_for_scoped_wait(monkeypatch, status_for_call)
+
+    try:
+        with pytest.raises(Exception, match="scope did not match any registered fragment"):
+            manager._wait_fte_query_scoped_for_test("query-unmatched-scope")
+        assert worker_handle.status_calls == 1
+    finally:
+        manager.shutdown()
+
+
+def test_ray_worker_manager_scoped_wait_allows_pending_registration(monkeypatch):
+    manager, worker_handle = _ray_worker_manager_for_scoped_wait(
+        monkeypatch,
+        lambda status_calls: {
+            "failed": False,
+            "finished": status_calls > 1,
+            "matched": status_calls > 1,
+            "canceled": False,
+            "registration_pending": status_calls == 1,
+        },
+    )
+
+    try:
+        manager._wait_fte_query_scoped_for_test("query-pending-scope")
+        assert worker_handle.status_calls == 2
+    finally:
+        manager.shutdown()
+
+
+def test_ray_worker_manager_scoped_wait_stops_when_query_is_canceled(monkeypatch):
+    manager, worker_handle = _ray_worker_manager_for_scoped_wait(
+        monkeypatch,
+        lambda _status_calls: {
+            "failed": False,
+            "finished": False,
+            "matched": False,
+            "canceled": True,
+            "registration_pending": False,
+            "message": "query registry is closing",
+        },
+    )
+
+    try:
+        with pytest.raises(Exception, match="FTE query canceled.*query registry is closing"):
+            manager._wait_fte_query_scoped_for_test("query-canceled-scope")
+        assert worker_handle.status_calls == 1
+    finally:
+        manager.shutdown()
+
+
+def test_ray_worker_manager_shutdown_cancels_unbounded_scoped_wait(monkeypatch):
+    status_entered = threading.Event()
+
+    def status_for_call(status_calls):
+        status_entered.set()
+        return {
+            "failed": False,
+            "finished": status_calls >= 50,
+            "matched": status_calls >= 50,
+            "canceled": False,
+            "registration_pending": status_calls < 50,
+        }
+
+    manager, worker_handle = _ray_worker_manager_for_scoped_wait(monkeypatch, status_for_call)
+
+    wait_outcomes: list[str] = []
+
+    def wait_query():
+        try:
+            manager._wait_fte_query_scoped_for_test("query-shutdown-scope")
+        except BaseException as exc:
+            wait_outcomes.append(f"error:{exc}")
+        else:
+            wait_outcomes.append("ok")
+
+    shutdown_finished = threading.Event()
+
+    def shutdown():
+        manager.shutdown()
+        shutdown_finished.set()
+
+    waiter = threading.Thread(target=wait_query)
+    closer = threading.Thread(target=shutdown)
+    waiter.start()
+    assert status_entered.wait(timeout=5)
+    closer.start()
+    waiter.join(timeout=5)
+    closer.join(timeout=5)
+
+    assert waiter.is_alive() is False
+    assert closer.is_alive() is False
+    assert shutdown_finished.is_set()
+    assert len(wait_outcomes) == 1
+    assert wait_outcomes[0].startswith("error:")
+    assert "shutting down" in wait_outcomes[0]
+    assert worker_handle.status_calls < 50
+
+
 def test_ray_worker_manager_shutdown_aborts_all_actors_after_prepare_error(monkeypatch):
     calls: list[tuple[str, str]] = []
 

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -11765,8 +11765,11 @@ def test_fte_wait_query_stops_when_query_registry_closes():
     handle = RayWorkerActorHandle(_FakeActor(), memory_capacity_bytes=1 << 60)
     fte_fragment_scheduler_mod.close_fte_registry_for_query(query_id)
 
-    with pytest.raises(RuntimeError, match=f"FTE query {query_id} canceled"):
-        handle.wait_fte_query(query_id, timeout_s=0)
+    try:
+        with pytest.raises(RuntimeError, match=f"FTE query {query_id} canceled"):
+            handle.wait_fte_query(query_id, timeout_s=0)
+    finally:
+        fte_fragment_scheduler_mod.open_fte_registry_for_query(query_id)
 
 
 def test_fte_wait_query_raises_on_failed_partition(monkeypatch):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -11760,6 +11760,15 @@ def test_fte_wait_query_finishes_from_status_events(monkeypatch):
     assert handle.pop_fte_result_handles("query-fte-wait") == []
 
 
+def test_fte_wait_query_stops_when_query_registry_closes():
+    query_id = "query-fte-wait-canceled"
+    handle = RayWorkerActorHandle(_FakeActor(), memory_capacity_bytes=1 << 60)
+    fte_fragment_scheduler_mod.close_fte_registry_for_query(query_id)
+
+    with pytest.raises(RuntimeError, match=f"FTE query {query_id} canceled"):
+        handle.wait_fte_query(query_id, timeout_s=0)
+
+
 def test_fte_wait_query_raises_on_failed_partition(monkeypatch):
     monkeypatch.setattr(
         RayWorkerActorHandle,

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -1309,7 +1309,37 @@ def test_fte_query_status_reports_unmatched_task_scope():
 
     assert status["matched"] is False
     assert status["finished"] is False
+    assert status["registration_pending"] is False
+    assert status["canceled"] is False
     assert status["fragment_execution_count"] == 0
+
+
+def test_fte_query_status_distinguishes_pending_registration_and_query_close():
+    query_id = "q-status-unmatched-lifecycle"
+    task_context_filter = [
+        {
+            "query_idx": 1,
+            "last_node_id": 4,
+            "task_id": 5,
+            "node_ids": [4],
+        }
+    ]
+
+    assert fte_fragment_scheduler.begin_fte_registry_operation(query_id)
+    try:
+        pending_status = fte_query_status(query_id, task_context_filter)
+        fte_fragment_scheduler.close_fte_registry_for_query(query_id)
+        closing_status = fte_query_status(query_id, task_context_filter)
+    finally:
+        fte_fragment_scheduler.end_fte_registry_operation(query_id)
+        fte_fragment_scheduler.open_fte_registry_for_query(query_id)
+
+    assert pending_status["matched"] is False
+    assert pending_status["registration_pending"] is True
+    assert pending_status["canceled"] is False
+    assert closing_status["matched"] is False
+    assert closing_status["registration_pending"] is True
+    assert closing_status["canceled"] is True
 
 
 def test_fte_query_status_handles_multiple_running_attempts():


### PR DESCRIPTION
## Summary

- expose query-closing and registry-ingress state in FTE worker status
- terminate scoped waits when no matching fragment can still be registered, while preserving polling during an in-flight registration
- cancel native manager waits during shutdown so operation guards can drain
- apply the same terminal-unmatched semantics to the generic Python backend and cover the C++ and Python wait paths

## Related issue

close: #412

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      AstroVela/vane-website.

This is an internal lifecycle correctness fix and does not change a documented public API.

## Validation

- Native incremental Release build with uv pip install . --no-build-isolation
- scripts/format root --changed
- python -m pytest tests/fast/test_ray_cpp_bindings.py tests/fast/test_ray_fte.py tests/fast/test_ray_fragment_submission.py tests/fast/test_vllm_native_regressions.py — 627 passed, 4 deselected
- scripts/run_release_tests.sh — 508 passed, 1 skipped; real-Ray shard 11 passed
- scripts/run_fast_tests.sh — main shard 6482 passed, 27 skipped, 8 xfailed, 1 xpassed; shared-Ray shard 101 passed, 6 skipped; seven test-owned Ray cases passed, with one expected vLLM dependency skip

Validation used the standard CPU-only test profile and its default 2 GiB Ray object store.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.