### PR TITLE
[fix](ray) Synchronize worker failure reconciliation

### DIFF
--- a/duckdb/runners/ray/fragment_worker_failures.py
+++ b/duckdb/runners/ray/fragment_worker_failures.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import Future
 from typing import Any
 
 from duckdb.runners.ray.fragment_registry import (
@@ -18,6 +20,9 @@ from duckdb.runners.ray.fte_fragment_scheduler import (
     _worker_actor_death_confirms_quiescence,
     _worker_failure_payload,
 )
+
+_WORKER_FAILURE_RECONCILIATION_LOCK = threading.Lock()
+_WORKER_FAILURE_RECONCILIATIONS: dict[tuple[str, str, str], Future[None]] = {}
 
 
 def quarantine_fte_worker(
@@ -68,19 +73,18 @@ def retire_fte_worker_for_failure(
     )
 
 
-def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[Any], list[Any]]]:
-    manager_instance_id = str(event.manager_instance_id)
-    worker_incarnation_id = str(event.worker_incarnation_id)
+def _reconcile_fte_worker_failure(
+    event: Any,
+    *,
+    manager_instance_id: str,
+    worker_incarnation_id: str,
+    event_query_id: str,
+) -> list[tuple[str, str, list[Any], list[Any]]]:
     failure = _worker_failure_payload(
         event.worker_id,
         event.error,
         worker_incarnation_id=worker_incarnation_id,
     )
-    event_query_id = str(event.query_id)
-    with _FTE_REGISTRY_LOCK:
-        event_scheduler = _FTE_SCHEDULERS.get(event_query_id)
-    if event_scheduler is not None and not event_scheduler.is_owned_by_manager_instance(manager_instance_id):
-        return []
     quarantine_fte_worker(
         event.worker_id,
         manager_instance_id=manager_instance_id,
@@ -124,3 +128,45 @@ def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[An
         if delay_s > 0:
             scheduler.arm_retry_delay(delay_s)
     return scheduled_by_fragment
+
+
+def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[Any], list[Any]]]:
+    manager_instance_id = str(event.manager_instance_id)
+    worker_incarnation_id = str(event.worker_incarnation_id)
+    event_query_id = str(event.query_id)
+    with _FTE_REGISTRY_LOCK:
+        event_scheduler = _FTE_SCHEDULERS.get(event_query_id)
+    if event_scheduler is not None and not event_scheduler.is_owned_by_manager_instance(manager_instance_id):
+        return []
+
+    # Independent status watchers can observe the same actor death. Only the
+    # owner mutates fragment state; later observers join its completion.
+    failure_key = (manager_instance_id, str(event.worker_id), worker_incarnation_id)
+    with _WORKER_FAILURE_RECONCILIATION_LOCK:
+        reconciliation = _WORKER_FAILURE_RECONCILIATIONS.get(failure_key)
+        owns_reconciliation = reconciliation is None
+        if owns_reconciliation:
+            reconciliation = Future()
+            _WORKER_FAILURE_RECONCILIATIONS[failure_key] = reconciliation
+    assert reconciliation is not None
+    if not owns_reconciliation:
+        reconciliation.result()
+        return []
+
+    try:
+        scheduled_by_fragment = _reconcile_fte_worker_failure(
+            event,
+            manager_instance_id=manager_instance_id,
+            worker_incarnation_id=worker_incarnation_id,
+            event_query_id=event_query_id,
+        )
+    except BaseException as exc:
+        reconciliation.set_exception(exc)
+        raise
+    else:
+        reconciliation.set_result(None)
+        return scheduled_by_fragment
+    finally:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if _WORKER_FAILURE_RECONCILIATIONS.get(failure_key) is reconciliation:
+                _WORKER_FAILURE_RECONCILIATIONS.pop(failure_key, None)

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -6289,6 +6289,128 @@ def test_fte_worker_failure_event_rejects_cross_manager_scheduler(failed_manager
     assert failed._fte_healthy is True
 
 
+def test_duplicate_fte_worker_failure_waits_for_active_reconciliation(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:duplicate-failure",
+        manager_instance_id="manager-a",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-duplicate-worker-failure")
+    failed._bind_fte_scheduler_handlers(scheduler)
+    event = WorkerFailed(
+        query_id=scheduler.query_id,
+        worker_id=failed.worker_id,
+        worker_incarnation_id=failed.worker_incarnation_id,
+        manager_instance_id=failed.manager_instance_id,
+        error=RuntimeError("planned duplicate failure"),
+    )
+    reconciliation_started = threading.Event()
+    release_reconciliation = threading.Event()
+    state_published = threading.Event()
+    duplicate_joined = threading.Event()
+    reconciliation_calls = []
+
+    class _ObservedReconciliation(Future):
+        def result(self, timeout=None):
+            duplicate_joined.set()
+            return super().result(timeout)
+
+    def reconcile_worker_failure(reported_event, **_kwargs):
+        reconciliation_calls.append(reported_event)
+        reconciliation_started.set()
+        assert release_reconciliation.wait(timeout=2.0)
+        state_published.set()
+        return []
+
+    monkeypatch.setattr(worker_failures_mod, "Future", _ObservedReconciliation)
+    monkeypatch.setattr(
+        worker_failures_mod,
+        "_reconcile_fte_worker_failure",
+        reconcile_worker_failure,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner = executor.submit(worker_failures_mod.mark_fte_worker_failed_for_event, event)
+        assert reconciliation_started.wait(timeout=1.0)
+        duplicate_entered = threading.Event()
+
+        def report_duplicate_failure():
+            duplicate_entered.set()
+            result = worker_failures_mod.mark_fte_worker_failed_for_event(event)
+            assert state_published.is_set()
+            return result
+
+        duplicate = executor.submit(report_duplicate_failure)
+        assert duplicate_entered.wait(timeout=1.0)
+        try:
+            assert duplicate_joined.wait(timeout=1.0)
+            assert not duplicate.done()
+        finally:
+            release_reconciliation.set()
+
+        assert owner.result(timeout=1.0) == []
+        assert duplicate.result(timeout=1.0) == []
+
+    assert reconciliation_calls == [event]
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+
+
+def test_duplicate_fte_worker_failure_replays_reconciliation_error(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:duplicate-failure-error",
+        manager_instance_id="manager-a",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-duplicate-worker-failure-error")
+    failed._bind_fte_scheduler_handlers(scheduler)
+    event = WorkerFailed(
+        query_id=scheduler.query_id,
+        worker_id=failed.worker_id,
+        worker_incarnation_id=failed.worker_incarnation_id,
+        manager_instance_id=failed.manager_instance_id,
+        error=RuntimeError("planned duplicate failure"),
+    )
+    reconciliation_started = threading.Event()
+    release_reconciliation = threading.Event()
+    duplicate_joined = threading.Event()
+
+    class _ObservedReconciliation(Future):
+        def result(self, timeout=None):
+            duplicate_joined.set()
+            return super().result(timeout)
+
+    def fail_reconciliation(*_args, **_kwargs):
+        reconciliation_started.set()
+        assert release_reconciliation.wait(timeout=2.0)
+        raise RuntimeError("planned reconciliation failure")
+
+    monkeypatch.setattr(worker_failures_mod, "Future", _ObservedReconciliation)
+    monkeypatch.setattr(
+        worker_failures_mod,
+        "_reconcile_fte_worker_failure",
+        fail_reconciliation,
+    )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner = executor.submit(worker_failures_mod.mark_fte_worker_failed_for_event, event)
+        assert reconciliation_started.wait(timeout=1.0)
+        duplicate = executor.submit(worker_failures_mod.mark_fte_worker_failed_for_event, event)
+        try:
+            assert duplicate_joined.wait(timeout=1.0)
+            assert not duplicate.done()
+        finally:
+            release_reconciliation.set()
+
+        with pytest.raises(RuntimeError, match="planned reconciliation failure"):
+            owner.result(timeout=1.0)
+        with pytest.raises(RuntimeError, match="planned reconciliation failure"):
+            duplicate.result(timeout=1.0)
+
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+
+
 def test_stale_worker_shutdown_does_not_fail_current_registry_owner(monkeypatch):
     stale = RayWorkerActorHandle(
         _FakeActor(),


### PR DESCRIPTION
## Summary

- serialize duplicate worker-failure reconciliation by manager, worker, and worker incarnation
- make duplicate status watchers wait until fragment failure state is fully published
- propagate reconciliation errors to every joined reporter and cover both success and failure paths deterministically

## Related issue

close: #496

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal Ray/FTE failure coordination only.

## Validation

- `python -m pytest tests/fast/test_ray_fragment_submission.py` (288 passed)
- `python -m pytest tests/fast/test_ray_fte_fault_injection.py::test_real_ray_actor_kill_without_replacement_fails_fte_fragment_execution` (1 passed)
- `scripts/run_release_tests.sh` (510 passed, 1 skipped; 11 real-Ray passed)
- `scripts/run_fast_tests.sh` (non-Ray: 6603 passed, 30 skipped, 8 xfailed, 1 xpassed; shared-Ray: 101 passed, 10 skipped; owner-Ray nodes passed, one optional vLLM node skipped)
- duplicate reconciliation success and error tests repeated 20 times (all passed)
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
