### PR TITLE
[fix](distributed) Convert recursive empty-output skip to loop in PlanResultStream

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
@@ -116,22 +116,23 @@ public:
 			}
 			return std::make_pair(true, curr_fragments_[curr_index_++]);
 		}
-		// Fetch next MaterializedOutput from receiver
-		auto opt = receiver_.recv();
-		if (status_) {
-			status_->ThrowIfError();
+		while (true) {
+			// Fetch next MaterializedOutput from receiver
+			auto opt = receiver_.recv();
+			if (status_) {
+				status_->ThrowIfError();
+			}
+			if (!opt.first)
+				return std::make_pair(false, ResultPartitionRef());
+			curr_fragments_ = opt.second.fragments();
+			curr_index_ = 0;
+			if (!curr_fragments_.empty()) {
+				if (status_) {
+					status_->ThrowIfError();
+				}
+				return std::make_pair(true, curr_fragments_[curr_index_++]);
+			}
 		}
-		if (!opt.first)
-			return std::make_pair(false, ResultPartitionRef());
-		curr_fragments_ = opt.second.fragments();
-		curr_index_ = 0;
-		if (curr_fragments_.empty()) {
-			return next(); // skip empty outputs
-		}
-		if (status_) {
-			status_->ThrowIfError();
-		}
-		return std::make_pair(true, curr_fragments_[curr_index_++]);
 	}
 
 	bool is_exhausted() const {

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/distributed_physical_plan.hpp
@@ -126,12 +126,16 @@ public:
 				return std::make_pair(false, ResultPartitionRef());
 			curr_fragments_ = opt.second.fragments();
 			curr_index_ = 0;
-			if (!curr_fragments_.empty()) {
+			if (curr_fragments_.empty()) {
 				if (status_) {
 					status_->ThrowIfError();
 				}
-				return std::make_pair(true, curr_fragments_[curr_index_++]);
+				continue;
 			}
+			if (status_) {
+				status_->ThrowIfError();
+			}
+			return std::make_pair(true, curr_fragments_[curr_index_++]);
 		}
 	}
 

--- a/external/duckdb/test/execution/distributed/test_streaming_channel.cpp
+++ b/external/duckdb/test/execution/distributed/test_streaming_channel.cpp
@@ -12,6 +12,7 @@
  * 3. Receiver abandonment closes the channel and releases queued values.
  * 4. Moving a receiver transfers its single-consumer ownership.
  * 5. Concurrent sender activity and receiver closure are thread-safe.
+ * 6. PlanResultStream skips empty outputs without recursion or lost errors.
  */
 
 #include <atomic>
@@ -28,6 +29,32 @@
 
 using namespace duckdb::distributed;
 using namespace duckdb::distributed::testing;
+
+namespace {
+
+class RecordErrorOnDestructionPartition : public ResultPartition {
+public:
+	explicit RecordErrorOnDestructionPartition(std::shared_ptr<PlanExecutionStatus> status)
+	    : status_(std::move(status)) {
+	}
+
+	~RecordErrorOnDestructionPartition() override {
+		status_->RecordError(DuckDBError::external_error("result partition destruction error"));
+	}
+
+	DuckDBResult<size_t> size_bytes() const override {
+		return DuckDBResult<size_t>::ok(0);
+	}
+
+	DuckDBResult<size_t> num_rows() const override {
+		return DuckDBResult<size_t>::ok(0);
+	}
+
+private:
+	std::shared_ptr<PlanExecutionStatus> status_;
+};
+
+} // namespace
 
 static_assert(!std::is_copy_constructible<UnboundedReceiver<int>>::value,
               "unbounded channels must have exactly one receiver owner");
@@ -242,6 +269,84 @@ TEST_CASE("Streaming channel: dropping plan result stream disconnects result rec
 	{ PlanResultStream stream(nullptr, std::move(receiver)); }
 
 	REQUIRE(sender.send(MaterializedOutput()).is_err());
+}
+
+TEST_CASE("Plan result stream: skips a large run of empty outputs", "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<MaterializedOutput>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+
+	// The recursive implementation retained one MaterializedOutput per call frame.
+	// This count exceeds the normal Linux test-process stack while descending.
+	constexpr idx_t EMPTY_OUTPUT_COUNT = 100000;
+	for (idx_t output_idx = 0; output_idx < EMPTY_OUTPUT_COUNT; output_idx++) {
+		sender.send(MaterializedOutput()).value();
+	}
+	{ auto dropped_sender = std::move(sender); }
+
+	PlanResultStream stream(nullptr, std::move(receiver));
+	auto result = stream.next();
+
+	REQUIRE_FALSE(result.first);
+	REQUIRE(result.second == nullptr);
+	REQUIRE(stream.is_exhausted());
+}
+
+TEST_CASE("Plan result stream: skips empty outputs before non-empty output", "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<MaterializedOutput>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+	std::shared_ptr<duckdb::ColumnDataCollection> empty_collection;
+	auto first_fragment = std::make_shared<ColumnDataResultPartition>(empty_collection);
+	auto second_fragment = std::make_shared<ColumnDataResultPartition>(empty_collection);
+	std::vector<ResultPartitionRef> fragments {first_fragment, second_fragment};
+
+	REQUIRE(sender.send(MaterializedOutput()).is_ok());
+	REQUIRE(sender.send(MaterializedOutput(std::move(fragments), nullptr)).is_ok());
+	{ auto dropped_sender = std::move(sender); }
+
+	PlanResultStream stream(nullptr, std::move(receiver));
+	auto first_result = stream.next();
+	auto second_result = stream.next();
+	auto exhausted_result = stream.next();
+
+	REQUIRE(first_result.first);
+	REQUIRE(first_result.second == first_fragment);
+	REQUIRE(second_result.first);
+	REQUIRE(second_result.second == second_fragment);
+	REQUIRE_FALSE(exhausted_result.first);
+	REQUIRE(exhausted_result.second == nullptr);
+	REQUIRE(stream.is_exhausted());
+}
+
+TEST_CASE("Plan result stream: checks errors before receiving after an empty output",
+          "[distributed][streaming_channel]") {
+	auto ch_pair_ = create_unbounded_channel<MaterializedOutput>();
+	auto sender = std::move(ch_pair_.first);
+	auto receiver = std::move(ch_pair_.second);
+	auto channel_state = sender.state();
+	auto status = std::make_shared<PlanExecutionStatus>();
+	std::vector<ResultPartitionRef> trigger_fragments;
+	trigger_fragments.push_back(std::make_shared<RecordErrorOnDestructionPartition>(status));
+	std::shared_ptr<duckdb::ColumnDataCollection> empty_collection;
+	auto queued_fragment = std::make_shared<ColumnDataResultPartition>(empty_collection);
+	std::vector<ResultPartitionRef> queued_fragments {queued_fragment};
+
+	REQUIRE(sender.send(MaterializedOutput(std::move(trigger_fragments), nullptr)).is_ok());
+	REQUIRE(sender.send(MaterializedOutput()).is_ok());
+	REQUIRE(sender.send(MaterializedOutput(std::move(queued_fragments), nullptr)).is_ok());
+
+	PlanResultStream stream(nullptr, std::move(receiver), status);
+	{
+		auto trigger_result = stream.next();
+		REQUIRE(trigger_result.first);
+		trigger_result.second.reset();
+	}
+
+	// Replacing the exhausted buffered fragments with the empty output records
+	// the error. The stream must observe it before consuming the queued output.
+	REQUIRE_THROWS_WITH(stream.next(), Catch::Matchers::Contains("result partition destruction error"));
+	REQUIRE_FALSE(channel_state->is_empty());
 }
 
 TEST_CASE("Streaming channel: receiver close races safely with active sender", "[distributed][streaming_channel]") {


### PR DESCRIPTION
## Summary

- Replaces the recursive empty-output skip in `PlanResultStream::next()` with an iterative loop, keeping stack use constant for arbitrarily long runs of empty `MaterializedOutput` values.
- Preserves the original `PlanExecutionStatus` error boundary after buffered fragments are released and before the next blocking receive.
- Adds native regressions for 100,000 consecutive empty outputs, empty-to-nonempty flattening, and error propagation before consuming the next queued output.

## Related issue

close: #426

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

No documentation changes are needed because this is an internal control-flow correction with no public API change.

## Validation

- `scripts/format duckdb --from-ref upstream/main --check`
- `build/native-cxx20/test/unittest "*Plan result stream*"` — 4 test cases and 19 assertions passed.
- `scripts/run_native_tests.sh "[streaming_channel]"` — 14 test cases and 3,258 assertions passed.
- `scripts/run_native_tests.sh "[distributed]"` — 187 test cases and 7,988 assertions passed.
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `scripts/run_release_tests.sh` — 507 non-Ray tests passed (4 skipped), and 11 real-Ray tests passed.
- Mutation checks confirmed that restoring recursion crashes the 100,000-empty-output regression and removing the restored error check consumes the sentinel output before throwing.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
      N/A: no dependencies or external assets were added.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
      N/A: the change does not add or alter those surfaces.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.