### PR TITLE
[fix](udf) Reject async generic callables

### DIFF
--- a/duckdb/execution/_udf_runtime.py
+++ b/duckdb/execution/_udf_runtime.py
@@ -86,7 +86,7 @@ def _load_runtime_callable(
             "callable class UDF constructors must be zero-argument; "
             "use environment variables or class-level defaults when configuration is required"
         )
-    return udf()
+    return ensure_synchronous_udf_result(udf())
 
 
 def _has_required_constructor_args(cls: type) -> bool:
@@ -243,6 +243,7 @@ def _effective_output_batch_size(payload: dict[str, Any]) -> int | None:
 
 def _iter_output_tables(result: Any) -> Iterable[pa.Table]:
     """Iterate over output batches from a stream UDF result."""
+    result = ensure_synchronous_udf_result(result)
     if result is None:
         return
 
@@ -747,6 +748,7 @@ class UDFExecutor:
                     yield from append_output_row(result)
                 else:
                     for out_row in result:
+                        out_row = ensure_synchronous_udf_result(out_row)
                         if out_row is None:
                             continue
                         yield from append_output_row(out_row)

--- a/duckdb/execution/_udf_runtime.py
+++ b/duckdb/execution/_udf_runtime.py
@@ -32,6 +32,7 @@ from duckdb.execution._common import (
     load_udf_from_payload,
     load_udf_from_payload_cached,
 )
+from duckdb.execution._udf_validation import ensure_synchronous_udf_result, validate_synchronous_udf_callable
 from duckdb.execution.udf_output_schema import empty_output_table_from_payload as _empty_output_table_from_payload
 from duckdb.execution.udf_ray_config import stream_output_enabled as _stream_output_enabled
 from duckdb.func import FunctionNullHandling
@@ -52,6 +53,8 @@ def _load_runtime_callable(
         udf = load_udf_from_payload_cached(payload, max_entries=cache_max_entries)
     else:
         udf = load_udf_from_payload(payload)
+
+    validate_synchronous_udf_callable(udf)
 
     backend = str(payload.get("execution_backend") or "").strip().lower()
     is_actor_backend = backend in ("subprocess_actor", "ray_actor")
@@ -620,7 +623,7 @@ class UDFExecutor:
         )
         for batch in batches:
             saw_compute_batch = True
-            result = self._map_fn(batch)
+            result = ensure_synchronous_udf_result(self._map_fn(batch))
             if self._is_map_batches_rows:
                 results.append(self._coerce_row_preserving_batch_output(result, batch.num_rows))
                 continue
@@ -677,7 +680,7 @@ class UDFExecutor:
             shared_output_buffer = RuntimeOutputBuffer(self._output_batch_size, self._output_target_max_bytes)
             for batch in batches:
                 saw_compute_batch = True
-                result = self._map_fn(batch)
+                result = ensure_synchronous_udf_result(self._map_fn(batch))
                 output_buffer = (
                     RuntimeOutputBuffer(self._output_batch_size, self._output_target_max_bytes)
                     if self._preserve_compute_batch_boundaries
@@ -735,7 +738,7 @@ class UDFExecutor:
 
         for batch in batches:
             for row_dict in _iter_table_row_dicts(batch):
-                result = self._map_fn(row_dict)
+                result = ensure_synchronous_udf_result(self._map_fn(row_dict))
                 if result is None:
                     continue
                 if isinstance(result, pa.RecordBatchReader):
@@ -788,6 +791,7 @@ class UDFExecutor:
                     outputs.append(None)
                     continue
                 raise
+            result = ensure_synchronous_udf_result(result)
             if isinstance(result, pa.RecordBatchReader):
                 raise TypeError("map UDF output must be scalar; RecordBatchReader is not supported")
             if self._default_null_handling() and result is None:
@@ -819,6 +823,7 @@ class UDFExecutor:
                     result = [None] * batch.num_rows
                 else:
                     raise
+            result = ensure_synchronous_udf_result(result)
             outputs.append(_coerce_scalar_array(result, batch.num_rows))
 
         if outputs:

--- a/duckdb/execution/_udf_validation.py
+++ b/duckdb/execution/_udf_validation.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared synchronous-callable contract for generic Python UDFs."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+_ASYNC_CALLABLE_ERROR = (
+    "generic UDF callables must be synchronous; async functions and async __call__ methods are not supported"
+)
+_AWAITABLE_RESULT_ERROR = "generic UDF callables must return values synchronously; received an awaitable result"
+
+
+def _is_async_function(value: Any) -> bool:
+    unwrapped = inspect.unwrap(value)
+    return (
+        inspect.iscoroutinefunction(value)
+        or inspect.isasyncgenfunction(value)
+        or inspect.iscoroutinefunction(unwrapped)
+        or inspect.isasyncgenfunction(unwrapped)
+    )
+
+
+def is_async_udf_callable(value: Any) -> bool:
+    """Return whether calling *value* uses an async function body."""
+    if _is_async_function(value):
+        return True
+
+    if inspect.isclass(value):
+        call = inspect.getattr_static(value, "__call__")
+        if isinstance(call, (classmethod, staticmethod)):
+            call = call.__func__
+        return _is_async_function(call)
+
+    if not (inspect.isfunction(value) or inspect.ismethod(value)) and callable(value):
+        call = inspect.getattr_static(type(value), "__call__")
+        if isinstance(call, (classmethod, staticmethod)):
+            call = call.__func__
+        return _is_async_function(call)
+
+    return False
+
+
+def validate_synchronous_udf_callable(value: Any) -> None:
+    """Reject async generic UDF functions and async callable classes."""
+    if is_async_udf_callable(value):
+        raise TypeError(_ASYNC_CALLABLE_ERROR)
+
+
+def ensure_synchronous_udf_result(result: Any) -> Any:
+    """Reject and close coroutine results returned by nominally sync UDFs."""
+    if not inspect.isawaitable(result):
+        return result
+    if inspect.iscoroutine(result):
+        result.close()
+    raise TypeError(_AWAITABLE_RESULT_ERROR)
+
+
+__all__ = [
+    "ensure_synchronous_udf_result",
+    "is_async_udf_callable",
+    "validate_synchronous_udf_callable",
+]

--- a/duckdb/execution/_udf_validation.py
+++ b/duckdb/execution/_udf_validation.py
@@ -5,13 +5,17 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
+from collections.abc import AsyncIterable
 from typing import Any
 
 _ASYNC_CALLABLE_ERROR = (
-    "generic UDF callables must be synchronous; async functions and async __call__ methods are not supported"
+    "generic UDF callables must be synchronous; async functions, constructors, and __call__ methods are not supported"
 )
-_AWAITABLE_RESULT_ERROR = "generic UDF callables must return values synchronously; received an awaitable result"
+_ASYNC_RESULT_ERROR = (
+    "generic UDF callables must return values synchronously; received an awaitable or async iterable result"
+)
 
 
 def _is_async_function(value: Any) -> bool:
@@ -19,29 +23,57 @@ def _is_async_function(value: Any) -> bool:
     return (
         inspect.iscoroutinefunction(value)
         or inspect.isasyncgenfunction(value)
+        or _is_generator_coroutine_function(value)
         or inspect.iscoroutinefunction(unwrapped)
         or inspect.isasyncgenfunction(unwrapped)
+        or _is_generator_coroutine_function(unwrapped)
     )
 
 
+def _is_generator_coroutine_function(value: Any) -> bool:
+    code = getattr(value, "__code__", None)
+    flags = getattr(code, "co_flags", 0)
+    return isinstance(flags, int) and bool(flags & inspect.CO_ITERABLE_COROUTINE)
+
+
+def _unwrap_method_descriptor(value: Any) -> Any:
+    if isinstance(value, (classmethod, staticmethod)):
+        return value.__func__
+    return value
+
+
 def is_async_udf_callable(value: Any) -> bool:
-    """Return whether calling *value* uses an async function body."""
-    if _is_async_function(value):
-        return True
+    """Return whether invoking *value* enters a declared async call protocol."""
+    seen: set[int] = set()
 
-    if inspect.isclass(value):
-        call = inspect.getattr_static(value, "__call__")
-        if isinstance(call, (classmethod, staticmethod)):
-            call = call.__func__
-        return _is_async_function(call)
+    def visit(candidate: Any) -> bool:
+        identity = id(candidate)
+        if identity in seen:
+            return False
+        seen.add(identity)
 
-    if not (inspect.isfunction(value) or inspect.ismethod(value)) and callable(value):
-        call = inspect.getattr_static(type(value), "__call__")
-        if isinstance(call, (classmethod, staticmethod)):
-            call = call.__func__
-        return _is_async_function(call)
+        if isinstance(candidate, (functools.partial, functools.partialmethod)):
+            return visit(_unwrap_method_descriptor(candidate.func))
 
-    return False
+        if _is_async_function(candidate):
+            return True
+
+        if inspect.isclass(candidate):
+            class_callables = (
+                inspect.getattr_static(candidate, "__call__"),
+                inspect.getattr_static(type(candidate), "__call__"),
+                inspect.getattr_static(candidate, "__new__"),
+                inspect.getattr_static(candidate, "__init__"),
+            )
+            return any(visit(_unwrap_method_descriptor(item)) for item in class_callables)
+
+        if not (inspect.isfunction(candidate) or inspect.ismethod(candidate)) and callable(candidate):
+            call = inspect.getattr_static(type(candidate), "__call__")
+            return visit(_unwrap_method_descriptor(call))
+
+        return False
+
+    return visit(value)
 
 
 def validate_synchronous_udf_callable(value: Any) -> None:
@@ -51,12 +83,13 @@ def validate_synchronous_udf_callable(value: Any) -> None:
 
 
 def ensure_synchronous_udf_result(result: Any) -> Any:
-    """Reject and close coroutine results returned by nominally sync UDFs."""
-    if not inspect.isawaitable(result):
+    """Reject results that require an asynchronous execution protocol."""
+    is_awaitable = inspect.isawaitable(result)
+    if not is_awaitable and not isinstance(result, AsyncIterable):
         return result
-    if inspect.iscoroutine(result):
+    if is_awaitable and (inspect.iscoroutine(result) or inspect.isgenerator(result)):
         result.close()
-    raise TypeError(_AWAITABLE_RESULT_ERROR)
+    raise TypeError(_ASYNC_RESULT_ERROR)
 
 
 __all__ = [

--- a/src/duckdb_py/include/duckdb_python/python_udf_utils.hpp
+++ b/src/duckdb_py/include/duckdb_python/python_udf_utils.hpp
@@ -20,6 +20,7 @@ namespace duckdb {
 
 unique_ptr<Expression> LowerRegisteredExpressionUDF(FunctionBindExpressionInput &input);
 unique_ptr<Expression> LowerRegisteredExpressionUDFPreservingFoldableNulls(FunctionBindExpressionInput &input);
+void ValidateSynchronousUDFCallable(const py::object &udf);
 
 Value BuildPythonUDFPayload(
     const string &name, const py::function &udf, const py::object &schema, const shared_ptr<DuckDBPyType> &return_type,

--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -1046,6 +1046,7 @@ DuckDBPyConnection::RegisterScalarUDF(const string &name, const py::function &ud
                                       const shared_ptr<DuckDBPyType> &return_type_p, PythonUDFType type,
                                       FunctionNullHandling null_handling, PythonExceptionHandling exception_handling,
                                       bool side_effects) {
+	ValidateSynchronousUDFCallable(udf);
 	auto &connection = con.GetConnection();
 	auto &context = *connection.context;
 
@@ -1188,6 +1189,7 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::RegisterTableUDF(const string
                                                                     const shared_ptr<DuckDBPyType> &return_type_p,
                                                                     const Optional<py::object> &batch_size,
                                                                     bool side_effects) {
+	ValidateSynchronousUDFCallable(udf);
 	auto &connection = con.GetConnection();
 	auto &context = *connection.context;
 

--- a/src/duckdb_py/python_udf.cpp
+++ b/src/duckdb_py/python_udf.cpp
@@ -177,20 +177,20 @@ static void VerifyVectorizedNullHandling(Vector &result, idx_t count) {
 	throw InvalidInputException(NullHandlingError());
 }
 
-static bool MayBeAwaitable(const py::object &result) {
+static bool MayBeAsynchronousResult(const py::object &result) {
 	if (!result) {
 		return false;
 	}
 	auto object = result.ptr();
-	if (PyCoro_CheckExact(object) || PyGen_Check(object)) {
+	if (PyCoro_CheckExact(object) || PyGen_Check(object) || PyAsyncGen_CheckExact(object)) {
 		return true;
 	}
 	auto async_methods = Py_TYPE(object)->tp_as_async;
-	return async_methods && async_methods->am_await;
+	return async_methods && (async_methods->am_await || async_methods->am_aiter || async_methods->am_anext);
 }
 
 static void EnsureSynchronousUDFResult(const py::object &result) {
-	if (!MayBeAwaitable(result)) {
+	if (!MayBeAsynchronousResult(result)) {
 		return;
 	}
 	py::module_::import("duckdb.execution._udf_validation").attr("ensure_synchronous_udf_result")(result);

--- a/src/duckdb_py/python_udf.cpp
+++ b/src/duckdb_py/python_udf.cpp
@@ -177,6 +177,25 @@ static void VerifyVectorizedNullHandling(Vector &result, idx_t count) {
 	throw InvalidInputException(NullHandlingError());
 }
 
+static bool MayBeAwaitable(const py::object &result) {
+	if (!result) {
+		return false;
+	}
+	auto object = result.ptr();
+	if (PyCoro_CheckExact(object) || PyGen_Check(object)) {
+		return true;
+	}
+	auto async_methods = Py_TYPE(object)->tp_as_async;
+	return async_methods && async_methods->am_await;
+}
+
+static void EnsureSynchronousUDFResult(const py::object &result) {
+	if (!MayBeAwaitable(result)) {
+		return;
+	}
+	py::module_::import("duckdb.execution._udf_validation").attr("ensure_synchronous_udf_result")(result);
+}
+
 static scalar_function_t CreateVectorizedFunction(PyObject *function, PythonExceptionHandling exception_handling,
                                                   FunctionNullHandling null_handling) {
 	// Through the capture of the lambda, we have access to the function pointer
@@ -248,6 +267,7 @@ static scalar_function_t CreateVectorizedFunction(PyObject *function, PythonExce
 		} else {
 			python_object = py::reinterpret_steal<py::object>(ret);
 		}
+		EnsureSynchronousUDFResult(python_object);
 		if (!py::isinstance(python_object, py::module_::import("pyarrow").attr("lib").attr("Table"))) {
 			// Try to convert into a table
 			py::list single_array(1);
@@ -361,6 +381,7 @@ static scalar_function_t CreateNativeFunction(PyObject *function, PythonExceptio
 					throw InvalidInputException(NullHandlingError());
 				}
 			}
+			EnsureSynchronousUDFResult(ret);
 			TransformPythonObject(ret, result, row);
 		}
 

--- a/src/duckdb_py/python_udf_utils.cpp
+++ b/src/duckdb_py/python_udf_utils.cpp
@@ -165,6 +165,7 @@ static bool IsTaskExecutionBackend(const string &backend) {
 }
 
 static void ValidateUDFCallableShape(const py::object &udf, const string &execution_backend) {
+	ValidateSynchronousUDFCallable(udf);
 	auto inspect_module = py::module_::import("inspect");
 	const bool is_class = py::cast<bool>(inspect_module.attr("isclass")(udf));
 	const bool is_function = py::cast<bool>(inspect_module.attr("isfunction")(udf));
@@ -294,6 +295,10 @@ static void AppendExpressionIdField(child_list_t<Value> &fields, const Optional<
 	fields.emplace_back("expression_id", Value(std::move(parsed_expression_id)));
 }
 } // namespace
+
+void ValidateSynchronousUDFCallable(const py::object &udf) {
+	py::module_::import("duckdb.execution._udf_validation").attr("validate_synchronous_udf_callable")(udf);
+}
 
 static unique_ptr<Expression> LowerRegisteredExpressionUDFInternal(FunctionBindExpressionInput &input,
                                                                    bool preserve_foldable_nulls) {

--- a/tests/fast/test_expression_cls_batch.py
+++ b/tests/fast/test_expression_cls_batch.py
@@ -145,7 +145,7 @@ def test_vane_cls_batch_rejects_async_call():
 
     import vane
 
-    with pytest.raises(TypeError, match="requires a synchronous Python __call__"):
+    with pytest.raises(TypeError, match="generic UDF callables must be synchronous"):
 
         @vane.cls.batch(actor_number=1, return_dtype=pa.int32())
         class AsyncBatch:

--- a/tests/fast/test_expression_udf_map_batches.py
+++ b/tests/fast/test_expression_udf_map_batches.py
@@ -43,7 +43,7 @@ def test_vane_function_batch_rejects_async_function():
 
     import vane
 
-    with pytest.raises(TypeError, match="requires a synchronous Python function"):
+    with pytest.raises(TypeError, match="generic UDF callables must be synchronous"):
 
         @vane.func.batch(return_dtype=pa.int32())
         async def identity(values):

--- a/tests/fast/test_udf_sync_contract.py
+++ b/tests/fast/test_udf_sync_contract.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import functools
 import gc
+import types
 import warnings
 
 import cloudpickle
@@ -16,6 +17,7 @@ import pytest
 import duckdb
 import vane
 from duckdb.execution._udf_runtime import UDFExecutor
+from duckdb.execution._udf_validation import ensure_synchronous_udf_result
 
 _ASYNC_CALLABLE_ERROR = "generic UDF callables must be synchronous"
 _AWAITABLE_RESULT_ERROR = "generic UDF callables must return values synchronously"
@@ -38,8 +40,59 @@ def _returns_awaitable(value):
     return _async_value(value)
 
 
+def _returns_async_iterable(value):
+    return _async_values(value)
+
+
 class _AsyncCallable:
     async def __call__(self, value):
+        return value
+
+
+class _AsyncConstructionMeta(type):
+    async def __call__(cls):
+        return super().__call__()
+
+
+class _AsyncConstructedCallable(metaclass=_AsyncConstructionMeta):
+    def __call__(self, value):
+        return value
+
+
+class _AsyncNewCallable:
+    async def __new__(cls):
+        return super().__new__(cls)
+
+    def __call__(self, value):
+        return value
+
+
+class _AsyncInitCallable:
+    async def __init__(self):
+        pass
+
+    def __call__(self, value):
+        return value
+
+
+class _PartialMethodAsyncCallable:
+    async def _call(self, value, *, offset):
+        return value + offset
+
+    __call__ = functools.partialmethod(_call, offset=0)
+
+
+class _PartialAsyncCallableDescriptor:
+    __call__ = functools.partial(_AsyncCallable())
+
+
+class _AwaitableConstructionMeta(type):
+    def __call__(cls):
+        return _async_value(super().__call__())
+
+
+class _AwaitablyConstructedCallable(metaclass=_AwaitableConstructionMeta):
+    def __call__(self, value):
         return value
 
 
@@ -55,6 +108,19 @@ class _SyncCallableWithShadowedAsyncCall:
 
     def __call__(self, value):
         return value
+
+
+@types.coroutine
+def _generator_coroutine():
+    yield None
+
+
+def _batch_yields_awaitable(table):
+    yield _async_value(table)
+
+
+def _flat_map_yields_awaitable(row):
+    yield _async_value(row)
 
 
 def _runtime_payload(target, call_mode, *, execution_backend="subprocess_task"):
@@ -92,11 +158,28 @@ def test_vane_decorators_reject_async_callables():
         pytest.param(_async_values, id="async-generator"),
         pytest.param(_wrapped_async_value, id="wrapped-async"),
         pytest.param(functools.partial(_async_value, 1), id="partial-async"),
+        pytest.param(functools.partial(_AsyncCallable()), id="partial-async-callable-instance"),
+        pytest.param(_generator_coroutine, id="generator-coroutine"),
     ],
 )
 def test_vane_func_rejects_indirect_async_callables(target):
     with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
         vane.func(target, return_dtype="INTEGER")
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        _AsyncConstructedCallable,
+        _AsyncNewCallable,
+        _AsyncInitCallable,
+        _PartialMethodAsyncCallable,
+        _PartialAsyncCallableDescriptor,
+    ],
+)
+def test_vane_class_rejects_async_construction_and_call_descriptors(target):
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.cls(target, actor_number=1, return_dtype="INTEGER")
 
 
 def test_vane_func_validates_the_effective_callable_object_call_method():
@@ -194,37 +277,63 @@ def test_attach_function_rejects_raw_async_callables():
 
 @pytest.mark.parametrize("udf_type", ["native", "arrow"])
 @pytest.mark.parametrize("exception_handling", ["default", "return_null"])
-def test_scalar_registration_rejects_awaitable_results_without_leaking_coroutines(udf_type, exception_handling):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(_returns_awaitable, id="awaitable"),
+        pytest.param(_returns_async_iterable, id="async-iterable"),
+    ],
+)
+def test_scalar_registration_rejects_async_results_without_leaking_coroutines(udf_type, exception_handling, target):
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         with duckdb.connect() as connection:
             connection.create_function(
-                "returns_awaitable",
-                _returns_awaitable,
+                "returns_async_result",
+                target,
                 [duckdb.sqltypes.INTEGER],
                 duckdb.sqltypes.INTEGER,
                 type=udf_type,
                 exception_handling=exception_handling,
             )
             with pytest.raises(duckdb.Error, match=_AWAITABLE_RESULT_ERROR):
-                connection.execute("SELECT returns_awaitable(1)").fetchall()
+                connection.execute("SELECT returns_async_result(1)").fetchall()
         gc.collect()
 
     assert not [warning for warning in caught if "was never awaited" in str(warning.message)]
 
 
 @pytest.mark.parametrize("call_mode", ["map", "map_batches", "flat_map"])
-def test_runtime_rejects_serialized_async_functions(call_mode):
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(_async_value, id="coroutine-function"),
+        pytest.param(_async_values, id="async-generator-function"),
+        pytest.param(_generator_coroutine, id="generator-coroutine-function"),
+    ],
+)
+def test_runtime_rejects_serialized_async_functions(call_mode, target):
     with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
-        UDFExecutor(_runtime_payload(_async_value, call_mode))
+        UDFExecutor(_runtime_payload(target, call_mode))
 
 
 @pytest.mark.parametrize("call_mode", ["map", "map_batches", "flat_map"])
-def test_runtime_rejects_serialized_async_actor_methods(call_mode):
+@pytest.mark.parametrize(
+    "target",
+    [
+        _AsyncCallable,
+        _AsyncConstructedCallable,
+        _AsyncNewCallable,
+        _AsyncInitCallable,
+        _PartialMethodAsyncCallable,
+        _PartialAsyncCallableDescriptor,
+    ],
+)
+def test_runtime_rejects_serialized_async_actor_methods(call_mode, target):
     with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
         UDFExecutor(
             _runtime_payload(
-                _AsyncCallable,
+                target,
                 call_mode,
                 execution_backend="subprocess_actor",
             )
@@ -232,8 +341,15 @@ def test_runtime_rejects_serialized_async_actor_methods(call_mode):
 
 
 @pytest.mark.parametrize("call_mode", ["map", "map_batches", "flat_map"])
-def test_runtime_rejects_awaitable_results_without_leaking_coroutines(call_mode):
-    executor = UDFExecutor(_runtime_payload(_returns_awaitable, call_mode))
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(_returns_awaitable, id="awaitable"),
+        pytest.param(_returns_async_iterable, id="async-iterable"),
+    ],
+)
+def test_runtime_rejects_async_results_without_leaking_coroutines(call_mode, target):
+    executor = UDFExecutor(_runtime_payload(target, call_mode))
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         try:
@@ -241,6 +357,68 @@ def test_runtime_rejects_awaitable_results_without_leaking_coroutines(call_mode)
                 executor.submit(pa.table({"value": [1]}))
         finally:
             executor.close()
+        gc.collect()
+
+    assert not [warning for warning in caught if "was never awaited" in str(warning.message)]
+
+
+def test_result_validation_closes_generator_based_coroutines():
+    result = _generator_coroutine()
+
+    with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+        ensure_synchronous_udf_result(result)
+
+    assert result.gi_frame is None
+
+
+@pytest.mark.parametrize(
+    ("call_mode", "target"),
+    [
+        pytest.param("map_batches", _batch_yields_awaitable, id="map-batches"),
+        pytest.param("flat_map", _flat_map_yields_awaitable, id="flat-map"),
+    ],
+)
+def test_runtime_rejects_awaitables_yielded_by_streaming_results(call_mode, target):
+    executor = UDFExecutor(_runtime_payload(target, call_mode))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+                executor.submit(pa.table({"value": [1]}))
+        finally:
+            executor.close()
+        gc.collect()
+
+    assert not [warning for warning in caught if "was never awaited" in str(warning.message)]
+
+
+def test_actor_construction_rejects_awaitable_results_without_leaking_coroutines():
+    row_class = vane.cls(_AwaitablyConstructedCallable, actor_number=1, return_dtype="INTEGER")()
+    batch_class = vane.cls.batch(actor_number=1, return_dtype=pa.int32())(_AwaitablyConstructedCallable)()
+    row_actor = row_class.actor_class(["value"])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            row_class(1)
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            batch_class(pa.array([1], type=pa.int32()))
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            UDFExecutor(
+                _runtime_payload(
+                    _AwaitablyConstructedCallable,
+                    "map",
+                    execution_backend="subprocess_actor",
+                )
+            )
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            UDFExecutor(
+                _runtime_payload(
+                    row_actor,
+                    "map_batches",
+                    execution_backend="subprocess_actor",
+                )
+            )
         gc.collect()
 
     assert not [warning for warning in caught if "was never awaited" in str(warning.message)]

--- a/tests/fast/test_udf_sync_contract.py
+++ b/tests/fast/test_udf_sync_contract.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic Python UDFs reject async callables at every public boundary."""
+
+from __future__ import annotations
+
+import functools
+import gc
+import warnings
+
+import cloudpickle
+import pyarrow as pa
+import pytest
+
+import duckdb
+import vane
+from duckdb.execution._udf_runtime import UDFExecutor
+
+_ASYNC_CALLABLE_ERROR = "generic UDF callables must be synchronous"
+_AWAITABLE_RESULT_ERROR = "generic UDF callables must return values synchronously"
+
+
+async def _async_value(value):
+    return value
+
+
+async def _async_values(value):
+    yield value
+
+
+@functools.wraps(_async_value)
+def _wrapped_async_value(value):
+    return _async_value(value)
+
+
+def _returns_awaitable(value):
+    return _async_value(value)
+
+
+class _AsyncCallable:
+    async def __call__(self, value):
+        return value
+
+
+class _SyncReturnsAwaitable:
+    def __call__(self, value):
+        return _async_value(value)
+
+
+class _SyncCallableWithShadowedAsyncCall:
+    def __init__(self):
+        self.__qualname__ = type(self).__qualname__
+        self.__call__ = _async_value
+
+    def __call__(self, value):
+        return value
+
+
+def _runtime_payload(target, call_mode, *, execution_backend="subprocess_task"):
+    payload = {
+        "function_pickle": cloudpickle.dumps(target),
+        "call_mode": call_mode,
+        "execution_backend": execution_backend,
+        "udf_worker_slots": 1,
+    }
+    if execution_backend.endswith("actor"):
+        payload["actor_number"] = 1
+    return payload
+
+
+def test_vane_decorators_reject_async_callables():
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.func(_async_value, return_dtype="INTEGER")
+
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.func.batch(return_dtype=pa.int32())(_async_value)
+
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.cls(_AsyncCallable, actor_number=1, return_dtype="INTEGER")
+
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.cls.batch(actor_number=1, return_dtype=pa.int32())(_AsyncCallable)
+
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.func(_AsyncCallable(), return_dtype="INTEGER")
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(_async_values, id="async-generator"),
+        pytest.param(_wrapped_async_value, id="wrapped-async"),
+        pytest.param(functools.partial(_async_value, 1), id="partial-async"),
+    ],
+)
+def test_vane_func_rejects_indirect_async_callables(target):
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        vane.func(target, return_dtype="INTEGER")
+
+
+def test_vane_func_validates_the_effective_callable_object_call_method():
+    fn = vane.func(_SyncCallableWithShadowedAsyncCall(), return_dtype="INTEGER", name="sync_callable")
+
+    assert fn(1) == 1
+
+
+@pytest.mark.parametrize("method", ["map", "map_batches", "flat_map"])
+def test_relation_task_udfs_reject_async_functions(method):
+    with duckdb.connect() as connection:
+        source = connection.sql("SELECT 1::INTEGER AS value")
+        kwargs = {"execution_backend": "subprocess_task"}
+        if method == "map":
+            kwargs["return_type"] = duckdb.sqltypes.INTEGER
+        else:
+            kwargs["schema"] = {"value": duckdb.sqltypes.INTEGER}
+
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            getattr(source, method)(_async_value, **kwargs)
+
+
+@pytest.mark.parametrize("method", ["map", "map_batches", "flat_map"])
+def test_relation_actor_udfs_reject_async_call_methods(method):
+    with duckdb.connect() as connection:
+        source = connection.sql("SELECT 1::INTEGER AS value")
+        kwargs = {
+            "execution_backend": "subprocess_actor",
+            "actor_number": 1,
+            "gpus": 0,
+        }
+        if method == "map":
+            kwargs["return_type"] = duckdb.sqltypes.INTEGER
+        else:
+            kwargs["schema"] = {"value": duckdb.sqltypes.INTEGER}
+
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            getattr(source, method)(_AsyncCallable, **kwargs)
+
+
+def test_connection_udf_registration_rejects_async_functions():
+    with duckdb.connect() as connection:
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            connection.create_function(
+                "async_scalar",
+                _async_value,
+                [duckdb.sqltypes.INTEGER],
+                duckdb.sqltypes.INTEGER,
+            )
+
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            connection.create_table_function(
+                "async_batches",
+                _async_value,
+                schema={"value": duckdb.sqltypes.INTEGER},
+            )
+
+
+def test_attach_function_rejects_raw_async_callables():
+    connection = vane.connect()
+    try:
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            vane.attach_function(
+                _async_value,
+                alias="async_scalar",
+                connection=connection,
+                parameters=["INTEGER"],
+                return_dtype="INTEGER",
+            )
+
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            vane.attach_function(
+                _async_value,
+                alias="async_batch",
+                connection=connection,
+                parameters=["INTEGER"],
+                input_names=["value"],
+                schema={"value": "INTEGER"},
+            )
+
+        with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+            vane.attach_function(
+                _AsyncCallable,
+                alias="async_actor",
+                connection=connection,
+                parameters=["INTEGER"],
+                input_names=["value"],
+                schema={"value": "INTEGER"},
+                actor_number=1,
+                gpus=0,
+            )
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("udf_type", ["native", "arrow"])
+@pytest.mark.parametrize("exception_handling", ["default", "return_null"])
+def test_scalar_registration_rejects_awaitable_results_without_leaking_coroutines(udf_type, exception_handling):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with duckdb.connect() as connection:
+            connection.create_function(
+                "returns_awaitable",
+                _returns_awaitable,
+                [duckdb.sqltypes.INTEGER],
+                duckdb.sqltypes.INTEGER,
+                type=udf_type,
+                exception_handling=exception_handling,
+            )
+            with pytest.raises(duckdb.Error, match=_AWAITABLE_RESULT_ERROR):
+                connection.execute("SELECT returns_awaitable(1)").fetchall()
+        gc.collect()
+
+    assert not [warning for warning in caught if "was never awaited" in str(warning.message)]
+
+
+@pytest.mark.parametrize("call_mode", ["map", "map_batches", "flat_map"])
+def test_runtime_rejects_serialized_async_functions(call_mode):
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        UDFExecutor(_runtime_payload(_async_value, call_mode))
+
+
+@pytest.mark.parametrize("call_mode", ["map", "map_batches", "flat_map"])
+def test_runtime_rejects_serialized_async_actor_methods(call_mode):
+    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
+        UDFExecutor(
+            _runtime_payload(
+                _AsyncCallable,
+                call_mode,
+                execution_backend="subprocess_actor",
+            )
+        )
+
+
+@pytest.mark.parametrize("call_mode", ["map", "map_batches", "flat_map"])
+def test_runtime_rejects_awaitable_results_without_leaking_coroutines(call_mode):
+    executor = UDFExecutor(_runtime_payload(_returns_awaitable, call_mode))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+                executor.submit(pa.table({"value": [1]}))
+        finally:
+            executor.close()
+        gc.collect()
+
+    assert not [warning for warning in caught if "was never awaited" in str(warning.message)]
+
+
+def test_vane_eager_udfs_reject_awaitable_results_without_leaking_coroutines():
+    scalar = vane.func(_returns_awaitable, return_dtype="INTEGER")
+    batch = vane.func.batch(return_dtype=pa.int32())(_returns_awaitable)
+    row_class = vane.cls(_SyncReturnsAwaitable, actor_number=1, return_dtype="INTEGER")()
+    batch_class = vane.cls.batch(actor_number=1, return_dtype=pa.int32())(_SyncReturnsAwaitable)()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            scalar(1)
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            batch(pa.array([1], type=pa.int32()))
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            row_class(1)
+        with pytest.raises(TypeError, match=_AWAITABLE_RESULT_ERROR):
+            batch_class(pa.array([1], type=pa.int32()))
+        gc.collect()
+
+    assert not [warning for warning in caught if "was never awaited" in str(warning.message)]

--- a/vane/_expression_udf.py
+++ b/vane/_expression_udf.py
@@ -18,6 +18,7 @@ from typing import Any
 import _duckdb
 
 import duckdb
+from duckdb.execution._udf_validation import ensure_synchronous_udf_result, validate_synchronous_udf_callable
 from vane._expressions import as_expression, is_expression
 from vane.config import current_config
 
@@ -367,7 +368,7 @@ def _execute_batch_callable(
     expected_length = len(columns[0])
     if any(len(column) != expected_length for column in columns[1:]):
         raise _invalid_input(f"batch UDF {udf_name!r} input columns must have equal lengths")
-    result = _invoke_batch_callable(fn, layout, columns)
+    result = ensure_synchronous_udf_result(_invoke_batch_callable(fn, layout, columns))
     normalized = _normalize_batch_result(
         result,
         output_arrow_type=output_arrow_type,
@@ -472,7 +473,6 @@ def _build_map_expression(
 @dataclass(frozen=True)
 class _ClassCallContract:
     signature: inspect.Signature
-    is_coroutine: bool
     positional_parameters: tuple[inspect.Parameter, ...]
     min_required_positional: int
     max_positional: int | None
@@ -526,7 +526,6 @@ def _class_call_contract(user_class: type) -> _ClassCallContract:
     )
     return _ClassCallContract(
         signature=signature,
-        is_coroutine=inspect.iscoroutinefunction(callable_object),
         positional_parameters=positional_parameters,
         min_required_positional=sum(
             parameter.default is inspect.Parameter.empty for parameter in positional_parameters
@@ -666,7 +665,7 @@ def _build_row_actor_class(
                 if any(value is None for value in row):
                     out.append(None)
                     continue
-                out.append(self._instance(*row, **captured_call_kwargs))
+                out.append(ensure_synchronous_udf_result(self._instance(*row, **captured_call_kwargs)))
             if pa.types.is_timestamp(output_arrow_type):
                 for value in out:
                     if isinstance(value, datetime) and value.tzinfo is not None and value.utcoffset() is not None:
@@ -752,6 +751,7 @@ class VaneFunction:
     def __init__(self, fn: Callable[..., Any], *, return_dtype: Any | None = None, name: str | None = None):
         if not callable(fn):
             raise TypeError("vane.func requires a callable")
+        validate_synchronous_udf_callable(fn)
         self._fn = fn
         self._return_dtype = return_dtype
         self._name = _resolve_udf_name(name, _callable_name(fn))
@@ -772,7 +772,7 @@ class VaneFunction:
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return _call_or_build_expression(
             has_expression=_has_expression(args) or _has_expression(kwargs.values()),
-            call_immediately=lambda: self._fn(*args, **kwargs),
+            call_immediately=lambda: ensure_synchronous_udf_result(self._fn(*args, **kwargs)),
             build_expression=lambda: _build_map_expression(self._fn, self._name, self._return_dtype, args, kwargs),
         )
 
@@ -798,8 +798,7 @@ class VaneBatchFunction:
     ) -> None:
         if not (inspect.isfunction(fn) or inspect.ismethod(fn)):
             raise TypeError("vane.func.batch requires a Python function")
-        if inspect.iscoroutinefunction(fn):
-            raise TypeError("vane.func.batch requires a synchronous Python function")
+        validate_synchronous_udf_callable(fn)
         if return_dtype is None:
             raise _invalid_input("return_dtype is required for vane.func.batch")
         normalized_return_dtype, return_arrow_dtype = _canonicalize_dtype(return_dtype)
@@ -918,6 +917,7 @@ class VaneClass:
     ) -> None:
         if not inspect.isclass(class_):
             raise TypeError("vane.cls requires a class")
+        validate_synchronous_udf_callable(class_)
         if return_dtype is None:
             raise _invalid_input("return_dtype is required for vane.cls")
         normalized_return_dtype, return_arrow_dtype = _canonicalize_dtype(return_dtype)
@@ -1010,7 +1010,7 @@ class VaneClassInstance:
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return _call_or_build_expression(
             has_expression=_has_expression(args) or _has_expression(kwargs.values()),
-            call_immediately=lambda: self._instance()(*args, **kwargs),
+            call_immediately=lambda: ensure_synchronous_udf_result(self._instance()(*args, **kwargs)),
             build_expression=lambda: self._build_expression(args, kwargs),
         )
 
@@ -1048,6 +1048,7 @@ class VaneClassBatch:
     ) -> None:
         if not inspect.isclass(class_):
             raise TypeError("vane.cls.batch requires a class")
+        validate_synchronous_udf_callable(class_)
         if return_dtype is None:
             raise _invalid_input("return_dtype is required for vane.cls.batch")
         normalized_return_dtype, return_arrow_dtype = _canonicalize_dtype(return_dtype)
@@ -1056,10 +1057,7 @@ class VaneClassBatch:
 
             if not pa.types.is_struct(return_arrow_dtype):
                 raise _invalid_input("unnest=True requires a Struct return_dtype")
-        contract = _class_call_contract(class_)
-        if contract.is_coroutine:
-            raise TypeError("vane.cls.batch requires a synchronous Python __call__")
-        signature = contract.signature
+        signature = _class_call_contract(class_).signature
         variadic = [
             parameter.name
             for parameter in signature.parameters.values()
@@ -1538,6 +1536,7 @@ def _preflight_vane_class_instance(
     actor_number: Any,
     replace: bool,
 ) -> _PreparedBatchSQLRegistration:
+    validate_synchronous_udf_callable(fn_or_instance.user_class)
     _reject_attach_override(
         "return_dtype",
         return_dtype,
@@ -1590,6 +1589,7 @@ def _preflight_vane_class_batch_instance(
     actor_number: Any,
     replace: bool,
 ) -> _PreparedBatchSQLRegistration:
+    validate_synchronous_udf_callable(fn_or_instance.user_class)
     _reject_attach_override(
         "return_dtype",
         return_dtype,
@@ -1654,6 +1654,7 @@ def _preflight_vane_batch_function(
     actor_number: Any,
     replace: bool,
 ) -> _PreparedBatchSQLRegistration:
+    validate_synchronous_udf_callable(fn_or_function.python_function)
     _reject_attach_override(
         "return_dtype",
         return_dtype,
@@ -1715,6 +1716,7 @@ def _preflight_vane_function(
     actor_number: Any,
     replace: bool,
 ) -> _PreparedScalarSQLRegistration:
+    validate_synchronous_udf_callable(fn_or_function.python_function)
     invalid_batch_options = [
         name
         for name, value in (
@@ -1760,6 +1762,7 @@ def _preflight_raw_callable(
 ) -> _PreparedSQLRegistration:
     if not callable(fn):
         raise TypeError("vane.attach_function requires a callable or vane.func object")
+    validate_synchronous_udf_callable(fn)
 
     has_input_names = input_names is not None
     has_schema = schema is not None

--- a/vane/_expression_udf.py
+++ b/vane/_expression_udf.py
@@ -656,7 +656,7 @@ def _build_row_actor_class(
 
     class _VaneRowActorAdapter:
         def __init__(self) -> None:
-            self._instance = user_class(*init_args, **captured_init_kwargs)
+            self._instance = ensure_synchronous_udf_result(user_class(*init_args, **captured_init_kwargs))
 
         def __call__(self, table: Any) -> Any:
             columns = [table.column(name).to_pylist() for name in captured_input_names]
@@ -693,7 +693,7 @@ def _build_batch_actor_class(
 
     class _VaneBatchActorAdapter:
         def __init__(self) -> None:
-            self._instance = user_class(*init_args, **captured_init_kwargs)
+            self._instance = ensure_synchronous_udf_result(user_class(*init_args, **captured_init_kwargs))
 
         def __call__(self, table: Any) -> Any:
             columns = [_arrow_batch_column(table, name) for name in captured_input_names]
@@ -990,7 +990,7 @@ class VaneClassInstance:
 
     def _instance(self) -> Any:
         if self._eager_instance is None:
-            self._eager_instance = self.user_class(*self._init_args, **self._init_kwargs)
+            self._eager_instance = ensure_synchronous_udf_result(self.user_class(*self._init_args, **self._init_kwargs))
         return self._eager_instance
 
     def input_names_for_expression(self, arg_count: int, call_kwargs: Mapping[str, Any]) -> list[str]:
@@ -1162,7 +1162,7 @@ class VaneClassBatchInstance:
 
     def _instance(self) -> Any:
         if self._eager_instance is None:
-            self._eager_instance = self.user_class(*self._init_args, **self._init_kwargs)
+            self._eager_instance = ensure_synchronous_udf_result(self.user_class(*self._init_args, **self._init_kwargs))
         return self._eager_instance
 
     def actor_class(self, layout: _BatchCallLayout) -> type:


### PR DESCRIPTION
Closes #488

## Summary

- centralize the synchronous-callable contract for generic Python UDFs
- reject async functions, async generators, wrapped/partial async functions, and async callable classes at every generic UDF registration boundary
- reject awaitable results uniformly in eager, native, Arrow, subprocess, and Ray worker execution without leaking coroutine objects
- keep AI-specific synchronous wrappers that explicitly drive their own async runtime unchanged

## Validation

- scripts/format root --changed --check
- 960 affected tests passed, 1 existing xfail
- scripts/run_release_tests.sh: 510 passed / 1 skipped, then 11 real-Ray tests passed
- scripts/run_fast_tests.sh: 6524 non-Ray tests passed; 101 shared-Ray tests passed; owner-Ray tests passed with expected optional-dependency skips
- scripts/run_native_tests.sh "[distributed]": 184 test cases passed with 7972 assertions

## Review

Review/fix cycles caught and corrected callable-instance special-method lookup, table-UDF preflight ordering, and staged-file formatting. Two clean review passes followed the final fix.