### PR TITLE
[chore](quality) Clean full-tree Ruff baseline and comments

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -70,7 +70,7 @@ jobs:
           scripts/format root --check
 
   run-checks:
-    name: Lint, format and type checks
+    name: Lint, format and type checks for changed files
     needs: validate-format-script
     runs-on: ubuntu-24.04
     steps:
@@ -101,17 +101,6 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Check the full-tree Ruff baseline
-        if: github.event_name != 'pull_request'
-        run: |
-          export PRE_COMMIT_HOME="$HOME/.cache/pre-commit"
-          pre-commit run ruff-check \
-            --show-diff-on-failure \
-            --color=always \
-            --all-files
-          git diff --exit-code
-          git diff --cached --exit-code
 
       - name: Run checks for the changed range
         env:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -70,7 +70,7 @@ jobs:
           scripts/format root --check
 
   run-checks:
-    name: Lint, format and type checks for changed files
+    name: Lint, format and type checks
     needs: validate-format-script
     runs-on: ubuntu-24.04
     steps:
@@ -101,6 +101,17 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Check the full-tree Ruff baseline
+        if: github.event_name != 'pull_request'
+        run: |
+          export PRE_COMMIT_HOME="$HOME/.cache/pre-commit"
+          pre-commit run ruff-check \
+            --show-diff-on-failure \
+            --color=always \
+            --all-files
+          git diff --exit-code
+          git diff --cached --exit-code
 
       - name: Run checks for the changed range
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,15 +18,13 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff-check
-        exclude: ^benchmarking/(parquet|tpcds)/
+        args: [--no-fix]
       # Run the formatter.
       - id: ruff-format
-        exclude: ^benchmarking/(parquet|tpcds)/
       - id: ruff-format
         alias: ruff-format-check
         name: ruff format (check)
         args: [--check]
-        exclude: ^benchmarking/(parquet|tpcds)/
         stages: [manual]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,23 +118,6 @@ pre-commit run --from-ref origin/main --to-ref HEAD
 
 Run `pre-commit install` once per clone.
 
-Run the full Python lint and format checks without modifying the checkout:
-
-```bash
-ruff check --no-fix .
-ruff format --check .
-```
-
-Apply repository-wide Ruff fixes and formatting explicitly:
-
-```bash
-ruff check --fix .
-ruff format .
-```
-
-These commands follow the exclusions in `pyproject.toml`; the imported
-`external/duckdb` tree uses its own formatter below.
-
 Add `--check` to verify formatting without modifying files. Use `workspace`
 when both Vane-owned files and the DuckDB subtree have changed:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -118,6 +118,23 @@ pre-commit run --from-ref origin/main --to-ref HEAD
 
 Run `pre-commit install` once per clone.
 
+Run the full Python lint and format checks without modifying the checkout:
+
+```bash
+ruff check --no-fix .
+ruff format --check .
+```
+
+Apply repository-wide Ruff fixes and formatting explicitly:
+
+```bash
+ruff check --fix .
+ruff format .
+```
+
+These commands follow the exclusions in `pyproject.toml`; the imported
+`external/duckdb` tree uses its own formatter below.
+
 Add `--check` to verify formatting without modifying files. Use `workspace`
 when both Vane-owned files and the DuckDB subtree have changed:
 

--- a/duckdb/execution/udf_ray_ref_bundle.py
+++ b/duckdb/execution/udf_ray_ref_bundle.py
@@ -8,7 +8,9 @@ from typing import Any
 import pyarrow as pa
 
 from duckdb.execution._common import ensure_table as _ensure_table
-from duckdb.execution.udf_output_schema import empty_output_table_from_payload
+from duckdb.execution.udf_output_schema import (
+    empty_output_table_from_payload as empty_output_table_from_payload,
+)
 
 
 def ref_bundle_slice_rows(slice_desc: Any, metadata: dict[str, Any] | None = None) -> int:

--- a/duckdb/pickle.py
+++ b/duckdb/pickle.py
@@ -5,5 +5,4 @@ from __future__ import annotations
 
 from cloudpickle import dumps, loads
 
-
 __all__ = ["dumps", "loads"]

--- a/duckdb/runners/fte/__init__.py
+++ b/duckdb/runners/fte/__init__.py
@@ -5,17 +5,35 @@ from __future__ import annotations
 
 from duckdb.runners.fte.backend import (
     FragmentTemplateStore as FragmentTemplateStore,
+)
+from duckdb.runners.fte.backend import (
     ResourceSnapshotProvider as ResourceSnapshotProvider,
+)
+from duckdb.runners.fte.backend import (
     TaskResultHandle as TaskResultHandle,
+)
+from duckdb.runners.fte.backend import (
     TaskResultPoll as TaskResultPoll,
+)
+from duckdb.runners.fte.backend import (
     TaskResultState as TaskResultState,
+)
+from duckdb.runners.fte.backend import (
     WorkerHandle as WorkerHandle,
+)
+from duckdb.runners.fte.backend import (
     WorkerManagerBackend as WorkerManagerBackend,
 )
 from duckdb.runners.fte.fte_attempts import (
     ExecutionClassTransition as ExecutionClassTransition,
+)
+from duckdb.runners.fte.fte_attempts import (
     ReadyTask as ReadyTask,
+)
+from duckdb.runners.fte.fte_attempts import (
     RevokedAttempt as RevokedAttempt,
+)
+from duckdb.runners.fte.fte_attempts import (
     ScheduledAttempt as ScheduledAttempt,
 )
 from duckdb.runners.fte.fte_config import (
@@ -32,57 +50,121 @@ from duckdb.runners.fte.fte_config import (
 )
 from duckdb.runners.fte.fte_descriptor import (
     FteTaskUpdateRequest as FteTaskUpdateRequest,
+)
+from duckdb.runners.fte.fte_descriptor import (
     TaskDescriptor as TaskDescriptor,
+)
+from duckdb.runners.fte.fte_descriptor import (
     TaskDescriptorStorage as TaskDescriptorStorage,
 )
 from duckdb.runners.fte.fte_exchange import (
     FteExchangeSourceOutputSelector as FteExchangeSourceOutputSelector,
+)
+from duckdb.runners.fte.fte_exchange import (
     FteExchangeTracker as FteExchangeTracker,
+)
+from duckdb.runners.fte.fte_exchange import (
     SpoolingExchangeManager as SpoolingExchangeManager,
+)
+from duckdb.runners.fte.fte_exchange import (
     collect_spooling_output_stats as collect_spooling_output_stats,
+)
+from duckdb.runners.fte.fte_exchange import (
     derive_exchange_sink_instance_for_attempt as derive_exchange_sink_instance_for_attempt,
 )
 from duckdb.runners.fte.fte_execution import (
     FteFragmentExecution as FteFragmentExecution,
+)
+from duckdb.runners.fte.fte_execution import (
     FteWorkerControlFailure as FteWorkerControlFailure,
+)
+from duckdb.runners.fte.fte_execution import (
     FteWorkerReservationUnavailable as FteWorkerReservationUnavailable,
 )
 from duckdb.runners.fte.fte_scheduler import (
     FteAttemptStatusWatcher as FteAttemptStatusWatcher,
+)
+from duckdb.runners.fte.fte_scheduler import (
     FteEventDrivenTaskSource as FteEventDrivenTaskSource,
+)
+from duckdb.runners.fte.fte_scheduler import (
     FteEventHandlers as FteEventHandlers,
+)
+from duckdb.runners.fte.fte_scheduler import (
     FteQueryScheduler as FteQueryScheduler,
+)
+from duckdb.runners.fte.fte_scheduler import (
     FteSchedulerRegistry as FteSchedulerRegistry,
+)
+from duckdb.runners.fte.fte_scheduler import (
     FteSchedulerStats as FteSchedulerStats,
+)
+from duckdb.runners.fte.fte_scheduler import (
     FteWorkerCommandExecutor as FteWorkerCommandExecutor,
 )
 from duckdb.runners.fte.fte_split_assigner import (
     ArbitrarySplitAssigner as ArbitrarySplitAssigner,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     AssignmentResult as AssignmentResult,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     HashSplitAssigner as HashSplitAssigner,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     HashTaskPartition as HashTaskPartition,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     NodeRequirements as NodeRequirements,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     PartitionInfo as PartitionInfo,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     PartitionUpdate as PartitionUpdate,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     SingleSplitAssigner as SingleSplitAssigner,
+)
+from duckdb.runners.fte.fte_split_assigner import (
     SplitAssigner as SplitAssigner,
 )
 from duckdb.runners.fte.fte_state import (
     FtePartitionState as FtePartitionState,
+)
+from duckdb.runners.fte.fte_state import (
     FteTaskExecutionClass as FteTaskExecutionClass,
+)
+from duckdb.runners.fte.fte_state import (
     FteTaskState as FteTaskState,
+)
+from duckdb.runners.fte.fte_state import (
     fte_task_execution_class_from_metadata as fte_task_execution_class_from_metadata,
+)
+from duckdb.runners.fte.fte_state import (
     fte_task_execution_class_metadata_present as fte_task_execution_class_metadata_present,
 )
 from duckdb.runners.fte.fte_types import (
     FteSplit as FteSplit,
+)
+from duckdb.runners.fte.fte_types import (
     FteTaskAttemptId as FteTaskAttemptId,
+)
+from duckdb.runners.fte.fte_types import (
     FteTaskId as FteTaskId,
+)
+from duckdb.runners.fte.fte_types import (
     _check_non_negative as _check_non_negative,
+)
+from duckdb.runners.fte.fte_types import (
     validate_fte_status_identity as validate_fte_status_identity,
 )
 from duckdb.runners.fte.fte_worker_runtime import (
     FteTaskExecution as FteTaskExecution,
+)
+from duckdb.runners.fte.fte_worker_runtime import (
     FteWorkerTaskManager as FteWorkerTaskManager,
+)
+from duckdb.runners.fte.fte_worker_runtime import (
     materialize_task_inputs as materialize_task_inputs,
 )

--- a/duckdb/runners/fte/backends/native/__init__.py
+++ b/duckdb/runners/fte/backends/native/__init__.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 from duckdb.runners.fte.backends.native.backend import (
     NativeFteWorkerManagerBackend as NativeFteWorkerManagerBackend,
+)
+from duckdb.runners.fte.backends.native.backend import (
     NativeTaskResultHandle as NativeTaskResultHandle,
+)
+from duckdb.runners.fte.backends.native.backend import (
     NativeWorkerHandle as NativeWorkerHandle,
 )
 

--- a/duckdb/runners/fte/backends/ray/__init__.py
+++ b/duckdb/runners/fte/backends/ray/__init__.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 
 from duckdb.runners.fte.backends.ray.backend import (
     RayTaskResultHandleAdapter as RayTaskResultHandleAdapter,
+)
+from duckdb.runners.fte.backends.ray.backend import (
     RayWorkerHandleAdapter as RayWorkerHandleAdapter,
+)
+from duckdb.runners.fte.backends.ray.backend import (
     RayWorkerManagerBackend as RayWorkerManagerBackend,
 )
 

--- a/duckdb/runners/ray/fragment_worker_assignment.py
+++ b/duckdb/runners/ray/fragment_worker_assignment.py
@@ -13,8 +13,8 @@ from duckdb.runners.fte import (
 )
 
 if TYPE_CHECKING:
-    from duckdb.runners.ray.fragment_registry import _FteFragmentState
     from duckdb.runners.fte import SplitAssigner
+    from duckdb.runners.ray.fragment_registry import _FteFragmentState
 
 
 def _dynamic_scan_max_splits_per_partition() -> int | None:

--- a/duckdb/runners/ray/fragment_worker_exchange.py
+++ b/duckdb/runners/ray/fragment_worker_exchange.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from duckdb.runners.fte import FteSplit
 from duckdb.runners.ray.fragment_registry import (
     _FTE_REGISTRY_LOCK,
 )
-from duckdb.runners.fte import FteSplit
 from duckdb.runners.ray.fte_fragment_scheduler import (
     _apply_exchange_selector_snapshot,
     _exchange_source_split_key,

--- a/duckdb/runners/ray/fragment_worker_ordering.py
+++ b/duckdb/runners/ray/fragment_worker_ordering.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from duckdb.runners.fte import FteTaskAttemptId, FteTaskExecutionClass
 from duckdb.runners.ray.fragment_registry import (
     _FTE_FRAGMENT_EXECUTION_IDS,
     _FTE_FRAGMENT_EXECUTIONS,
     _FTE_REGISTRY_LOCK,
 )
-from duckdb.runners.fte import FteTaskAttemptId, FteTaskExecutionClass
 
 
 def fragment_id_for_fte_fragment_execution_id(query_id: str, fragment_execution_id: int) -> str | None:

--- a/external/duckdb/physical_operator_serialization_examples.cpp
+++ b/external/duckdb/physical_operator_serialization_examples.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 //===----------------------------------------------------------------------===//
-// PhysicalOperator 序列化使用示例
+// PhysicalOperator serialization examples
 //===----------------------------------------------------------------------===//
 
 #include "duckdb/execution/operator/filter/physical_filter.hpp"
@@ -15,15 +15,15 @@
 
 namespace duckdb {
 
-// 示例：序列化和反序列化 PhysicalFilter
+// Example: serialize and deserialize PhysicalFilter
 void ExampleSerializePhysicalFilter() {
-    // 注意：这是伪代码示例，实际使用需要完整的 DuckDB 上下文
+    // This is pseudocode; real usage requires a complete DuckDB context.
     
     /* 
-    // 1. 创建 PhysicalPlan
+    // 1. Create a PhysicalPlan.
     PhysicalPlan physical_plan;
     
-    // 2. 创建过滤表达式 (例如: column > 10)
+    // 2. Create a filter expression, such as column > 10.
     vector<unique_ptr<Expression>> filter_expressions;
     auto left = make_uniq<BoundReferenceExpression>("column", LogicalType::INTEGER, 0);
     auto right = make_uniq<BoundConstantExpression>(Value::INTEGER(10));
@@ -34,7 +34,7 @@ void ExampleSerializePhysicalFilter() {
     );
     filter_expressions.push_back(std::move(comparison));
     
-    // 3. 创建 PhysicalFilter 算子
+    // 3. Create the PhysicalFilter operator.
     vector<LogicalType> types = {LogicalType::INTEGER, LogicalType::VARCHAR};
     auto filter_op = make_uniq<PhysicalFilter>(
         physical_plan,
@@ -43,40 +43,39 @@ void ExampleSerializePhysicalFilter() {
         1000  // estimated_cardinality
     );
     
-    // 4. 序列化
+    // 4. Serialize it.
     BinarySerializer serializer;
     filter_op->Serialize(serializer);
     auto serialized_data = serializer.GetData();
     
-    // 5. 反序列化
+    // 5. Deserialize it.
     BinaryDeserializer deserializer(serialized_data);
     auto deserialized_filter = PhysicalFilter::Deserialize(deserializer, physical_plan);
     
-    // 6. 使用反序列化的算子
-    // deserialized_filter 现在可以像原始算子一样使用
+    // 6. Use the deserialized operator like the original one.
     */
 }
 
-// 示例：序列化和反序列化 PhysicalProjection
+// Example: serialize and deserialize PhysicalProjection
 void ExampleSerializePhysicalProjection() {
     /* 
-    // 1. 创建 PhysicalPlan
+    // 1. Create a PhysicalPlan.
     PhysicalPlan physical_plan;
     
-    // 2. 创建投影表达式列表
+    // 2. Create the projection expression list.
     vector<unique_ptr<Expression>> select_list;
     
-    // 投影第一列
+    // Project the first column.
     select_list.push_back(
         make_uniq<BoundReferenceExpression>("col1", LogicalType::INTEGER, 0)
     );
     
-    // 投影第二列
+    // Project the second column.
     select_list.push_back(
         make_uniq<BoundReferenceExpression>("col2", LogicalType::VARCHAR, 1)
     );
     
-    // 3. 创建 PhysicalProjection 算子
+    // 3. Create the PhysicalProjection operator.
     vector<LogicalType> output_types = {LogicalType::INTEGER, LogicalType::VARCHAR};
     auto projection_op = make_uniq<PhysicalProjection>(
         physical_plan,
@@ -85,130 +84,129 @@ void ExampleSerializePhysicalProjection() {
         1000  // estimated_cardinality
     );
     
-    // 4. 序列化
+    // 4. Serialize it.
     BinarySerializer serializer;
     projection_op->Serialize(serializer);
     auto serialized_data = serializer.GetData();
     
-    // 5. 反序列化
+    // 5. Deserialize it.
     BinaryDeserializer deserializer(serialized_data);
     auto deserialized_projection = PhysicalProjection::Deserialize(deserializer, physical_plan);
     
-    // 6. 验证
+    // 6. Verify the result.
     assert(deserialized_projection->select_list.size() == 2);
     */
 }
 
-// 示例：尝试序列化未实现的算子
+// Example: try to serialize an unsupported operator
 void ExampleUnimplementedOperator() {
     /* 
-    // 对于未实现序列化的算子，会抛出 NotImplementedException
+    // Operators without serialization support throw NotImplementedException.
     
     try {
-        // 假设某个算子没有实现序列化
+        // Assume an operator does not implement serialization.
         PhysicalPlan physical_plan;
-        // ... 创建某个未实现序列化的算子 ...
+        // ... create an operator without serialization support ...
         
         BinarySerializer serializer;
-        // operator->Serialize(serializer);  // 会抛出异常
+        // operator->Serialize(serializer);  // Throws an exception.
         
     } catch (const NotImplementedException &e) {
-        // 错误信息类似: "Serialization not implemented for operator type: XXX"
+        // The error resembles: "Serialization not implemented for operator type: XXX".
         std::cout << "Expected error: " << e.what() << std::endl;
     }
     */
 }
 
-// 示例：序列化包含子算子的算子树
+// Example: serialize an operator tree with child operators
 void ExampleSerializeOperatorTree() {
     /* 
-    // 对于包含子算子的情况，需要递归序列化
+    // Trees with child operators require recursive serialization.
     
     PhysicalPlan physical_plan;
     
-    // 1. 创建叶子算子（如 TableScan）
-    // ... 创建 table_scan ...
+    // 1. Create a leaf operator such as TableScan.
+    // ... create table_scan ...
     
-    // 2. 创建 Projection 算子，以 TableScan 为子算子
+    // 2. Create a Projection operator with TableScan as its child.
     vector<unique_ptr<Expression>> proj_list;
-    // ... 添加投影表达式 ...
+    // ... add projection expressions ...
     auto projection = make_uniq<PhysicalProjection>(
         physical_plan,
         types,
         std::move(proj_list),
         1000
     );
-    // projection->children.push_back(table_scan);  // 添加子算子
+    // projection->children.push_back(table_scan);  // Add the child operator.
     
-    // 3. 创建 Filter 算子，以 Projection 为子算子
+    // 3. Create a Filter operator with Projection as its child.
     vector<unique_ptr<Expression>> filter_exprs;
-    // ... 添加过滤表达式 ...
+    // ... add filter expressions ...
     auto filter = make_uniq<PhysicalFilter>(
         physical_plan,
         types,
         std::move(filter_exprs),
         500
     );
-    // filter->children.push_back(projection);  // 添加子算子
+    // filter->children.push_back(projection);  // Add the child operator.
     
-    // 4. 序列化整个算子树
-    // 注意：当前实现需要手动处理子算子的序列化
-    // 未来可以在基类中实现通用的子算子序列化逻辑
+    // 4. Serialize the complete operator tree.
+    // The current implementation requires child operators to be handled manually.
+    // Common child-operator serialization could be added to the base class later.
     */
 }
 
 } // namespace duckdb
 
-// 主要用法总结
+// Usage summary
 /* 
 
-## 基本用法
+## Basic usage
 
-### 序列化
+### Serialization
 ```cpp
-// 1. 创建算子
+// 1. Create an operator.
 auto op = make_uniq<PhysicalFilter>(...);
 
-// 2. 创建序列化器
+// 2. Create a serializer.
 BinarySerializer serializer;
 
-// 3. 序列化
+// 3. Serialize the operator.
 op->Serialize(serializer);
 
-// 4. 获取序列化数据
+// 4. Retrieve the serialized data.
 auto data = serializer.GetData();
 ```
 
-### 反序列化
+### Deserialization
 ```cpp
-// 1. 创建反序列化器
+// 1. Create a deserializer.
 BinaryDeserializer deserializer(data);
 
-// 2. 反序列化
+// 2. Deserialize the operator.
 auto op = PhysicalFilter::Deserialize(deserializer, physical_plan);
 
-// 3. 使用算子
-// op 现在可以正常使用了
+// 3. Use the operator normally.
 ```
 
-## 已实现的算子
+## Supported operators
 
-1. **PhysicalFilter** - 完整实现
-   - 序列化过滤表达式
-   - 支持复杂的布尔表达式
+1. **PhysicalFilter** - fully implemented
+   - Serializes filter expressions
+   - Supports complex Boolean expressions
 
-2. **PhysicalProjection** - 完整实现
-   - 序列化投影表达式列表
-   - 支持多列投影
+2. **PhysicalProjection** - fully implemented
+   - Serializes projection expression lists
+   - Supports multi-column projections
 
-3. **PhysicalTableScan** - 部分实现
-   - 声明了接口
-   - 实现会抛出 NotImplementedException
-   - 原因：需要 catalog context 和 TableFunction 序列化
+3. **PhysicalTableScan** - partially implemented
+   - Declares the interface
+   - Throws NotImplementedException
+   - Requires catalog context and TableFunction serialization
 
-## 错误处理
+## Error handling
 
-未实现序列化的算子会抛出清晰的错误：
+Operators without serialization support throw a clear error:
 ```cpp
 throw NotImplementedException(
     "Serialization not implemented for operator type: %s",
@@ -216,29 +214,29 @@ throw NotImplementedException(
 );
 ```
 
-## 扩展指南
+## Extension guide
 
-为新算子添加序列化支持：
+To add serialization support to a new operator:
 
-1. 在头文件中声明：
+1. Declare the methods in the header:
 ```cpp
 void Serialize(Serializer &serializer) const override;
 static unique_ptr<PhysicalOperator> Deserialize(Deserializer &deserializer, PhysicalPlan &physical_plan);
 ```
 
-2. 在实现文件中：
+2. Define them in the implementation file:
 ```cpp
 void MyOperator::Serialize(Serializer &serializer) const {
     serializer.WriteProperty(100, "type", type);
     serializer.WriteProperty(101, "types", types);
     serializer.WriteProperty(102, "estimated_cardinality", estimated_cardinality);
-    // ... 序列化算子特定字段 ...
+    // ... serialize operator-specific fields ...
 }
 
 unique_ptr<PhysicalOperator> MyOperator::Deserialize(Deserializer &deserializer, PhysicalPlan &physical_plan) {
     auto types = deserializer.ReadProperty<vector<LogicalType>>(101, "types");
     auto estimated_cardinality = deserializer.ReadProperty<idx_t>(102, "estimated_cardinality");
-    // ... 反序列化算子特定字段 ...
+    // ... deserialize operator-specific fields ...
     return make_uniq<MyOperator>(physical_plan, ...);
 }
 ```

--- a/external/duckdb/src/execution/operator/exchange/repartition.cpp
+++ b/external/duckdb/src/execution/operator/exchange/repartition.cpp
@@ -58,7 +58,6 @@ std::vector<ExprRef> CopyRangeExpressions(const vector<BoundOrderByNode> &orders
 
 } // namespace
 
-// HashRepartitionConfig 实现
 HashRepartitionConfig::HashRepartitionConfig(size_t num_partitions, std::vector<ExprRef> by)
     : num_partitions(num_partitions), by(std::move(by)) {
 }
@@ -82,7 +81,6 @@ std::shared_ptr<HashRepartitionConfig> HashRepartitionConfig::create(size_t num_
 	return std::make_shared<HashRepartitionConfig>(num_partitions, std::move(by));
 }
 
-// RandomShuffleConfig 实现
 RandomShuffleConfig::RandomShuffleConfig(size_t num_partitions) : num_partitions(num_partitions) {
 }
 
@@ -94,7 +92,6 @@ std::shared_ptr<RandomShuffleConfig> RandomShuffleConfig::create(size_t num_part
 	return std::make_shared<RandomShuffleConfig>(num_partitions);
 }
 
-// RangeRepartitionConfig 实现
 RangeRepartitionConfig::RangeRepartitionConfig(size_t num_partitions, vector<BoundOrderByNode> orders,
                                                vector<string> boundaries)
     : num_partitions_(num_partitions), orders_(std::move(orders)), boundaries_(std::move(boundaries)) {
@@ -147,7 +144,6 @@ vector<BoundOrderByNode> RangeRepartitionConfig::CopyOrders() const {
 	return CopyRangeOrders(orders_);
 }
 
-// IntoPartitionsConfig 实现
 IntoPartitionsConfig::IntoPartitionsConfig(size_t num_partitions) : num_partitions(num_partitions) {
 }
 
@@ -159,7 +155,6 @@ std::shared_ptr<IntoPartitionsConfig> IntoPartitionsConfig::create(size_t num_pa
 	return std::make_shared<IntoPartitionsConfig>(num_partitions);
 }
 
-// RepartitionSpec 工厂方法
 std::shared_ptr<RepartitionSpec> RepartitionSpec::create_hash(size_t num_partitions, std::vector<ExprRef> by) {
 	auto config = HashRepartitionConfig::create(num_partitions, std::move(by));
 	return std::make_shared<HashRepartitionSpec>(config);
@@ -181,7 +176,6 @@ std::shared_ptr<RepartitionSpec> RepartitionSpec::create_range(size_t num_partit
 	return std::make_shared<RangeRepartitionSpec>(std::move(config));
 }
 
-// HashRepartitionSpec 实现
 HashRepartitionSpec::HashRepartitionSpec(std::shared_ptr<HashRepartitionConfig> config) : config_(std::move(config)) {
 }
 
@@ -195,10 +189,6 @@ ClusteringSpecRef HashRepartitionSpec::to_clustering_spec(size_t upstream_num_pa
 	return ClusteringSpec::from_hash_config(clustering_config);
 }
 
-// 其他 RepartitionSpec 派生类的实现类似...
-// 为简洁起见，这里省略详细实现
-
-// RandomRepartitionSpec 实现
 RandomRepartitionSpec::RandomRepartitionSpec(std::shared_ptr<RandomShuffleConfig> config) : config_(std::move(config)) {
 }
 
@@ -212,7 +202,6 @@ ClusteringSpecRef RandomRepartitionSpec::to_clustering_spec(size_t upstream_num_
 	return ClusteringSpec::from_random_config(cfg);
 }
 
-// IntoPartitionsRepartitionSpec 实现
 IntoPartitionsRepartitionSpec::IntoPartitionsRepartitionSpec(std::shared_ptr<IntoPartitionsConfig> config)
     : config_(std::move(config)) {
 }
@@ -226,7 +215,6 @@ ClusteringSpecRef IntoPartitionsRepartitionSpec::to_clustering_spec(size_t /*ups
 	return ClusteringSpec::from_unknown_config(cfg);
 }
 
-// RangeRepartitionSpec 实现
 RangeRepartitionSpec::RangeRepartitionSpec(std::shared_ptr<const RangeRepartitionConfig> config)
     : config_(std::move(config)) {
 	if (!config_) {
@@ -244,7 +232,6 @@ ClusteringSpecRef RangeRepartitionSpec::to_clustering_spec(size_t upstream_num_p
 	return ClusteringSpec::from_range_config(RangeClusteringConfig(actual, config_->CopyOrders()));
 }
 
-// RangeClusteringConfig 实现
 RangeClusteringConfig::RangeClusteringConfig(size_t num_partitions, vector<BoundOrderByNode> orders)
     : num_partitions_(num_partitions), orders_(std::move(orders)) {
 	ValidateRangeOrders(orders_);
@@ -285,12 +272,10 @@ std::vector<ExprRef> RangeClusteringConfig::partition_by() const {
 	return CopyRangeExpressions(orders_);
 }
 
-// HashClusteringConfig 实现
 HashClusteringConfig::HashClusteringConfig(size_t num_partitions, std::vector<ExprRef> by)
     : num_partitions(num_partitions), by(std::move(by)) {
 }
 
-// HashClusteringSpec 实现
 HashClusteringSpec::HashClusteringSpec(const HashClusteringConfig &config) : config_(config) {
 }
 
@@ -306,7 +291,6 @@ std::vector<std::string> HashClusteringSpec::multiline_display() const {
 	return config_.multiline_display();
 }
 
-// RandomClusteringSpec 实现
 RandomClusteringSpec::RandomClusteringSpec(const RandomClusteringConfig &config) : config_(config) {
 }
 
@@ -322,7 +306,6 @@ std::vector<std::string> RandomClusteringSpec::multiline_display() const {
 	return config_.multiline_display();
 }
 
-// UnknownClusteringSpec 实现
 UnknownClusteringSpec::UnknownClusteringSpec(const UnknownClusteringConfig &config) : config_(config) {
 }
 
@@ -353,7 +336,6 @@ std::vector<std::string> HashClusteringConfig::multiline_display() const {
 	return result;
 }
 
-// RandomClusteringConfig 实现
 RandomClusteringConfig::RandomClusteringConfig(size_t num_partitions) : num_partitions(num_partitions) {
 }
 
@@ -361,7 +343,6 @@ std::vector<std::string> RandomClusteringConfig::multiline_display() const {
 	return {"Num partitions = " + std::to_string(num_partitions)};
 }
 
-// UnknownClusteringConfig 实现
 UnknownClusteringConfig::UnknownClusteringConfig(size_t num_partitions) : num_partitions(num_partitions) {
 }
 
@@ -369,10 +350,6 @@ std::vector<std::string> UnknownClusteringConfig::multiline_display() const {
 	return {"Num partitions = " + std::to_string(num_partitions)};
 }
 
-// ClusteringSpec 静态工厂方法
-// The ClusteringSpec factory helpers are now implemented inline in repartition.hpp.
-
-// RangeClusteringSpec 实现
 RangeClusteringSpec::RangeClusteringSpec(RangeClusteringConfig config) : config_(std::move(config)) {
 }
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/common/display/lib.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/common/display/lib.hpp
@@ -7,11 +7,11 @@
 namespace duckdb {
 namespace distributed {
 
-// 显示级别枚举
+// Display detail levels
 enum class DisplayLevel {
-	Compact, // 紧凑显示，仅展示最重要信息
-	Default, // 默认显示，展示常用信息
-	Verbose  // 详细显示，展示所有可用信息
+	Compact, // Show only the most important information
+	Default, // Show commonly useful information
+	Verbose  // Show all available information
 };
 
 } // namespace distributed

--- a/external/duckdb/src/include/duckdb/execution/distributed/common_types.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/common_types.hpp
@@ -666,7 +666,7 @@ private:
 	size_t distributed_worker_slots_;
 	size_t scan_task_backlog_;
 
-	// 环境变量名常量
+	// Environment variable names
 	static constexpr const char *ENV_VANE_SHUFFLE_ALGORITHM = "VANE_SHUFFLE_ALGORITHM";
 	static constexpr const char *ENV_VANE_MIN_CPU_PER_TASK = "VANE_MIN_CPU_PER_TASK";
 	static constexpr const char *ENV_SCAN_TASK_SIZE_GROUPING = "VANE_RAY_SCAN_TASK_SIZE_GROUPING";
@@ -679,7 +679,6 @@ private:
 	static constexpr const char *ENV_SCAN_TASK_MIN_PARTITION_NUM = "VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM";
 
 public:
-	// 默认构造函数
 	DuckDBExecutionConfig()
 	    : shuffle_algorithm_(""), min_cpu_per_task_(1), scan_task_size_grouping_enabled_(true),
 	      scan_task_min_bytes_(96ULL * 1024 * 1024), scan_task_max_bytes_(384ULL * 1024 * 1024),
@@ -687,11 +686,9 @@ public:
 	      distributed_worker_slots_(0), scan_task_backlog_(0) {
 	}
 
-	// 从环境变量创建配置
 	static DuckDBExecutionConfig from_env() {
 		DuckDBExecutionConfig cfg;
 
-		// 解析字符串环境变量
 		{
 			auto val = parse_string_from_env(ENV_VANE_SHUFFLE_ALGORITHM, true);
 			if (val.first) {
@@ -699,7 +696,6 @@ public:
 			}
 		}
 
-		// 解析整数环境变量
 		{
 			auto val = parse_int_from_env(ENV_VANE_MIN_CPU_PER_TASK);
 			if (val.first) {
@@ -760,7 +756,6 @@ public:
 		return cfg;
 	}
 
-	// Getter 方法
 	const std::string &shuffle_algorithm() const {
 		return shuffle_algorithm_;
 	}
@@ -802,7 +797,6 @@ public:
 	}
 
 private:
-	// 解析字符串环境变量
 	static std::pair<bool, std::string> parse_string_from_env(const char *env_name, bool trim_whitespace = false) {
 		const char *val = std::getenv(env_name);
 		if (val == nullptr) {
@@ -818,7 +812,6 @@ private:
 		return std::make_pair(true, result);
 	}
 
-	// 解析布尔值环境变量
 	static std::pair<bool, bool> parse_bool_from_env(const char *env_name) {
 		const char *val = std::getenv(env_name);
 		if (val == nullptr) {
@@ -837,7 +830,6 @@ private:
 		return std::make_pair(false, false);
 	}
 
-	// 解析整数环境变量
 	static std::pair<bool, int> parse_int_from_env(const char *env_name) {
 		const char *val = std::getenv(env_name);
 		if (val == nullptr) {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
@@ -156,9 +156,7 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
-// PipelineNodeImpl - 流水线节点接口
-// 对应 DuckDB 的 PipelineNodeImpl trait
-// 所有具体节点类型必须实现此接口
+// Distributed task stream primitives
 //===----------------------------------------------------------------------===//
 // Forward declarations needed by the stream types
 template <typename TaskT>
@@ -207,23 +205,21 @@ private:
 	TaskT task_;
 };
 
-// 可提交任务流类
+// Stream of tasks ready for submission
 template <typename TaskT>
 class SubmittableTaskStream {
 public:
-	// 从接收器构造（对应 From<Receiver> trait 实现）
+	// Construct from a receiver, mirroring the From<Receiver> trait implementation
 	static SubmittableTaskStream from_receiver(Receiver<SubmittableTask<TaskT>> receiver);
 
-	// 构造函数
 	SubmittableTaskStream(std::unique_ptr<BoxStream<SubmittableTask<TaskT>>> task_stream)
 	    : task_stream_(std::move(task_stream)) {
 	}
 
-	// 物化方法 - 返回 MaterializeResult (synchronous for C++11)
+	// Materialize and return a MaterializeResult (synchronous for C++11)
 	MaterializeResult materialize(FteTaskSubmitter *fte_task_submitter = nullptr,
 	                              MaterializedOutputCallback on_output = {});
 
-	// 管道指令方法
 	template <typename F>
 	SubmittableTaskStream pipeline_instruction(std::shared_ptr<PipelineNodeImpl> node, F plan_builder,
 	                                           ::duckdb::ClientContext *client_context = nullptr) {
@@ -387,7 +383,7 @@ public:
 		return SubmittableTaskStream(std::move(boxed_stream));
 	}
 
-	// 流接口的轮询方法
+	// Poll the stream interface
 	std::pair<bool, SubmittableTask<TaskT>> poll_next() {
 		return task_stream_->poll_next();
 	}
@@ -409,20 +405,18 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-// PipelineNodeImpl - 流水线节点接口
-// 对应 DuckDB 的 PipelineNodeImpl trait
-// 所有具体节点类型必须实现此接口
+// PipelineNodeImpl interface for pipeline nodes.
+// This mirrors DuckDB's PipelineNodeImpl trait and is implemented by every concrete node type.
 //===----------------------------------------------------------------------===//
 class PipelineNodeImpl {
 public:
-	// 纯虚函数：必须在派生类中实现
 	virtual const PipelineNodeContext &context() const = 0;
 	virtual const PipelineNodeConfig &config() const = 0;
 
 	virtual std::vector<PipelineNodeRef> children() const = 0;
-	//! 产生可提交的任务流
-	//! 对应 Rust: fn produce_tasks(...) -> BoxStream<'static, SubmittableTask<WorkerTask>>
-	//! C++20 协程版本返回 Generator，使用 co_yield 产出任务
+	//! Produce a stream of tasks ready for submission.
+	//! Corresponds to Rust: fn produce_tasks(...) -> BoxStream<'static, SubmittableTask<WorkerTask>>.
+	//! The C++20 coroutine returns a Generator and yields tasks with co_yield.
 	virtual SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) = 0;
 	virtual NodeName name() const {
 		return this->context().node_name();
@@ -474,7 +468,6 @@ class DistributedPipelineNode : public PipelineNodeImpl,
                                 public TreeDisplay,
                                 public std::enable_shared_from_this<DistributedPipelineNode> {
 public:
-	// 构造函数
 	DistributedPipelineNode(std::shared_ptr<PipelineNodeImpl> op) : op_(std::move(op)) {
 		// Defensive: if op_ is null, do not attempt to inspect children.
 		if (!op_)
@@ -490,26 +483,21 @@ public:
 		}
 	}
 
-	// 拷贝构造函数（对应 #[derive(Clone)]）
 	DistributedPipelineNode(const DistributedPipelineNode &other) : op_(other.op_), children_(other.children_) {
 	}
 
-	// 获取上下文
 	const PipelineNodeContext &context() const {
 		return op_->context();
 	}
 
-	// 获取配置
 	const PipelineNodeConfig &config() const {
 		return op_->config();
 	}
 
-	// 获取节点ID
 	NodeID node_id() const {
 		return op_->node_id();
 	}
 
-	// 获取节点名称
 	NodeName name() const {
 		return op_->name();
 	}
@@ -530,19 +518,16 @@ public:
 		return op_;
 	}
 
-	// 获取分区数量
 	size_t num_partitions() const;
 
 	// If this node is a ScanSource with scan tasks, return them.
 	bool try_get_scan_tasks(std::vector<ScanTaskDescriptor> &out) const;
 
-	// 生产任务流
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override {
 		auto result = op_->produce_tasks(plan_context);
 		return std::move(result);
 	}
 
-	// 转换为树显示接口
 	const TreeDisplay *as_tree_display() const {
 		return this;
 	}
@@ -567,20 +552,18 @@ public:
 		return DuckDBResult<DistributedPipelineNodeRef>::ok(std::move(node));
 	}
 
-	// TreeDisplay 接口实现
 	std::string display_as(DisplayLevel level) const {
 		switch (level) {
 		case DisplayLevel::Compact:
 			return get_name();
 		case DisplayLevel::Default: {
 			auto display_lines = op_->multiline_display(false);
-			// 将字符串向量连接为单个字符串
 			std::string result;
 			for (const auto &line : display_lines) {
 				result += line + "\n";
 			}
 			if (!result.empty())
-				result.pop_back(); // 移除最后一个换行符
+				result.pop_back(); // Remove the trailing newline
 			return result;
 		}
 		case DisplayLevel::Verbose: {
@@ -602,9 +585,8 @@ public:
 		return op_->multiline_display(verbose);
 	}
 
-	// JSON 表示（简化版，实际需要完整的 JSON 库支持）
+	// Simplified JSON representation; full support requires a JSON library
 	std::string repr_json() const {
-		// 简化实现，实际需要使用 JSON 库
 		return "{\"id\":\"" + std::to_string(node_id()) + "\",\"type\":\"" + name() + "\",\"name\":\"" + get_name() +
 		       "\"}";
 	}
@@ -628,8 +610,6 @@ public:
 	}
 
 private:
-	// 私有构造函数，用于 with_new_children
-	// Private constructor used by with_new_children
 	DistributedPipelineNode(std::shared_ptr<PipelineNodeImpl> op, std::vector<DistributedPipelineNodeRef> children)
 	    : op_(op), children_(std::move(children)) {
 	}

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
@@ -21,7 +21,6 @@ class ExchangeManager;
 namespace duckdb {
 namespace distributed {
 
-// 重分区节点类
 class RepartitionNode : public PipelineNodeImpl, public std::enable_shared_from_this<RepartitionNode> {
 private:
 	PipelineNodeConfig config_;
@@ -36,17 +35,14 @@ private:
 	static constexpr const char *NODE_NAME = "Repartition";
 
 public:
-	// 构造函数
 	static std::shared_ptr<RepartitionNode> create(NodeID node_id, const std::shared_ptr<PlanConfig> &plan_config,
 	                                               std::shared_ptr<::duckdb::RepartitionSpec> repartition_spec,
 	                                               size_t num_partitions, SchemaRef schema,
 	                                               std::shared_ptr<DistributedPipelineNode> child,
 	                                               std::shared_ptr<ExchangeManager> exchange_mgr = nullptr);
 
-	// 转换为分布式管道节点
 	std::shared_ptr<DistributedPipelineNode> into_node();
 
-	// PipelineNodeImpl 接口实现
 	const PipelineNodeContext &context() const override;
 
 	const PipelineNodeConfig &config() const override;
@@ -73,16 +69,13 @@ public:
 		                                              : std::vector<NodeID> {};
 	}
 
-	// 生成任务流（核心方法）
 	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
 
-	// 节点ID获取方法
 	NodeID node_id() const override {
 		return context_.node_id();
 	}
 
 private:
-	// 私有构造函数
 	RepartitionNode(PipelineNodeConfig config, PipelineNodeContext context,
 	                std::shared_ptr<::duckdb::RepartitionSpec> repartition_spec, size_t num_partitions,
 	                std::shared_ptr<DistributedPipelineNode> child, std::shared_ptr<ExchangeManager> exchange_mgr);

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -60,7 +60,6 @@ private:
 	DuckPhysicalPlanRef plan_;
 	std::shared_ptr<ExchangeManager> exchange_mgr_;
 
-	// 辅助方法：获取下一个节点ID
 	int get_next_pipeline_node_id() {
 		return ++pipeline_node_id_counter_;
 	}
@@ -85,24 +84,24 @@ private:
 	// stack of constructed DistributedPipelineNodes corresponding to visited operators
 	std::vector<std::shared_ptr<DistributedPipelineNode>> node_stack_;
 
-	// 生成 shuffle 节点（实现自 Rust 逻辑）
+	// Generate a shuffle node using the logic from the Rust implementation
 	std::shared_ptr<DistributedPipelineNode> gen_shuffle_node(std::shared_ptr<RepartitionSpec> repartition_spec,
 	                                                          SchemaRef schema,
 	                                                          std::shared_ptr<DistributedPipelineNode> child);
 
-	// 生成无预聚合的聚合节点（GroupBy/Shuffle/Gather）
+	// Generate aggregation nodes without pre-aggregation (GroupBy/Shuffle/Gather)
 	std::shared_ptr<DistributedPipelineNode> gen_without_pre_agg(std::shared_ptr<DistributedPipelineNode> input_node,
 	                                                             const std::vector<BoundExpr> &group_by,
 	                                                             const std::vector<BoundAggExpr> &aggregations,
 	                                                             SchemaRef output_schema,
 	                                                             const std::vector<BoundExpr> &partition_by);
 
-	// 生成有预聚合的聚合节点（两阶段聚合：pre-agg -> shuffle -> final agg -> project）
+	// Generate two-stage aggregation nodes (pre-agg -> shuffle -> final agg -> project)
 	std::shared_ptr<DistributedPipelineNode> gen_with_pre_agg(std::shared_ptr<DistributedPipelineNode> input_node,
 	                                                          const GroupByAggSplit &split_details,
 	                                                          SchemaRef output_schema);
 
-	// 生成聚合节点（主入口，选择有或无预聚合路径）
+	// Generate aggregation nodes, selecting the path with or without pre-aggregation
 	std::shared_ptr<DistributedPipelineNode> gen_agg_nodes(std::shared_ptr<DistributedPipelineNode> input_node,
 	                                                       const std::vector<BoundExpr> &group_by,
 	                                                       const std::vector<BoundAggExpr> &aggregations,
@@ -115,7 +114,7 @@ private:
 	                      const std::vector<std::vector<idx_t>> &grouping_functions,
 	                      const std::vector<LogicalType> &input_types, SchemaRef output_schema);
 
-	// 生成 gather 节点（使用 RepartitionNode with num_partitions=1）
+	// Generate a gather node using RepartitionNode with num_partitions=1
 	std::shared_ptr<DistributedPipelineNode> gen_gather_node(std::shared_ptr<DistributedPipelineNode> input_node);
 
 	std::shared_ptr<PipelineNodeImpl>

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
@@ -38,29 +38,24 @@ private:
 	DuckDBExecutionConfigRef config_;
 
 public:
-	// 构造函数
 	DistributedPhysicalPlan(uint16_t query_idx, std::string query_id,
 	                        std::shared_ptr<duckdb::PhysicalPlan> physical_plan, DuckDBExecutionConfigRef config)
 	    : query_idx_(query_idx), query_id_(std::move(query_id)), physical_plan_(std::move(physical_plan)),
 	      config_(std::move(config)) {
 	}
 
-	// 获取查询索引
 	uint16_t idx() const {
 		return query_idx_;
 	}
 
-	// 获取查询ID
 	const std::string &query_id() const {
 		return query_id_;
 	}
 
-	// 获取物理计划（返回引用避免不必要的拷贝）
 	const std::shared_ptr<duckdb::PhysicalPlan> &physical_plan() const {
 		return physical_plan_;
 	}
 
-	// 获取执行配置
 	DuckDBExecutionConfigRef execution_config() const {
 		return config_;
 	}
@@ -76,7 +71,6 @@ public:
 	                     DuckDBExecutionConfigRef config = nullptr);
 
 private:
-	// 禁用默认构造函数
 	DistributedPhysicalPlan() = delete;
 };
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/utils/channel.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/utils/channel.hpp
@@ -554,7 +554,7 @@ std::pair<UnboundedSender<T>, UnboundedReceiver<T>> create_unbounded_channel() {
 // Types used as streams should provide:
 //   - std::pair<bool, value_type> poll_next()
 
-// 简化的流类型别名（对应 Rust 的 BoxStream）
+// Simplified stream alias corresponding to Rust's BoxStream
 template <typename T>
 class BoxStream {
 public:
@@ -631,7 +631,7 @@ private:
 	std::unique_ptr<StreamConcept> stream_;
 };
 
-// 工具函数：将流装箱（对应 .boxed() 方法）
+// Box a stream, corresponding to Rust's .boxed() method
 template <typename T, typename StreamType>
 std::unique_ptr<BoxStream<T>> boxed(StreamType &&stream) {
 	return std::unique_ptr<BoxStream<T>>(new BoxStream<T>(std::forward<StreamType>(stream)));

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/repartition.hpp
@@ -13,7 +13,6 @@
 
 namespace duckdb {
 
-// 前置声明
 class Expression;
 class ClusteringSpec;
 
@@ -33,14 +32,12 @@ class HashClusteringSpec;
 class RandomClusteringSpec;
 class UnknownClusteringSpec;
 
-// 基础配置类
 class BaseConfig {
 public:
 	virtual ~BaseConfig() = default;
 	virtual std::vector<std::string> multiline_display() const = 0;
 };
 
-// 哈希重新分区配置
 class HashRepartitionConfig : public BaseConfig {
 public:
 	size_t num_partitions; // 0 means auto
@@ -52,7 +49,6 @@ public:
 	static std::shared_ptr<HashRepartitionConfig> create(size_t num_partitions, std::vector<ExprRef> by);
 };
 
-// 随机洗牌配置
 class RandomShuffleConfig : public BaseConfig {
 public:
 	size_t num_partitions; // 0 means auto
@@ -63,7 +59,6 @@ public:
 	static std::shared_ptr<RandomShuffleConfig> create(size_t num_partitions);
 };
 
-// 范围重新分区配置
 class RangeRepartitionConfig : public BaseConfig {
 public:
 	RangeRepartitionConfig(size_t num_partitions, vector<BoundOrderByNode> orders, vector<string> boundaries);
@@ -92,7 +87,6 @@ private:
 	vector<string> boundaries_;
 };
 
-// 分区数配置
 class IntoPartitionsConfig : public BaseConfig {
 public:
 	size_t num_partitions;
@@ -103,7 +97,6 @@ public:
 	static std::shared_ptr<IntoPartitionsConfig> create(size_t num_partitions);
 };
 
-// 重新分区规范枚举的类层次结构
 class RepartitionSpec {
 public:
 	enum class Type { Hash, Random, IntoPartitions, Range };
@@ -115,7 +108,6 @@ public:
 	virtual std::vector<std::string> multiline_display() const = 0;
 	virtual ClusteringSpecRef to_clustering_spec(size_t upstream_num_partitions) const = 0;
 
-	// 静态工厂方法
 	static std::shared_ptr<RepartitionSpec> create_hash(size_t num_partitions, std::vector<ExprRef> by);
 	static std::shared_ptr<RepartitionSpec> create_random(size_t num_partitions);
 	static std::shared_ptr<RepartitionSpec> create_into_partitions(size_t num_partitions);
@@ -123,7 +115,6 @@ public:
 	                                                     vector<string> boundaries);
 };
 
-// 聚类规范（ClusteringSpec）基础类
 class ClusteringSpec {
 public:
 	enum class Type { Range, Hash, Random, Unknown };
@@ -156,7 +147,6 @@ class HashClusteringConfig;
 class RandomClusteringConfig;
 class UnknownClusteringConfig;
 
-// 具体的重新分区规范实现
 class HashRepartitionSpec : public RepartitionSpec {
 private:
 	std::shared_ptr<HashRepartitionConfig> config_;
@@ -288,7 +278,6 @@ public:
 	std::vector<std::string> multiline_display() const override;
 };
 
-// 具体的聚类规范实现
 class RangeClusteringSpec : public ClusteringSpec {
 private:
 	RangeClusteringConfig config_;

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -6,7 +6,7 @@
 //
 // test_physical_plan_translator.cpp
 //
-// 单元测试：DuckDB 物理计划到分布式流水线节点的转换
+// Unit tests for translating DuckDB physical plans into distributed pipeline nodes.
 //===----------------------------------------------------------------------===//
 
 #include "catch.hpp"
@@ -352,7 +352,7 @@ TEST_CASE("Streaming UDF passthrough schema preserves physical column boundaries
 }
 
 TEST_CASE("PhysicalPlanTranslator: simple projection", "[distributed]") {
-	// 构造一个简单的物理计划: TableScan -> Projection
+	// Construct a simple physical plan: TableScan -> Projection.
 	Allocator allocator;
 	PhysicalPlan plan(allocator);
 	LogicalType int_type = LogicalType::INTEGER;
@@ -388,7 +388,6 @@ TEST_CASE("PhysicalPlanTranslator: simple projection", "[distributed]") {
 	plan_ptr->SetRoot(projection2);
 	auto result = duckdb::distributed::physical_plan_to_pipeline_node(duckdb::distributed::PlanConfig {}, plan_ptr);
 	REQUIRE(result.ok);
-	// ...检查类型和警告...
 }
 
 TEST_CASE("PhysicalPlanTranslator: filter + projection", "[distributed]") {
@@ -434,7 +433,6 @@ TEST_CASE("PhysicalPlanTranslator: filter + projection", "[distributed]") {
 	plan_ptr2->SetRoot(projection3);
 	auto result2 = duckdb::distributed::physical_plan_to_pipeline_node(duckdb::distributed::PlanConfig {}, plan_ptr2);
 	REQUIRE(result2.ok);
-	// ...检查类型和警告...
 }
 
 TEST_CASE("PhysicalPlanTranslator: null plan returns error", "[distributed]") {
@@ -1092,8 +1090,6 @@ TEST_CASE("GroupedAggregateData: initialize with BoundAggregateExpression", "[di
 	// Should not throw
 	gad.InitializeGroupby(std::move(groups), std::move(aggrs), {});
 }
-
-// 此测试已被上面两个更详细的测试覆盖，可移除或重写为更复杂的计划测试
 
 TEST_CASE("PhysicalPlanTranslator: grouped hash aggregate produces Aggregate node", "[distributed]") {
 	Allocator allocator;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -513,6 +513,7 @@ ignore_errors = true
 
 [[tool.mypy.overrides]]
 module = [
+    "cloudpickle",
     "fsspec.*",
     "pandas",
     "polars",

--- a/tests/fast/test_ray_cxx_helper.py
+++ b/tests/fast/test_ray_cxx_helper.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
+import _duckdb
 import pytest
 
-import _duckdb
 import duckdb
 from duckdb._ray_cxx import require_ray_cxx_attr
 


### PR DESCRIPTION
## Summary

- Establish a clean Ruff lint and format baseline across every Python file covered by the repository configuration, including the benchmark files that pre-commit previously skipped.
- Keep Ruff verification non-mutating, run a full-tree Ruff check on non-PR code-quality events, and retain changed-range checks for pull requests.
- Preserve the intentional UDF schema helper re-export while applying Ruff's canonical import ordering everywhere else.
- Remove redundant Chinese comments from Vane-owned C++ sources and translate comments that carry useful design or behavior information; multilingual test fixtures and vendored third-party sources remain unchanged.
- Document explicit repository-wide Ruff check and fix commands, and account for the existing untyped cloudpickle dependency in changed-file mypy checks.

## Related issue

close: #376

## Documentation impact

- [ ] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [x] <!-- docs-follow-up --> A follow-up issue is required in
      AstroVela/vane-website.

Mirror the new Ruff check/fix guidance from DEVELOPMENT.md into the published Development Guide.

## Validation

- scripts/format workspace --changed --check
- Changed-file pre-commit suite, including Ruff, workflow validation, and mypy
- uvx --from ruff==0.15.22 ruff check --no-fix . (All checks passed!)
- uvx --from ruff==0.15.22 ruff format --check . (684 files already formatted)
- Incremental native wheel install with SKBUILD_BUILD_DIR="$PWD/build/python-release", SKBUILD_CMAKE_BUILD_TYPE=Release, and the existing x64-linux vcpkg prefix; _duckdb and duckdb imports succeeded
- python -m pytest -m "not external_service and not real_ray" tests/fast/test_ray_cxx_helper.py tests/fast/test_fte_native_backend.py tests/fast/test_fte_ray_backend_adapter.py tests/fast/test_ray_fragment_submission.py tests/fast/test_udf_executor_lifecycle.py tests/fast/test_udf_ray_actor_row_preserving.py (688 passed)
- scripts/run_release_tests.sh (510 passed, 1 skipped in the non-real-Ray shard; 11 passed in the real-Ray shard)
- CJK source audit: no Chinese comments remain in Vane-owned sources; remaining matches are Unicode/multilingual fixtures or vendored ICU content
- git diff --check

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
