### PR TITLE
[fix](ai) Reject empty nested objects and case-colliding schema fields

### DIFF
--- a/tests/ai/test_prompt_schema.py
+++ b/tests/ai/test_prompt_schema.py
@@ -8,6 +8,7 @@ import json
 import pyarrow as pa
 import pytest
 
+import duckdb
 from vane.ai._schema import OutputValidationError, SchemaValidationError, compile_return_format
 
 PORTABLE_SCHEMA = {
@@ -251,11 +252,119 @@ def test_non_pydantic_class_with_schema_method_is_rejected():
             {"type": "object", "properties": {"x": {"$ref": "https://example.test/schema"}}},
             "only local",
         ),
+        (
+            {
+                "type": "object",
+                "properties": {"meta": {"type": "object", "properties": {}}},
+            },
+            "at least one",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}, "ANSWER": {"type": "integer"}},
+            },
+            "differ only by case",
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {
+                    "nested": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}, "VALUE": {"type": "integer"}},
+                    }
+                },
+            },
+            "differ only by case",
+        ),
     ],
 )
 def test_schema_subset_rejects_unsupported_shapes(schema, match):
     with pytest.raises(SchemaValidationError, match=match):
         compile_return_format(schema)
+
+
+def test_case_insensitive_collision_in_definitions_is_rejected():
+    with pytest.raises(SchemaValidationError, match="differ only by case"):
+        compile_return_format(
+            {
+                "$defs": {
+                    "Detail": {
+                        "type": "object",
+                        "properties": {"label": {"type": "string"}, "LABEL": {"type": "string"}},
+                    }
+                },
+                "type": "object",
+                "properties": {"detail": {"$ref": "#/$defs/Detail"}},
+            }
+        )
+
+
+def test_empty_nested_object_in_array_items_is_rejected():
+    with pytest.raises(SchemaValidationError, match="at least one property"):
+        compile_return_format(
+            {
+                "type": "object",
+                "properties": {"items": {"type": "array", "items": {"type": "object", "properties": {}}}},
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {
+            "type": "object",
+            "properties": {
+                "s": {"type": "string"},
+                "i": {"type": "integer"},
+                "n": {"type": "number"},
+                "b": {"type": "boolean"},
+            },
+        },
+        {"type": "object", "properties": {"a": {"type": "array", "items": {"type": "integer"}}}},
+        {
+            "type": "object",
+            "properties": {
+                "a": {"type": "array", "items": {"type": "object", "properties": {"x": {"type": "string"}}}}
+            },
+        },
+        {
+            "type": "object",
+            "properties": {"a": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}}},
+        },
+        {"type": "object", "properties": {"x": {"anyOf": [{"type": "string"}, {"type": "null"}]}}},
+        {"type": "object", "properties": {"x": {"type": ["integer", "null"]}}},
+        {"type": "object", "properties": {"e": {"type": "string", "enum": ["a", "b"]}}},
+        {"type": "object", "properties": {"e": {"type": ["string", "null"], "enum": ["a"]}}},
+        {
+            "$defs": {"Detail": {"type": "object", "properties": {"y": {"type": "integer"}}}},
+            "type": "object",
+            "properties": {"d": {"$ref": "#/$defs/Detail"}},
+        },
+        {
+            "type": "object",
+            "properties": {
+                "a": {
+                    "type": "object",
+                    "properties": {
+                        "b": {
+                            "type": "object",
+                            "properties": {"c": {"type": "object", "properties": {"d": {"type": "string"}}}},
+                        }
+                    },
+                }
+            },
+        },
+    ],
+)
+def test_every_supported_schema_shape_derives_a_duckdb_bindable_type(schema):
+    spec = compile_return_format(schema)
+    assert spec is not None
+
+    duckdb.sqltype(spec.duckdb_type)
+    duckdb.sql(f"SELECT CAST(NULL AS {spec.duckdb_type})")
 
 
 @pytest.mark.parametrize(

--- a/vane/ai/_schema.py
+++ b/vane/ai/_schema.py
@@ -372,8 +372,6 @@ class _Compiler:
         root = self._compile_node(self.schema, "$", ())
         if root.kind != "object" or root.nullable:
             raise _schema_error("$", "root type must be a non-nullable object")
-        if not root.properties:
-            raise _schema_error("$.properties", "root object must define at least one property")
         for reference in self.definitions:
             self._compile_reference(reference, f"definition {reference}", ())
         return root
@@ -478,6 +476,18 @@ class _Compiler:
                 raise _schema_error(
                     f"{path}.properties", "property names must match [A-Za-z0-9_-] and contain 1-64 characters"
                 )
+        if not properties:
+            raise _schema_error(f"{path}.properties", "object schemas must define at least one property")
+        seen: dict[str, str] = {}
+        for name in properties:
+            folded = name.casefold()
+            if folded in seen:
+                raise _schema_error(
+                    f"{path}.properties",
+                    f"property names differ only by case, which DuckDB treats as the same STRUCT member: "
+                    f"{seen[folded]!r} and {name!r}",
+                )
+            seen[folded] = name
         required_raw = schema.get("required", [])
         if not isinstance(required_raw, list) or any(not isinstance(name, str) for name in required_raw):
             raise _schema_error(f"{path}.required", "must be a string array")


### PR DESCRIPTION
## Summary

The Prompt structured-output compiler accepted two schema shapes that derive
DuckDB types DuckDB itself rejects at bind time, deferring the failure past
Vane's schema validation:

- An object below the root may declare an empty `properties` mapping, deriving
  `STRUCT(...)` with zero children, which DuckDB cannot bind
  (`STRUCT("meta" STRUCT())` raises a ParserException).
- Distinct property spellings that differ only by case derive STRUCT members
  DuckDB treats as the same name (`answer`/`ANSWER` raises
  `BinderException: Duplicate STRUCT type argument name`).

Both are now rejected at compile time in `_compile_object`, the single
recursive compilation point, so nested objects, array items, and `$defs`
references are all covered. The root-only empty-object check in `compile()`
was folded into the same check.

Long-term hardening: a parametrized corpus test compiles every supported
schema shape and asserts the derived `duckdb_type` parses with
`duckdb.sqltype()` and binds in `CAST(NULL AS ...)`, so any future construct
that maps to an unparseable DuckDB type fails at compile/test time instead of
at the DuckDB boundary.

## Related issue

close: #466
close: #472

## Documentation impact

- [x] No user-facing documentation update is required.

Both schemas previously compiled and then failed at the DuckDB boundary, so
the rejection only tightens validation of behavior that never worked.

## Validation

- `python -m pytest tests/ai/test_prompt_schema.py` — 35 passed, 2 skipped
  (pydantic not installed in the environment).
- Regression tests fail on the pre-fix `_schema.py` (verified by reverting the
  module change: 5 new tests fail) and pass with the fix.
- `ruff check` and `ruff format --check` clean on both changed files.
- `scripts/format root --changed` run.
- Full `tests/ai` run: 505 passed; the 14 failures are all pre-existing
  `ModuleNotFoundError: No module named 'openai'` in this environment,
  unrelated to this change.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.