### PR TITLE
[fix](ray) Bound datasource lifetime to stream

### DIFF
--- a/duckdb/runners/ray/runner.py
+++ b/duckdb/runners/ray/runner.py
@@ -146,22 +146,27 @@ class RayRunner(Runner):
             return client
 
     def run_iter(self, relation: duckdb.DuckDBPyRelation) -> Iterator[RayMaterializedResult]:
-        query_id = str(uuid.uuid4())
+        # PyLogicalPlan is transport-only. This generator owns the source
+        # relation until the client stream and its teardown have finished.
+        try:
+            query_id = str(uuid.uuid4())
 
-        PyLogicalPlan = require_ray_cxx_attr(
-            "PyLogicalPlan",
-            hint="Ensure the C++ ray extension is built and importable in worker processes.",
-        )
+            PyLogicalPlan = require_ray_cxx_attr(
+                "PyLogicalPlan",
+                hint="Ensure the C++ ray extension is built and importable in worker processes.",
+            )
 
-        logical_plan = PyLogicalPlan.from_duckdb_relation(relation, query_id)
-        session_id = str(logical_plan.session_id())
+            logical_plan = PyLogicalPlan.from_duckdb_relation(relation, query_id)
+            session_id = str(logical_plan.session_id())
 
-        client = self._client_for_session(session_id)
+            client = self._client_for_session(session_id)
 
-        # Send PyLogicalPlan to Driver — Driver will create physical plan
-        yield from client.stream_plan(
-            logical_plan,
-        )
+            # Send PyLogicalPlan to Driver — Driver will create physical plan
+            yield from client.stream_plan(
+                logical_plan,
+            )
+        finally:
+            del relation
 
     def run_write(self, relation: duckdb.DuckDBPyRelation) -> dict[str, Any]:
         """Execute a distributed COPY/write plan and return file metadata."""
@@ -191,5 +196,8 @@ class RayRunner(Runner):
         return client.retry_copy_cleanup(operation_id)
 
     def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
-        for result in self.run_iter(relation):
-            yield result.partition()
+        try:
+            for result in self.run_iter(relation):
+                yield result.partition()
+        finally:
+            del relation

--- a/src/duckdb_py/ray/distributed_plan_bindings.cpp
+++ b/src/duckdb_py/ray/distributed_plan_bindings.cpp
@@ -990,14 +990,10 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj, py::o
 		throw duckdb::InternalException("Connection is required for to_physical_plan");
 	}
 
-	string logical_payload;
-	if (!serialized_logical_plan_.empty()) {
-		logical_payload = serialized_logical_plan_;
-	} else if (relation_) {
-		logical_payload = SerializeLogicalPlanFromRelation(relation_);
-	} else {
-		throw duckdb::InternalException("Logical plan is empty and no relation is available");
+	if (serialized_logical_plan_.empty()) {
+		throw duckdb::InternalException("PyLogicalPlan missing serialized logical plan");
 	}
+	const auto &logical_payload = serialized_logical_plan_;
 
 	py::object planning_conn = ResolvePlanningConnectionForSnapshot(conn_obj, source_connection_, connection_snapshot_);
 	auto &conn_wrapper = ExtractPyConnectionWrapper(planning_conn);

--- a/src/duckdb_py/ray/logical_plan_bindings.cpp
+++ b/src/duckdb_py/ray/logical_plan_bindings.cpp
@@ -10,7 +10,6 @@ struct PyLogicalPlan {
 	string serialized_logical_plan_;
 	// Driver-local source connection; intentionally omitted from pickle state.
 	py::object source_connection_ = py::none();
-	duckdb::shared_ptr<duckdb::Relation> relation_;
 	py::object udf_registrations_ = py::none();
 	py::object connection_snapshot_ = py::none();
 

--- a/src/duckdb_py/ray/ray_module.cpp
+++ b/src/duckdb_py/ray/ray_module.cpp
@@ -929,7 +929,7 @@ void register_ray_bindings(py::module_ &mod) {
 			                string query_id = query_id_obj.is_none() ? string() : py::cast<string>(query_id_obj);
 			                PyLogicalPlan plan;
 			                plan.query_id_ = std::move(query_id);
-			                plan.relation_ = rel;
+			                plan.serialized_logical_plan_ = SerializeLogicalPlanFromRelation(rel);
 			                auto connection_owner = pyrel.GetConnectionOwner();
 			                if (connection_owner && !connection_owner.is_none() &&
 			                    py::isinstance<DuckDBPyConnection>(connection_owner)) {
@@ -957,12 +957,7 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def(py::pickle(
 	        [](const PyLogicalPlan &p) {
 		        if (p.serialized_logical_plan_.empty()) {
-			        if (!p.relation_) {
-				        throw duckdb::InternalException("PyLogicalPlan missing serialized logical plan");
-			        }
-			        auto serialized = SerializeLogicalPlanFromRelation(p.relation_);
-			        return py::make_tuple(p.query_id_, py::bytes(serialized), p.udf_registrations_,
-			                              p.connection_snapshot_);
+			        throw duckdb::InternalException("PyLogicalPlan missing serialized logical plan");
 		        }
 		        return py::make_tuple(p.query_id_, py::bytes(p.serialized_logical_plan_), p.udf_registrations_,
 		                              p.connection_snapshot_);

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -222,6 +222,59 @@ def test_datasource_relation_keeps_source_alive_until_relation_is_released(duckd
     assert not source_path.exists()
 
 
+@pytest.mark.parametrize("stream_outcome", ["complete", "close", "error"])
+def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
+    duckdb_conn,
+    monkeypatch,
+    stream_outcome,
+    tmp_path,
+):
+    from duckdb.runners.ray.runner import RayRunner
+
+    source_path = tmp_path / "runner-plan-retention-source.txt"
+    source_path.write_text("43", encoding="utf-8")
+    source = SourceKeepaliveProbe(str(source_path))
+    source_ref = weakref.ref(source)
+    relation = read_datasource(source, con=duckdb_conn, limit=1)
+    result = object()
+
+    class _RetainingClient:
+        def __init__(self):
+            self.plan = None
+
+        def stream_plan(self, plan):
+            self.plan = plan
+            assert source_ref() is not None
+            yield result
+            assert source_ref() is not None
+            if stream_outcome == "error":
+                raise RuntimeError("planned stream failure")
+
+    client = _RetainingClient()
+    runner = object.__new__(RayRunner)
+    monkeypatch.setattr(RayRunner, "_client_for_session", lambda _self, _session_id: client)
+
+    results = runner.run_iter(relation)
+    del source
+    del relation
+    gc.collect()
+
+    assert source_ref() is not None
+    if stream_outcome == "complete":
+        assert list(results) == [result]
+    elif stream_outcome == "close":
+        assert next(results) is result
+        results.close()
+    else:
+        with pytest.raises(RuntimeError, match="planned stream failure"):
+            list(results)
+    assert client.plan is not None
+
+    gc.collect()
+    assert source_ref() is None
+    assert not source_path.exists()
+
+
 def test_ray_runner_keeps_source_alive_until_distributed_scan_finishes(ray_runner, duckdb_conn, tmp_path):
     source_path = tmp_path / "distributed-source-keepalive.txt"
     source_path.write_text("43", encoding="utf-8")


### PR DESCRIPTION
## Summary

- eagerly serialize `PyLogicalPlan` when it is created from a DuckDB relation
- remove the driver-local relation member and all lazy serialization/fallback paths from the transport plan
- make Ray streaming APIs explicitly own the source relation through stream teardown, then release it even if a transport layer retains the serialized plan
- cover normal completion, explicit generator close, and stream failure with deterministic datasource lifetime tests

## Related issue

close: #495

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal Ray logical-plan ownership and serialization timing only.

## Validation

- `python -m pytest tests/fast/test_datasource_distributed_scan.py` (15 passed)
- `python -m pytest tests/fast/test_ray_serialization.py tests/fast/test_ray_e2e_serialization.py tests/fast/test_ray_connection_snapshot.py` (36 passed)
- `scripts/run_native_tests.sh '[distributed]'` (184 test cases, 7972 assertions passed)
- `scripts/run_release_tests.sh` (510 passed, 1 skipped; 11 real-Ray passed)
- `scripts/run_fast_tests.sh` (non-Ray: 6603 passed, 30 skipped, 8 xfailed, 1 xpassed; shared-Ray: 101 passed, 10 skipped; owner-Ray nodes passed, one optional vLLM node skipped)
- deterministic complete/close/error lifetime test repeated 20 times (all passed)
- original real-Ray datasource lifetime node passed 16 consecutive visible reruns after the full gate
- `pre-commit run --from-ref upstream/main --to-ref HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
