### PR TITLE
[fix](vllm) Batch Ray actor results

### DIFF
--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -1147,6 +1147,8 @@ class RemoteVLLMExecutor(VLLMExecutor):
             )
         if rows.num_rows != count:
             raise RuntimeError(f"vllm actor result row count ({rows.num_rows}) does not match output count ({count})")
+        # Actor pools must be deployment-version homogeneous. Mixed-version
+        # pools and legacy scalar reservation IDs are intentionally unsupported.
         if not isinstance(reservation_completions, list) or not reservation_completions:
             raise RuntimeError("vllm actor result must include reservation completion counts")
 

--- a/duckdb/execution/vllm.py
+++ b/duckdb/execution/vllm.py
@@ -20,6 +20,7 @@ from numbers import Integral, Real
 from typing import Any, Callable, overload
 
 import pyarrow as pa
+from _duckdb import __standard_vector_size__ as DUCKDB_STANDARD_VECTOR_SIZE  # type: ignore[import-not-found]
 
 from duckdb.execution._vllm_options_protocol import (
     _NATIVE_OPTIONS_NORMALIZED_SECRET_KEY,
@@ -588,7 +589,9 @@ class LocalVLLMExecutor(VLLMExecutor):
     def take_ready_result(self, executor_id: None = None) -> tuple[list[str | None], pa.Table] | None: ...
 
     @overload
-    def take_ready_result(self, executor_id: str) -> tuple[list[str | None], pa.Table, str] | None: ...
+    def take_ready_result(
+        self, executor_id: str
+    ) -> tuple[list[str | None], pa.Table, list[tuple[str, int]]] | None: ...
 
     def take_ready_result(self, executor_id: str | None = None) -> tuple[Any, ...] | None:
         if self.on_error == "raise":
@@ -599,17 +602,30 @@ class LocalVLLMExecutor(VLLMExecutor):
         source_deque = (
             self._per_executor_deques.setdefault(executor_id, deque()) if executor_id else self.completed_tasks
         )
-        try:
-            item = source_deque.popleft()
-        except IndexError:
+        if not source_deque:
             return None
-        output, row, *extra = item
-        self._notify_state_change()
-        if executor_id:
+        if not executor_id:
+            output, row = source_deque.popleft()
+            self._notify_state_change()
+            return [output], row
+
+        outputs: list[str | None] = []
+        row_tables: list[pa.Table] = []
+        reservation_counts: OrderedDict[str, int] = OrderedDict()
+        while source_deque and len(outputs) < DUCKDB_STANDARD_VECTOR_SIZE:
+            output, row, *extra = source_deque.popleft()
             if len(extra) != 1 or not isinstance(extra[0], str) or not extra[0]:
                 raise RuntimeError("vllm per-executor result must include a non-empty reservation_id")
-            return [output], row, extra[0]
-        return [output], row
+            row = _ensure_table(row)
+            if row.num_rows != 1:
+                raise RuntimeError("vllm per-executor result row must contain exactly one row")
+            reservation_id = extra[0]
+            outputs.append(output)
+            row_tables.append(row)
+            reservation_counts[reservation_id] = reservation_counts.get(reservation_id, 0) + 1
+
+        self._notify_state_change()
+        return outputs, _concat_tables(row_tables), list(reservation_counts.items())
 
     def finished_submitting(self) -> None:
         self._finished_submitting = True
@@ -1119,12 +1135,46 @@ class RemoteVLLMExecutor(VLLMExecutor):
             )
         result = resolve_object_refs_blocking(self.llm_actors[actor_idx].take_ready_result.remote(self._executor_id))
         if not isinstance(result, tuple) or len(result) != 3:
-            raise RuntimeError("vllm actor result must be a 3-item tuple including reservation_id")
-        results_text, rows, reservation_id = result
-        if not isinstance(reservation_id, str) or not reservation_id:
-            raise RuntimeError("vllm actor result must include a non-empty reservation_id")
-        count = len(results_text) if results_text else 0
-        self._complete_reservation(reservation_id, count)
+            raise RuntimeError("vllm actor result must be a 3-item tuple including reservation completion counts")
+        results_text, rows, reservation_completions = result
+        if not isinstance(results_text, list) or not results_text:
+            raise RuntimeError("vllm actor result must include a non-empty output list")
+        rows = _ensure_table(rows)
+        count = len(results_text)
+        if count > DUCKDB_STANDARD_VECTOR_SIZE:
+            raise RuntimeError(
+                f"vllm actor result contains {count} outputs; maximum batch size is {DUCKDB_STANDARD_VECTOR_SIZE}"
+            )
+        if rows.num_rows != count:
+            raise RuntimeError(f"vllm actor result row count ({rows.num_rows}) does not match output count ({count})")
+        if not isinstance(reservation_completions, list) or not reservation_completions:
+            raise RuntimeError("vllm actor result must include reservation completion counts")
+
+        normalized_completions: list[tuple[str, int]] = []
+        seen_reservations: set[str] = set()
+        completed_count = 0
+        for completion in reservation_completions:
+            if not isinstance(completion, (list, tuple)) or len(completion) != 2:
+                raise RuntimeError("vllm actor reservation completion must be a (reservation_id, count) pair")
+            reservation_id, completion_count = completion
+            if not isinstance(reservation_id, str) or not reservation_id:
+                raise RuntimeError("vllm actor reservation completion must include a non-empty reservation_id")
+            if reservation_id in seen_reservations:
+                raise RuntimeError(f"vllm actor result contains duplicate reservation {reservation_id}")
+            if isinstance(completion_count, bool) or not isinstance(completion_count, Integral):
+                raise RuntimeError("vllm actor reservation completion count must be a positive integer")
+            completion_count = int(completion_count)
+            if completion_count <= 0:
+                raise RuntimeError("vllm actor reservation completion count must be a positive integer")
+            seen_reservations.add(reservation_id)
+            normalized_completions.append((reservation_id, completion_count))
+            completed_count += completion_count
+        if completed_count != count:
+            raise RuntimeError(
+                f"vllm actor reservation completion count ({completed_count}) does not match output count ({count})"
+            )
+
+        self._complete_reservation_batch(actor_idx, normalized_completions)
         with self._result_cv:
             if self._wait_refs_by_actor[actor_idx] == ready_ref:
                 self._wait_refs_by_actor[actor_idx] = None
@@ -1137,34 +1187,48 @@ class RemoteVLLMExecutor(VLLMExecutor):
         self._ensure_wait_ref(actor_idx)
         self._notify_state_change()
 
-    def _complete_reservation(self, reservation_id: str | None, count: int) -> None:
-        if reservation_id is None or count <= 0:
+    def _complete_reservation_batch(self, actor_idx: int, completions: list[tuple[str, int]]) -> None:
+        if not completions:
             return
-        reservation_id = str(reservation_id)
         with self._reservation_rpc_lock:
             with self._reservation_lock:
-                reservation = self._reservations.get(reservation_id)
-                if reservation is None:
-                    raise RuntimeError(f"vllm result references unknown reservation {reservation_id}")
-                released = min(count, reservation["remaining"])
-                remaining_before = reservation["remaining"]
-                actor_idx = reservation["actor_idx"]
-            self._router_release(
-                "complete",
-                released,
-                reservation_id,
-                released,
-                operation_id=f"{self._executor_id}:complete:{reservation_id}:{remaining_before}:{released}",
-            )
-            with self._reservation_lock:
-                current = self._reservations.get(reservation_id)
-                if current is not reservation or current["remaining"] != remaining_before:
-                    raise RuntimeError(f"vllm reservation {reservation_id} changed during completion")
-                reservation["remaining"] -= released
-                if reservation["remaining"] == 0:
-                    self._reservations.pop(reservation_id, None)
-            with self._inflight_lock:
-                self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - released)
+                for reservation_id, count in completions:
+                    reservation = self._reservations.get(reservation_id)
+                    if reservation is None:
+                        raise RuntimeError(f"vllm result references unknown reservation {reservation_id}")
+                    if reservation["actor_idx"] != actor_idx:
+                        raise RuntimeError(
+                            f"vllm actor {actor_idx} result references reservation {reservation_id} "
+                            f"owned by actor {reservation['actor_idx']}"
+                        )
+                    if count > reservation["remaining"]:
+                        raise RuntimeError(
+                            f"vllm result completes {count} prompts for reservation {reservation_id}; "
+                            f"only {reservation['remaining']} remain"
+                        )
+
+            # Reservation RPCs are serialized by _reservation_rpc_lock, so the
+            # full preflight above remains valid throughout the batch.
+            for reservation_id, count in completions:
+                with self._reservation_lock:
+                    reservation = self._reservations[reservation_id]
+                    remaining_before = reservation["remaining"]
+                self._router_release(
+                    "complete",
+                    count,
+                    reservation_id,
+                    count,
+                    operation_id=f"{self._executor_id}:complete:{reservation_id}:{remaining_before}:{count}",
+                )
+                with self._reservation_lock:
+                    current = self._reservations.get(reservation_id)
+                    if current is not reservation or current["remaining"] != remaining_before:
+                        raise RuntimeError(f"vllm reservation {reservation_id} changed during completion")
+                    reservation["remaining"] -= count
+                    if reservation["remaining"] == 0:
+                        self._reservations.pop(reservation_id, None)
+                with self._inflight_lock:
+                    self._inflight_per_actor[actor_idx] = max(0, self._inflight_per_actor[actor_idx] - count)
 
     def _rollback_reservation(
         self,

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -1000,7 +1000,7 @@ def test_vllm_remote_wait_for_result_drains_ready_actor(monkeypatch):
 
     class FakeReadyMethod:
         def remote(self, _executor_id):
-            return FakeRef((["out-a", "out-b"], rows, "reservation-1"))
+            return FakeRef((["out-a", "out-b"], rows, [("reservation-1", 2)]))
 
     class FakeRouter:
         report_start = FakeRemoteMethod()

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -396,7 +396,7 @@ def test_ray_actor_releases_only_terminal_per_executor_state():
     executor._per_executor_abort_wait_tokens = {}
 
     assert executor.release_executor("executor") is False
-    assert executor.take_ready_result("executor") == ([None], rows, "reservation")
+    assert executor.take_ready_result("executor") == ([None], rows, [("reservation", 1)])
     assert executor.release_executor("executor") is True
 
     executor._per_executor_deques["aborted"] = deque()
@@ -406,6 +406,45 @@ def test_ray_actor_releases_only_terminal_per_executor_state():
     asyncio.run(executor.abort_executor("aborted"))
     assert "aborted" in executor._per_executor_aborted
     assert executor.release_executor("aborted") is True
+
+
+def test_ray_actor_batches_ready_results_to_standard_vector_size():
+    import duckdb.execution.vllm as vllm
+
+    vector_size = vllm.DUCKDB_STANDARD_VECTOR_SIZE
+    source_rows = pa.table({"id": range(vector_size + 3)})
+    ready = deque()
+    for row_id in range(vector_size + 3):
+        if row_id < vector_size // 2:
+            reservation_id = "reservation-a"
+        elif row_id < vector_size:
+            reservation_id = "reservation-b"
+        else:
+            reservation_id = "reservation-c"
+        ready.append((f"output-{row_id}", source_rows.slice(row_id, 1), reservation_id))
+
+    executor = vllm.RayLocalVLLMExecutor.__new__(vllm.RayLocalVLLMExecutor)
+    executor.on_error = "raise"
+    executor.completed_tasks = deque()
+    executor._per_executor_errors = {}
+    executor._per_executor_deques = {"executor": ready}
+    notifications = []
+    executor._notify_state_change = lambda **_kwargs: notifications.append(True)
+
+    first_outputs, first_rows, first_completions = executor.take_ready_result("executor")
+    assert first_outputs == [f"output-{row_id}" for row_id in range(vector_size)]
+    assert first_rows.to_pydict() == {"id": list(range(vector_size))}
+    assert first_completions == [
+        ("reservation-a", vector_size // 2),
+        ("reservation-b", vector_size // 2),
+    ]
+
+    second_outputs, second_rows, second_completions = executor.take_ready_result("executor")
+    assert second_outputs == [f"output-{row_id}" for row_id in range(vector_size, vector_size + 3)]
+    assert second_rows.to_pydict() == {"id": list(range(vector_size, vector_size + 3))}
+    assert second_completions == [("reservation-c", 3)]
+    assert executor.take_ready_result("executor") is None
+    assert notifications == [True, True]
 
 
 def test_ray_actor_abort_waiter_does_not_depend_on_default_thread_pool_capacity():
@@ -706,6 +745,7 @@ class _FakeVLLMActor:
     def __init__(self):
         self.submissions = []
         self.results = deque()
+        self.take_calls = 0
         self.wait_refs = deque()
         self.wait_tokens = []
         self.released = []
@@ -729,6 +769,7 @@ class _FakeVLLMActor:
         return ref
 
     def _take(self, _executor_id):
+        self.take_calls += 1
         return self.results.popleft()
 
     def _finish(self, executor_id):
@@ -743,7 +784,7 @@ class _FakeVLLMActor:
         self.abort_wait_tokens.append((executor_id, wait_token))
 
     def publish(self, outputs, rows, reservation_id):
-        self.results.append((outputs, rows, reservation_id))
+        self.results.append((outputs, rows, [(reservation_id, len(outputs))]))
         self.wait_refs.popleft().set_result(True)
 
 
@@ -794,7 +835,7 @@ def test_remote_reservation_rpc_does_not_block_submit_and_serializes_shutdown(mo
 
     shutdown_future = None
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
-        complete_future = pool.submit(executor._complete_reservation, first_reservation, 1)
+        complete_future = pool.submit(executor._complete_reservation_batch, 0, [(first_reservation, 1)])
         assert complete_entered.wait(1)
         submit_future = pool.submit(submit_second)
         submit_was_not_blocked = submit_finished.wait(1)
@@ -868,6 +909,48 @@ def test_remote_executor_uses_router_reservation_and_one_shot_wakeup(monkeypatch
     assert executor._actors_owner.shutdown_calls == 1
 
 
+def test_remote_executor_consumes_multi_reservation_actor_batch_in_one_rpc(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    first_rows = pa.table({"id": [1]})
+    second_rows = pa.table({"id": [2]})
+    executor.submit(None, ["first"], first_rows)
+    executor.submit(None, ["second"], second_rows)
+    first_reservation = actor.submissions[0][3]
+    second_reservation = actor.submissions[1][3]
+    assert executor.take_ready_result() is None
+
+    combined_rows = pa.concat_tables([first_rows, second_rows])
+    actor.results.append(
+        (
+            ["out-first", "out-second"],
+            combined_rows,
+            [(first_reservation, 1), (second_reservation, 1)],
+        )
+    )
+    actor.wait_refs.popleft().set_result(True)
+
+    assert executor.take_ready_result() == (["out-first", "out-second"], combined_rows)
+    assert actor.take_calls == 1
+    assert router.inflight == [0]
+    assert executor._reservations == {}
+    executor.finished_submitting()
+    assert executor.all_tasks_finished() is True
+
+
 def test_remote_executor_rejects_actor_result_without_reservation_id(monkeypatch):
     import duckdb.execution.vllm as vllm
 
@@ -891,6 +974,42 @@ def test_remote_executor_rejects_actor_result_without_reservation_id(monkeypatch
     try:
         with pytest.raises(RuntimeError, match="3-item tuple"):
             executor._drain_ready_actor(0, True, actor.wait_refs[0])
+    finally:
+        executor.shutdown()
+
+
+def test_remote_executor_validates_batch_reservations_before_completion(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="pool")
+    rows = pa.table({"id": [1, 2]})
+    executor.submit(None, ["first", "second"], rows)
+    reservation_id = actor.submissions[0][3]
+    actor.results.append(
+        (
+            ["out-first", "out-second"],
+            rows,
+            [(reservation_id, 1), ("unknown-reservation", 1)],
+        )
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="unknown reservation"):
+            executor._drain_ready_actor(0, True, actor.wait_refs[0])
+        assert router.inflight == [2]
+        assert executor._reservations[reservation_id]["remaining"] == 2
     finally:
         executor.shutdown()
 
@@ -1062,7 +1181,7 @@ def test_remote_executor_rearms_wait_for_already_buffered_actor_result(monkeypat
     second_reservation = actor.submissions[1][3]
 
     actor.publish(["out-first"], first_rows, first_reservation)
-    actor.results.append((["out-second"], second_rows, second_reservation))
+    actor.results.append((["out-second"], second_rows, [(second_reservation, 1)]))
 
     assert executor.take_ready_result() == (["out-first"], first_rows)
     assert executor.take_ready_result() == (["out-second"], second_rows)

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -978,6 +978,36 @@ def test_remote_executor_rejects_actor_result_without_reservation_id(monkeypatch
         executor.shutdown()
 
 
+def test_remote_executor_rejects_legacy_named_pool_actor_result(monkeypatch):
+    import duckdb.execution.vllm as vllm
+
+    actor = _FakeVLLMActor()
+    router = vllm.PrefixRouter([actor], load_balance_threshold=0)
+
+    class Owner:
+        router_actor = _RemoteProxy(router)
+        llm_actors = [actor]
+
+        @staticmethod
+        def shutdown():
+            return None
+
+    monkeypatch.setattr(vllm, "resolve_object_refs_blocking", lambda ref, **_kwargs: ref.resolve())
+    executor = vllm.RemoteVLLMExecutor(Owner(), pool_name="named-pool")
+    rows = pa.table({"id": [1]})
+    executor.submit(None, ["prompt"], rows)
+    reservation_id = actor.submissions[0][3]
+    actor.results.append((["output"], rows, reservation_id))
+
+    try:
+        with pytest.raises(RuntimeError, match="reservation completion counts"):
+            executor._drain_ready_actor(0, True, actor.wait_refs[0])
+        assert router.inflight == [1]
+        assert executor._reservations[reservation_id]["remaining"] == 1
+    finally:
+        executor.shutdown()
+
+
 def test_remote_executor_validates_batch_reservations_before_completion(monkeypatch):
     import duckdb.execution.vllm as vllm
 


### PR DESCRIPTION
## Summary

- Drain up to DuckDB standard-vector cardinality (2048) of currently ready vLLM results in one actor RPC instead of returning one row per call.
- Preserve output/row order while aggregating exact completion counts across interleaved router reservations.
- Validate the batched actor protocol before mutating reservation state, including batch size, row alignment, reservation ownership, and remaining counts.

This is an internal Ray actor protocol change; public SQL options and local non-Ray result behavior are unchanged. The actor does not add a batching delay: it drains results that are already ready. Named actor pools must be deployment-version homogeneous; mixed-version actor protocols and backward-compatibility fallbacks are intentionally unsupported, and protocol mismatches fail fast.

## Related issue

close: #447

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `python -m pytest -q tests/fast/test_vllm_runtime_fixes.py tests/fast/test_vllm_native_regressions.py` — 101 passed.
- `python -m pytest -q tests/fast/test_udf_executor_lifecycle.py -k vllm` — 22 passed.
- `python -m pytest -q tests/slow/test_vllm_ray_protocol_e2e.py` — 4 passed with a local CPU-only Ray cluster.
- `scripts/run_release_tests.sh` — 505 passed, 4 skipped, then 11 real-Ray tests passed.
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed.
- Batch boundary regression uses 2,051 synthetic Arrow rows (2,048 + 3), no model weights or GPU.
- The PR diff is Python-only; after rebasing onto latest `upstream/main`, the Release extension was rebuilt locally before the release gate.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.