### PR TITLE
[fix](benchmark) Bound video Parquet row-group memory

### DIFF
--- a/multimodal_inference_benchmarks/README.md
+++ b/multimodal_inference_benchmarks/README.md
@@ -204,12 +204,21 @@ export NUM_GPU_NODES=1
   RUN_ID=$(date +%Y%m%d_%H%M%S)
   export INPUT_PATH=/data/multimodal_inference_benchmarks/hollywood2/AVIClips
   export BATCH_SIZE=32
+  export PARQUET_ROW_GROUP_SIZE=122880
+  export PARQUET_ROW_GROUP_SIZE_BYTES=256MB
 
   VANE_RUNNER=ray OUTPUT_PATH="/tmp/vane_video_$RUN_ID" python vane_main.py
   OUTPUT_PATH="/tmp/ray_data_video_$RUN_ID" python ray_data_main.py
   OUTPUT_PATH="/tmp/daft_video_$RUN_ID" python daft_main.py
 )
 ```
+
+The Parquet row-group settings apply to the Vane entrypoint. The byte limit
+makes DuckDB flush each writer's buffered row group once its estimated size
+reaches the threshold, independently of its row count. Vane disables
+insertion-order preservation for this write because DuckDB requires it when
+`ROW_GROUP_SIZE_BYTES` is set; output row order is not part of this
+benchmark's result contract.
 
 ## Batch-size sweep
 

--- a/multimodal_inference_benchmarks/video_object_detection/vane_main.py
+++ b/multimodal_inference_benchmarks/video_object_detection/vane_main.py
@@ -21,13 +21,13 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from vane.datasource import read_datasource
 from vane.datasource.video_reader import VideoFrameSource
-
-import vane
 from video_kernels import (
     crop_bbox_to_png,
     frames_to_torch_tensor,
     yolo_result_to_features,
 )
+
+import vane
 
 INPUT_PATH = Path(
     os.environ.get(
@@ -38,6 +38,8 @@ INPUT_PATH = Path(
 OUTPUT_DIR = Path(os.environ.get("OUTPUT_PATH", f"/tmp/vane_video_{uuid.uuid4().hex}")).expanduser()
 BATCH_SIZE = int(os.environ.get("BATCH_SIZE", "32"))
 NUM_GPU_NODES = int(os.environ.get("NUM_GPU_NODES", "1"))
+PARQUET_ROW_GROUP_SIZE = int(os.environ.get("PARQUET_ROW_GROUP_SIZE", "122880"))
+PARQUET_ROW_GROUP_SIZE_BYTES = os.environ.get("PARQUET_ROW_GROUP_SIZE_BYTES", "256MB").strip()
 
 FRAME_HEIGHT = 640
 FRAME_WIDTH = 640
@@ -56,8 +58,10 @@ FRAME_TYPE = vane.tensor_type(vane.sqltypes.UTINYINT, (FRAME_HEIGHT, FRAME_WIDTH
 FEATURE_TYPE = vane.type("STRUCT(label BIGINT, confidence DOUBLE, bbox DOUBLE[])")
 FEATURE_LIST_TYPE = vane.type("STRUCT(label BIGINT, confidence DOUBLE, bbox DOUBLE[])[]")
 
-if BATCH_SIZE <= 0 or NUM_GPU_NODES <= 0:
-    raise ValueError("BATCH_SIZE and NUM_GPU_NODES must be positive")
+if min(BATCH_SIZE, NUM_GPU_NODES, PARQUET_ROW_GROUP_SIZE) <= 0:
+    raise ValueError("BATCH_SIZE, NUM_GPU_NODES, and PARQUET_ROW_GROUP_SIZE must be positive")
+if not PARQUET_ROW_GROUP_SIZE_BYTES:
+    raise ValueError("PARQUET_ROW_GROUP_SIZE_BYTES must be non-empty")
 
 
 def _video_files(path: Path) -> list[str]:
@@ -146,6 +150,8 @@ def main() -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     con = vane.connect()
     try:
+        con.execute("SET preserve_insertion_order=false")
+        print(f"Parquet row groups: rows={PARQUET_ROW_GROUP_SIZE}, bytes={PARQUET_ROW_GROUP_SIZE_BYTES}")
         rel = read_datasource(
             VideoFrameSource(
                 _video_files(INPUT_PATH),
@@ -173,7 +179,12 @@ def main() -> None:
                 "object": vane.sqltypes.BLOB,
             },
         )
-        rel.write_parquet(str(OUTPUT_DIR), per_thread_output=True)
+        rel.write_parquet(
+            str(OUTPUT_DIR),
+            per_thread_output=True,
+            row_group_size=PARQUET_ROW_GROUP_SIZE,
+            row_group_size_bytes=PARQUET_ROW_GROUP_SIZE_BYTES,
+        )
     finally:
         con.close()
 


### PR DESCRIPTION
## Summary

- Add configurable `PARQUET_ROW_GROUP_SIZE` and
  `PARQUET_ROW_GROUP_SIZE_BYTES` settings to the Vane video benchmark, with
  defaults of 122,880 rows and 256 MB.
- Disable insertion-order preservation on the benchmark connection, as required
  by DuckDB when a Parquet byte threshold is configured.
- Document the settings, their Vane-only scope, and the output-order impact.

The crop stage emits variable-size PNG `BLOB` values. A row-count-only Parquet
threshold can therefore retain several GiB in a writer row group before it
reaches 122,880 rows, eventually hitting the DuckDB worker's memory limit. The
byte threshold makes each writer flush based on estimated buffered bytes as well
as row count.

## Related issue

N/A — this is a focused benchmark configuration fix.

## Related pull request

Follow-up benchmark hardening identified while validating #490.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The multimodal benchmark README documents both environment variables and the
required insertion-order setting.

## Validation

- `scripts/format root --changed` — passed.
- `pre-commit run --files multimodal_inference_benchmarks/README.md multimodal_inference_benchmarks/video_object_detection/vane_main.py`
  — passed.
- `python -m pytest -q tests/fast/api/test_to_parquet.py -k row_group_size`
  — 3 passed, 19 deselected.
- Temporary benchmark-configuration tests — 8 passed; the temporary test file
  was removed before commit.
- Local-fast synthetic large-`BLOB` write with a 128 MB DuckDB memory limit and
  an 8 MB row-group byte threshold — 8,192 rows preserved in 4 row groups.
- Ray distributed synthetic large-`BLOB` write with the same byte threshold —
  8,192 rows preserved in 4 row groups.
- `scripts/run_release_tests.sh` after rebuilding the non-editable native
  installation for this source tree — 510 passed, 1 skipped, 15 deselected;
  real-Ray shard 11 passed, 515 deselected.
- Full Hollywood2 Vane video benchmark at commit `a84beca970` — passed:
  - local input and output; all 1,000 `AVIClips` inputs entered the scan;
  - `VANE_RUNNER=ray`, one NVIDIA GeForce RTX 2080 Ti,
    `NUM_GPU_NODES=1`, `BATCH_SIZE=32`, and the default 50% query
    object-store soft limit;
  - `PARQUET_ROW_GROUP_SIZE=122880`,
    `PARQUET_ROW_GROUP_SIZE_BYTES=256MB`, and
    `preserve_insertion_order=false`;
  - runtime 7,728.99 seconds (2:08:48.99), total wall clock 2:08:56, exit
    status 0;
  - approximately 293,000 frames processed and 671,886 crop rows written;
  - one 64,997,376,644-byte (60.53 GiB) Parquet file with the expected
    `frame_index`, `features`, and `object` schema;
  - 250 row groups containing all 671,886 rows; 388–9,539 rows per group and
    no group reached the 122,880-row limit;
  - row groups averaged 260,017,299 bytes and reached at most 276,378,254
    bytes (263.58 MiB), a 7.58 MiB chunk-boundary overshoot above the 256 MiB
    threshold;
  - no OOM, spill, traceback, or execution error. The largest periodically
    sampled worker RSS peak was about 5.95 GiB and fell to about 3.06 GiB on
    the next sample instead of accumulating toward DuckDB's memory limit.
- `git diff --check` — passed.

The current PR CI has two unrelated Ray timing failures. The exact shared-Ray
weak-reference failure is tracked by #495; the isolated actor-kill failure is in
the same FTE timing family as #496. This PR changes only the benchmark README and
entry point, and both exact tests passed in the successful CI run for its
unchanged base commit `8acff2c1e0` immediately before this PR run.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No dependency, copied code,
      model asset, or dataset is added.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. This change does not expand
      those boundaries.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. This PR has no native changes.