### PR TITLE
[fix](ai) Remove legacy text classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable user-visible changes are documented here. Vane is currently in alpha
 - Positioned the current project as the Vane Data developer preview.
 - Prompt uses ordered `messages`, first-class call parameters, and the closed
   `PromptOptions` keyword surface. OpenAI Responses is the default endpoint.
+- Removed the legacy Python-only zero-shot classification API, Provider
+  protocol, and Transformers runtime. Prompt and Embed are now the complete AI
+  surface, and their shared retry layer retries only classified transient
+  failures.
 - Defined `DuckDBPyRelation.map` exclusively as a row-wise scalar UDF with a
   required `return_type`; batch transforms use `map_batches` with an explicit
   output `schema`. The inherited pandas DataFrame-style DuckDB `map` contract

--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -19,15 +19,12 @@ import pyarrow as pa
 import pytest
 
 import vane
-from vane.ai.protocols import (
-    TextClassifierDescriptor,
-    TextEmbedderDescriptor,
-)
+from vane.ai.protocols import TextEmbedderDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import EmbeddingDimensions
 
 if TYPE_CHECKING:
-    from vane.ai.protocols import TextClassifier, TextEmbedder
+    from vane.ai.protocols import TextEmbedder
     from vane.ai.typing import Options
 
 
@@ -94,28 +91,6 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
         return MockTextEmbedder(dim=self.dim)
 
 
-class MockTextClassifier:
-    """Returns the first label for every input."""
-
-    def classify_text(self, text: list[str], labels: list[str]) -> list[str]:
-        return [labels[0] for _ in text]
-
-
-@dataclass
-class MockTextClassifierDescriptor(TextClassifierDescriptor):
-    def get_provider(self) -> str:
-        return "mock"
-
-    def get_model(self) -> str:
-        return "mock-classifier"
-
-    def get_options(self) -> Options:
-        return {"batch_size": 2}
-
-    def instantiate(self) -> TextClassifier:
-        return MockTextClassifier()
-
-
 class MockProvider(Provider):
     """Provider that returns mock descriptors."""
 
@@ -125,9 +100,6 @@ class MockProvider(Provider):
 
     def get_text_embedder(self, model=None, dimensions=None, *, options=None) -> TextEmbedderDescriptor:
         return MockTextEmbedderDescriptor(dim=dimensions or 4)
-
-    def get_text_classifier(self, model=None, **_options) -> TextClassifierDescriptor:
-        return MockTextClassifierDescriptor()
 
 
 # ---------------------------------------------------------------------------
@@ -209,43 +181,22 @@ class TestEmbed:
         assert rows[0][1] is None
 
 
-class TestClassifyText:
-    def test_classify_text_basic(self):
-        """classify_text produces a relation with label column."""
-        from vane.ai.functions import classify_text
+def test_legacy_classification_surface_is_removed():
+    import vane.ai as ai
+    from vane.ai import functions, protocols
+    from vane.ai import provider as provider_module
+    from vane.ai.providers import transformers
 
-        conn = vane.connect()
-        rel = conn.sql("SELECT 'great product' AS text UNION ALL SELECT 'terrible' AS text")
-
-        result = classify_text(
-            rel,
-            "text",
-            labels=["positive", "negative"],
-            provider=MockProvider(),
-        )
-
-        rows = result.fetchall()
-        assert len(rows) == 2
-        # MockTextClassifier always returns the first label
-        for row in rows:
-            assert row[0] == "positive"
-
-    def test_classify_text_custom_output(self):
-        from vane.ai.functions import classify_text
-
-        conn = vane.connect()
-        rel = conn.sql("SELECT 'test' AS text")
-
-        result = classify_text(
-            rel,
-            "text",
-            labels=["a", "b"],
-            provider=MockProvider(),
-            output_column="sentiment",
-        )
-
-        rows = result.fetchall()
-        assert len(rows) == 1
+    assert "classify_text" not in ai.__all__
+    assert not hasattr(ai, "classify_text")
+    assert not hasattr(functions, "classify_text")
+    assert not hasattr(functions, "_ClassifyTextBatch")
+    assert not hasattr(protocols, "TextClassifier")
+    assert not hasattr(protocols, "TextClassifierDescriptor")
+    assert not hasattr(provider_module.Provider, "get_text_classifier")
+    assert not hasattr(transformers.TransformersProvider, "get_text_classifier")
+    assert not hasattr(transformers, "TransformersTextClassifier")
+    assert not hasattr(transformers, "TransformersTextClassifierDescriptor")
 
 
 class TestMockDescriptorPickle:
@@ -258,13 +209,6 @@ class TestMockDescriptorPickle:
         result = embedder.embed_text(["hello"])
         assert len(result) == 1
         assert len(result[0]) == 16
-
-    def test_classifier_descriptor_pickle(self):
-        desc = MockTextClassifierDescriptor()
-        restored = pickle.loads(pickle.dumps(desc))
-        classifier = restored.instantiate()
-        result = classifier.classify_text(["test"], ["a", "b"])
-        assert result == ["a"]
 
 
 class TestWrapperPickle:
@@ -279,16 +223,6 @@ class TestWrapperPickle:
         result = _drive(restored, table)
         assert result.num_rows == 2
         assert result.column_names == ["emb"]
-
-    def test_classify_wrapper_pickle(self):
-        from vane.ai.functions import _ClassifyTextBatch
-
-        wrapper = _ClassifyTextBatch(MockTextClassifierDescriptor(), "text", "label", ["a", "b"])
-        restored = pickle.loads(pickle.dumps(wrapper))
-        table = pa.table({"text": ["hello"]})
-        result = restored(table)
-        assert result.num_rows == 1
-        assert result.column("label").to_pylist() == ["a"]
 
 
 # ---------------------------------------------------------------------------
@@ -2156,38 +2090,54 @@ class TestRetryCall:
         assert result == "ok"
         assert len(calls) == 1
 
-    def test_retry_then_success(self):
+    def test_retry_then_success(self, monkeypatch):
         from vane.ai.functions import _retry_call
 
+        monkeypatch.setattr("vane.ai.functions.time.sleep", lambda _seconds: None)
         calls = []
+
+        class ServiceUnavailableError(ValueError):
+            status_code = 503
 
         def fn():
             calls.append(1)
             if len(calls) < 3:
-                raise ValueError("transient")
+                raise ServiceUnavailableError("transient")
             return "recovered"
 
         result = _retry_call(fn, max_retries=3, on_error="raise")
         assert result == "recovered"
         assert len(calls) == 3
 
-    def test_retry_exhausted_raises(self):
+    def test_retry_exhausted_raises(self, monkeypatch):
         from vane.ai.functions import _retry_call
 
-        def fn():
-            raise RuntimeError("permanent")
+        monkeypatch.setattr("vane.ai.functions.time.sleep", lambda _seconds: None)
+        calls = []
 
-        with pytest.raises(RuntimeError, match="permanent"):
+        class ServiceUnavailableError(RuntimeError):
+            status_code = 503
+
+        def fn():
+            calls.append(1)
+            raise ServiceUnavailableError("unavailable")
+
+        with pytest.raises(ServiceUnavailableError, match="unavailable"):
             _retry_call(fn, max_retries=1, on_error="raise")
+        assert len(calls) == 2
 
-    def test_on_error_log_returns_default(self):
+    def test_nontransient_error_is_not_retried(self):
         from vane.ai.functions import _retry_call
 
-        def fn():
-            raise RuntimeError("fail")
+        calls = []
 
-        result = _retry_call(fn, max_retries=0, on_error="log", default="fallback")
-        assert result == "fallback"
+        def fn():
+            calls.append(1)
+            raise ValueError("invalid request")
+
+        with pytest.raises(ValueError, match="invalid request"):
+            _retry_call(fn, max_retries=3, on_error="raise")
+        assert len(calls) == 1
 
     def test_on_error_ignore_returns_default(self):
         from vane.ai.functions import _retry_call
@@ -2206,6 +2156,19 @@ class TestRetryCall:
 
         result = _retry_call(fn, max_retries=0, on_error="ignore")
         assert result is None
+
+    @pytest.mark.parametrize("on_error", ["log", None, ["ignore"]])
+    def test_invalid_on_error_is_rejected_before_call(self, on_error):
+        from vane.ai.functions import _retry_call
+
+        calls = []
+
+        def fn():
+            calls.append(1)
+
+        with pytest.raises(ValueError, match="on_error must be 'raise' or 'ignore'"):
+            _retry_call(fn, on_error=on_error)
+        assert calls == []
 
     def test_awaitable_result_handled(self):
         """_retry_call drives awaitables through the provided run_async."""
@@ -2233,7 +2196,53 @@ class TestRetryCall:
         with pytest.raises(RuntimeError, match="bind_async_runtime"):
             _retry_call(async_fn, max_retries=0, on_error="ignore")
 
-    def test_retry_call_async(self):
+    def test_retry_call_async(self, monkeypatch):
+        import asyncio
+
+        from vane.ai.functions import _retry_call_async
+
+        async def no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(asyncio, "sleep", no_sleep)
+        calls = []
+
+        class ServiceUnavailableError(ValueError):
+            status_code = 503
+
+        async def fn():
+            calls.append(1)
+            if len(calls) < 2:
+                raise ServiceUnavailableError("transient")
+            return "ok"
+
+        result = asyncio.run(_retry_call_async(fn, max_retries=2, on_error="raise"))
+        assert result == "ok"
+        assert len(calls) == 2
+
+    def test_retry_call_async_exhausted_raises(self, monkeypatch):
+        import asyncio
+
+        from vane.ai.functions import _retry_call_async
+
+        async def no_sleep(_seconds):
+            return None
+
+        monkeypatch.setattr(asyncio, "sleep", no_sleep)
+        calls = []
+
+        class ServiceUnavailableError(RuntimeError):
+            status_code = 503
+
+        async def fn():
+            calls.append(1)
+            raise ServiceUnavailableError("boom")
+
+        with pytest.raises(ServiceUnavailableError, match="boom"):
+            asyncio.run(_retry_call_async(fn, max_retries=1, on_error="raise"))
+        assert len(calls) == 2
+
+    def test_retry_call_async_nontransient_error_is_not_retried(self):
         import asyncio
 
         from vane.ai.functions import _retry_call_async
@@ -2242,39 +2251,38 @@ class TestRetryCall:
 
         async def fn():
             calls.append(1)
-            if len(calls) < 2:
-                raise ValueError("transient")
-            return "ok"
+            raise ValueError("invalid request")
 
-        result = asyncio.run(_retry_call_async(fn, max_retries=2, on_error="raise"))
-        assert result == "ok"
-        assert len(calls) == 2
+        with pytest.raises(ValueError, match="invalid request"):
+            asyncio.run(_retry_call_async(fn, max_retries=3, on_error="raise"))
+        assert len(calls) == 1
 
-    def test_retry_call_async_exhausted_raises(self):
+    @pytest.mark.parametrize("on_error", ["log", None, ["ignore"]])
+    def test_retry_call_async_rejects_invalid_on_error_before_call(self, on_error):
         import asyncio
 
         from vane.ai.functions import _retry_call_async
 
-        async def fn():
-            raise RuntimeError("boom")
-
-        with pytest.raises(RuntimeError, match="boom"):
-            asyncio.run(_retry_call_async(fn, max_retries=1, on_error="raise"))
-
-    def test_retry_call_async_on_error_log(self):
-        import asyncio
-
-        from vane.ai.functions import _retry_call_async
+        calls = []
 
         async def fn():
-            raise RuntimeError("fail")
+            calls.append(1)
 
-        result = asyncio.run(_retry_call_async(fn, max_retries=0, on_error="log", default="safe"))
-        assert result == "safe"
+        with pytest.raises(ValueError, match="on_error must be 'raise' or 'ignore'"):
+            asyncio.run(_retry_call_async(fn, on_error=on_error))
+        assert calls == []
 
 
 class TestWrapperRetry:
     """Tests that wrapper classes use retry/on_error correctly."""
+
+    def test_wrappers_reject_invalid_on_error(self):
+        from vane.ai.functions import _EmbedTextBatch, _PromptBatch
+
+        with pytest.raises(ValueError, match="on_error must be 'raise' or 'ignore'"):
+            _EmbedTextBatch(object(), "text", "embedding", 3, on_error="log")
+        with pytest.raises(ValueError, match="on_error must be 'raise' or 'ignore'"):
+            _PromptBatch(object(), ["message"], "response", on_error="log")
 
     def _make_embed_descriptor(self, embed_fn):
         """Create a minimal descriptor + embedder for testing."""
@@ -2371,21 +2379,6 @@ class TestWrapperRetry:
         table = pa.table({"text": ["hello"]})
         result = _drive(wrapper, table)
         assert result.column("emb").to_pylist() == [None]
-
-    def test_classify_on_error_log(self):
-        from vane.ai.functions import _ClassifyTextBatch
-
-        def classify(_texts, _labels):
-            raise RuntimeError("fail")
-
-        desc = MagicMock(spec=[])
-        classifier = MagicMock(spec=[])
-        classifier.classify_text = classify
-        desc.instantiate = MagicMock(return_value=classifier)
-        wrapper = _ClassifyTextBatch(desc, "text", "label", ["a", "b"], max_retries=0, on_error="log")
-        table = pa.table({"text": ["hello"]})
-        result = wrapper(table)
-        assert result.column("label").to_pylist() == [None]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -75,15 +75,6 @@ def _transformers_embedder_descriptor():
     )
 
 
-def _transformers_classifier_descriptor():
-    from vane.ai.providers.transformers import TransformersTextClassifierDescriptor
-
-    return TransformersTextClassifierDescriptor(
-        model="facebook/bart-large-mnli",
-        classify_options={"batch_size": 4, "token": HUB_TOKEN},
-    )
-
-
 def _openai_prompt_descriptor(options):
     from vane.ai.providers.openai import OpenAIPrompterDescriptor
 
@@ -117,7 +108,6 @@ def _vllm_prompt_plan(options):
 ALL_DESCRIPTOR_FACTORIES = [
     pytest.param(_openai_embedder_descriptor, id="openai-embedder"),
     pytest.param(_google_embedder_descriptor, id="google-embedder"),
-    pytest.param(_transformers_classifier_descriptor, id="transformers-classifier"),
 ]
 
 
@@ -422,22 +412,6 @@ class TestOptionsAtExecutionBoundary:
                     "revision": "pinned",
                     "device": "cpu",
                 },
-            )
-        ]
-
-    def test_transformers_classifier_pipeline_receives_plaintext_token(self, monkeypatch):
-        pipeline_calls = []
-
-        def fake_pipeline(task, **options):
-            pipeline_calls.append((task, options))
-            return object()
-
-        monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(pipeline=fake_pipeline))
-        _transformers_classifier_descriptor().instantiate()
-        assert pipeline_calls == [
-            (
-                "zero-shot-classification",
-                {"model": "facebook/bart-large-mnli", "trust_remote_code": False, "token": HUB_TOKEN},
             )
         ]
 

--- a/tests/ai/test_descriptors.py
+++ b/tests/ai/test_descriptors.py
@@ -217,22 +217,6 @@ class TestTransformersDescriptorPickle:
         assert restored.get_provider() == "transformers"
         assert restored.get_model() == "sentence-transformers/all-MiniLM-L6-v2"
 
-    def test_text_classifier_descriptor_roundtrip(self):
-        from vane.ai.providers.transformers import (
-            TransformersTextClassifierDescriptor,
-        )
-
-        desc = TransformersTextClassifierDescriptor(
-            model="facebook/bart-large-mnli",
-            classify_options={"max_retries": 5},
-        )
-
-        data = pickle.dumps(desc)
-        restored = pickle.loads(data)
-
-        assert restored.model == desc.model
-        assert restored.get_provider() == "transformers"
-
 
 class TestOpenAIDescriptorPickle:
     def test_text_embedder_descriptor_roundtrip(self):
@@ -349,15 +333,6 @@ class TestProtocols:
                 return [[] for _ in text]
 
         assert isinstance(MyEmbedder(), TextEmbedder)
-
-    def test_text_classifier_protocol_check(self):
-        from vane.ai.protocols import TextClassifier
-
-        class MyClassifier:
-            def classify_text(self, text, _labels):
-                return ["pos" for _ in text]
-
-        assert isinstance(MyClassifier(), TextClassifier)
 
     def test_prompter_protocol_check(self):
         from vane.ai.protocols import Prompter

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -418,9 +418,10 @@ def test_ai_embed_rejects_invalid_dimensions(dimensions):
         vane.ai.embed(vane.col("text"), provider=MockProvider(), dimensions=dimensions)
 
 
-def test_ai_embed_rejects_nonfinal_on_error_value():
+@pytest.mark.parametrize("on_error", ["log", ["ignore"]])
+def test_ai_embed_rejects_nonfinal_on_error_value(on_error):
     with pytest.raises(ValueError, match="on_error"):
-        vane.ai.embed(vane.col("text"), provider=MockProvider(), on_error="log")
+        vane.ai.embed(vane.col("text"), provider=MockProvider(), on_error=on_error)
 
 
 def test_ai_embed_expression_rejects_relation_only_options():

--- a/tests/ai/test_relation_patch.py
+++ b/tests/ai/test_relation_patch.py
@@ -15,14 +15,13 @@ import duckdb
 import vane
 from vane.ai.protocols import (
     PrompterDescriptor,
-    TextClassifierDescriptor,
     TextEmbedderDescriptor,
 )
 from vane.ai.provider import Provider
 from vane.ai.typing import EmbeddingDimensions
 
 if TYPE_CHECKING:
-    from vane.ai.protocols import Prompter, TextClassifier, TextEmbedder
+    from vane.ai.protocols import Prompter, TextEmbedder
     from vane.ai.typing import Options
 
 # ---------------------------------------------------------------------------
@@ -58,26 +57,6 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
         return MockTextEmbedder(dim=self.dim)
 
 
-class MockTextClassifier:
-    def classify_text(self, text: list[str], labels: list[str]) -> list[str]:
-        return [labels[0] for _ in text]
-
-
-@dataclass
-class MockTextClassifierDescriptor(TextClassifierDescriptor):
-    def get_provider(self) -> str:
-        return "mock"
-
-    def get_model(self) -> str:
-        return "mock-classifier"
-
-    def get_options(self) -> Options:
-        return {"batch_size": 2}
-
-    def instantiate(self) -> TextClassifier:
-        return MockTextClassifier()
-
-
 class MockPrompter:
     async def prompt(self, messages: tuple[object, ...]) -> str:
         return "prompt:" + ":".join(part if isinstance(part, str) else bytes(part).hex() for part in messages)
@@ -105,9 +84,6 @@ class MockProvider(Provider):
 
     def get_text_embedder(self, model=None, dimensions=None, *, options=None):
         return MockTextEmbedderDescriptor(dim=dimensions or 4)
-
-    def get_text_classifier(self, model=None, **options):
-        return MockTextClassifierDescriptor()
 
     def get_prompter(
         self,
@@ -150,17 +126,6 @@ class TestRelationPatch:
         assert result.columns == ["text", "embedding"]
         assert result.fetchone() == ("hello", (5.0, 5.0, 5.0, 5.0))
 
-    def test_classify_text_on_relation(self):
-        """rel.classify_text() produces labels."""
-        conn = duckdb.connect()
-        rel = conn.sql("SELECT 'great' AS text UNION ALL SELECT 'bad' AS text")
-
-        result = rel.classify_text("text", labels=["positive", "negative"], provider=MockProvider())
-        rows = result.fetchall()
-        assert len(rows) == 2
-        for row in rows:
-            assert row[0] == "positive"
-
     def test_prompt_on_relation(self):
         conn = vane.connect()
         rel = conn.sql("SELECT 1 AS id, 'hello' AS text, from_hex('89504e47') AS image")
@@ -196,7 +161,7 @@ class TestRelationPatch:
         """DuckDBPyRelation has the patched methods."""
         assert hasattr(duckdb.DuckDBPyRelation, "embed")
         assert not hasattr(duckdb.DuckDBPyRelation, "embed_text")
-        assert hasattr(duckdb.DuckDBPyRelation, "classify_text")
+        assert not hasattr(duckdb.DuckDBPyRelation, "classify_text")
         assert hasattr(duckdb.DuckDBPyRelation, "prompt")
 
     def test_patch_is_idempotent(self):

--- a/tests/fast/test_ai_release_contracts.py
+++ b/tests/fast/test_ai_release_contracts.py
@@ -277,13 +277,16 @@ def test_retry_after_cancellation_retains_no_original_exception_data():
     assert all(secret not in surface for surface in surfaces)
 
 
-def test_ordinary_provider_error_is_not_attached_to_backoff_cancellation(monkeypatch):
+def test_transient_provider_error_is_not_attached_to_backoff_cancellation(monkeypatch):
     from vane.ai.functions import _retry_call_async
 
     secret = "hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
+    class ServiceUnavailableError(RuntimeError):
+        status_code = 503
+
     async def fail():
-        raise RuntimeError(secret)
+        raise ServiceUnavailableError(secret)
 
     async def cancel_sleep(_seconds):
         raise asyncio.CancelledError

--- a/tests/fast/test_transformers_provider_security.py
+++ b/tests/fast/test_transformers_provider_security.py
@@ -8,7 +8,6 @@ import pytest
 
 from vane.ai.providers.transformers import (
     TransformersProvider,
-    TransformersTextClassifier,
     TransformersTextEmbedder,
     TransformersTextEmbedderDescriptor,
 )
@@ -114,9 +113,8 @@ def test_remote_code_requires_an_explicit_option(monkeypatch):
     ]
 
 
-def test_remote_code_is_enabled_only_by_the_boolean_true(monkeypatch):
+def test_remote_code_string_does_not_enable_remote_code(monkeypatch):
     sentence_transformer_calls = []
-    pipeline_calls = []
 
     class FakeSentenceTransformer:
         def __init__(self, model, **options):
@@ -125,19 +123,12 @@ def test_remote_code_is_enabled_only_by_the_boolean_true(monkeypatch):
         def eval(self):
             return self
 
-    def fake_pipeline(task, **options):
-        pipeline_calls.append((task, options))
-        return object()
-
     monkeypatch.setitem(
         sys.modules,
         "sentence_transformers",
         SimpleNamespace(SentenceTransformer=FakeSentenceTransformer),
     )
-    monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(pipeline=fake_pipeline))
 
     TransformersTextEmbedder("reviewed-model", trust_remote_code="true")
-    TransformersTextClassifier("reviewed-classifier", trust_remote_code="true")
 
     assert sentence_transformer_calls[0][1]["trust_remote_code"] is False
-    assert pipeline_calls[0][1]["trust_remote_code"] is False

--- a/vane/ai/__init__.py
+++ b/vane/ai/__init__.py
@@ -3,13 +3,13 @@
 
 """Vane AI — high-level AI function APIs.
 
-Provides one-line functions for common AI tasks (embedding, classification,
-prompting) that integrate with Vane's distributed execution engine.
+Provides one-line functions for embedding and prompting that integrate with
+Vane's distributed execution engine.
 
 Quick start::
 
     import vane
-    from vane.ai import classify_text, embed, prompt
+    from vane.ai import embed, prompt
 
     conn = vane.connect()
     rel = conn.sql("SELECT text FROM documents")
@@ -39,7 +39,6 @@ __all__ = [
     "SchemaValidationError",
     "TokenMetricsEntry",
     "UDFOptions",
-    "classify_text",
     "embed",
     "get_token_metrics",
     "get_token_metrics_summary",
@@ -62,7 +61,6 @@ _LAZY_EXPORTS = {
     "SchemaValidationError": ("vane.ai._schema", "SchemaValidationError"),
     "TokenMetricsEntry": ("vane.ai.metrics", "TokenMetricsEntry"),
     "UDFOptions": ("vane.ai.typing", "UDFOptions"),
-    "classify_text": ("vane.ai.functions", "classify_text"),
     "embed": ("vane.ai.functions", "embed"),
     "get_token_metrics": ("vane.ai.metrics", "get_token_metrics"),
     "get_token_metrics_summary": ("vane.ai.metrics", "get_token_metrics_summary"),

--- a/vane/ai/_relation_patch.py
+++ b/vane/ai/_relation_patch.py
@@ -3,8 +3,8 @@
 
 """Monkey-patch AI convenience methods onto DuckDBPyRelation.
 
-This module adds ``.embed()``, ``.classify_text()``, and ``.prompt()``
-directly to :class:`duckdb.DuckDBPyRelation` so users can write::
+This module adds ``.embed()`` and ``.prompt()`` directly to
+:class:`duckdb.DuckDBPyRelation` so users can write::
 
     rel.embed(vane.col("text_col"), provider="transformers")
 
@@ -60,32 +60,6 @@ def _embed(
     )
 
 
-def _classify_text(
-    self: DuckDBPyRelation,
-    column: str,
-    *,
-    labels: list[str],
-    provider: Any = None,
-    model: str | None = None,
-    output_column: str = "label",
-    execution_backend: str | None = None,
-    **options: Any,
-) -> DuckDBPyRelation:
-    """Classify a text column. See :func:`vane.ai.classify_text` for details."""
-    from vane.ai.functions import classify_text
-
-    return classify_text(
-        self,
-        column,
-        labels=labels,
-        provider=provider,
-        model=model,
-        output_column=output_column,
-        execution_backend=execution_backend,
-        **options,
-    )
-
-
 def _prompt(
     self: DuckDBPyRelation,
     messages: Expression | list[Expression],
@@ -120,8 +94,6 @@ def _patch() -> None:
     """Apply AI methods to DuckDBPyRelation (idempotent)."""
     if not hasattr(DuckDBPyRelation, "embed"):
         DuckDBPyRelation.embed = _embed  # type: ignore[attr-defined]
-    if not hasattr(DuckDBPyRelation, "classify_text"):
-        DuckDBPyRelation.classify_text = _classify_text  # type: ignore[attr-defined]
     if not hasattr(DuckDBPyRelation, "prompt"):
         DuckDBPyRelation.prompt = _prompt  # type: ignore[attr-defined]
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -11,7 +11,7 @@ These functions create stateful wrapper classes that:
 Usage::
 
     import vane
-    from vane.ai.functions import classify_text, embed
+    from vane.ai.functions import embed
 
     conn = vane.connect()
     rel = conn.sql("SELECT text FROM documents")
@@ -24,13 +24,6 @@ Usage::
         model="sentence-transformers/all-MiniLM-L6-v2",
     )
 
-    # Text classification — returns relation with 'label' column
-    classified = classify_text(
-        rel,
-        "text",
-        labels=["positive", "negative"],
-        provider="transformers",
-    )
 """
 
 from __future__ import annotations
@@ -81,10 +74,8 @@ else:
     BaseModel = Any
 
 
-def _resolve_provider(provider: str | Provider | None, default: str = "transformers") -> Provider:
+def _resolve_provider(provider: str | Provider) -> Provider:
     """Resolve a provider argument to a Provider instance."""
-    if provider is None:
-        return load_provider(default)
     if isinstance(provider, str):
         return load_provider(provider)
     return provider
@@ -136,7 +127,12 @@ def _provider_is_loop_bound(provider: Any, method_name: str) -> bool:
 # Retry / on_error helpers
 # ---------------------------------------------------------------------------
 
-_OnError = Literal["raise", "log", "ignore"]
+_OnError = Literal["raise", "ignore"]
+
+
+def _validate_on_error(on_error: object) -> None:
+    if not isinstance(on_error, str) or on_error not in ("raise", "ignore"):
+        raise ValueError("on_error must be 'raise' or 'ignore'")
 
 
 class RetryAfterError(Exception):
@@ -220,7 +216,6 @@ def _retry_call(
     default: Any = None,
     run_async: Any = None,
     on_awaitable: Any = None,
-    retry_if: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Call *fn* with exponential-backoff retry and on_error handling.
@@ -228,8 +223,8 @@ def _retry_call(
     Args:
         fn: Callable (sync or async) to invoke.
         max_retries: Number of retry attempts after the first failure (0 = no retries).
-        on_error: ``"raise"`` re-raises on final failure; ``"log"`` and
-            ``"ignore"`` return *default*.
+        on_error: ``"raise"`` re-raises on final failure; ``"ignore"``
+            returns *default*.
         default: Value to return when on_error is not ``"raise"``.
         run_async: Callable used to drive awaitable results. Batch wrappers
             pass their executor-bound runtime so cached SDK clients see one
@@ -238,10 +233,8 @@ def _retry_call(
             returns an awaitable — lets a wrapper learn its provider is
             loop-bound even when static inspection cannot tell (a plain
             ``def`` that returns an awaitable), so ``close()`` releases it.
-        retry_if: Optional predicate that must accept an exception and return
-            true for retryable failures. By default, ordinary exceptions keep
-            the historical retry behavior.
     """
+    _validate_on_error(on_error)
     last_exc: Exception | None = None
     for attempt in range(1 + max(0, max_retries)):
         wait: float | None = None
@@ -266,7 +259,7 @@ def _retry_call(
                 (ProviderCapabilityError, _ProviderResultError, OutputValidationError, RawResponseSerializationError),
             ):
                 break
-            if retry_if is not None and not retry_if(exc):
+            if not _is_transient_provider_error(exc):
                 break
             if attempt < max_retries:
                 if isinstance(exc, RetryAfterError):
@@ -292,7 +285,6 @@ async def _retry_call_async(
     on_error: _OnError = "raise",
     default: Any = None,
     on_awaitable: Any = None,
-    retry_if: Any = None,
     **kwargs: Any,
 ) -> Any:
     """Async variant of :func:`_retry_call`.
@@ -302,6 +294,7 @@ async def _retry_call_async(
     method is a plain ``def`` returning an awaitable (which
     ``iscoroutinefunction`` cannot classify).
     """
+    _validate_on_error(on_error)
     last_exc: Exception | None = None
     for attempt in range(1 + max(0, max_retries)):
         wait: float | None = None
@@ -317,7 +310,7 @@ async def _retry_call_async(
                 (ProviderCapabilityError, _ProviderResultError, OutputValidationError, RawResponseSerializationError),
             ):
                 break
-            if retry_if is not None and not retry_if(exc):
+            if not _is_transient_provider_error(exc):
                 break
             if attempt < max_retries:
                 if isinstance(exc, RetryAfterError):
@@ -424,10 +417,9 @@ def _prepare_embed_call(
     if model is not None and (not isinstance(model, str) or not model.strip()):
         raise ValueError("model must be a non-empty string or None")
     explicit_dimensions = _validate_embedding_dimension(dimensions)
-    if on_error not in {"raise", "ignore"}:
-        raise ValueError("on_error must be 'raise' or 'ignore'")
+    _validate_on_error(on_error)
 
-    resolved_provider = _resolve_provider(provider, "openai")
+    resolved_provider = _resolve_provider(provider)
     if not isinstance(resolved_provider, Provider):
         raise TypeError("provider must be a provider name or Provider object")
     family = _embedding_provider_family(resolved_provider)
@@ -633,6 +625,7 @@ class _EmbedTextBatch:
         on_error: _OnError = "raise",
         normalize: bool = False,
     ) -> None:
+        _validate_on_error(on_error)
         self._descriptor = descriptor
         self._column = column
         self._output_column = output_column
@@ -740,7 +733,6 @@ class _EmbedTextBatch:
                 on_error="raise",
                 run_async=self._require_run_async(),
                 on_awaitable=self._mark_loop_bound,
-                retry_if=_is_transient_provider_error,
             )
         except _MissingAsyncRuntimeError:
             raise
@@ -851,56 +843,6 @@ class _EmbedTextBatch:
         return results
 
 
-class _ClassifyTextBatch:
-    """Stateful wrapper for text classification."""
-
-    def __init__(
-        self,
-        descriptor: Any,
-        column: str,
-        output_column: str,
-        labels: list[str],
-        max_retries: int = 3,
-        on_error: _OnError = "raise",
-    ) -> None:
-        self._descriptor = descriptor
-        self._column = column
-        self._output_column = output_column
-        self._labels = labels
-        self._max_retries = max_retries
-        self._on_error: _OnError = on_error
-        self._classifier = None  # lazy: instantiate on first __call__
-
-    def __call__(self, table: pa.Table) -> pa.Table:
-        capability_error: ProviderCapabilityError | None = None
-        provider_error: Exception | None = None
-        try:
-            if self._classifier is None:
-                self._classifier = self._descriptor.instantiate()
-            texts = table.column(self._column).to_pylist()
-            texts = [t if t is not None else "" for t in texts]
-            results = _retry_call(
-                self._classifier.classify_text,
-                texts,
-                self._labels,
-                max_retries=self._max_retries,
-                on_error=self._on_error,
-            )
-        except ProviderCapabilityError as exc:
-            capability_error = exc
-        except Exception as exc:
-            provider_error = exc
-        if capability_error is not None:
-            raise _safe_provider_capability_error(capability_error) from None
-        if provider_error is not None:
-            provider, model = _descriptor_identity(self._descriptor)
-            raise _safe_provider_execution_error(provider, model, "classification", provider_error) from None
-        if results is None:
-            results = [None] * len(texts)
-
-        return pa.table({self._output_column: results})
-
-
 class _PromptBatch:
     """Stateful row-preserving wrapper for ordered text/image Prompt parts."""
 
@@ -918,6 +860,7 @@ class _PromptBatch:
     ) -> None:
         if not message_columns:
             raise ValueError("Prompt message_columns cannot be empty")
+        _validate_on_error(on_error)
         self._descriptor = descriptor
         self._message_columns = list(message_columns)
         self._output_column = output_column
@@ -1095,7 +1038,6 @@ class _PromptBatch:
                     max_retries=max_retries,
                     on_error=on_error,
                     on_awaitable=self._mark_loop_bound,
-                    retry_if=_is_transient_provider_error,
                 )
             except ProviderCapabilityError as exc:
                 capability_error = exc
@@ -1454,60 +1396,6 @@ def embed(
 
 
 # ---------------------------------------------------------------------------
-# classify_text
-# ---------------------------------------------------------------------------
-
-
-def classify_text(
-    rel: Any,
-    column: str,
-    *,
-    labels: list[str],
-    provider: str | Provider | None = None,
-    model: str | None = None,
-    output_column: str = "label",
-    execution_backend: str | None = None,
-    **options: Any,
-) -> Any:
-    """Classify a text column using zero-shot classification.
-
-    Args:
-        rel: A DuckDB relation containing the source data.
-        column: Name of the text column to classify.
-        labels: List of candidate labels.
-        provider: Provider name or instance (default: ``"transformers"``).
-        model: Model identifier (provider-specific default if ``None``).
-        output_column: Name of the output column (default: ``"label"``).
-        execution_backend: Optional UDF backend. If omitted, the relation API infers task backend
-            from the active runner.
-        **options: Forwarded to the provider's ``get_text_classifier``.
-
-    Returns:
-        A new relation with the ``output_column`` appended.
-    """
-    prov = _resolve_provider(provider, "transformers")
-    descriptor = prov.get_text_classifier(model=model, **options)
-    udf_opts = descriptor.get_udf_options()
-
-    wrapper = _ClassifyTextBatch(
-        descriptor,
-        column,
-        output_column,
-        labels,
-        max_retries=udf_opts.max_retries,
-        on_error=udf_opts.on_error,
-    )
-    kwargs = _map_batches_kwargs(udf_opts, execution_backend)
-    kwargs["schema"] = {output_column: "VARCHAR"}
-    udf = _adapt_batch_wrapper_for_backend(
-        wrapper,
-        kwargs.get("execution_backend"),
-        force_actor="actor_number" in kwargs,
-    )
-    return rel.map_batches(udf, **kwargs)
-
-
-# ---------------------------------------------------------------------------
 # prompt
 # ---------------------------------------------------------------------------
 
@@ -1549,11 +1437,10 @@ def _prepare_prompt_call(
         raise TypeError("system_message must be a string or None")
     if not isinstance(return_raw_response, bool):
         raise TypeError("return_raw_response must be a bool")
-    if on_error not in {"raise", "ignore"}:
-        raise ValueError("on_error must be 'raise' or 'ignore'")
+    _validate_on_error(on_error)
     structured_output = compile_return_format(return_format)
 
-    resolved_provider = _resolve_provider(provider, "openai")
+    resolved_provider = _resolve_provider(provider)
     if not isinstance(resolved_provider, Provider):
         raise TypeError("provider must be a provider name or Provider object")
     family = _prompt_provider_family(resolved_provider)

--- a/vane/ai/metrics.py
+++ b/vane/ai/metrics.py
@@ -4,7 +4,7 @@
 """Token usage metrics for AI providers.
 
 Provides a lightweight, thread-safe mechanism for recording and querying
-token usage across all AI provider calls (prompt, embed, classify).
+token usage across all AI provider calls (Prompt and Embed).
 
 Usage::
 
@@ -74,7 +74,7 @@ def record_token_metrics(
     """Record token usage from a single API response.
 
     Args:
-        protocol: The AI protocol (``"prompt"``, ``"embed"``, ``"classify"``).
+        protocol: The AI protocol (``"prompt"`` or ``"embed"``).
         model: The model name (e.g. ``"gpt-4o"``).
         provider: The provider name (e.g. ``"openai"``).
         input_tokens: Number of input/prompt tokens consumed.

--- a/vane/ai/protocols.py
+++ b/vane/ai/protocols.py
@@ -14,12 +14,12 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from vane.ai.typing import Descriptor, UDFOptions
+from vane.ai.typing import Descriptor
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
-    from vane.ai.typing import Embedding, EmbeddingDimensions, Label
+    from vane.ai.typing import Embedding, EmbeddingDimensions
 
 
 # ---------------------------------------------------------------------------
@@ -45,33 +45,6 @@ class TextEmbedderDescriptor(Descriptor["TextEmbedder"]):
     def is_async(self) -> bool:
         """Whether ``embed_text`` returns an awaitable."""
         return False
-
-
-# ---------------------------------------------------------------------------
-# Text classification
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class TextClassifier(Protocol):
-    """Classifies a batch of text strings."""
-
-    def classify_text(self, text: list[str], labels: Label | list[Label]) -> list[Label]: ...
-
-
-class TextClassifierDescriptor(Descriptor["TextClassifier"]):
-    """Serializable factory for a :class:`TextClassifier`."""
-
-    def get_udf_options(self) -> UDFOptions:
-        """Preserve the legacy Classify execution-option contract."""
-        options = self.get_options()
-        return UDFOptions(
-            actor_number=options.get("actor_number"),
-            num_gpus=options.get("num_gpus"),
-            max_retries=options.get("max_retries", 3),
-            on_error=options.get("on_error", "raise"),
-            batch_size=options.get("batch_size"),
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/vane/ai/provider.py
+++ b/vane/ai/provider.py
@@ -3,9 +3,9 @@
 
 """Provider base class and registry for AI model backends.
 
-A :class:`Provider` maps high-level intents (embed text, classify text, prompt)
-to either concrete :class:`~vane.ai.typing.Descriptor` factories or native
-planning metadata. Both forms are lightweight and serializable.
+A :class:`Provider` maps high-level Prompt and Embed intents to either concrete
+:class:`~vane.ai.typing.Descriptor` factories or native planning metadata. Both
+forms are lightweight and serializable.
 
 Supported providers are loaded lazily so optional dependencies (e.g.
 ``transformers``, ``openai``) are only imported when actually used.
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from vane.ai.protocols import (
         NativePrompterPlan,
         PrompterDescriptor,
-        TextClassifierDescriptor,
         TextEmbedderDescriptor,
     )
 
@@ -246,8 +245,8 @@ def _not_implemented(provider: Provider, method: str) -> NotImplementedError:
 class Provider(ABC):
     """Base class for AI model providers.
 
-    Subclasses implement ``get_text_embedder``, ``get_text_classifier``, etc.
-    to return lightweight descriptors or native planning metadata.
+    Subclasses implement Prompt and Embed factories that return lightweight
+    descriptors or native planning metadata.
     """
 
     @property
@@ -266,11 +265,6 @@ class Provider(ABC):
         options: Mapping[str, Any] | None = None,
     ) -> TextEmbedderDescriptor:
         raise _not_implemented(self, "embed_text")
-
-    # -- Text classification ------------------------------------------------
-
-    def get_text_classifier(self, model: str | None = None, **options: Any) -> TextClassifierDescriptor:
-        raise _not_implemented(self, "classify_text")
 
     # -- Prompting / chat completion ----------------------------------------
 

--- a/vane/ai/providers/transformers.py
+++ b/vane/ai/providers/transformers.py
@@ -1,10 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""HuggingFace Transformers provider for Vane AI.
-
-Supports text embedding via ``sentence-transformers`` and text
-classification via ``transformers`` zero-shot-classification pipelines.
+"""HuggingFace Transformers provider for Vane AI text embedding.
 
 Requires::
 
@@ -20,15 +17,15 @@ import pyarrow as pa
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.options import validate_embed_options
-from vane.ai.protocols import TextClassifierDescriptor, TextEmbedderDescriptor
+from vane.ai.protocols import TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError
 from vane.ai.typing import EmbeddingDimensions, UDFOptions
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from vane.ai.protocols import TextClassifier, TextEmbedder
-    from vane.ai.typing import Embedding, Label, Options
+    from vane.ai.protocols import TextEmbedder
+    from vane.ai.typing import Embedding, Options
 
 
 _EMBEDDING_DIMS = {"sentence-transformers/all-MiniLM-L6-v2": 384}
@@ -44,7 +41,6 @@ class TransformersProvider(Provider):
     """Provider backed by HuggingFace Transformers / SentenceTransformers."""
 
     DEFAULT_TEXT_EMBEDDER = "sentence-transformers/all-MiniLM-L6-v2"
-    DEFAULT_TEXT_CLASSIFIER = "facebook/bart-large-mnli"
 
     def __init__(self, name: str | None = None):
         self._name = name or "transformers"
@@ -66,12 +62,6 @@ class TransformersProvider(Provider):
             provider_name=self._name,
             dimensions=dimensions,
             options=resolved_options,
-        )
-
-    def get_text_classifier(self, model: str | None = None, **options: Any) -> TextClassifierDescriptor:
-        return TransformersTextClassifierDescriptor(
-            model=model or self.DEFAULT_TEXT_CLASSIFIER,
-            classify_options=options,
         )
 
 
@@ -203,75 +193,3 @@ class TransformersTextEmbedder:
         if capability_error is not None:
             raise capability_error from None
         return list(batch)
-
-
-# ---------------------------------------------------------------------------
-# Text Classification
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class TransformersTextClassifierDescriptor(TextClassifierDescriptor):
-    """Serializable factory for a Transformers zero-shot classifier."""
-
-    model: str
-    classify_options: dict[str, Any] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        self.classify_options = wrap_sensitive_options(self.classify_options)
-
-    def get_provider(self) -> str:
-        return "transformers"
-
-    def get_model(self) -> str:
-        return self.model
-
-    def get_options(self) -> Options:
-        return dict(self.classify_options)
-
-    def get_udf_options(self) -> UDFOptions:
-        return UDFOptions(
-            batch_size=self.classify_options.get("batch_size"),
-            max_retries=self.classify_options.get("max_retries", 3),
-            on_error=self.classify_options.get("on_error", "raise"),
-        )
-
-    def instantiate(self) -> TextClassifier:
-        pipeline_options = {
-            k: v
-            for k, v in self.classify_options.items()
-            if k
-            not in {
-                "batch_size",
-                "max_retries",
-                "on_error",
-                "actor_number",
-                "num_gpus",
-            }
-        }
-        return TransformersTextClassifier(self.model, **pipeline_options)
-
-
-class TransformersTextClassifier:
-    """Concrete text classifier using ``transformers`` zero-shot pipeline."""
-
-    def __init__(self, model_name: str, **options: Any):
-        from transformers import pipeline
-
-        # Restore plaintext credentials sealed by the descriptor; plain dicts
-        # from direct callers pass through unchanged.
-        options = unwrap_sensitive_options(options)
-        options["trust_remote_code"] = options.get("trust_remote_code") is True
-        self.pipeline = pipeline(
-            "zero-shot-classification",
-            model=model_name,
-            **options,
-        )
-
-    def classify_text(self, text: list[str], labels: Label | list[Label]) -> list[Label]:
-        if isinstance(labels, str):
-            labels = [labels]
-        results = self.pipeline(text, candidate_labels=labels)
-        if not isinstance(results, list):
-            results = [results]
-        return [r["labels"][0] for r in results]

--- a/vane/ai/typing.py
+++ b/vane/ai/typing.py
@@ -20,7 +20,6 @@ else:
 
 Options = dict[str, Any]
 JSONSchema: TypeAlias = dict[str, Any]
-Label = str
 
 T = TypeVar("T")
 
@@ -85,6 +84,6 @@ class UDFOptions:
     actor_number: int | None = None
     num_gpus: int | None = None
     max_retries: int = 3
-    on_error: Literal["raise", "log", "ignore"] = "raise"
+    on_error: Literal["raise", "ignore"] = "raise"
     batch_size: int | None = None
     max_concurrency_per_actor: int | None = None


### PR DESCRIPTION
## Summary

- remove the legacy classify_text function, Relation method, batch wrapper, Provider protocol, and Transformers classifier runtime
- remove the obsolete classifier error-policy and provider-resolution fallbacks instead of retaining compatibility shims
- make the shared sync and async retry core intrinsically retry only classified transient provider failures and reject invalid on_error values before execution
- update the changelog and retain negative contract tests for every removed entry point

## Why

PR #397 resolved the zero-fill and retry behavior for the replacement Prompt and Embed paths. The only scope left in #106 was the legacy _ClassifyTextBatch path, which still used the broad historical retry behavior. Removing that obsolete vertical slice and its fallbacks completes the contract.

Closes #106

## Related issues

- Partially addresses #100 and #148 by removing the non-logging log mode and invalid-policy fallback from the remaining shared Python retry surface.
- Partially addresses #151 by removing the classifier side of the Transformers GPU-allocation asymmetry.
- Related to #152 and #243 because the legacy classifier protocol and serialized classifier descriptor path are removed; their broader remaining scopes stay open.

## Validation

- scripts/format root --changed
- pre-commit on all 16 changed files
- 432 directly affected AI and release-contract tests passed
- scripts/run_release_tests.sh: 508 passed and 1 skipped in the non-Ray shard; 11 passed in the real-Ray shard
- full fast launcher: non-Ray and shared-Ray phases passed; owner-Ray phase passed on a complete phase rerun with 7 passed and 1 dependency skip after one fault-injection test flaked once and passed immediately in isolation
- two consecutive clean review rounds on the final unchanged diff
