### PR TITLE
[fix](ai) Reject non-finite embedding results

### DIFF
--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -795,6 +795,195 @@ def test_embed_dynamic_dimension_mismatch_is_a_result_type_error():
         loop.close()
 
 
+def _drive_embed_wrapper(wrapper: Any, texts: list[str | None]) -> pa.Table:
+    loop = asyncio.new_event_loop()
+    wrapper.bind_async_runtime(loop.run_until_complete)
+    try:
+        return wrapper(pa.table({"text": texts}))
+    finally:
+        loop.close()
+
+
+@pytest.mark.parametrize(
+    "invalid_component",
+    [float("nan"), float("inf"), float("-inf"), 1e100],
+    ids=["nan", "positive-infinity", "negative-infinity", "float32-overflow"],
+)
+def test_embed_non_finite_result_raises_without_retry(invalid_component):
+    from vane.ai.functions import _EmbedTextBatch
+    from vane.ai.provider import _ProviderResultError
+
+    calls = []
+
+    class NonFiniteEmbedder:
+        def embed_text(self, texts):
+            calls.append(list(texts))
+            return [[1.0, invalid_component, 2.0] for _ in texts]
+
+    class Descriptor:
+        def get_provider(self):
+            return "mock"
+
+        def get_model(self):
+            return "non-finite-model"
+
+        def instantiate(self):
+            return NonFiniteEmbedder()
+
+    wrapper = _EmbedTextBatch(Descriptor(), "text", "embedding", 3, max_retries=3)
+
+    with pytest.raises(_ProviderResultError, match="embedding containing non-finite components"):
+        _drive_embed_wrapper(wrapper, ["bad"])
+
+    assert calls == [["bad"]]
+
+
+@pytest.mark.parametrize(
+    "invalid_embedding",
+    [
+        [1.0, float("nan"), 2.0],
+        ["not", "numeric", "values"],
+        [1.0, 2.0],
+    ],
+    ids=["non-finite", "non-numeric", "wrong-dimensions"],
+)
+def test_embed_on_error_ignore_nulls_invalid_result_row_without_reinvoking_provider(invalid_embedding):
+    from vane.ai.functions import _EmbedTextBatch
+
+    calls = []
+
+    class MixedEmbedder:
+        def embed_text(self, texts):
+            calls.append(list(texts))
+            vectors = {
+                "first": [3.0, 0.0, 4.0],
+                "bad": invalid_embedding,
+                "last": [0.0, 5.0, 0.0],
+            }
+            return [vectors[text] for text in texts]
+
+    class Descriptor:
+        def instantiate(self):
+            return MixedEmbedder()
+
+    wrapper = _EmbedTextBatch(
+        Descriptor(),
+        "text",
+        "embedding",
+        3,
+        max_retries=3,
+        on_error="ignore",
+        normalize=True,
+    )
+
+    result = _drive_embed_wrapper(wrapper, ["first", "bad", None, "last"])
+    embeddings = result.column("embedding").to_pylist()
+
+    np.testing.assert_allclose(embeddings[0], [0.6, 0.0, 0.8], rtol=1e-6)
+    assert embeddings[1:3] == [None, None]
+    np.testing.assert_allclose(embeddings[3], [0.0, 1.0, 0.0], rtol=1e-6)
+    assert calls == [["first", "bad", "last"]]
+    assert result.schema.field("embedding").type == pa.list_(pa.float32(), 3)
+
+
+@pytest.mark.parametrize(
+    "magnitude",
+    [np.finfo(np.float32).max, np.finfo(np.float32).tiny],
+    ids=["large", "small"],
+)
+def test_embed_normalization_uses_float64_for_extreme_finite_vector(magnitude):
+    from vane.ai.functions import _EmbedTextBatch
+
+    class ExtremeFiniteEmbedder:
+        def embed_text(self, texts):
+            return [np.array([magnitude, magnitude], dtype=np.float32) for _ in texts]
+
+    class Descriptor:
+        def instantiate(self):
+            return ExtremeFiniteEmbedder()
+
+    wrapper = _EmbedTextBatch(Descriptor(), "text", "embedding", 2, max_retries=0, normalize=True)
+    embedding = _drive_embed_wrapper(wrapper, ["extreme"]).column("embedding")[0].as_py()
+
+    assert all(math.isfinite(value) for value in embedding)
+    np.testing.assert_allclose(embedding, [math.sqrt(0.5), math.sqrt(0.5)], rtol=1e-6)
+
+
+def test_embed_normalization_preserves_finite_zero_vector():
+    from vane.ai.functions import _EmbedTextBatch
+
+    class ZeroEmbedder:
+        def embed_text(self, texts):
+            return [np.zeros(3, dtype=np.float32) for _ in texts]
+
+    class Descriptor:
+        def instantiate(self):
+            return ZeroEmbedder()
+
+    wrapper = _EmbedTextBatch(Descriptor(), "text", "embedding", 3, max_retries=0, normalize=True)
+
+    assert _drive_embed_wrapper(wrapper, ["zero"]).column("embedding").to_pylist() == [[0.0, 0.0, 0.0]]
+
+
+def test_embed_non_finite_chunk_nulls_parent_without_reinvoking_provider():
+    from vane.ai.functions import _EmbedTextBatch
+
+    calls = []
+
+    class ChunkEmbedder:
+        def embed_text(self, texts):
+            calls.append(list(texts))
+            return [[float("nan"), 0.0] if text == "bbbb" else [1.0, 0.0] for text in texts]
+
+    class Descriptor:
+        def instantiate(self):
+            return ChunkEmbedder()
+
+    wrapper = _EmbedTextBatch(
+        Descriptor(),
+        "text",
+        "embedding",
+        2,
+        max_chunk_chars=4,
+        chunk_overlap_chars=0,
+        max_retries=3,
+        on_error="ignore",
+    )
+
+    result = _drive_embed_wrapper(wrapper, ["aaaabbbb", "ccccdddd"])
+
+    assert result.column("embedding").to_pylist() == [None, [1.0, 0.0]]
+    assert calls == [["aaaa", "bbbb", "cccc", "dddd"]]
+
+
+def test_embed_final_contract_rejects_non_finite_normalized_output(monkeypatch):
+    from vane.ai.functions import _EmbedTextBatch
+
+    class FiniteEmbedder:
+        def embed_text(self, texts):
+            return [[1.0, 2.0] for _ in texts]
+
+    class Descriptor:
+        def instantiate(self):
+            return FiniteEmbedder()
+
+    monkeypatch.setattr(
+        "vane.ai.functions._normalize_embedding",
+        lambda _embedding: np.array([1.0, float("inf")], dtype=np.float32),
+    )
+    wrapper = _EmbedTextBatch(
+        Descriptor(),
+        "text",
+        "embedding",
+        2,
+        max_retries=0,
+        on_error="ignore",
+        normalize=True,
+    )
+
+    assert _drive_embed_wrapper(wrapper, ["row"]).column("embedding").to_pylist() == [None]
+
+
 def test_ai_prompt_expression_basic():
     conn = vane.connect()
     rel = conn.sql(

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -582,18 +582,15 @@ def _descriptor_identity(descriptor: Any) -> tuple[str, str]:
     return values[0], values[1]
 
 
-def _normalize_embeddings(values: list[Any]) -> list[Any]:
-    normalized: list[Any] = []
-    for value in values:
-        if value is None:
-            normalized.append(None)
-            continue
-        arr = np.asarray(value, dtype=np.float32)
-        norm = float(np.linalg.norm(arr))
-        if norm > 0:
-            arr = arr / norm
-        normalized.append(arr)
-    return normalized
+def _normalize_embedding(value: np.ndarray) -> np.ndarray:
+    """L2-normalize a finite float32 embedding without float32 overflow."""
+    working = np.asarray(value, dtype=np.float64)
+    norm = float(np.linalg.norm(working))
+    if not np.isfinite(norm):
+        raise _ProviderResultError("Embedding normalization produced a non-finite norm")
+    if norm > 0:
+        working /= norm
+    return working.astype(np.float32)
 
 
 # ---------------------------------------------------------------------------
@@ -710,18 +707,62 @@ class _EmbedTextBatch:
 
     def _coerce_embedding(self, value: Any) -> np.ndarray:
         try:
-            embedding = np.asarray(value, dtype=np.float32)
+            with np.errstate(over="ignore", invalid="ignore"):
+                embedding = np.asarray(value, dtype=np.float32)
         except Exception:
-            raise TypeError("Provider returned a non-numeric embedding") from None
-        if embedding.ndim != 1 or embedding.size != self._dimensions:
+            raise _ProviderResultError("Provider returned a non-numeric embedding") from None
+        if embedding.ndim != 1:
             provider, model = _descriptor_identity(self._descriptor)
-            raise TypeError(
+            raise _ProviderResultError(
+                f"Provider {provider!r} model {model!r} "
+                f"returned an embedding with shape {embedding.shape}; expected a one-dimensional "
+                f"embedding with length {self._dimensions}"
+            )
+        if embedding.size != self._dimensions:
+            provider, model = _descriptor_identity(self._descriptor)
+            raise _ProviderResultError(
                 f"Provider {provider!r} model {model!r} "
                 f"returned an embedding with length {embedding.size}; expected {self._dimensions}"
             )
+        if not bool(np.isfinite(embedding).all()):
+            provider, model = _descriptor_identity(self._descriptor)
+            raise _ProviderResultError(
+                f"Provider {provider!r} model {model!r} returned an embedding containing non-finite components"
+            )
         return embedding
 
-    def _invoke_embedder(self, texts: list[str]) -> list[np.ndarray]:
+    def _coerce_embedding_rows(
+        self,
+        values: list[Any],
+        *,
+        allow_nulls: bool,
+        normalize: bool = False,
+    ) -> list[np.ndarray | None]:
+        """Enforce the typed embedding contract for known result rows.
+
+        A row-aligned result violation is already attributable to one input,
+        so ``on_error="ignore"`` can null that row without calling the provider
+        again. ``allow_nulls`` is reserved for rows already nulled by that
+        policy or by a failed chunk.
+        """
+        embeddings: list[np.ndarray | None] = []
+        for value in values:
+            if value is None and allow_nulls:
+                embeddings.append(None)
+                continue
+            try:
+                embedding = self._coerce_embedding(value)
+                if normalize:
+                    embedding = self._coerce_embedding(_normalize_embedding(embedding))
+            except _ProviderResultError:
+                if self._on_error == "raise":
+                    raise
+                embeddings.append(None)
+                continue
+            embeddings.append(embedding)
+        return embeddings
+
+    def _invoke_embedder(self, texts: list[str]) -> list[np.ndarray | None]:
         capability_error: ProviderCapabilityError | None = None
         provider_error: Exception | None = None
         try:
@@ -749,13 +790,13 @@ class _EmbedTextBatch:
         try:
             values = list(raw)
         except TypeError:
-            raise TypeError("Provider embedding result must be a sequence") from None
+            raise _ProviderResultError("Provider embedding result must be a sequence") from None
         if len(values) != len(texts):
-            raise ValueError(
+            raise _ProviderResultError(
                 f"Provider returned {len(values)} embeddings for {len(texts)} inputs; "
                 "embedding calls must preserve row count and order"
             )
-        return [self._coerce_embedding(value) for value in values]
+        return self._coerce_embedding_rows(values, allow_nulls=False)
 
     def _embed_texts(self, texts: list[str]) -> list[np.ndarray | None]:
         if not texts:
@@ -796,8 +837,11 @@ class _EmbedTextBatch:
             else:
                 active_results = self._embed_texts(active_texts)
 
-            if self._normalize:
-                active_results = _normalize_embeddings(active_results)
+            active_results = self._coerce_embedding_rows(
+                active_results,
+                allow_nulls=True,
+                normalize=self._normalize,
+            )
             for index, value in zip(active_indices, active_results, strict=True):
                 results[index] = value
 


### PR DESCRIPTION
## Summary

Enforce Embed's fixed-length float32 result contract at the shared provider boundary. Provider rows containing NaN, infinity, non-numeric values, invalid shapes, or float32 conversion overflow now fail with a non-retryable result error.

Apply `on_error="ignore"` directly to row-aligned result violations without repeating provider requests. Batch failures whose row is unknown still use per-row isolation. Chunk aggregation and L2 normalization use float64 intermediates, and transformed results are validated again before Arrow output.

## Related issue

close: #471

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The existing Embed API and output type are unchanged; invalid provider output now follows the configured error policy instead of reaching downstream calculations.

## Validation

- `python -m pytest -q tests/ai/test_expression_ai_functions.py` — 171 passed
- `python -m pytest -q tests/ai` — 527 passed, 6 deselected
- `python -m pytest -q tests/fast/test_ai_async_runtime.py tests/fast/test_ai_release_contracts.py` — 31 passed
- `python -m pytest -q tests/ai/test_ai_functions.py -k 'TestChunking or TestWrapperRetry'` — 21 passed, 167 deselected
- `pre-commit run --files vane/ai/functions.py tests/ai/test_expression_ai_functions.py` — passed
- Release non-Ray selection — 506 passed, 4 skipped; its SourceID-only assertion reported the expected mismatch because validation reused a compatible native extension built from another worktree. This PR is Python-only and does not require a native rebuild.
- Release real-Ray selection — 11 passed, 515 deselected
- Python 3.12, CPU

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependencies or assets are added.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. Error messages do not include embedding payloads, and invalid provider results are not retried.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. This change is Python-only.
