### PR TITLE
[fix](distributed) Return empty Optional for unconfigured broadcast receiver repartition override

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -187,7 +187,7 @@ DistributedJoinStrategyOverride GetJoinStrategyOverride() {
 Optional<bool> BroadcastReceiverRepartitionOverride() {
 	const char *env = std::getenv("VANE_DISTRIBUTED_BROADCAST_JOIN_RECEIVER_REPARTITION");
 	if (!env || !*env) {
-		return 0;
+		return Optional<bool>{};
 	}
 	std::string value(env);
 	std::transform(value.begin(), value.end(), value.begin(),
@@ -198,7 +198,7 @@ Optional<bool> BroadcastReceiverRepartitionOverride() {
 	if (value == "0" || value == "false" || value == "no" || value == "off") {
 		return false;
 	}
-	return 0;
+	return Optional<bool>{};
 }
 
 } // namespace

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -187,7 +187,7 @@ DistributedJoinStrategyOverride GetJoinStrategyOverride() {
 Optional<bool> BroadcastReceiverRepartitionOverride() {
 	const char *env = std::getenv("VANE_DISTRIBUTED_BROADCAST_JOIN_RECEIVER_REPARTITION");
 	if (!env || !*env) {
-		return Optional<bool>{};
+		return Optional<bool> {};
 	}
 	std::string value(env);
 	std::transform(value.begin(), value.end(), value.begin(),
@@ -198,7 +198,7 @@ Optional<bool> BroadcastReceiverRepartitionOverride() {
 	if (value == "0" || value == "false" || value == "no" || value == "off") {
 		return false;
 	}
-	return Optional<bool>{};
+	return Optional<bool> {};
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Fix BroadcastReceiverRepartitionOverride() to return an empty Optional<bool>
instead of a present false when the environment variable is absent or
invalid. Returning integer 0 constructed a present false value because the
return type is Optional<bool>, making "unconfigured" and "explicitly
disabled" indistinguishable to callers. Return Optional<bool>{} in those
branches so the absence is preserved and value_or(false) fallback behaves
correctly.

## Related issue

close: #420

## Documentation impact

- [x] No user-facing documentation update is required.

## Validation

- Code review: verified the fix returns Optional<bool>{} for absent and
  invalid env values while preserving the existing return values for
  explicitly true/false configurations. The existing caller using
  value_or(false) continues to work correctly.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.