### PR TITLE
[fix](ai) Remove misleading embedding dtype metadata

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -21,7 +21,6 @@ import pytest
 import vane
 from vane.ai.protocols import TextEmbedderDescriptor
 from vane.ai.provider import Provider
-from vane.ai.typing import EmbeddingDimensions
 
 if TYPE_CHECKING:
     from vane.ai.protocols import TextEmbedder
@@ -84,8 +83,8 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_options(self) -> Options:
         return {"batch_size": 2}
 
-    def get_dimensions(self) -> EmbeddingDimensions:
-        return EmbeddingDimensions(size=self.dim, dtype=pa.float32())
+    def get_dimensions(self) -> int:
+        return self.dim
 
     def instantiate(self) -> TextEmbedder:
         return MockTextEmbedder(dim=self.dim)
@@ -237,7 +236,7 @@ class TestGoogleProviderEmbedPlanning:
         descriptor = GoogleProvider().get_text_embedder()
 
         assert descriptor.model_name == "gemini-embedding-2"
-        assert descriptor.get_dimensions().size == 3072
+        assert descriptor.get_dimensions() == 3072
 
     def test_get_text_embedder_default_rejects_unsupported_request_options(self):
         from vane.ai.providers.google import GoogleProvider
@@ -277,9 +276,9 @@ class TestGoogleProviderEmbedPlanning:
             embedding_dimensions=128,
         ).get_text_embedder()
 
-        assert (builtin.get_dimensions().size, builtin.request_dimensions) == (3072, None)
-        assert (explicit.get_dimensions().size, explicit.request_dimensions) == (256, 256)
-        assert (unknown.get_dimensions().size, unknown.request_dimensions) == (128, None)
+        assert (builtin.get_dimensions(), builtin.request_dimensions) == (3072, None)
+        assert (explicit.get_dimensions(), explicit.request_dimensions) == (256, 256)
+        assert (unknown.get_dimensions(), unknown.request_dimensions) == (128, None)
 
     @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
     def test_provider_dimension_metadata_is_not_sent_as_request_override(self):
@@ -292,9 +291,7 @@ class TestGoogleProviderEmbedPlanning:
         async def request_for(descriptor):
             client = MagicMock()
             client.aio.models.embed_content = AsyncMock(
-                return_value=SimpleNamespace(
-                    embeddings=[SimpleNamespace(values=[1.0] * descriptor.get_dimensions().size)]
-                )
+                return_value=SimpleNamespace(embeddings=[SimpleNamespace(values=[1.0] * descriptor.get_dimensions())])
             )
             with patch("google.genai.Client", return_value=client):
                 embedder = descriptor.instantiate()
@@ -305,7 +302,7 @@ class TestGoogleProviderEmbedPlanning:
         metadata_only = provider.get_text_embedder()
         explicit_override = provider.get_text_embedder(dimensions=3)
 
-        assert metadata_only.get_dimensions().size == 4
+        assert metadata_only.get_dimensions() == 4
         assert "config" not in asyncio.run(request_for(metadata_only))
         explicit_request = asyncio.run(request_for(explicit_override))
         assert explicit_request["config"]["output_dimensionality"] == 3
@@ -629,7 +626,7 @@ class TestChunking:
                 return {}
 
             def get_dimensions(self):
-                return EmbeddingDimensions(size=dim)
+                return dim
 
             def instantiate(self):
                 return FakeEmbedder()
@@ -672,7 +669,7 @@ class TestChunking:
                 return {}
 
             def get_dimensions(self):
-                return EmbeddingDimensions(size=dim)
+                return dim
 
             def instantiate(self):
                 return CountingEmbedder()
@@ -708,7 +705,7 @@ class TestChunking:
                 return {}
 
             def get_dimensions(self):
-                return EmbeddingDimensions(size=dim)
+                return dim
 
             def instantiate(self):
                 return SimpleEmbedder()
@@ -2287,12 +2284,7 @@ class TestWrapperRetry:
     def _make_embed_descriptor(self, embed_fn):
         """Create a minimal descriptor + embedder for testing."""
         desc = MagicMock(spec=[])
-        desc.get_dimensions = MagicMock(
-            return_value=MagicMock(
-                as_arrow_type=MagicMock(return_value=pa.list_(pa.float32(), 3)),
-                list_size=3,
-            )
-        )
+        desc.get_dimensions = MagicMock(return_value=3)
         embedder = MagicMock(spec=[])
         embedder.embed_text = embed_fn
         desc.instantiate = MagicMock(return_value=embedder)

--- a/tests/ai/test_descriptor_secret_redaction.py
+++ b/tests/ai/test_descriptor_secret_redaction.py
@@ -386,7 +386,7 @@ class TestOptionsAtExecutionBoundary:
 
         monkeypatch.setitem(sys.modules, "transformers", SimpleNamespace(AutoConfig=FakeAutoConfig))
         descriptor = _transformers_embedder_descriptor()
-        assert descriptor.get_dimensions().size == 384
+        assert descriptor.get_dimensions() == 384
         assert auto_config_calls == []
 
     def test_transformers_embedder_model_receives_registered_loading_options(self, monkeypatch):

--- a/tests/ai/test_descriptors.py
+++ b/tests/ai/test_descriptors.py
@@ -9,7 +9,6 @@ import base64
 import pickle
 
 import numpy as np
-import pyarrow as pa
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -152,7 +151,7 @@ class TestProviderLoading:
             options={"base_url": "https://compatible.example.test/v1"},
         )
 
-        assert descriptor.get_dimensions().size == dimensions
+        assert descriptor.get_dimensions() == dimensions
 
     def test_openai_compatible_endpoint_requires_explicit_dimensions(self):
         from vane.ai.providers.openai import OpenAIProvider
@@ -310,13 +309,6 @@ class TestDescriptorAPI:
         opts = desc.get_udf_options()
         assert opts.batch_size is None
         assert opts.num_gpus == 0
-
-    def test_embedding_dimensions_arrow_type(self):
-        from vane.ai.typing import EmbeddingDimensions
-
-        dims = EmbeddingDimensions(size=384, dtype=pa.float32())
-        arrow_type = dims.as_arrow_type()
-        assert isinstance(arrow_type, pa.DataType)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -21,7 +21,7 @@ from vane.ai import provider as provider_registry
 from vane.ai.options import EmbedOptions, PromptOptions
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
-from vane.ai.typing import EmbeddingDimensions, UDFOptions
+from vane.ai.typing import UDFOptions
 
 
 class MockTextEmbedder:
@@ -49,8 +49,8 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
             "actor_number": self.actor_number,
         }
 
-    def get_dimensions(self) -> EmbeddingDimensions:
-        return EmbeddingDimensions(size=self.dim, dtype=pa.float32())
+    def get_dimensions(self) -> int:
+        return self.dim
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(
@@ -625,6 +625,36 @@ def test_ai_embed_explicit_dimensions_skip_provider_dimension_lookup():
     expr = vane.ai.embed(vane.col("text"), provider=ExplicitProvider(), dimensions=7)
 
     assert [str(value) for value in rel.select(expr).types] == ["FLOAT[7]"]
+
+
+@pytest.mark.parametrize("value", [True, 0, -1, 3.0, "3"])
+def test_ai_embed_rejects_invalid_provider_dimensions(value):
+    class Descriptor(MockTextEmbedderDescriptor):
+        def get_dimensions(self):
+            return value
+
+    class InvalidProvider(MockProvider):
+        def get_text_embedder(self, model=None, dimensions=None, *, options=None):
+            return Descriptor(dim=3)
+
+    with pytest.raises(ValueError, match=r"get_dimensions\(\).*positive integer"):
+        vane.ai.embed(vane.col("text"), provider=InvalidProvider())
+
+
+def test_ai_embed_rejects_legacy_dimension_metadata_object():
+    class LegacyDimensions:
+        size = 3
+
+    class Descriptor(MockTextEmbedderDescriptor):
+        def get_dimensions(self):
+            return LegacyDimensions()
+
+    class LegacyProvider(MockProvider):
+        def get_text_embedder(self, model=None, dimensions=None, *, options=None):
+            return Descriptor(dim=3)
+
+    with pytest.raises(ValueError, match=r"get_dimensions\(\).*positive integer"):
+        vane.ai.embed(vane.col("text"), provider=LegacyProvider())
 
 
 def test_embed_on_error_ignore_returns_fixed_type_nulls():

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -22,7 +22,7 @@ import vane
 from vane.ai import provider as provider_registry
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
-from vane.ai.typing import EmbeddingDimensions, UDFOptions
+from vane.ai.typing import UDFOptions
 
 
 class MockTextEmbedder:
@@ -47,8 +47,8 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_options(self) -> dict[str, object]:
         return {}
 
-    def get_dimensions(self) -> EmbeddingDimensions:
-        return EmbeddingDimensions(self.dimensions)
+    def get_dimensions(self) -> int:
+        return self.dimensions
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0, batch_size=2, max_retries=0)

--- a/tests/ai/test_relation_patch.py
+++ b/tests/ai/test_relation_patch.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import numpy as np
-import pyarrow as pa
 
 import duckdb
 import vane
@@ -18,7 +17,6 @@ from vane.ai.protocols import (
     TextEmbedderDescriptor,
 )
 from vane.ai.provider import Provider
-from vane.ai.typing import EmbeddingDimensions
 
 if TYPE_CHECKING:
     from vane.ai.protocols import Prompter, TextEmbedder
@@ -50,8 +48,8 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_options(self) -> Options:
         return {"batch_size": 2}
 
-    def get_dimensions(self) -> EmbeddingDimensions:
-        return EmbeddingDimensions(size=self.dim, dtype=pa.float32())
+    def get_dimensions(self) -> int:
+        return self.dim
 
     def instantiate(self) -> TextEmbedder:
         return MockTextEmbedder(dim=self.dim)

--- a/tests/fast/test_ai_release_contracts.py
+++ b/tests/fast/test_ai_release_contracts.py
@@ -65,9 +65,9 @@ def test_google_embedding_metadata_and_retry_contract_without_optional_sdk(monke
 
     metadata_embedder = metadata_only.instantiate()
     explicit_embedder = explicit_override.instantiate()
-    assert metadata_only.get_dimensions().size == 4
+    assert metadata_only.get_dimensions() == 4
     assert metadata_embedder._dimensions is None
-    assert explicit_override.get_dimensions().size == 3
+    assert explicit_override.get_dimensions() == 3
     assert explicit_embedder._dimensions == 3
     assert [call["http_options"].retry_options.attempts for call in calls] == [1, 1]
 

--- a/tests/fast/test_transformers_provider_security.py
+++ b/tests/fast/test_transformers_provider_security.py
@@ -96,7 +96,7 @@ def test_remote_code_requires_an_explicit_option(monkeypatch):
         options={"revision": _PINNED_REVISION, "trust_remote_code": True},
     )
 
-    assert descriptor.get_dimensions().size == 384
+    assert descriptor.get_dimensions() == 384
     descriptor.instantiate()
 
     assert auto_config_calls == []

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -388,8 +388,7 @@ def _resolve_embedding_dimension(descriptor: Any, explicit: int | None) -> int:
     if explicit is not None:
         return explicit
     try:
-        metadata = descriptor.get_dimensions()
-        resolved = getattr(metadata, "size", metadata)
+        resolved = descriptor.get_dimensions()
     except Exception as exc:
         model = getattr(descriptor, "get_model", lambda: "unknown")()
         raise ValueError(
@@ -397,7 +396,7 @@ def _resolve_embedding_dimension(descriptor: Any, explicit: int | None) -> int:
             "pass dimensions=... explicitly"
         ) from exc
     if isinstance(resolved, bool) or not isinstance(resolved, int) or resolved <= 0:
-        raise ValueError("Provider embedding dimension metadata must be a positive integer")
+        raise ValueError("Provider get_dimensions() must return a positive integer")
     return int(resolved)
 
 

--- a/vane/ai/protocols.py
+++ b/vane/ai/protocols.py
@@ -19,7 +19,7 @@ from vane.ai.typing import Descriptor
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
-    from vane.ai.typing import Embedding, EmbeddingDimensions
+    from vane.ai.typing import Embedding
 
 
 # ---------------------------------------------------------------------------
@@ -38,8 +38,8 @@ class TextEmbedderDescriptor(Descriptor["TextEmbedder"]):
     """Serializable factory for a :class:`TextEmbedder`."""
 
     @abstractmethod
-    def get_dimensions(self) -> EmbeddingDimensions:
-        """Return the embedding dimensions produced by this embedder."""
+    def get_dimensions(self) -> int:
+        """Return the positive number of float32 values in each embedding."""
         ...
 
     def is_async(self) -> bool:

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -33,7 +33,7 @@ from vane.ai.options import (
 )
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
-from vane.ai.typing import EmbeddingDimensions, UDFOptions
+from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -414,10 +414,10 @@ class GoogleTextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_options(self) -> Options:
         return dict(self.options)
 
-    def get_dimensions(self) -> EmbeddingDimensions:
+    def get_dimensions(self) -> int:
         if self.dimensions is not None:
-            return EmbeddingDimensions(size=self.dimensions)
-        return EmbeddingDimensions(size=_EMBEDDING_DIMS[_canonical_model_id(self.model_name)])
+            return self.dimensions
+        return _EMBEDDING_DIMS[_canonical_model_id(self.model_name)]
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0)

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 import numpy as np
-import pyarrow as pa
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import (
@@ -31,7 +30,7 @@ from vane.ai._schema import (
 from vane.ai.options import validate_embed_options, validate_prompt_options
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
-from vane.ai.typing import EmbeddingDimensions, UDFOptions
+from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -483,12 +482,12 @@ class OpenAITextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_options(self) -> Options:
         return dict(self.options)
 
-    def get_dimensions(self) -> EmbeddingDimensions:
+    def get_dimensions(self) -> int:
         if self.dimensions is not None:
-            return EmbeddingDimensions(size=self.dimensions, dtype=pa.float32())
+            return self.dimensions
         normalized_model = self.model_name.strip().casefold()
         if _uses_official_openai_endpoint(self.options.get("base_url")) and normalized_model in _MODEL_DIMS:
-            return EmbeddingDimensions(size=_MODEL_DIMS[normalized_model], dtype=pa.float32())
+            return _MODEL_DIMS[normalized_model]
         raise ValueError(
             f"Cannot determine embedding dimensions for OpenAI-compatible model {self.model_name!r} "
             "from trusted local metadata; pass dimensions=... explicitly"

--- a/vane/ai/providers/transformers.py
+++ b/vane/ai/providers/transformers.py
@@ -13,13 +13,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import pyarrow as pa
-
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai.options import validate_embed_options
 from vane.ai.protocols import TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError
-from vane.ai.typing import EmbeddingDimensions, UDFOptions
+from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -108,11 +106,11 @@ class TransformersTextEmbedderDescriptor(TextEmbedderDescriptor):
     def get_options(self) -> Options:
         return dict(self.options)
 
-    def get_dimensions(self) -> EmbeddingDimensions:
+    def get_dimensions(self) -> int:
         if self.dimensions is not None:
-            return EmbeddingDimensions(size=self.dimensions, dtype=pa.float32())
+            return self.dimensions
         if self.model in _EMBEDDING_DIMS:
-            return EmbeddingDimensions(size=_EMBEDDING_DIMS[self.model], dtype=pa.float32())
+            return _EMBEDDING_DIMS[self.model]
         raise ValueError(
             f"Cannot determine embedding dimensions for Transformers model {self.model!r} "
             "from trusted local metadata; pass dimensions=... explicitly"

--- a/vane/ai/typing.py
+++ b/vane/ai/typing.py
@@ -9,8 +9,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar
 
-import pyarrow as pa
-
 if TYPE_CHECKING:
     import numpy as np
 
@@ -64,17 +62,6 @@ class Descriptor(ABC, Generic[T]):
         of execution defaults.
         """
         return UDFOptions()
-
-
-@dataclass(frozen=True)
-class EmbeddingDimensions:
-    """Describes the shape and dtype of an embedding vector."""
-
-    size: int
-    dtype: pa.DataType = pa.float32()
-
-    def as_arrow_type(self) -> pa.DataType:
-        return pa.list_(self.dtype, self.size)
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Remove `EmbeddingDimensions` and make `TextEmbedderDescriptor.get_dimensions()` return the positive integer vector size directly. Embed owns the existing fixed `float32` / `FLOAT[N]` product contract, so providers can no longer declare a dtype that runtime execution silently ignores.

This intentionally does not preserve compatibility: custom descriptors must return an `int`, and legacy metadata objects with a `.size` attribute are rejected instead of accepted through a fallback. The built-in Google, OpenAI, and Transformers descriptors and their contract tests are migrated to the new API.

## Related issue

close: #494

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The removed type was not documented or exported from the top-level `vane.ai` API; the public compatibility impact is described above.

## Validation

- `scripts/format root --from-ref upstream/main --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `python -m pytest -q tests/ai/test_ai_functions.py tests/ai/test_descriptor_secret_redaction.py tests/ai/test_descriptors.py tests/ai/test_expression_ai_functions.py tests/ai/test_expression_ai_sql.py tests/ai/test_relation_patch.py tests/fast/test_ai_release_contracts.py tests/fast/test_transformers_provider_security.py` — 472 passed, 20 skipped
- `python -m pytest -q tests/ai` — 496 passed, 21 skipped, 6 deselected
- `scripts/run_release_tests.sh` — 510 passed, 1 skipped, 15 deselected; real-Ray phase 11 passed, 515 deselected
- `uvx --from mypy mypy --config-file tests/typing/ai_mypy.ini tests/typing/ai_embed.py` — passed
- Python 3.12.3; Python-only change, so no native rebuild was required

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependencies or assets are added.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. This changes planning metadata only and retains runtime shape/type validation.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. This PR is Python-only.
