### PR TITLE
[fix](udf) Enforce vane.func function contract

### DIFF
--- a/tests/fast/test_expression_udf_map.py
+++ b/tests/fast/test_expression_udf_map.py
@@ -124,15 +124,34 @@ def test_vane_function_immediate_call_without_expression():
     assert add_one(41) == 42
 
 
-def test_vane_function_rejects_missing_qualified_name_without_fallback():
+@pytest.mark.parametrize("name", [None, "callable_object"])
+def test_vane_function_rejects_callable_classes_and_instances_at_decoration(name):
     import vane
 
     class CallableObject:
         def __call__(self, value):
             return value
 
+    for target in (CallableObject, CallableObject()):
+        with pytest.raises(TypeError, match=r"vane\.func requires a Python function or bound method"):
+            vane.func(target, return_dtype="INTEGER", name=name)
+
+
+def test_vane_function_explicit_name_does_not_evaluate_default_qualified_name():
+    import vane
+
+    def identity(value):
+        return value
+
+    identity.__qualname__ = ""
+
     with pytest.raises(vane.InvalidInputException, match="must expose a non-empty __qualname__"):
-        vane.func(return_dtype="INTEGER")(CallableObject())
+        vane.func(identity, return_dtype="INTEGER")
+
+    decorated = vane.func(identity, return_dtype="INTEGER", name="identity")
+
+    assert decorated.sql_name == "identity"
+    assert decorated(1) == 1
 
 
 def test_vane_function_rejects_empty_explicit_name_without_defaulting():

--- a/tests/fast/test_udf_sync_contract.py
+++ b/tests/fast/test_udf_sync_contract.py
@@ -17,10 +17,11 @@ import pytest
 import duckdb
 import vane
 from duckdb.execution._udf_runtime import UDFExecutor
-from duckdb.execution._udf_validation import ensure_synchronous_udf_result
+from duckdb.execution._udf_validation import ensure_synchronous_udf_result, validate_synchronous_udf_callable
 
 _ASYNC_CALLABLE_ERROR = "generic UDF callables must be synchronous"
 _AWAITABLE_RESULT_ERROR = "generic UDF callables must return values synchronously"
+_FUNCTION_SHAPE_ERROR = r"vane\.func requires a Python function or bound method"
 
 
 async def _async_value(value):
@@ -103,7 +104,6 @@ class _SyncReturnsAwaitable:
 
 class _SyncCallableWithShadowedAsyncCall:
     def __init__(self):
-        self.__qualname__ = type(self).__qualname__
         self.__call__ = _async_value
 
     def __call__(self, value):
@@ -148,23 +148,31 @@ def test_vane_decorators_reject_async_callables():
     with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
         vane.cls.batch(actor_number=1, return_dtype=pa.int32())(_AsyncCallable)
 
-    with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
-        vane.func(_AsyncCallable(), return_dtype="INTEGER")
-
 
 @pytest.mark.parametrize(
     "target",
     [
         pytest.param(_async_values, id="async-generator"),
         pytest.param(_wrapped_async_value, id="wrapped-async"),
-        pytest.param(functools.partial(_async_value, 1), id="partial-async"),
-        pytest.param(functools.partial(_AsyncCallable()), id="partial-async-callable-instance"),
         pytest.param(_generator_coroutine, id="generator-coroutine"),
     ],
 )
-def test_vane_func_rejects_indirect_async_callables(target):
+def test_vane_func_rejects_indirect_async_functions(target):
     with pytest.raises(TypeError, match=_ASYNC_CALLABLE_ERROR):
         vane.func(target, return_dtype="INTEGER")
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        pytest.param(_AsyncCallable(), id="async-callable-instance"),
+        pytest.param(functools.partial(_async_value, 1), id="partial-async"),
+        pytest.param(functools.partial(_AsyncCallable()), id="partial-async-callable-instance"),
+    ],
+)
+def test_vane_func_rejects_non_function_async_callables_by_shape(target):
+    with pytest.raises(TypeError, match=_FUNCTION_SHAPE_ERROR):
+        vane.func(target, return_dtype="INTEGER", name="invalid_callable")
 
 
 @pytest.mark.parametrize(
@@ -182,10 +190,12 @@ def test_vane_class_rejects_async_construction_and_call_descriptors(target):
         vane.cls(target, actor_number=1, return_dtype="INTEGER")
 
 
-def test_vane_func_validates_the_effective_callable_object_call_method():
-    fn = vane.func(_SyncCallableWithShadowedAsyncCall(), return_dtype="INTEGER", name="sync_callable")
+def test_sync_validator_uses_the_effective_type_call_method():
+    target = _SyncCallableWithShadowedAsyncCall()
 
-    assert fn(1) == 1
+    validate_synchronous_udf_callable(target)
+
+    assert target(1) == 1
 
 
 @pytest.mark.parametrize("method", ["map", "map_batches", "flat_map"])

--- a/vane/_expression_udf.py
+++ b/vane/_expression_udf.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from math import isfinite
 from numbers import Real
-from typing import Any
+from types import CodeType
+from typing import Any, Protocol
 
 import _duckdb
 
@@ -21,6 +22,16 @@ import duckdb
 from duckdb.execution._udf_validation import ensure_synchronous_udf_result, validate_synchronous_udf_callable
 from vane._expressions import as_expression, is_expression
 from vane.config import current_config
+
+
+class _PythonFunction(Protocol):
+    __name__: str
+    __qualname__: str
+    __code__: CodeType
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def __get__(self, instance: Any, owner: Any | None = None) -> _PythonFunction: ...
 
 
 def _invalid_input(message: str) -> duckdb.InvalidInputException:
@@ -187,13 +198,19 @@ def _callable_name(fn: Callable[..., Any]) -> str:
     return _qualified_name(fn, kind="UDF callable")
 
 
+def _validate_function_udf_callable(fn: Any, *, api: str) -> None:
+    if not (inspect.isfunction(fn) or inspect.ismethod(fn)):
+        raise TypeError(f"{api} requires a Python function or bound method")
+    validate_synchronous_udf_callable(fn)
+
+
 def _class_name(cls: type) -> str:
     return _qualified_name(cls, kind="UDF class")
 
 
-def _resolve_udf_name(name: Any, default_name: str) -> str:
+def _resolve_udf_name(name: Any, default_name: Callable[[], str]) -> str:
     if name is None:
-        return default_name
+        return default_name()
     if not isinstance(name, str) or not name:
         raise _invalid_input("name must be a non-empty string")
     return name
@@ -741,20 +758,24 @@ def _validate_sql_actor_callable(fn: Any) -> None:
 
 
 class VaneFunction:
-    """Expression UDF decorator wrapper.
+    """Synchronous Python function or bound-method scalar UDF wrapper.
 
     When used as an instance-method descriptor, the serialized callable
     captures that instance's current snapshot. Persistent cross-batch state is
     intentionally provided only by :func:`vane.cls`.
     """
 
-    def __init__(self, fn: Callable[..., Any], *, return_dtype: Any | None = None, name: str | None = None):
-        if not callable(fn):
-            raise TypeError("vane.func requires a callable")
-        validate_synchronous_udf_callable(fn)
+    def __init__(
+        self,
+        fn: _PythonFunction,
+        *,
+        return_dtype: Any | None = None,
+        name: str | None = None,
+    ):
+        _validate_function_udf_callable(fn, api="vane.func")
         self._fn = fn
         self._return_dtype = return_dtype
-        self._name = _resolve_udf_name(name, _callable_name(fn))
+        self._name = _resolve_udf_name(name, lambda: _callable_name(fn))
         functools.update_wrapper(self, fn)
 
     @property
@@ -762,7 +783,7 @@ class VaneFunction:
         return self._return_dtype
 
     @property
-    def python_function(self) -> Callable[..., Any]:
+    def python_function(self) -> _PythonFunction:
         return self._fn
 
     @property
@@ -784,11 +805,11 @@ class VaneFunction:
 
 
 class VaneBatchFunction:
-    """Decorator wrapper for row-preserving Arrow column batch UDFs."""
+    """Synchronous Python function or bound-method Arrow column batch UDF wrapper."""
 
     def __init__(
         self,
-        fn: Callable[..., Any],
+        fn: _PythonFunction,
         *,
         return_dtype: Any,
         name: str | None = None,
@@ -796,9 +817,7 @@ class VaneBatchFunction:
         unnest: bool = False,
         gpus: float | None = None,
     ) -> None:
-        if not (inspect.isfunction(fn) or inspect.ismethod(fn)):
-            raise TypeError("vane.func.batch requires a Python function")
-        validate_synchronous_udf_callable(fn)
+        _validate_function_udf_callable(fn, api="vane.func.batch")
         if return_dtype is None:
             raise _invalid_input("return_dtype is required for vane.func.batch")
         normalized_return_dtype, return_arrow_dtype = _canonicalize_dtype(return_dtype)
@@ -811,14 +830,14 @@ class VaneBatchFunction:
         self._signature = _batch_function_signature(fn)
         self._return_dtype = normalized_return_dtype
         self._return_arrow_dtype = return_arrow_dtype
-        self._name = _resolve_udf_name(name, _callable_name(fn))
+        self._name = _resolve_udf_name(name, lambda: _callable_name(fn))
         self._batch_size = _normalize_batch_size(batch_size)
         self._unnest = bool(unnest)
         self._gpus = _normalize_gpus(gpus)
         functools.update_wrapper(self, fn)
 
     @property
-    def python_function(self) -> Callable[..., Any]:
+    def python_function(self) -> _PythonFunction:
         return self._fn
 
     @property
@@ -925,7 +944,7 @@ class VaneClass:
         self._actor_number = _validate_actor_number(actor_number)
         self._return_dtype = normalized_return_dtype
         self._return_arrow_dtype = return_arrow_dtype
-        self._name = _resolve_udf_name(name, _class_name(class_))
+        self._name = _resolve_udf_name(name, lambda: _class_name(class_))
         self._gpus = 0 if gpus is None else gpus
         functools.update_wrapper(self, class_, updated=())
 
@@ -1071,7 +1090,7 @@ class VaneClassBatch:
         self._actor_number = _validate_actor_number(actor_number)
         self._return_dtype = normalized_return_dtype
         self._return_arrow_dtype = return_arrow_dtype
-        self._name = _resolve_udf_name(name, _class_name(class_))
+        self._name = _resolve_udf_name(name, lambda: _class_name(class_))
         self._batch_size = _normalize_batch_size(batch_size)
         self._unnest = bool(unnest)
         self._gpus = 0.0 if gpus is None else _normalize_gpus(gpus)
@@ -1337,7 +1356,7 @@ def _build_map_batches_expression(
     resolved_backend = _runner_to_task_backend() if execution_backend is None else execution_backend
     return _duckdb._VaneUDFMapBatchesExpression(
         fn,
-        _resolve_udf_name(name, _callable_name(fn)),
+        _resolve_udf_name(name, lambda: _callable_name(fn)),
         normalized_schema,
         resolved_backend,
         input_names,
@@ -1381,11 +1400,12 @@ def _build_actor_map_batches_expression(
 
 
 def func(
-    fn: Callable[..., Any] | None = None,
+    fn: _PythonFunction | None = None,
     *,
     return_dtype: Any | None = None,
     name: str | None = None,
-) -> VaneFunction | Callable[[Callable[..., Any]], VaneFunction]:
+) -> VaneFunction | Callable[[_PythonFunction], VaneFunction]:
+    """Decorate a synchronous Python function or bound method as a scalar expression UDF."""
     if fn is None:
         return lambda actual_fn: VaneFunction(actual_fn, return_dtype=return_dtype, name=name)
     return VaneFunction(fn, return_dtype=return_dtype, name=name)
@@ -1398,8 +1418,8 @@ def _func_batch(
     batch_size: int | None = None,
     unnest: bool = False,
     gpus: float | None = None,
-) -> Callable[[Callable[..., Any]], VaneBatchFunction]:
-    """Decorate a row-preserving Arrow column batch function.
+) -> Callable[[_PythonFunction], VaneBatchFunction]:
+    """Decorate a synchronous Python function or bound method as an Arrow column batch UDF.
 
     Each decorated input is delivered as ``pyarrow.Array`` or
     ``pyarrow.ChunkedArray``. The function must return one of those column


### PR DESCRIPTION
## Summary

- Require `vane.func` and `vane.func.batch` inputs to be synchronous Python functions or bound methods at the public decorator boundary, matching the task backend contract.
- Narrow the published typing contract so ordinary functions and bound methods type-check while callable classes, callable instances, and `functools.partial` do not.
- Resolve default UDF names lazily so an explicit `name=` never evaluates `__qualname__`.
- Keep function/method async validation and bound-method descriptor behavior unchanged. This is a deliberate breaking contract: callable instances receive an immediate `TypeError`; there is no compatibility fallback. Callable classes belong under `vane.cls` or `vane.cls.batch`.

## Related issue

close: #492

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public decorator and wrapper docstrings now state the synchronous Python function or bound-method contract.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Affected UDF suite after the final rebase: 234 passed
- `scripts/run_release_tests.sh` after the final rebase:
  - non-Ray: 510 passed, 1 skipped, 15 deselected
  - real-Ray: 11 passed, 515 deselected
- Complete fast suite before rebasing the unrelated upstream #490:
  - non-Ray: 6564 passed, 30 skipped, 118 deselected, 8 xfailed, 1 xpassed
  - shared-Ray: 101 passed, 10 skipped, 6610 deselected on full-phase rerun
  - owner-Ray: 7 passed, 1 skipped on full-phase rerun
- Two unrelated Ray timing flakes observed on their first runs passed both exact-node and complete-phase reruns and were recorded without proposed fixes: #495 and #496.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.