### PR TITLE
[fix](ray) Enforce disjoint backpressure reservations

### DIFF
--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -115,6 +115,48 @@ class _TaskAdmissionPlan:
 
 
 @dataclass(frozen=True)
+class _ObjectStoreUnitBudget:
+    task_reserved_bytes: int
+    output_reserved_bytes: int
+    task_internal_usage_bytes: int
+    output_usage_bytes: int
+
+    @property
+    def task_budget_usage_bytes(self) -> int:
+        return self.task_internal_usage_bytes + max(
+            0,
+            self.output_usage_bytes - self.output_reserved_bytes,
+        )
+
+    @property
+    def task_reserved_remaining_bytes(self) -> int:
+        return max(0, self.task_reserved_bytes - self.task_budget_usage_bytes)
+
+    @property
+    def output_reserved_remaining_bytes(self) -> int:
+        return max(0, self.output_reserved_bytes - self.output_usage_bytes)
+
+    @property
+    def shared_used_bytes(self) -> int:
+        return max(0, self.task_budget_usage_bytes - self.task_reserved_bytes)
+
+
+@dataclass(frozen=True)
+class _ObjectStoreBudgetState:
+    limit_bytes: int
+    ineligible_usage_bytes: int
+    shared_pool_bytes: int
+    shared_used_bytes: int
+    query_usage_bytes: int
+    reservation_unit_ids: tuple[str, ...]
+    units: dict[str, _ObjectStoreUnitBudget]
+
+    @property
+    def shared_remaining_bytes(self) -> int:
+        return max(0, self.shared_pool_bytes - self.shared_used_bytes)
+
+
+@dataclass(frozen=True)
 class _QueuedTaskEvaluation:
     rank: tuple[int, int, int]
     request: TaskRequest
@@ -253,8 +295,8 @@ class RayQueryResourceManager:
         on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
     ) -> None:
         ratio = float(reservation_ratio)
-        if not math.isfinite(ratio) or ratio <= 0 or ratio > 1:
-            raise ValueError("reservation_ratio must be in (0, 1]")
+        if not math.isfinite(ratio) or ratio < 0 or ratio > 1:
+            raise ValueError("reservation_ratio must be in [0, 1]")
         self.graph = graph
         self.allocation = allocation
         self._allocation_admission_open = bool(admission_open)
@@ -276,6 +318,13 @@ class RayQueryResourceManager:
                 self._direct_downstream_unit_ids[input_unit_id].add(unit.resource_unit_id)
         self._topological_unit_ids = graph.topological_unit_ids()
         self._reverse_topological_unit_ids = graph.reverse_topological_unit_ids()
+        self._transitive_upstream_unit_ids: dict[str, frozenset[str]] = {}
+        for resource_unit_id in self._topological_unit_ids:
+            upstream_unit_ids: set[str] = set()
+            for input_unit_id in self._units[resource_unit_id].spec.input_unit_ids:
+                upstream_unit_ids.add(input_unit_id)
+                upstream_unit_ids.update(self._transitive_upstream_unit_ids[input_unit_id])
+            self._transitive_upstream_unit_ids[resource_unit_id] = frozenset(upstream_unit_ids)
         self._reverse_topological_rank = {
             resource_unit_id: index for index, resource_unit_id in enumerate(self._reverse_topological_unit_ids)
         }
@@ -297,8 +346,8 @@ class RayQueryResourceManager:
         self._observed_output_blocks = BoundedSet[str](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
         self._generated_output_count_by_task_lease: dict[str, int] = {}
         self._terminal_output_blocks = BoundedSet[str](capacity=_TERMINAL_IDENTITY_REPLAY_CAPACITY)
-        self._active_liveness_task_lease_id: str | None = None
-        self._active_liveness_output_lease_id: str | None = None
+        self._active_liveness_task_lease_ids_by_unit: dict[str, str] = {}
+        self._active_liveness_output_lease_ids_by_unit: dict[str, str] = {}
         self._task_liveness_grants_total = 0
         self._output_liveness_grants_total = 0
         self._completed_materialization_barrier_ids: set[str] = set()
@@ -434,9 +483,9 @@ class RayQueryResourceManager:
             # soft query budget.  Lifting the cap only on that direct input can
             # deadlock a longer chain: the live materializer keeps a task lease
             # while an upstream UDF needs another task to produce the remaining
-            # input, so the global-idle task escape cannot fire.  Follow only
-            # the explicitly materialized side upstream; deferred inputs such
-            # as a broadcast probe remain backpressured.
+            # input, so the downstream-chain task escape cannot run backward.
+            # Follow only the explicitly materialized side upstream; deferred
+            # inputs such as a broadcast probe remain backpressured.
             pending = list(barrier.materialized_input_unit_ids)
             while pending:
                 resource_unit_id = pending.pop()
@@ -1187,7 +1236,10 @@ class RayQueryResourceManager:
         if retained < 0:
             return "invalid_retained_input_bytes", True, empty_plan
         resources = _resource_with_object_store(unit.spec.per_task, retained)
-        pending_output_estimate = self._pending_output_estimate_per_task_locked(unit.spec)
+        pending_output_estimate = self._pending_output_estimate_for_admission_locked(
+            unit.spec,
+            actor_index=actor_index,
+        )
         commitment = _resource_with_object_store(
             resources,
             retained + pending_output_estimate,
@@ -1210,17 +1262,11 @@ class RayQueryResourceManager:
         object_store_backpressure_disabled = (
             unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
         )
-        if (
-            not object_store_backpressure_disabled
-            and commitment.object_store_bytes > 0
-            and usage_after.object_store_bytes > self.allocation.resources.object_store_bytes
-        ):
-            return "query_soft_object_store_bytes", False, plan
-
         soft_reason = self._unit_soft_block_reason_locked(
             unit.spec.resource_unit_id,
             commitment,
             ignore_object_store=object_store_backpressure_disabled,
+            object_store_request_kind="task",
         )
         if soft_reason is not None:
             return soft_reason, False, plan
@@ -1250,7 +1296,14 @@ class RayQueryResourceManager:
             return int(spec.output_window_bytes)
         state = self._units[spec.resource_unit_id]
         if state.num_task_outputs_generated <= 0:
-            return 0
+            if state.num_tasks_finished > 0:
+                return 0
+            # Before the first real block arrives, charge the declared generator
+            # window instead of treating every running task as output-free.  A
+            # zero seed can admit a full CPU wave and then create query-wide
+            # object-store debt when the first observation retroactively teaches
+            # the manager the real per-task pending-output size.
+            return int(spec.output_window_bytes)
         pending_blocks = float(spec.generator_buffer_blocks)
         if state.num_tasks_finished > 0:
             pending_blocks = min(
@@ -1259,6 +1312,21 @@ class RayQueryResourceManager:
             )
         estimate = math.ceil(state.bytes_task_outputs_generated * pending_blocks / state.num_task_outputs_generated)
         return min(int(spec.output_window_bytes), max(0, estimate))
+
+    def _pending_output_estimate_for_admission_locked(
+        self,
+        spec: ResourceUnitSpec,
+        *,
+        actor_index: int | None,
+    ) -> int:
+        if spec.backend == "ray_actor":
+            if actor_index is None:
+                raise RuntimeError("Ray actor admission requires a selected actor slot")
+            if self._actor_slot_lease_count_locked((spec.resource_unit_id, actor_index)) > 0:
+                # A prefetched actor call retains its exact input but cannot
+                # populate the single active generator window for that actor.
+                return 0
+        return self._pending_output_estimate_per_task_locked(spec)
 
     def _pending_output_estimate_for_lease_locked(self, lease: TaskLease) -> int:
         spec = self._units[lease.resource_unit_id].spec
@@ -1310,52 +1378,30 @@ class RayQueryResourceManager:
         *,
         ignore_object_store: bool = False,
         excluded_waiting_block_id: str | None = None,
+        object_store_request_kind: str = "task",
     ) -> str | None:
         """Enforce protected shares across current eligible resource units."""
-        usage_by_unit = {
-            key: self._unit_usage_locked(
-                key,
-                excluded_waiting_block_id=excluded_waiting_block_id,
-            )
-            for key in self._units
-        }
-        current = usage_by_unit[resource_unit_id]
-        limits = self.allocation.resources
-        for field_name in _RESOURCE_FIELDS:
-            if field_name == "object_store_bytes" and ignore_object_store:
-                continue
+        process_fields = ("cpu", "gpu", "heap_bytes")
+        usage_by_unit: dict[str, ResourceVector] | None = None
+        if any(getattr(request, field_name) > 0 for field_name in process_fields):
+            usage_by_unit = {
+                key: self._unit_usage_locked(
+                    key,
+                    excluded_waiting_block_id=excluded_waiting_block_id,
+                )
+                for key in self._units
+            }
+        for field_name in process_fields:
             amount = getattr(request, field_name)
             if amount <= 0:
                 continue
-            dimension_unit_ids = self._dimension_reservation_unit_ids_locked(
+            assert usage_by_unit is not None
+            dimension_unit_ids, reserved_by_unit, limit = self._dimension_reservations_locked(
                 field_name,
                 requested_unit_id=resource_unit_id,
             )
-            if resource_unit_id not in dimension_unit_ids:
-                raise RuntimeError(f"unit {resource_unit_id} requested undeclared {field_name} capacity")
-            limit = getattr(limits, field_name)
-            baseline_by_unit = {
-                key: self._unit_dimension_commitment(self._units[key].spec, field_name) for key in dimension_unit_ids
-            }
-            baseline_total = sum(baseline_by_unit.values())
-            if baseline_total <= limit + _EPSILON:
-                bonus_pool = max(0.0, limit - baseline_total) * self.reservation_ratio
-                bonus = bonus_pool / len(dimension_unit_ids)
-                reserved_by_unit = {key: baseline + bonus for key, baseline in baseline_by_unit.items()}
-            else:
-                reservation_pool = limit * self.reservation_ratio
-                reserved_by_unit = {
-                    key: reservation_pool * baseline / baseline_total for key, baseline in baseline_by_unit.items()
-                }
-            maximum_by_unit = {
-                key: self._unit_dimension_maximum_locked(self._units[key].spec, field_name)
-                for key in dimension_unit_ids
-            }
-            reserved_by_unit = {key: min(reserved, maximum_by_unit[key]) for key, reserved in reserved_by_unit.items()}
-            if field_name in {"heap_bytes", "object_store_bytes"}:
-                reserved_by_unit = {key: math.floor(reserved) for key, reserved in reserved_by_unit.items()}
             reserved = reserved_by_unit[resource_unit_id]
-            current_amount = getattr(current, field_name)
+            current_amount = getattr(usage_by_unit[resource_unit_id], field_name)
             if current_amount + amount <= reserved + _EPSILON:
                 continue
             shared_pool = max(0.0, limit - sum(reserved_by_unit.values()))
@@ -1369,6 +1415,203 @@ class RayQueryResourceManager:
             shared_need = amount - max(0.0, reserved - current_amount)
             if shared_used + shared_need > shared_pool + _EPSILON:
                 return f"unit_soft_{field_name}"
+
+        if not ignore_object_store and request.object_store_bytes > 0:
+            return self._object_store_soft_block_reason_locked(
+                resource_unit_id,
+                request.object_store_bytes,
+                request_kind=object_store_request_kind,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+                usage_by_unit=usage_by_unit,
+            )
+        return None
+
+    def _dimension_reservations_locked(
+        self,
+        field_name: str,
+        *,
+        requested_unit_id: str | None,
+        reservation_limit: int | float | None = None,
+    ) -> tuple[tuple[str, ...], dict[str, int | float], int | float]:
+        dimension_unit_ids = self._dimension_reservation_unit_ids_locked(
+            field_name,
+            requested_unit_id=requested_unit_id,
+        )
+        global_limit = getattr(self.allocation.resources, field_name)
+        limit = global_limit if reservation_limit is None else min(global_limit, max(0, reservation_limit))
+        if not dimension_unit_ids:
+            return dimension_unit_ids, {}, global_limit
+
+        baseline_by_unit = {
+            key: self._unit_dimension_commitment(self._units[key].spec, field_name) for key in dimension_unit_ids
+        }
+        baseline_total = sum(baseline_by_unit.values())
+        if baseline_total <= limit + _EPSILON:
+            bonus_pool = max(0.0, limit - baseline_total) * self.reservation_ratio
+            bonus = bonus_pool / len(dimension_unit_ids)
+            reserved_by_unit = {key: baseline + bonus for key, baseline in baseline_by_unit.items()}
+        else:
+            reservation_pool = limit * self.reservation_ratio
+            reserved_by_unit = {
+                key: reservation_pool * baseline / baseline_total for key, baseline in baseline_by_unit.items()
+            }
+        maximum_by_unit = {
+            key: self._unit_dimension_maximum_locked(self._units[key].spec, field_name) for key in dimension_unit_ids
+        }
+        reserved_by_unit = {key: min(reserved, maximum_by_unit[key]) for key, reserved in reserved_by_unit.items()}
+        if field_name in {"heap_bytes", "object_store_bytes"}:
+            reserved_by_unit = {key: math.floor(reserved) for key, reserved in reserved_by_unit.items()}
+        return dimension_unit_ids, reserved_by_unit, global_limit
+
+    def _object_store_output_usage_for_unit_locked(
+        self,
+        resource_unit_id: str,
+        *,
+        excluded_waiting_block_id: str | None,
+    ) -> int:
+        waiting_bytes = sum(
+            int(request.size_bytes)
+            for block_id, request in self._waiting_output_blocks.items()
+            if block_id != excluded_waiting_block_id and str(request.producer_unit_id) == resource_unit_id
+        )
+        return self._live_output_bytes_for_unit_locked(resource_unit_id) + waiting_bytes
+
+    def _object_store_budget_state_locked(
+        self,
+        *,
+        excluded_waiting_block_id: str | None = None,
+        usage_by_unit: dict[str, ResourceVector] | None = None,
+    ) -> _ObjectStoreBudgetState:
+        """Partition current usage into per-unit protected and shared bytes.
+
+        Completed or otherwise ineligible units keep their exact bytes charged
+        and are removed before current-phase reservations and the shared pool
+        are calculated. Streaming producers split their protected share evenly
+        between task/internal usage and output handoff; only eligible usage
+        beyond those shares consumes the common pool.
+        """
+
+        reservation_unit_ids = self._dimension_reservation_unit_ids_locked(
+            "object_store_bytes",
+            requested_unit_id=None,
+        )
+        object_limit = int(self.allocation.resources.object_store_bytes)
+        if usage_by_unit is None:
+            usage_by_unit = {
+                resource_unit_id: self._unit_usage_locked(
+                    resource_unit_id,
+                    excluded_waiting_block_id=excluded_waiting_block_id,
+                )
+                for resource_unit_id in self._units
+            }
+        total_usage_by_unit = {
+            resource_unit_id: usage.object_store_bytes for resource_unit_id, usage in usage_by_unit.items()
+        }
+        output_usage_by_unit = {
+            resource_unit_id: self._object_store_output_usage_for_unit_locked(
+                resource_unit_id,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
+            for resource_unit_id in self._units
+        }
+        reservation_unit_id_set = set(reservation_unit_ids)
+        ineligible_usage = sum(
+            total_usage
+            for resource_unit_id, total_usage in total_usage_by_unit.items()
+            if resource_unit_id not in reservation_unit_id_set
+        )
+        _, total_reserved_by_unit, _ = self._dimension_reservations_locked(
+            "object_store_bytes",
+            requested_unit_id=None,
+            reservation_limit=max(0, object_limit - ineligible_usage),
+        )
+        units: dict[str, _ObjectStoreUnitBudget] = {}
+        shared_used = 0
+        for resource_unit_id, unit in self._units.items():
+            total_usage = total_usage_by_unit[resource_unit_id]
+            output_usage = output_usage_by_unit[resource_unit_id]
+            if output_usage > total_usage:
+                raise RuntimeError(f"unit {resource_unit_id} output usage exceeds total object-store usage")
+
+            total_reserved = int(total_reserved_by_unit.get(resource_unit_id, 0))
+            has_streaming_outputs = bool(
+                unit.spec.target_output_block_bytes > 0 and unit.spec.generator_buffer_blocks > 0
+            )
+            output_reserved = (total_reserved + 1) // 2 if has_streaming_outputs else 0
+            budget = _ObjectStoreUnitBudget(
+                task_reserved_bytes=total_reserved - output_reserved,
+                output_reserved_bytes=output_reserved,
+                task_internal_usage_bytes=total_usage - output_usage,
+                output_usage_bytes=output_usage,
+            )
+            units[resource_unit_id] = budget
+            if resource_unit_id in reservation_unit_id_set:
+                shared_used += budget.shared_used_bytes
+
+        query_usage = self._soft_allocation_usage_locked(
+            excluded_waiting_block_id=excluded_waiting_block_id,
+        ).object_store_bytes
+        accounted_usage = sum(budget.task_internal_usage_bytes + budget.output_usage_bytes for budget in units.values())
+        if accounted_usage != query_usage:
+            raise RuntimeError(
+                "per-unit object-store accounting does not match query usage: "
+                f"units={accounted_usage} query={query_usage}"
+            )
+
+        shared_pool = max(
+            0,
+            object_limit - ineligible_usage - sum(int(total_reserved_by_unit[key]) for key in reservation_unit_ids),
+        )
+        return _ObjectStoreBudgetState(
+            limit_bytes=object_limit,
+            ineligible_usage_bytes=ineligible_usage,
+            shared_pool_bytes=shared_pool,
+            shared_used_bytes=shared_used,
+            query_usage_bytes=query_usage,
+            reservation_unit_ids=reservation_unit_ids,
+            units=units,
+        )
+
+    def _object_store_soft_block_reason_locked(
+        self,
+        resource_unit_id: str,
+        amount: int,
+        *,
+        request_kind: str,
+        excluded_waiting_block_id: str | None,
+        usage_by_unit: dict[str, ResourceVector] | None,
+    ) -> str | None:
+        """Allow protected progress before considering shared-pool debt."""
+
+        if request_kind not in {"task", "output"}:
+            raise ValueError(f"invalid object-store request kind: {request_kind}")
+        state = self._object_store_budget_state_locked(
+            excluded_waiting_block_id=excluded_waiting_block_id,
+            usage_by_unit=usage_by_unit,
+        )
+        if resource_unit_id not in state.reservation_unit_ids:
+            if request_kind == "output":
+                # Completion and phase changes fence new tasks immediately but
+                # preserve live leases.  Their already-produced ObjectRefs must
+                # still cross the driver handoff after the producer stops being
+                # reservation-eligible.  The bytes remain fully charged as
+                # ineligible usage; there is no current reservation to enforce.
+                return None
+            raise RuntimeError(f"unit {resource_unit_id} requested undeclared object_store_bytes capacity")
+
+        unit = state.units[resource_unit_id]
+        protected_remaining = unit.task_reserved_remaining_bytes
+        if request_kind == "output":
+            protected_remaining += unit.output_reserved_remaining_bytes
+        shared_need = max(0, int(amount) - protected_remaining)
+        if shared_need <= 0:
+            return None
+
+        query_usage_after = state.query_usage_bytes + int(amount)
+        if query_usage_after > state.limit_bytes:
+            return "query_soft_object_store_bytes"
+        if state.shared_used_bytes + shared_need > state.shared_pool_bytes:
+            return "unit_soft_object_store_bytes"
         return None
 
     @staticmethod
@@ -1428,9 +1671,7 @@ class RayQueryResourceManager:
         plan: _TaskAdmissionPlan,
     ) -> str | None:
         del plan
-        # Match Ray Data's global-idle escape: soft limits may be bypassed for
-        # one task only when no task is active anywhere in the current query.
-        if self._task_leases or self._active_liveness_task_lease_id is not None:
+        if not self._task_liveness_chain_available_locked(request.resource_unit_id):
             return "liveness_task_active"
         if self._has_normal_task_candidate_locked():
             return "normal_candidate_available"
@@ -1442,6 +1683,29 @@ class RayQueryResourceManager:
             if selected.key != (str(request.task_id), str(request.attempt_id)):
                 return "liveness_candidate_not_selected"
         return None
+
+    def _task_liveness_chain_available_locked(self, resource_unit_id: str) -> bool:
+        """Keep escaped tasks on one downstream dependency chain.
+
+        A query-global-idle escape cannot start a starving downstream UDF while
+        upstream tasks retain the object-store budget that the UDF must drain.
+        Permit one escaped task per unit along a strict downstream chain. The
+        first escape may advance from any live upstream unit; subsequent
+        escapes must descend from every active escape, which keeps parallel
+        branches closed while allowing a multi-UDF pipeline to drain.
+        """
+
+        resource_unit_key = str(resource_unit_id)
+        if self._active_task_count_for_unit_locked(resource_unit_key) > 0:
+            return False
+
+        active_liveness_unit_ids = set(self._active_liveness_task_lease_ids_by_unit)
+        upstream_unit_ids = self._transitive_upstream_unit_ids[resource_unit_key]
+        if active_liveness_unit_ids:
+            return active_liveness_unit_ids.issubset(upstream_unit_ids)
+        if not self._task_leases:
+            return True
+        return any(lease.resource_unit_id in upstream_unit_ids for lease in self._task_leases.values())
 
     def _has_normal_task_candidate_locked(self) -> bool:
         # Liveness arbitration must consider real dispatchable work only. A
@@ -1524,7 +1788,7 @@ class RayQueryResourceManager:
         selected = self._select_waiting_task_evaluation_locked(evaluations)
         if selected is None:
             return "no_liveness_candidate"
-        if self._task_leases or self._active_liveness_task_lease_id is not None:
+        if not self._task_liveness_chain_available_locked(selected.request.resource_unit_id):
             return "liveness_task_active"
         return None
 
@@ -1549,8 +1813,9 @@ class RayQueryResourceManager:
                 raise RuntimeError("Ray task leases must leave placement to Ray Core")
         elif not str(plan.node_id or "").strip():
             raise RuntimeError(f"{unit.backend} task lease requires a concrete runtime node")
-        if liveness and (self._task_leases or self._active_liveness_task_lease_id is not None):
-            raise RuntimeError("task liveness state changed during atomic admission")
+        resource_unit_id = str(request.resource_unit_id)
+        if liveness and not self._task_liveness_chain_available_locked(resource_unit_id):
+            raise RuntimeError("cannot grant more than one liveness task per downstream chain unit")
 
         actor_index = plan.actor_index
         lease_id = uuid.uuid4().hex
@@ -1567,7 +1832,7 @@ class RayQueryResourceManager:
         lease = TaskLease(
             lease_id=lease_id,
             query_id=self.graph.query_id,
-            resource_unit_id=str(request.resource_unit_id),
+            resource_unit_id=resource_unit_id,
             task_id=str(request.task_id),
             attempt_id=str(request.attempt_id),
             node_id=plan.node_id,
@@ -1588,7 +1853,7 @@ class RayQueryResourceManager:
         self._waiting_task_inputs.pop((lease.task_id, lease.attempt_id), None)
         self._recompute_unit_queued_input_locked(lease.resource_unit_id)
         if liveness:
-            self._active_liveness_task_lease_id = lease.lease_id
+            self._active_liveness_task_lease_ids_by_unit[lease.resource_unit_id] = lease.lease_id
             self._task_liveness_grants_total += 1
         self._publish_change_locked()
         return TaskGrant(True, lease=lease, liveness=liveness)
@@ -1719,13 +1984,14 @@ class RayQueryResourceManager:
             return True
 
     def _maybe_clear_task_liveness_locked(self, task_lease_id: str) -> None:
-        """Return the single global-idle escape when its task terminates."""
+        """Return one unit's downstream-chain escape when its task terminates."""
         task_key = str(task_lease_id)
-        if self._active_liveness_task_lease_id != task_key:
-            return
         if task_key in self._task_leases:
             return
-        self._active_liveness_task_lease_id = None
+        for resource_unit_id, lease_id in tuple(self._active_liveness_task_lease_ids_by_unit.items()):
+            if lease_id == task_key:
+                self._active_liveness_task_lease_ids_by_unit.pop(resource_unit_id)
+                return
 
     def try_acquire_output_block(self, request: OutputBlockRequest) -> OutputBlockGrant:
         with self._lock:
@@ -1739,7 +2005,7 @@ class RayQueryResourceManager:
                 return self._grant_output_block_locked(request, liveness=False)
             if fatal or blocked_reason not in _SOFT_OUTPUT_BLOCK_REASONS:
                 return OutputBlockGrant(False, blocked_reason=blocked_reason, fatal=fatal)
-            if self._active_liveness_output_lease_id is not None:
+            if not self._output_liveness_chain_available_locked(request.producer_unit_id):
                 return OutputBlockGrant(False, blocked_reason="liveness_output_active")
             if self._has_normal_output_candidate_locked():
                 return OutputBlockGrant(False, blocked_reason="normal_output_candidate_available")
@@ -1796,20 +2062,21 @@ class RayQueryResourceManager:
             if not soft_blocked:
                 return None, None
 
-            if self._active_liveness_output_lease_id is not None:
-                _, request, _, _ = min(soft_blocked, key=lambda item: item[0])
-                return request, OutputBlockGrant(
-                    False,
-                    blocked_reason="liveness_output_active",
-                )
             liveness_candidates = [
-                item for item in soft_blocked if self._output_consumer_starving_locked(item[1].producer_unit_id)
+                item
+                for item in soft_blocked
+                if self._output_consumer_starving_locked(item[1].producer_unit_id)
+                and self._output_liveness_chain_available_locked(item[1].producer_unit_id)
             ]
             if not liveness_candidates:
                 _, request, _, _ = min(soft_blocked, key=lambda item: item[0])
                 return request, OutputBlockGrant(
                     False,
-                    blocked_reason="output_liveness_not_needed",
+                    blocked_reason=(
+                        "liveness_output_active"
+                        if self._active_liveness_output_lease_ids_by_unit
+                        else "output_liveness_not_needed"
+                    ),
                 )
             _, request, _, _ = min(liveness_candidates, key=lambda item: item[0])
             return request, self._grant_output_block_locked(
@@ -1833,21 +2100,16 @@ class RayQueryResourceManager:
         # has already been exposed to the executor. Pulling this block adds its
         # exact bytes; it does not replace the pending-generator estimate.
         delta = size
-        object_limit = self.allocation.resources.object_store_bytes
-        usage_after = self._query_usage_locked(
-            excluded_waiting_block_id=excluded_waiter,
-        ) + ResourceVector(object_store_bytes=delta)
         object_store_backpressure_disabled = (
             unit.spec.resource_unit_id in self._materializing_object_store_unlimited_unit_ids_locked()
         )
-        if not object_store_backpressure_disabled and delta > 0 and usage_after.object_store_bytes > object_limit:
-            return "query_soft_object_store_bytes", False, delta
         if delta > 0:
             soft = self._unit_soft_block_reason_locked(
                 unit.spec.resource_unit_id,
                 ResourceVector(object_store_bytes=delta),
                 ignore_object_store=object_store_backpressure_disabled,
                 excluded_waiting_block_id=excluded_waiter,
+                object_store_request_kind="output",
             )
             if soft is not None:
                 return soft, False, delta
@@ -1892,6 +2154,8 @@ class RayQueryResourceManager:
                 continue
             if not self._output_consumer_starving_locked(resource_unit_id):
                 continue
+            if not self._output_liveness_chain_available_locked(resource_unit_id):
+                continue
             if resource_unit_id != str(current_request.producer_unit_id) and unit.queued_output_bytes <= 0:
                 continue
             if resource_unit_id == str(current_request.producer_unit_id):
@@ -1922,6 +2186,26 @@ class RayQueryResourceManager:
             if not fatal and reason in _SOFT_OUTPUT_BLOCK_REASONS:
                 candidates.append(resource_unit_id)
         return candidates[0] if candidates else None
+
+    def _output_liveness_chain_available_locked(self, producer_unit_id: str) -> bool:
+        """Keep one escape per unit along one strictly downstream dependency chain.
+
+        A producer block can remain in ``unit_queue`` while a downstream UDF
+        has already consumed earlier blocks and is waiting to publish its own
+        output. A single query-global output token deadlocks that pipeline: the
+        downstream output cannot drain, so it can never free capacity for the
+        upstream token. Allowing only strict descendants of every active token
+        advances that same dependency chain without opening parallel branches
+        or admitting a second escaped block from the same producer.
+        """
+
+        producer_key = str(producer_unit_id)
+        active_unit_ids = set(self._active_liveness_output_lease_ids_by_unit)
+        if not active_unit_ids:
+            return True
+        if producer_key in active_unit_ids:
+            return False
+        return active_unit_ids.issubset(self._transitive_upstream_unit_ids[producer_key])
 
     def _output_consumer_starving_locked(self, producer_unit_id: str) -> bool:
         if self._external_consumer_waiting:
@@ -1955,11 +2239,14 @@ class RayQueryResourceManager:
         task = self._task_leases.get(str(request.task_lease_id))
         if task is None:
             raise RuntimeError("cannot grant an output block without an active task lease")
+        producer_unit_id = str(request.producer_unit_id)
+        if liveness and not self._output_liveness_chain_available_locked(producer_unit_id):
+            raise RuntimeError("cannot grant more than one liveness output per downstream chain unit")
         self._record_output_observation_locked(request)
         lease = OutputBlockLease(
             lease_id=uuid.uuid4().hex,
             query_id=self.graph.query_id,
-            producer_unit_id=str(request.producer_unit_id),
+            producer_unit_id=producer_unit_id,
             task_lease_id=str(request.task_lease_id),
             attempt_id=str(request.attempt_id),
             block_id=str(request.block_id),
@@ -1974,7 +2261,7 @@ class RayQueryResourceManager:
         self._waiting_output_blocks.pop(lease.block_id, None)
         self._recompute_unit_queued_output_locked(lease.producer_unit_id)
         if liveness:
-            self._active_liveness_output_lease_id = lease.lease_id
+            self._active_liveness_output_lease_ids_by_unit[lease.producer_unit_id] = lease.lease_id
             self._output_liveness_grants_total += 1
         self._publish_change_locked()
         return OutputBlockGrant(True, lease=lease, liveness=liveness)
@@ -1993,12 +2280,15 @@ class RayQueryResourceManager:
             if target_index != current_index + 1:
                 raise ValueError(f"invalid output lease transition: {lease.state} -> {target}")
             self._output_leases[lease_key] = OutputBlockLease(**{**asdict(lease), "state": target})
-            if target == "downstream_input" and self._active_liveness_output_lease_id == lease_key:
-                # A liveness escape limits producer-side progress to one full
-                # block at a time. The handed-off object stays charged, while
-                # returning the token lets a partial downstream batch request
-                # its next block.
-                self._active_liveness_output_lease_id = None
+            if (
+                target == "downstream_input"
+                and self._active_liveness_output_lease_ids_by_unit.get(lease.producer_unit_id) == lease_key
+            ):
+                # A liveness escape limits each producer to one full block at
+                # a time. The handed-off object stays charged, while returning
+                # this unit's token lets a partial downstream batch request its
+                # next block.
+                self._active_liveness_output_lease_ids_by_unit.pop(lease.producer_unit_id)
             if target == "downstream_input":
                 self._maybe_clear_task_liveness_locked(lease.task_lease_id)
             self._recompute_unit_queued_output_locked(lease.producer_unit_id)
@@ -2013,8 +2303,8 @@ class RayQueryResourceManager:
                 return False
             self._output_lease_by_block.pop(lease.block_id, None)
             self._terminal_output_blocks.add(lease.block_id)
-            if self._active_liveness_output_lease_id == lease_key:
-                self._active_liveness_output_lease_id = None
+            if self._active_liveness_output_lease_ids_by_unit.get(lease.producer_unit_id) == lease_key:
+                self._active_liveness_output_lease_ids_by_unit.pop(lease.producer_unit_id)
             self._maybe_clear_task_liveness_locked(lease.task_lease_id)
             self._recompute_unit_queued_output_locked(lease.producer_unit_id)
             self._publish_change_locked()
@@ -2045,8 +2335,8 @@ class RayQueryResourceManager:
             self._waiting_output_blocks.clear()
             for resource_unit_id in self._units:
                 self._recompute_unit_queued_output_locked(resource_unit_id)
-            self._active_liveness_task_lease_id = None
-            self._active_liveness_output_lease_id = None
+            self._active_liveness_task_lease_ids_by_unit.clear()
+            self._active_liveness_output_lease_ids_by_unit.clear()
             for unit in self._units.values():
                 if unit.spec.backend == "ray_actor":
                     unit.actor_ready = False
@@ -2156,13 +2446,26 @@ class RayQueryResourceManager:
         active_task_ids: set[str],
         *,
         resource_unit_id: str | None = None,
+        excluded_waiting_block_id: str | None = None,
     ) -> int:
-        return sum(
+        leased = sum(
             output.size_bytes
             for output in self._output_leases.values()
             if output.task_lease_id not in active_task_ids
             and (resource_unit_id is None or output.producer_unit_id == resource_unit_id)
         )
+        # Failure cleanup can retire a completed task concurrently with
+        # cancelling its final driver-owned output waiter.  The ObjectRef still
+        # exists during that bounded handoff, so keep its exact bytes charged
+        # even after the task estimate disappears.
+        waiting = sum(
+            int(request.size_bytes)
+            for block_id, request in self._waiting_output_blocks.items()
+            if block_id != excluded_waiting_block_id
+            and str(request.task_lease_id) not in active_task_ids
+            and (resource_unit_id is None or str(request.producer_unit_id) == resource_unit_id)
+        )
+        return leased + waiting
 
     def _query_usage_locked(
         self,
@@ -2176,10 +2479,24 @@ class RayQueryResourceManager:
                 lease,
                 excluded_waiting_block_id=excluded_waiting_block_id,
             )
-        return total + ResourceVector(object_store_bytes=self._uncovered_inactive_output_bytes_locked(active_task_ids))
+        return total + ResourceVector(
+            object_store_bytes=self._uncovered_inactive_output_bytes_locked(
+                active_task_ids,
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
+        )
 
-    def _soft_allocation_usage_locked(self) -> ResourceVector:
-        return self._query_usage_locked() + self._actor_resident_usage_locked()
+    def _soft_allocation_usage_locked(
+        self,
+        *,
+        excluded_waiting_block_id: str | None = None,
+    ) -> ResourceVector:
+        return (
+            self._query_usage_locked(
+                excluded_waiting_block_id=excluded_waiting_block_id,
+            )
+            + self._actor_resident_usage_locked()
+        )
 
     def _update_soft_allocation_warning_locked(
         self,
@@ -2233,6 +2550,7 @@ class RayQueryResourceManager:
             object_store_bytes=self._uncovered_inactive_output_bytes_locked(
                 active_task_ids,
                 resource_unit_id=resource_unit_id,
+                excluded_waiting_block_id=excluded_waiting_block_id,
             )
         )
         if self._units[resource_unit_id].spec.backend == "ray_actor":
@@ -2276,6 +2594,8 @@ class RayQueryResourceManager:
             frontier_barriers = self._frontier_materialization_barriers_locked()
             eligible_unit_ids = self._eligible_resource_unit_ids_locked()
             object_store_unlimited_unit_ids = self._materializing_object_store_unlimited_unit_ids_locked()
+            object_store_budget = self._object_store_budget_state_locked()
+            object_store_reservation_unit_ids = set(object_store_budget.reservation_unit_ids)
             preferred_task, grant_class = self._preferred_waiting_task_locked()
             actor_resident_usage_by_node = {
                 node_id: self._actor_resident_usage_locked(node_id=node_id)
@@ -2283,6 +2603,8 @@ class RayQueryResourceManager:
             }
             submitted_actor_slots = set(self._submitted_actor_slots)
             ready_actor_slots = set(self._actor_node_by_slot)
+            active_task_lease_ids_by_unit = dict(self._active_liveness_task_lease_ids_by_unit)
+            active_output_lease_ids_by_unit = dict(self._active_liveness_output_lease_ids_by_unit)
             return {
                 "query_id": self.graph.query_id,
                 "graph": self.graph.to_dict(),
@@ -2333,8 +2655,8 @@ class RayQueryResourceManager:
                 "failure_reason": self._failure_reason,
                 "external_consumer_waiting": self._external_consumer_waiting,
                 "liveness": {
-                    "active_task_lease_id": self._active_liveness_task_lease_id,
-                    "active_output_lease_id": self._active_liveness_output_lease_id,
+                    "active_task_lease_ids_by_unit": active_task_lease_ids_by_unit,
+                    "active_output_lease_ids_by_unit": active_output_lease_ids_by_unit,
                     "task_grants_total": self._task_liveness_grants_total,
                     "output_grants_total": self._output_liveness_grants_total,
                 },
@@ -2365,6 +2687,14 @@ class RayQueryResourceManager:
                             )
                         )
                         for field_name in _RESOURCE_FIELDS
+                    },
+                    "object_store": {
+                        "limit_bytes": object_store_budget.limit_bytes,
+                        "ineligible_usage_bytes": object_store_budget.ineligible_usage_bytes,
+                        "shared_pool_bytes": object_store_budget.shared_pool_bytes,
+                        "shared_used_bytes": object_store_budget.shared_used_bytes,
+                        "shared_remaining_bytes": object_store_budget.shared_remaining_bytes,
+                        "query_usage_bytes": object_store_budget.query_usage_bytes,
                     },
                 },
                 "units": {
@@ -2397,6 +2727,30 @@ class RayQueryResourceManager:
                         "phase_eligible": resource_unit_id in eligible_unit_ids,
                         "object_store_backpressure_disabled": (resource_unit_id in object_store_unlimited_unit_ids),
                         "usage": self._unit_usage_locked(resource_unit_id).to_dict(),
+                        "object_store_budget": {
+                            "reservation_eligible": (resource_unit_id in object_store_reservation_unit_ids),
+                            "task_reserved_bytes": (object_store_budget.units[resource_unit_id].task_reserved_bytes),
+                            "output_reserved_bytes": (
+                                object_store_budget.units[resource_unit_id].output_reserved_bytes
+                            ),
+                            "task_internal_usage_bytes": (
+                                object_store_budget.units[resource_unit_id].task_internal_usage_bytes
+                            ),
+                            "output_usage_bytes": (object_store_budget.units[resource_unit_id].output_usage_bytes),
+                            "ineligible_usage_bytes": (
+                                0
+                                if resource_unit_id in object_store_reservation_unit_ids
+                                else (
+                                    object_store_budget.units[resource_unit_id].task_internal_usage_bytes
+                                    + object_store_budget.units[resource_unit_id].output_usage_bytes
+                                )
+                            ),
+                            "shared_used_bytes": (
+                                object_store_budget.units[resource_unit_id].shared_used_bytes
+                                if resource_unit_id in object_store_reservation_unit_ids
+                                else 0
+                            ),
+                        },
                         "active_task_count": self._active_task_count_for_unit_locked(resource_unit_id),
                     }
                     for resource_unit_id, unit in self._units.items()

--- a/duckdb/runners/ray/query_resource_manager.py
+++ b/duckdb/runners/ray/query_resource_manager.py
@@ -1296,16 +1296,15 @@ class RayQueryResourceManager:
             return int(spec.output_window_bytes)
         state = self._units[spec.resource_unit_id]
         if state.num_task_outputs_generated <= 0:
-            if state.num_tasks_finished > 0:
-                return 0
             # Before the first real block arrives, charge the declared generator
             # window instead of treating every running task as output-free.  A
-            # zero seed can admit a full CPU wave and then create query-wide
-            # object-store debt when the first observation retroactively teaches
-            # the manager the real per-task pending-output size.
+            # zero-output partition is not evidence that later data-dependent
+            # partitions are also empty.  Dropping the seed after such a task can
+            # admit a full CPU wave and then create query-wide object-store debt
+            # when a later partition emits the first real block.
             return int(spec.output_window_bytes)
         pending_blocks = float(spec.generator_buffer_blocks)
-        if state.num_tasks_finished > 0:
+        if state.num_outputs_of_finished_tasks > 0:
             pending_blocks = min(
                 pending_blocks,
                 state.num_outputs_of_finished_tasks / state.num_tasks_finished,

--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -2865,7 +2865,10 @@ def test_task_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
         resources = ResourceVector(
             cpu=10,
             heap_bytes=1_000,
-            object_store_bytes=200,
+            # Ten 20-byte generator windows must fit without consuming the
+            # protected output-handoff portion of the object-store budget; this
+            # test exercises pump batching rather than resource backpressure.
+            object_store_bytes=400,
         )
         manager.update_allocation(
             QueryAllocation(

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -1801,7 +1801,7 @@ def test_declared_generator_window_seeds_admission_before_the_first_output():
     }
 
 
-def test_completed_zero_output_task_releases_the_cold_start_estimate():
+def test_completed_zero_output_task_keeps_cold_start_estimate_until_positive_output():
     unit = _unit(
         "resource:f:filter",
         resources=_r(cpu=1, heap=10),
@@ -1823,10 +1823,35 @@ def test_completed_zero_output_task_releases_the_cold_start_estimate():
 
     snapshot = manager.snapshot()
     assert snapshot["units"][unit.resource_unit_id]["num_tasks_finished"] == 1
-    assert snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"] == 0
+    assert snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"] == 100
     second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
     assert second.granted and not second.liveness
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 0
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 100
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            second.lease.lease_id,
+            second.lease.attempt_id,
+            "positive-output",
+            10,
+        )
+    )
+    assert output.granted
+    snapshot = manager.snapshot()
+    assert snapshot["usage"]["object_store_bytes"] == 30
+    assert snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"] == 20
+
+    assert manager.release_output_block(output.lease.lease_id)
+    assert manager.release_task_lease(
+        second.lease.lease_id,
+        attempt_id=second.lease.attempt_id,
+    )
+    learned = manager.snapshot()["units"][unit.resource_unit_id]
+    assert learned["num_tasks_finished"] == 2
+    assert learned["average_output_blocks_per_finished_task"] == pytest.approx(0.5)
+    assert learned["pending_output_estimate_per_active_task_bytes"] == 5
 
 
 def test_ineligible_output_usage_reduces_current_phase_reservations():

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import random
 
 import pytest
 
@@ -157,6 +158,138 @@ def _task(resource_unit_id, partition, attempt="0", retained=None, node_id=None)
         node_id=node_id,
         retained_input_bytes=retained,
     )
+
+
+def _assert_object_store_budget_invariants(snapshot):
+    state = snapshot["admission"]["object_store"]
+    budgets = [unit["object_store_budget"] for unit in snapshot["units"].values()]
+    total_reserved = sum(
+        budget["task_reserved_bytes"] + budget["output_reserved_bytes"]
+        for budget in budgets
+        if budget["reservation_eligible"]
+    )
+
+    assert state["ineligible_usage_bytes"] == sum(budget["ineligible_usage_bytes"] for budget in budgets)
+    assert state["shared_used_bytes"] == sum(budget["shared_used_bytes"] for budget in budgets)
+    assert state["shared_pool_bytes"] == max(
+        0,
+        state["limit_bytes"] - state["ineligible_usage_bytes"] - total_reserved,
+    )
+    assert state["shared_remaining_bytes"] == max(
+        0,
+        state["shared_pool_bytes"] - state["shared_used_bytes"],
+    )
+    assert state["query_usage_bytes"] == sum(
+        budget["task_internal_usage_bytes"] + budget["output_usage_bytes"] for budget in budgets
+    )
+    for budget in budgets:
+        if budget["reservation_eligible"]:
+            assert budget["ineligible_usage_bytes"] == 0
+        else:
+            assert budget["task_reserved_bytes"] == 0
+            assert budget["output_reserved_bytes"] == 0
+            assert budget["shared_used_bytes"] == 0
+
+
+@pytest.mark.parametrize(
+    ("task_reserved", "output_reserved"),
+    [(0, 0), (0, 3), (3, 0), (3, 4), (7, 8)],
+)
+def test_object_store_unit_budget_exhaustively_partitions_protected_and_shared_usage(
+    task_reserved,
+    output_reserved,
+):
+    for task_internal_usage in range(10):
+        for output_usage in range(10):
+            budget = manager_module._ObjectStoreUnitBudget(
+                task_reserved_bytes=task_reserved,
+                output_reserved_bytes=output_reserved,
+                task_internal_usage_bytes=task_internal_usage,
+                output_usage_bytes=output_usage,
+            )
+            output_protected_used = min(output_usage, output_reserved)
+            expected_task_budget_usage = task_internal_usage + max(0, output_usage - output_reserved)
+            task_protected_used = min(expected_task_budget_usage, task_reserved)
+
+            assert budget.task_budget_usage_bytes == expected_task_budget_usage
+            assert budget.task_reserved_remaining_bytes == max(0, task_reserved - expected_task_budget_usage)
+            assert budget.output_reserved_remaining_bytes == max(0, output_reserved - output_usage)
+            assert budget.shared_used_bytes == max(0, expected_task_budget_usage - task_reserved)
+            assert task_internal_usage + output_usage == (
+                output_protected_used + task_protected_used + budget.shared_used_bytes
+            )
+
+
+@pytest.mark.parametrize("reservation_ratio", [-0.01, 1.01, float("nan"), float("inf")])
+def test_reservation_ratio_rejects_nonfinite_or_out_of_range_values(reservation_ratio):
+    with pytest.raises(ValueError, match=r"reservation_ratio must be in \[0, 1\]"):
+        _manager(_unit("resource:f:ratio-invalid"), reservation_ratio=reservation_ratio)
+
+
+@pytest.mark.parametrize(
+    ("reservation_ratio", "task_reserved", "output_reserved", "shared_pool"),
+    [
+        (0.0, 0, 0, 7),
+        (0.5, 1, 2, 4),
+        (1.0, 3, 4, 0),
+    ],
+)
+def test_object_store_reservation_ratio_endpoints_and_odd_byte_rounding(
+    reservation_ratio,
+    task_reserved,
+    output_reserved,
+    shared_pool,
+):
+    unit = _unit("resource:f:ratio", target=1, blocks=1)
+    manager = _manager(
+        unit,
+        resources=_r(cpu=10, heap=100, store=7),
+        reservation_ratio=reservation_ratio,
+    )
+    snapshot = manager.snapshot()
+
+    _assert_object_store_budget_invariants(snapshot)
+    assert snapshot["admission"]["object_store"]["shared_pool_bytes"] == shared_pool
+    assert snapshot["units"][unit.resource_unit_id]["object_store_budget"] == {
+        "reservation_eligible": True,
+        "task_reserved_bytes": task_reserved,
+        "output_reserved_bytes": output_reserved,
+        "task_internal_usage_bytes": 0,
+        "output_usage_bytes": 0,
+        "ineligible_usage_bytes": 0,
+        "shared_used_bytes": 0,
+    }
+
+
+def test_zero_reservation_ratio_uses_only_shared_credit_then_bounded_liveness():
+    unit = _unit("resource:f:zero-ratio", target=1, blocks=1)
+    manager = _manager(
+        unit,
+        resources=_r(cpu=10, heap=100, store=2),
+        reservation_ratio=0,
+    )
+    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
+
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    third_request = _task(unit.resource_unit_id, 2)
+    assert first.granted and not first.liveness
+    assert second.granted and not second.liveness
+    assert manager._normal_task_block_reason_locked(third_request)[0] == "query_soft_object_store_bytes"
+    third = manager.try_acquire_task(third_request)
+    assert not third.granted and third.blocked_reason == "liveness_task_active"
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            first.lease.lease_id,
+            first.lease.attempt_id,
+            "zero-ratio-liveness-output",
+            1,
+        )
+    )
+    assert output.granted and output.liveness
 
 
 def test_task_admission_requires_runnable_registered_unit_and_ready_actor():
@@ -672,7 +805,9 @@ def test_submitted_actor_processes_are_charged_once_to_soft_usage():
             cpu=2,
             gpu=1,
             heap=200,
-            store=20,
+            # Two retained 10-byte inputs plus one declared 20-byte
+            # generator window for each active actor slot.
+            store=60,
         ).to_dict()
     )
 
@@ -793,6 +928,8 @@ def test_fixed_actor_soft_debt_does_not_block_zero_increment_invocations():
         "resource:f:soft-debt-actor",
         resources=_r(),
         resident=_r(cpu=1, gpu=1, heap=100),
+        target=0,
+        blocks=0,
         backend="ray_actor",
         actor_pool_size=1,
     )
@@ -1024,8 +1161,498 @@ def test_identical_waiter_and_unit_state_updates_do_not_publish_spurious_edges()
     assert len(changes) == after_first_waiter
 
 
+def test_object_store_ledgers_remain_disjoint_through_a_mixed_lifecycle():
+    upstream = _unit("resource:f:ledger-upstream", target=1, blocks=1)
+    downstream = _unit(
+        "resource:f:ledger-downstream",
+        inputs=(upstream.resource_unit_id,),
+        target=1,
+        blocks=1,
+    )
+    manager = _manager(
+        upstream,
+        downstream,
+        resources=_r(cpu=10, heap=100, store=100),
+    )
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+    _assert_object_store_budget_invariants(manager.snapshot())
+
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0, retained=20))
+    request = OutputBlockRequest(
+        "q",
+        upstream.resource_unit_id,
+        upstream_task.lease.lease_id,
+        upstream_task.lease.attempt_id,
+        "ledger-output",
+        15,
+    )
+    assert manager.note_output_waiting(request) is None
+    _assert_object_store_budget_invariants(manager.snapshot())
+
+    selected, output = manager.try_acquire_next_queued_output_block({request.block_id})
+    assert selected == request and output.granted
+    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
+    assert manager.release_task_lease(
+        upstream_task.lease.lease_id,
+        attempt_id=upstream_task.lease.attempt_id,
+    )
+    manager.update_unit_state(upstream.resource_unit_id, runnable=False, completed=True)
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=100), generation=2),
+        admission_open=True,
+    )
+    _assert_object_store_budget_invariants(manager.snapshot())
+
+    downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0, retained=10))
+    assert downstream_task.granted
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=40), generation=3),
+        admission_open=True,
+    )
+    _assert_object_store_budget_invariants(manager.snapshot())
+
+    assert manager.release_output_block(output.lease.lease_id)
+    assert manager.release_task_lease(
+        downstream_task.lease.lease_id,
+        attempt_id=downstream_task.lease.attempt_id,
+    )
+    _assert_object_store_budget_invariants(manager.snapshot())
+
+
+def test_object_store_ledgers_hold_across_seeded_lifecycle_traces():
+    """Exercise valid lifecycle interleavings while checking an independent ledger."""
+
+    for seed in range(12):
+        randomizer = random.Random(seed)
+        upstream = _unit(f"resource:f:trace-{seed}-upstream", target=1, blocks=1)
+        middle = _unit(
+            f"resource:f:trace-{seed}-middle",
+            inputs=(upstream.resource_unit_id,),
+            target=3,
+            blocks=1,
+        )
+        downstream = _unit(
+            f"resource:f:trace-{seed}-downstream",
+            inputs=(middle.resource_unit_id,),
+            target=5,
+            blocks=1,
+        )
+        units = (upstream, middle, downstream)
+        manager = _manager(
+            *units,
+            resources=_r(cpu=100, heap=1_000, store=(17, 31, 64)[seed % 3]),
+            reservation_ratio=(0.0, 0.5, 1.0)[seed % 3],
+        )
+        _ready(
+            manager,
+            *(unit.resource_unit_id for unit in units),
+            consumer_waiting=True,
+        )
+
+        active_tasks = []
+        waiting_outputs = {}
+        active_outputs = {}
+        output_states = {}
+        completed_unit_ids = set()
+        next_identity = 0
+        allocation_generation = 1
+
+        for step in range(120):
+            action = randomizer.randrange(8)
+            live_unit_ids = [unit.resource_unit_id for unit in units if unit.resource_unit_id not in completed_unit_ids]
+
+            if action == 0 and live_unit_ids:
+                resource_unit_id = randomizer.choice(live_unit_ids)
+                request = _task(
+                    resource_unit_id,
+                    f"{seed}-{next_identity}",
+                    retained=randomizer.randrange(24),
+                )
+                next_identity += 1
+                grant = manager.try_acquire_task(request)
+                if grant.granted:
+                    active_tasks.append(grant.lease)
+            elif action == 1 and active_tasks:
+                task = randomizer.choice(active_tasks)
+                request = OutputBlockRequest(
+                    "q",
+                    task.resource_unit_id,
+                    task.lease_id,
+                    task.attempt_id,
+                    f"trace-{seed}-block-{next_identity}",
+                    randomizer.randrange(1, 24),
+                )
+                next_identity += 1
+                assert manager.note_output_waiting(request) is None
+                waiting_outputs[request.block_id] = request
+            elif action == 2 and waiting_outputs:
+                request = randomizer.choice(list(waiting_outputs.values()))
+                selected, grant = manager.try_acquire_next_queued_output_block({request.block_id})
+                assert selected == request
+                assert grant is not None
+                if grant.granted:
+                    waiting_outputs.pop(request.block_id)
+                    active_outputs[grant.lease.lease_id] = grant.lease
+                    output_states[grant.lease.lease_id] = grant.lease.state
+                elif grant.fatal:
+                    assert manager.remove_output_waiter(request.block_id)
+                    waiting_outputs.pop(request.block_id)
+            elif action == 3 and active_outputs:
+                transitionable = [
+                    lease_id for lease_id, state in output_states.items() if state in {"unit_queue", "downstream_input"}
+                ]
+                if transitionable:
+                    lease_id = randomizer.choice(transitionable)
+                    target = "downstream_input" if output_states[lease_id] == "unit_queue" else "external_consumer"
+                    assert manager.transition_output_block(lease_id, target)
+                    output_states[lease_id] = target
+            elif action == 4 and active_tasks:
+                task = randomizer.choice(active_tasks)
+                assert manager.release_task_lease(task.lease_id, attempt_id=task.attempt_id)
+                active_tasks.remove(task)
+            elif action == 5 and active_outputs:
+                lease_id = randomizer.choice(list(active_outputs))
+                assert manager.release_output_block(lease_id)
+                active_outputs.pop(lease_id)
+                output_states.pop(lease_id)
+            elif action == 6:
+                allocation_generation += 1
+                manager.update_allocation(
+                    _allocation(
+                        _r(
+                            cpu=100,
+                            heap=1_000,
+                            store=randomizer.choice((0, 7, 17, 31, 64, 101)),
+                        ),
+                        generation=allocation_generation,
+                    ),
+                    admission_open=True,
+                )
+            elif step >= 30:
+                completable = [
+                    unit.resource_unit_id for unit in units[:-1] if unit.resource_unit_id not in completed_unit_ids
+                ]
+                if completable:
+                    resource_unit_id = randomizer.choice(completable)
+                    manager.update_unit_state(resource_unit_id, runnable=False, completed=True)
+                    completed_unit_ids.add(resource_unit_id)
+                    allocation_generation += 1
+                    manager.update_allocation(
+                        _allocation(
+                            _r(cpu=100, heap=1_000, store=randomizer.choice((7, 31, 64))),
+                            generation=allocation_generation,
+                        ),
+                        admission_open=True,
+                    )
+
+            snapshot = manager.snapshot()
+            _assert_object_store_budget_invariants(snapshot)
+
+            expected_output_bytes_by_unit = {unit.resource_unit_id: 0 for unit in units}
+            for request in waiting_outputs.values():
+                expected_output_bytes_by_unit[request.producer_unit_id] += request.size_bytes
+            for output in active_outputs.values():
+                expected_output_bytes_by_unit[output.producer_unit_id] += output.size_bytes
+            for resource_unit_id, expected in expected_output_bytes_by_unit.items():
+                assert snapshot["units"][resource_unit_id]["object_store_budget"]["output_usage_bytes"] == expected
+
+            expected_query_usage = sum(task.resources.object_store_bytes for task in active_tasks)
+            expected_query_usage += sum(expected_output_bytes_by_unit.values())
+            expected_query_usage += sum(
+                snapshot["units"][unit.resource_unit_id]["active_task_count"]
+                * snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"]
+                for unit in units
+            )
+            assert snapshot["admission"]["object_store"]["query_usage_bytes"] == expected_query_usage
+
+            expected_task_liveness = {task.resource_unit_id: task.lease_id for task in active_tasks if task.liveness}
+            expected_output_liveness = {
+                output.producer_unit_id: output.lease_id
+                for output in active_outputs.values()
+                if output.liveness and output_states[output.lease_id] in {"generator_pending", "unit_queue"}
+            }
+            assert snapshot["liveness"]["active_task_lease_ids_by_unit"] == expected_task_liveness
+            assert snapshot["liveness"]["active_output_lease_ids_by_unit"] == expected_output_liveness
+
+
+def test_task_admission_cannot_consume_the_output_handoff_reservation():
+    unit = _unit("resource:f:task-output-split", target=1, blocks=1)
+    manager = _manager(
+        unit,
+        resources=_r(cpu=10, heap=100, store=100),
+        reservation_ratio=1.0,
+    )
+    _ready(manager, unit.resource_unit_id)
+
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=49))
+    assert task.granted and not task.liveness
+    next_request = _task(unit.resource_unit_id, 1, retained=0)
+    assert manager._normal_task_block_reason_locked(next_request)[0] == "unit_soft_object_store_bytes"
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            task.lease.lease_id,
+            task.lease.attempt_id,
+            "fills-output-reservation",
+            50,
+        )
+    )
+    assert output.granted and not output.liveness
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 100
+
+
+def test_output_handoff_can_use_unused_task_reservation_without_shared_credit():
+    unit = _unit("resource:f:output-borrows-task", target=1, blocks=1)
+    manager = _manager(
+        unit,
+        resources=_r(cpu=10, heap=100, store=100),
+        reservation_ratio=1.0,
+    )
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=0))
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            task.lease.lease_id,
+            task.lease.attempt_id,
+            "uses-both-protected-halves",
+            99,
+        )
+    )
+
+    assert output.granted and not output.liveness
+    budget = manager.snapshot()["units"][unit.resource_unit_id]["object_store_budget"]
+    assert budget == {
+        "reservation_eligible": True,
+        "task_reserved_bytes": 50,
+        "output_reserved_bytes": 50,
+        "task_internal_usage_bytes": 1,
+        "output_usage_bytes": 99,
+        "ineligible_usage_bytes": 0,
+        "shared_used_bytes": 0,
+    }
+
+
+def test_query_debt_still_preserves_an_independent_units_protected_progress():
+    oversized = _unit(
+        "resource:f:oversized-branch",
+        resources=_r(cpu=1, heap=10, store=101),
+        target=0,
+        blocks=0,
+    )
+    protected = _unit("resource:f:protected-branch", target=1, blocks=1)
+    manager = _manager(
+        oversized,
+        protected,
+        terminals=(oversized.resource_unit_id, protected.resource_unit_id),
+        resources=_r(cpu=10, heap=100, store=100),
+    )
+    _ready(manager, oversized.resource_unit_id, protected.resource_unit_id)
+
+    debt = manager.try_acquire_task(_task(oversized.resource_unit_id, 0))
+    assert debt.granted and debt.liveness
+    protected_task = manager.try_acquire_task(_task(protected.resource_unit_id, 0, retained=11))
+    assert protected_task.granted and not protected_task.liveness
+    protected_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            protected.resource_unit_id,
+            protected_task.lease.lease_id,
+            protected_task.lease.attempt_id,
+            "parallel-protected-output",
+            13,
+        )
+    )
+    assert protected_output.granted and not protected_output.liveness
+
+    shared_request = _task(protected.resource_unit_id, 1, retained=0)
+    assert manager._normal_task_block_reason_locked(shared_request)[0] == "query_soft_object_store_bytes"
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 126
+
+
+@pytest.mark.parametrize("retained_output_bytes", [100, 101])
+def test_ineligible_usage_at_or_above_the_limit_zeroes_current_reservations(retained_output_bytes):
+    completed = _unit(
+        "resource:f:completed-native",
+        target=1,
+        blocks=1,
+        backend="ray_worker",
+    )
+    current = _unit(
+        "resource:f:current",
+        inputs=(completed.resource_unit_id,),
+        target=1,
+        blocks=1,
+    )
+    manager = _manager(
+        completed,
+        current,
+        resources=_r(cpu=10, heap=100, store=100),
+    )
+    _ready(manager, completed.resource_unit_id, current.resource_unit_id)
+    task = manager.try_acquire_task(_task(completed.resource_unit_id, 0, node_id="node-a"))
+    manager.finish_task_with_outputs(
+        task.lease.lease_id,
+        attempt_id=task.lease.attempt_id,
+        outputs=(
+            OutputBlockRequest(
+                "q",
+                completed.resource_unit_id,
+                task.lease.lease_id,
+                task.lease.attempt_id,
+                f"completed-{retained_output_bytes}",
+                retained_output_bytes,
+            ),
+        ),
+    )
+    manager.update_unit_state(completed.resource_unit_id, runnable=False, completed=True)
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=100), generation=2),
+        admission_open=True,
+    )
+
+    snapshot = manager.snapshot()
+    _assert_object_store_budget_invariants(snapshot)
+    assert snapshot["admission"]["object_store"] == {
+        "limit_bytes": 100,
+        "ineligible_usage_bytes": retained_output_bytes,
+        "shared_pool_bytes": 0,
+        "shared_used_bytes": 0,
+        "shared_remaining_bytes": 0,
+        "query_usage_bytes": retained_output_bytes,
+    }
+    completed_budget = snapshot["units"][completed.resource_unit_id]["object_store_budget"]
+    assert completed_budget["reservation_eligible"] is False
+    assert completed_budget["ineligible_usage_bytes"] == retained_output_bytes
+    assert completed_budget["shared_used_bytes"] == 0
+    assert snapshot["units"][current.resource_unit_id]["object_store_budget"]["task_reserved_bytes"] == 0
+    assert snapshot["units"][current.resource_unit_id]["object_store_budget"]["output_reserved_bytes"] == 0
+    assert manager._normal_task_block_reason_locked(_task(current.resource_unit_id, 0))[0] == (
+        "query_soft_object_store_bytes"
+    )
+
+
+def test_completed_producer_can_handoff_an_already_waiting_output_without_a_reservation():
+    unit = _unit("resource:f:completed-output-handoff", target=10, blocks=1)
+    manager = _manager(unit, resources=_r(cpu=10, heap=100, store=10))
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=0))
+    request = OutputBlockRequest(
+        "q",
+        unit.resource_unit_id,
+        task.lease.lease_id,
+        task.lease.attempt_id,
+        "completed-output-handoff",
+        7,
+    )
+    assert manager.note_output_waiting(request) is None
+
+    manager.update_unit_state(unit.resource_unit_id, runnable=False, completed=True)
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=10), generation=2),
+        admission_open=True,
+    )
+    before = manager.snapshot()
+    _assert_object_store_budget_invariants(before)
+    assert before["units"][unit.resource_unit_id]["object_store_budget"] == {
+        "reservation_eligible": False,
+        "task_reserved_bytes": 0,
+        "output_reserved_bytes": 0,
+        "task_internal_usage_bytes": 7,
+        "output_usage_bytes": 7,
+        "ineligible_usage_bytes": 14,
+        "shared_used_bytes": 0,
+    }
+
+    selected, output = manager.try_acquire_next_queued_output_block({request.block_id})
+
+    assert selected == request
+    assert output.granted and not output.liveness
+    after = manager.snapshot()
+    _assert_object_store_budget_invariants(after)
+    assert after["usage"]["object_store_bytes"] == before["usage"]["object_store_bytes"]
+    assert after["units"][unit.resource_unit_id]["object_store_budget"]["ineligible_usage_bytes"] == 14
+
+
+def test_allocation_shrink_preserves_output_credit_and_growth_restores_shared_credit():
+    unit = _unit("resource:f:object-allocation-resize", target=1, blocks=1)
+    manager = _manager(unit, resources=_r(cpu=10, heap=100, store=200))
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=99))
+    assert task.granted and not task.liveness
+
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=100), generation=2),
+        admission_open=True,
+    )
+    shrunk = manager.snapshot()
+    assert shrunk["units"][unit.resource_unit_id]["object_store_budget"] == {
+        "reservation_eligible": True,
+        "task_reserved_bytes": 25,
+        "output_reserved_bytes": 25,
+        "task_internal_usage_bytes": 100,
+        "output_usage_bytes": 0,
+        "ineligible_usage_bytes": 0,
+        "shared_used_bytes": 75,
+    }
+    assert shrunk["admission"]["object_store"]["shared_remaining_bytes"] == 0
+
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            task.lease.lease_id,
+            task.lease.attempt_id,
+            "protected-after-shrink",
+            25,
+        )
+    )
+    assert output.granted and not output.liveness
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 125
+
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=300), generation=3),
+        admission_open=True,
+    )
+    assert manager._normal_task_block_reason_locked(_task(unit.resource_unit_id, 1, retained=0))[0] is None
+
+
+def test_completing_an_idle_unit_reassigns_its_protected_reservation():
+    completed = _unit("resource:f:idle-completed", target=1, blocks=1)
+    remaining = _unit("resource:f:remaining", target=1, blocks=1)
+    manager = _manager(
+        completed,
+        remaining,
+        terminals=(completed.resource_unit_id, remaining.resource_unit_id),
+        resources=_r(cpu=10, heap=100, store=100),
+    )
+    before = manager.snapshot()
+    assert before["units"][remaining.resource_unit_id]["object_store_budget"]["task_reserved_bytes"] == 12
+    assert before["units"][remaining.resource_unit_id]["object_store_budget"]["output_reserved_bytes"] == 13
+
+    manager.update_unit_state(completed.resource_unit_id, runnable=False, completed=True)
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=100), generation=2),
+        admission_open=True,
+    )
+    after = manager.snapshot()
+    assert after["units"][completed.resource_unit_id]["object_store_budget"]["task_reserved_bytes"] == 0
+    assert after["units"][completed.resource_unit_id]["object_store_budget"]["output_reserved_bytes"] == 0
+    assert after["units"][remaining.resource_unit_id]["object_store_budget"]["task_reserved_bytes"] == 25
+    assert after["units"][remaining.resource_unit_id]["object_store_budget"]["output_reserved_bytes"] == 25
+
+
 def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=30))
+    unit = _unit(
+        "resource:f:decode",
+        resources=_r(cpu=1, heap=100, store=30),
+        target=0,
+        blocks=0,
+    )
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=1_000))
     _ready(manager, unit.resource_unit_id)
 
@@ -1040,7 +1667,12 @@ def test_retained_input_uses_exact_dynamic_credit_above_nominal_target():
 
 
 def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
-    unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100, store=101))
+    unit = _unit(
+        "resource:f:decode",
+        resources=_r(cpu=1, heap=100, store=101),
+        target=0,
+        blocks=0,
+    )
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
     _ready(manager, unit.resource_unit_id)
 
@@ -1051,6 +1683,211 @@ def test_retained_input_larger_than_soft_budget_uses_one_liveness_task():
     assert granted.granted
     assert granted.liveness
     assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
+
+
+def test_object_store_debt_preserves_downstream_task_and_output_reservations():
+    upstream = _unit(
+        "resource:f:decode",
+        resources=_r(cpu=1, heap=10, store=101),
+        target=0,
+        blocks=0,
+    )
+    downstream = _unit(
+        "resource:f:model",
+        inputs=(upstream.resource_unit_id,),
+        resources=_r(cpu=1, heap=10, store=1),
+        target=1,
+        blocks=1,
+    )
+    sink = _unit(
+        "resource:f:sink",
+        inputs=(downstream.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        upstream,
+        downstream,
+        sink,
+        resources=_r(cpu=10, heap=100, store=100),
+    )
+    _ready(
+        manager,
+        upstream.resource_unit_id,
+        downstream.resource_unit_id,
+        sink.resource_unit_id,
+    )
+
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    assert upstream_task.granted and upstream_task.liveness
+    assert manager.snapshot()["soft_object_store_debt_bytes"] == 1
+
+    downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0, retained=11))
+    assert downstream_task.granted and not downstream_task.liveness
+
+    downstream_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            downstream.resource_unit_id,
+            downstream_task.lease.lease_id,
+            downstream_task.lease.attempt_id,
+            "model-output",
+            1,
+        )
+    )
+    assert downstream_output.granted and not downstream_output.liveness
+
+    shared_borrower = _task(upstream.resource_unit_id, 1, retained=1)
+    assert manager._normal_task_block_reason_locked(shared_borrower)[0] == "query_soft_object_store_bytes"
+    blocked = manager.try_acquire_task(shared_borrower)
+    assert not blocked.granted
+    assert blocked.blocked_reason == "liveness_task_active"
+
+    snapshot = manager.snapshot()
+    assert snapshot["admission"]["object_store"] == {
+        "limit_bytes": 100,
+        "ineligible_usage_bytes": 0,
+        "shared_pool_bytes": 50,
+        "shared_used_bytes": 76,
+        "shared_remaining_bytes": 0,
+        "query_usage_bytes": 114,
+    }
+    assert snapshot["units"][downstream.resource_unit_id]["object_store_budget"] == {
+        "reservation_eligible": True,
+        "task_reserved_bytes": 12,
+        "output_reserved_bytes": 13,
+        "task_internal_usage_bytes": 12,
+        "output_usage_bytes": 1,
+        "ineligible_usage_bytes": 0,
+        "shared_used_bytes": 0,
+    }
+
+
+def test_declared_generator_window_seeds_admission_before_the_first_output():
+    unit = _unit(
+        "resource:f:decode",
+        resources=_r(cpu=1, heap=10),
+        target=50,
+        blocks=2,
+    )
+    manager = _manager(
+        unit,
+        resources=_r(cpu=10, heap=100, store=300),
+    )
+    _ready(manager, unit.resource_unit_id)
+
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    third_request = _task(unit.resource_unit_id, 2)
+
+    assert first.granted and not first.liveness
+    assert second.granted and not second.liveness
+    assert manager._normal_task_block_reason_locked(third_request)[0] == "unit_soft_object_store_bytes"
+    third = manager.try_acquire_task(third_request)
+    assert not third.granted
+    assert third.blocked_reason == "liveness_task_active"
+
+    snapshot = manager.snapshot()
+    assert snapshot["usage"]["object_store_bytes"] == 200
+    assert snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"] == 100
+    assert snapshot["units"][unit.resource_unit_id]["object_store_budget"] == {
+        "reservation_eligible": True,
+        "task_reserved_bytes": 75,
+        "output_reserved_bytes": 75,
+        "task_internal_usage_bytes": 200,
+        "output_usage_bytes": 0,
+        "ineligible_usage_bytes": 0,
+        "shared_used_bytes": 125,
+    }
+
+
+def test_completed_zero_output_task_releases_the_cold_start_estimate():
+    unit = _unit(
+        "resource:f:filter",
+        resources=_r(cpu=1, heap=10),
+        target=50,
+        blocks=2,
+    )
+    manager = _manager(
+        unit,
+        resources=_r(cpu=10, heap=100, store=300),
+    )
+    _ready(manager, unit.resource_unit_id)
+
+    first = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 100
+    assert manager.release_task_lease(
+        first.lease.lease_id,
+        attempt_id=first.lease.attempt_id,
+    )
+
+    snapshot = manager.snapshot()
+    assert snapshot["units"][unit.resource_unit_id]["num_tasks_finished"] == 1
+    assert snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"] == 0
+    second = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    assert second.granted and not second.liveness
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 0
+
+
+def test_ineligible_output_usage_reduces_current_phase_reservations():
+    upstream = _unit("resource:f:completed-producer", target=10, blocks=1)
+    downstream = _unit(
+        "resource:f:current-producer",
+        inputs=(upstream.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    manager = _manager(
+        upstream,
+        downstream,
+        resources=_r(cpu=10, heap=100, store=100),
+    )
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    upstream_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            upstream.resource_unit_id,
+            upstream_task.lease.lease_id,
+            upstream_task.lease.attempt_id,
+            "retained-output",
+            80,
+        )
+    )
+    assert upstream_output.granted and upstream_output.liveness
+    assert manager.transition_output_block(upstream_output.lease.lease_id, "unit_queue")
+    assert manager.transition_output_block(upstream_output.lease.lease_id, "downstream_input")
+    assert manager.release_task_lease(
+        upstream_task.lease.lease_id,
+        attempt_id=upstream_task.lease.attempt_id,
+    )
+    manager.update_unit_state(
+        upstream.resource_unit_id,
+        runnable=False,
+        completed=True,
+    )
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=100, store=100), generation=2),
+        admission_open=True,
+    )
+
+    budget = manager.snapshot()["admission"]["object_store"]
+    assert budget == {
+        "limit_bytes": 100,
+        "ineligible_usage_bytes": 80,
+        "shared_pool_bytes": 10,
+        "shared_used_bytes": 0,
+        "shared_remaining_bytes": 10,
+        "query_usage_bytes": 80,
+    }
+    downstream_budget = manager.snapshot()["units"][downstream.resource_unit_id]["object_store_budget"]
+    assert downstream_budget["task_reserved_bytes"] == 5
+    assert downstream_budget["output_reserved_bytes"] == 5
+
+    downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
+    assert downstream_task.granted and not downstream_task.liveness
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 90
 
 
 def test_global_idle_liveness_is_bounded_to_one_task_across_units():
@@ -1088,6 +1925,159 @@ def test_global_idle_liveness_is_bounded_to_one_task_across_units():
     assert next_escape.granted and next_escape.liveness
 
 
+def test_task_liveness_cannot_move_back_upstream():
+    upstream = _unit("resource:f:liveness-upstream", target=0, blocks=0)
+    downstream = _unit(
+        "resource:f:liveness-downstream",
+        inputs=(upstream.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(upstream, downstream, resources=_r())
+    _ready(manager, upstream.resource_unit_id, downstream.resource_unit_id)
+
+    downstream_escape = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
+    upstream_request = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+
+    assert downstream_escape.granted and downstream_escape.liveness
+    assert not upstream_request.granted
+    assert upstream_request.blocked_reason == "liveness_task_active"
+
+
+def test_task_liveness_can_cross_a_diamond_only_after_convergence():
+    source = _unit("resource:f:diamond-source", target=0, blocks=0)
+    left = _unit(
+        "resource:f:diamond-left",
+        inputs=(source.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    right = _unit(
+        "resource:f:diamond-right",
+        inputs=(source.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    join = _unit(
+        "resource:f:diamond-join",
+        inputs=(left.resource_unit_id, right.resource_unit_id),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        source,
+        left,
+        right,
+        join,
+        resources=_r(cpu=2, heap=20),
+    )
+    _ready(
+        manager,
+        source.resource_unit_id,
+        left.resource_unit_id,
+        right.resource_unit_id,
+        join.resource_unit_id,
+    )
+
+    source_task = manager.try_acquire_task(_task(source.resource_unit_id, 0))
+    left_escape = manager.try_acquire_task(_task(left.resource_unit_id, 0))
+    right_parallel = manager.try_acquire_task(_task(right.resource_unit_id, 0))
+    join_escape = manager.try_acquire_task(_task(join.resource_unit_id, 0))
+
+    assert source_task.granted and not source_task.liveness
+    assert left_escape.granted and left_escape.liveness
+    assert not right_parallel.granted and right_parallel.blocked_reason == "liveness_task_active"
+    assert join_escape.granted and join_escape.liveness
+    assert manager.snapshot()["liveness"]["active_task_lease_ids_by_unit"] == {
+        left.resource_unit_id: left_escape.lease.lease_id,
+        join.resource_unit_id: join_escape.lease.lease_id,
+    }
+
+
+def test_task_liveness_advances_a_bounded_downstream_chain():
+    upstream = _unit("resource:f:decode", target=10, blocks=1)
+    middle = _unit(
+        "resource:f:first-model",
+        inputs=(upstream.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    downstream = _unit(
+        "resource:f:second-model",
+        inputs=(middle.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    sink = _unit(
+        "resource:f:sink",
+        inputs=(downstream.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        upstream,
+        middle,
+        downstream,
+        sink,
+        resources=_r(cpu=10, heap=1_000, store=100),
+    )
+    _ready(manager, upstream.resource_unit_id)
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    _ready(
+        manager,
+        middle.resource_unit_id,
+        downstream.resource_unit_id,
+        sink.resource_unit_id,
+    )
+    middle_task = manager.try_acquire_task(_task(middle.resource_unit_id, 0, retained=101))
+    downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0, retained=101))
+
+    assert upstream_task.granted and not upstream_task.liveness
+    assert middle_task.granted and middle_task.liveness
+    assert downstream_task.granted and downstream_task.liveness
+    assert manager.snapshot()["liveness"]["active_task_lease_ids_by_unit"] == {
+        middle.resource_unit_id: middle_task.lease.lease_id,
+        downstream.resource_unit_id: downstream_task.lease.lease_id,
+    }
+
+    same_unit = manager.try_acquire_task(_task(downstream.resource_unit_id, 1, retained=101))
+    assert not same_unit.granted
+    assert same_unit.blocked_reason == "liveness_task_active"
+
+
+def test_task_liveness_does_not_open_a_parallel_downstream_branch():
+    upstream = _unit("resource:f:source", target=10, blocks=1)
+    left = _unit(
+        "resource:f:left",
+        inputs=(upstream.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    right = _unit(
+        "resource:f:right",
+        inputs=(upstream.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    manager = _manager(
+        upstream,
+        left,
+        right,
+        resources=_r(cpu=10, heap=1_000, store=100),
+        terminals=(left.resource_unit_id, right.resource_unit_id),
+    )
+    _ready(manager, upstream.resource_unit_id)
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    _ready(manager, left.resource_unit_id, right.resource_unit_id)
+    left_task = manager.try_acquire_task(_task(left.resource_unit_id, 0, retained=101))
+    right_task = manager.try_acquire_task(_task(right.resource_unit_id, 0, retained=101))
+
+    assert upstream_task.granted and not upstream_task.liveness
+    assert left_task.granted and left_task.liveness
+    assert not right_task.granted
+    assert right_task.blocked_reason == "liveness_task_active"
+
+
 def test_task_lease_release_is_attempt_aware_and_idempotent():
     unit = _unit("resource:f:decode")
     manager = _manager(unit)
@@ -1122,7 +2112,7 @@ def test_output_blocks_add_exact_refs_to_dynamic_pending_generator_estimate():
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=1_000))
     _ready(manager, unit.resource_unit_id)
     task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
-    assert manager.snapshot()["usage"]["object_store_bytes"] == 10
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 110
 
     first = manager.try_acquire_output_block(
         OutputBlockRequest("q", unit.resource_unit_id, task.lease.lease_id, "0", "block-1", 40)
@@ -1203,6 +2193,9 @@ def test_prefetched_actor_invocation_has_no_pending_generator_estimate():
     _ready(manager, actor.resource_unit_id)
     active = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
     prefetched = manager.try_acquire_task(_task(actor.resource_unit_id, 1, retained=0))
+    assert active.granted and prefetched.granted
+    # Only the active call can populate this actor's generator window.
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 100
     output = manager.try_acquire_output_block(
         OutputBlockRequest(
             "q",
@@ -1214,7 +2207,7 @@ def test_prefetched_actor_invocation_has_no_pending_generator_estimate():
         )
     )
 
-    assert active.granted and prefetched.granted and output.granted
+    assert output.granted
     # 10 exact output bytes + 20 estimated bytes for only the active call.
     assert manager.snapshot()["usage"]["object_store_bytes"] == 30
     assert manager.release_task_lease(
@@ -1224,6 +2217,31 @@ def test_prefetched_actor_invocation_has_no_pending_generator_estimate():
     # The promoted call now uses the learned 10-byte/one-output estimate, while
     # the first call's ObjectRef remains exact.
     assert manager.snapshot()["usage"]["object_store_bytes"] == 20
+
+
+def test_prefetched_actor_admission_does_not_reserve_a_second_generator_window():
+    actor = _unit(
+        "resource:f:actor-prefetch-admission",
+        resources=_r(),
+        resident=_r(cpu=1, heap=10),
+        target=50,
+        blocks=2,
+        backend="ray_actor",
+        actor_pool_size=1,
+        actor_prefetch_depth=2,
+    )
+    manager = _manager(
+        actor,
+        resources=_r(cpu=1, heap=10, store=100),
+    )
+    _ready(manager, actor.resource_unit_id)
+
+    active = manager.try_acquire_task(_task(actor.resource_unit_id, 0, retained=0))
+    prefetched = manager.try_acquire_task(_task(actor.resource_unit_id, 1, retained=0))
+
+    assert active.granted and active.liveness
+    assert prefetched.granted and not prefetched.liveness
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 100
 
 
 def test_frontier_materializer_disables_object_store_backpressure_for_input():
@@ -1401,6 +2419,115 @@ def test_output_lease_transitions_preserve_bytes_and_release_after_task_completi
     assert manager.snapshot()["usage"]["object_store_bytes"] == 0
 
 
+def test_multiple_waiting_outputs_are_counted_once_when_each_becomes_a_lease():
+    unit = _unit("resource:f:multiple-waiters", target=10, blocks=1)
+    manager = _manager(unit, resources=_r(cpu=10, heap=100, store=1_000))
+    _ready(manager, unit.resource_unit_id)
+    first_task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    second_task = manager.try_acquire_task(_task(unit.resource_unit_id, 1))
+    first_request = OutputBlockRequest(
+        "q",
+        unit.resource_unit_id,
+        first_task.lease.lease_id,
+        first_task.lease.attempt_id,
+        "first-waiting-output",
+        7,
+    )
+    second_request = OutputBlockRequest(
+        "q",
+        unit.resource_unit_id,
+        second_task.lease.lease_id,
+        second_task.lease.attempt_id,
+        "second-waiting-output",
+        11,
+    )
+    assert manager.note_output_waiting(first_request) is None
+    assert manager.note_output_waiting(second_request) is None
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 36
+
+    selected, first_grant = manager.try_acquire_next_queued_output_block({first_request.block_id})
+    assert selected == first_request and first_grant.granted
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 36
+    selected, second_grant = manager.try_acquire_next_queued_output_block({second_request.block_id})
+    assert selected == second_request and second_grant.granted
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 36
+
+    assert manager.release_task_lease(
+        first_task.lease.lease_id,
+        attempt_id=first_task.lease.attempt_id,
+    )
+    assert manager.release_task_lease(
+        second_task.lease.lease_id,
+        attempt_id=second_task.lease.attempt_id,
+    )
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 18
+    assert manager.release_output_block(first_grant.lease.lease_id)
+    assert manager.release_output_block(second_grant.lease.lease_id)
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 0
+
+
+def test_removing_a_waiting_output_drops_exact_bytes_but_keeps_the_learned_window():
+    unit = _unit("resource:f:removed-waiter", target=10, blocks=1)
+    manager = _manager(unit, resources=_r(cpu=10, heap=100, store=100))
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    request = OutputBlockRequest(
+        "q",
+        unit.resource_unit_id,
+        task.lease.lease_id,
+        task.lease.attempt_id,
+        "removed-waiter",
+        7,
+    )
+    assert manager.note_output_waiting(request) is None
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 14
+
+    assert manager.remove_output_waiter(request.block_id)
+    snapshot = manager.snapshot()
+    assert snapshot["usage"]["object_store_bytes"] == 7
+    assert snapshot["units"][unit.resource_unit_id]["num_task_outputs_generated"] == 1
+    assert snapshot["units"][unit.resource_unit_id]["pending_output_estimate_per_active_task_bytes"] == 7
+
+
+def test_waiting_output_stays_charged_during_task_completion_cleanup_race():
+    unit = _unit("resource:f:cleanup-race", target=10, blocks=1)
+    manager = _manager(unit, resources=_r(cpu=10, heap=100, store=100))
+    _ready(manager, unit.resource_unit_id)
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0))
+    request = OutputBlockRequest(
+        "q",
+        unit.resource_unit_id,
+        task.lease.lease_id,
+        task.lease.attempt_id,
+        "waiting-during-task-cleanup",
+        7,
+    )
+    assert manager.note_output_waiting(request) is None
+
+    assert manager.release_task_lease(
+        task.lease.lease_id,
+        attempt_id=task.lease.attempt_id,
+    )
+    snapshot = manager.snapshot()
+    assert snapshot["usage"]["object_store_bytes"] == 7
+    assert snapshot["units"][unit.resource_unit_id]["object_store_budget"] == {
+        "reservation_eligible": True,
+        "task_reserved_bytes": 25,
+        "output_reserved_bytes": 25,
+        "task_internal_usage_bytes": 0,
+        "output_usage_bytes": 7,
+        "ineligible_usage_bytes": 0,
+        "shared_used_bytes": 0,
+    }
+
+    selected, denied = manager.try_acquire_next_queued_output_block({request.block_id})
+    assert selected == request
+    assert denied is not None and denied.fatal
+    assert denied.blocked_reason == "task_lease_not_active"
+    assert manager.remove_output_waiter(request.block_id)
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 0
+
+
 def test_released_output_block_identity_cannot_be_leased_again():
     unit = _unit("resource:f:decode", resources=_r(cpu=1, heap=100), target=50, blocks=2)
     manager = _manager(unit)
@@ -1515,6 +2642,46 @@ def test_output_transition_rejects_skips_and_attempt_mismatch():
         manager.transition_output_block(block.lease.lease_id, "external_consumer")
 
 
+def test_task_and_output_liveness_tokens_have_independent_lifetimes():
+    unit = _unit("resource:f:liveness-lifetimes", target=1, blocks=1)
+    manager = _manager(unit, resources=_r(cpu=10, heap=100, store=1))
+    _ready(manager, unit.resource_unit_id, consumer_waiting=True)
+
+    task = manager.try_acquire_task(_task(unit.resource_unit_id, 0, retained=2))
+    assert task.granted and task.liveness
+    output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            unit.resource_unit_id,
+            task.lease.lease_id,
+            task.lease.attempt_id,
+            "liveness-lifetime-output",
+            2,
+        )
+    )
+    assert output.granted and output.liveness
+    assert manager.snapshot()["liveness"] == {
+        "active_task_lease_ids_by_unit": {unit.resource_unit_id: task.lease.lease_id},
+        "active_output_lease_ids_by_unit": {unit.resource_unit_id: output.lease.lease_id},
+        "task_grants_total": 1,
+        "output_grants_total": 1,
+    }
+
+    assert manager.transition_output_block(output.lease.lease_id, "unit_queue")
+    assert manager.snapshot()["liveness"]["active_output_lease_ids_by_unit"] == {
+        unit.resource_unit_id: output.lease.lease_id
+    }
+    assert manager.transition_output_block(output.lease.lease_id, "downstream_input")
+    handed_off = manager.snapshot()["liveness"]
+    assert handed_off["active_output_lease_ids_by_unit"] == {}
+    assert handed_off["active_task_lease_ids_by_unit"] == {unit.resource_unit_id: task.lease.lease_id}
+
+    assert manager.release_task_lease(task.lease.lease_id, attempt_id=task.lease.attempt_id)
+    assert manager.snapshot()["liveness"]["active_task_lease_ids_by_unit"] == {}
+    assert manager.release_output_block(output.lease.lease_id)
+    assert manager.snapshot()["usage"]["object_store_bytes"] == 0
+
+
 def test_oversized_output_block_uses_one_bounded_liveness_grant():
     unit = _unit("resource:f:decode", target=50, blocks=2)
     manager = _manager(unit, resources=_r(cpu=10, heap=1_000, store=100))
@@ -1546,6 +2713,209 @@ def test_oversized_output_block_uses_one_bounded_liveness_grant():
     assert manager.snapshot()["soft_object_store_debt_bytes"] == 102
 
 
+def test_output_liveness_advances_a_bounded_downstream_chain():
+    upstream = _unit("resource:f:decode", target=10, blocks=1)
+    bridge = _unit(
+        "resource:f:bridge",
+        inputs=(upstream.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    downstream = _unit(
+        "resource:f:model",
+        inputs=(bridge.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    sink = _unit(
+        "resource:f:sink",
+        inputs=(downstream.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        upstream,
+        bridge,
+        downstream,
+        sink,
+        resources=_r(cpu=10, heap=1_000, store=10),
+    )
+    _ready(
+        manager,
+        upstream.resource_unit_id,
+        bridge.resource_unit_id,
+        downstream.resource_unit_id,
+        sink.resource_unit_id,
+    )
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
+    upstream_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            upstream.resource_unit_id,
+            upstream_task.lease.lease_id,
+            upstream_task.lease.attempt_id,
+            "decode-output",
+            11,
+        )
+    )
+    assert upstream_output.granted and upstream_output.liveness
+    assert manager.transition_output_block(upstream_output.lease.lease_id, "unit_queue")
+
+    downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0, retained=0))
+    assert downstream_task.granted
+    model_output = OutputBlockRequest(
+        "q",
+        downstream.resource_unit_id,
+        downstream_task.lease.lease_id,
+        downstream_task.lease.attempt_id,
+        "model-output",
+        2,
+    )
+    assert manager.note_output_waiting(model_output) is None
+
+    selected, grant = manager.try_acquire_next_queued_output_block({model_output.block_id})
+
+    assert selected == model_output
+    assert grant.granted and grant.liveness
+    assert manager.snapshot()["liveness"]["active_output_lease_ids_by_unit"] == {
+        upstream.resource_unit_id: upstream_output.lease.lease_id,
+        downstream.resource_unit_id: grant.lease.lease_id,
+    }
+
+    next_model_output = OutputBlockRequest(
+        "q",
+        downstream.resource_unit_id,
+        downstream_task.lease.lease_id,
+        downstream_task.lease.attempt_id,
+        "next-model-output",
+        1,
+    )
+    assert manager.note_output_waiting(next_model_output) is None
+    blocked_request, blocked = manager.try_acquire_next_queued_output_block({next_model_output.block_id})
+    assert blocked_request == next_model_output
+    assert not blocked.granted and blocked.blocked_reason == "liveness_output_active"
+
+    assert manager.transition_output_block(grant.lease.lease_id, "downstream_input")
+    selected, next_grant = manager.try_acquire_next_queued_output_block({next_model_output.block_id})
+    assert selected == next_model_output
+    assert next_grant.granted and next_grant.liveness
+
+
+def test_output_liveness_cannot_move_back_upstream():
+    upstream = _unit("resource:f:output-liveness-upstream", target=10, blocks=1)
+    downstream = _unit(
+        "resource:f:output-liveness-downstream",
+        inputs=(upstream.resource_unit_id,),
+        target=10,
+        blocks=1,
+    )
+    manager = _manager(
+        upstream,
+        downstream,
+        resources=_r(cpu=10, heap=1_000, store=100),
+    )
+    _ready(
+        manager,
+        upstream.resource_unit_id,
+        downstream.resource_unit_id,
+        consumer_waiting=True,
+    )
+    upstream_task = manager.try_acquire_task(_task(upstream.resource_unit_id, 0, retained=0))
+    downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0, retained=0))
+    manager.update_allocation(
+        _allocation(_r(cpu=10, heap=1_000, store=10), generation=2),
+        admission_open=True,
+    )
+
+    downstream_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            downstream.resource_unit_id,
+            downstream_task.lease.lease_id,
+            downstream_task.lease.attempt_id,
+            "downstream-liveness-first",
+            11,
+        )
+    )
+    upstream_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            upstream.resource_unit_id,
+            upstream_task.lease.lease_id,
+            upstream_task.lease.attempt_id,
+            "upstream-cannot-follow",
+            11,
+        )
+    )
+
+    assert downstream_output.granted and downstream_output.liveness
+    assert not upstream_output.granted
+    assert upstream_output.blocked_reason == "liveness_output_active"
+    assert manager.snapshot()["liveness"]["active_output_lease_ids_by_unit"] == {
+        downstream.resource_unit_id: downstream_output.lease.lease_id
+    }
+
+
+def test_output_liveness_does_not_open_a_parallel_branch():
+    left = _unit("resource:f:left", target=10, blocks=1)
+    left_sink = _unit(
+        "resource:f:left-sink",
+        inputs=(left.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    right = _unit("resource:f:right", target=10, blocks=1)
+    right_sink = _unit(
+        "resource:f:right-sink",
+        inputs=(right.resource_unit_id,),
+        target=0,
+        blocks=0,
+    )
+    manager = _manager(
+        left,
+        left_sink,
+        right,
+        right_sink,
+        terminals=(left_sink.resource_unit_id, right_sink.resource_unit_id),
+        resources=_r(cpu=10, heap=1_000, store=40),
+    )
+    _ready(
+        manager,
+        left.resource_unit_id,
+        left_sink.resource_unit_id,
+        right.resource_unit_id,
+        right_sink.resource_unit_id,
+    )
+    left_task = manager.try_acquire_task(_task(left.resource_unit_id, 0))
+    right_task = manager.try_acquire_task(_task(right.resource_unit_id, 0))
+    left_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            left.resource_unit_id,
+            left_task.lease.lease_id,
+            left_task.lease.attempt_id,
+            "left-output",
+            41,
+        )
+    )
+    assert left_output.granted and left_output.liveness
+    assert manager.transition_output_block(left_output.lease.lease_id, "unit_queue")
+
+    right_output = manager.try_acquire_output_block(
+        OutputBlockRequest(
+            "q",
+            right.resource_unit_id,
+            right_task.lease.lease_id,
+            right_task.lease.attempt_id,
+            "right-output",
+            41,
+        )
+    )
+
+    assert not right_output.granted
+    assert right_output.blocked_reason == "liveness_output_active"
+
+
 def test_queued_output_liveness_skips_higher_ranked_nonstarving_branch():
     starving_producer = _unit("resource:f:a-producer", target=10, blocks=1)
     starving_consumer = _unit(
@@ -1567,7 +2937,7 @@ def test_queued_output_liveness_skips_higher_ranked_nonstarving_branch():
         busy_producer,
         busy_consumer,
         terminals=(starving_consumer.resource_unit_id, busy_consumer.resource_unit_id),
-        resources=_r(cpu=100, heap=1_000, store=10),
+        resources=_r(cpu=100, heap=1_000, store=40),
     )
     _ready(
         manager,
@@ -1587,7 +2957,7 @@ def test_queued_output_liveness_skips_higher_ranked_nonstarving_branch():
         starving_task.lease.lease_id,
         starving_task.lease.attempt_id,
         "starving-output",
-        11,
+        41,
     )
     busy_request = OutputBlockRequest(
         "q",
@@ -1595,7 +2965,7 @@ def test_queued_output_liveness_skips_higher_ranked_nonstarving_branch():
         busy_task.lease.lease_id,
         busy_task.lease.attempt_id,
         "busy-output",
-        11,
+        41,
     )
     assert manager.note_output_waiting(starving_request) is None
     assert manager.note_output_waiting(busy_request) is None
@@ -1745,7 +3115,7 @@ def test_native_task_and_materialized_output_preserve_the_actual_runtime_node():
     )
     manager = _manager(
         unit,
-        resources=_r(cpu=2, heap=20, store=40),
+        resources=_r(cpu=2, heap=20, store=60),
     )
     _ready(manager, unit.resource_unit_id)
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -259,7 +259,11 @@ def _register_fte_query(query_id: str, node_id: str, *, partitions: int, task_sl
     allocation_resources = ResourceVector(
         cpu=task_slots,
         heap_bytes=task_slots * 2 * _GIB,
-        object_store_bytes=task_slots * 256 * _MIB,
+        # A streaming unit reserves 25% of its object-store allocation for
+        # output handoff. Size the fixture so the remaining 75% admits exactly
+        # ``task_slots`` native 256 MiB generator windows; these tests exercise
+        # FTE lease ownership rather than output backpressure.
+        object_store_bytes=(task_slots * 256 * _MIB * 4 + 2) // 3,
     )
     manager = register_query_resource_graph(
         graph,

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -307,7 +307,11 @@ def _register_fault_query(tasks) -> None:
     allocation_resources = ResourceVector(
         cpu=max(1, len(tasks)),
         heap_bytes=max(1, len(tasks)) * 64 * 1024 * 1024,
-        object_store_bytes=max(1, len(tasks)) * target_output_block_bytes,
+        # These tests exercise FTE recovery rather than object-store
+        # backpressure.  A streaming unit keeps 25% of the default allocation
+        # protected for output handoff, so size the fixture such that the
+        # remaining 75% admits every native generator window concurrently.
+        object_store_bytes=(max(1, len(tasks)) * target_output_block_bytes * 4 + 2) // 3,
     )
     manager = register_query_resource_graph(
         QueryResourceGraph(


### PR DESCRIPTION
## Summary

- Replace overlapping object-store accounting with a disjoint ledger for retained usage, protected task/output reservations, and shared capacity.
- Keep upstream overage from consuming the reservation needed by an eligible downstream work unit.
- Transfer completed producer-output accounting to its downstream consumer and track retained usage that is not currently eligible.
- Scope liveness admission to the blocked downstream work unit, including cold actor and prefetch estimates.
- Expand resource-manager, lease, FTE, and fault-injection coverage for soft-limit, expansion, completion-handoff, actor, and liveness corner cases.
- This is an internal scheduling change with no public API or schema change. The previous reservation snapshot/accounting path is replaced without a compatibility fallback.

## Related issue

close: #491

## Related pull request

Follow-up to #245.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

Tests and static checks:

- `python -m pytest tests/fast/test_query_resource_manager.py` — 91 passed.
- Affected cross-module tests — 508 passed.
- `scripts/run_fast_tests.sh`:
  - non-Ray shard — 6527 passed;
  - shared-Ray shard — 101 passed, 6 skipped;
  - Ray-owned shard — 7 passed, 1 skipped.
- `scripts/run_release_tests.sh`:
  - base release suite — 508 passed, 1 skipped;
  - real-Ray shard — 11 passed.
- `scripts/format root --changed`, Ruff, mypy, and `git diff --check` passed.

Full local Vane multimodal benchmarks used `VANE_RUNNER=ray`, the default 50% object-store fraction, one NVIDIA GeForce RTX 2080 Ti, local inputs/outputs, and Ray workers loading this worktree:

- document embedding — 70,780 rows, 198.73 s, complete output coverage;
- image classification — 803,580 rows, 678.14 s, complete output coverage;
- audio transcription — 113,800 rows, 2175.50 s, complete output coverage;

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependency, copied code,
      model asset, or dataset is added by this PR.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. This change does not expand those
      boundaries.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. This PR is Python-only.
