### PR TITLE
[fix](ai) Enforce provider-specific image MIME policies

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2570,22 +2570,6 @@ def test_google_request_mapping_preserves_text_image_order():
     assert kwargs["config"].stop_sequences == ["END"]
 
 
-@pytest.mark.parametrize(
-    ("module_name", "helper_name"),
-    [
-        ("vane.ai.providers.openai", "_guess_mime_type"),
-        ("vane.ai.providers.anthropic", "_guess_media_type"),
-        ("vane.ai.providers.google", "_guess_media_type"),
-    ],
-)
-def test_prompt_image_detection_rejects_unknown_or_non_image_content(module_name, helper_name):
-    from importlib import import_module
-
-    helper = getattr(import_module(module_name), helper_name)
-    assert helper(b"%PDF-1.7") is None
-    assert helper(b"not-an-image") is None
-
-
 def test_prompt_provider_capability_error_preserves_context():
     import asyncio
     from unittest.mock import AsyncMock, MagicMock

--- a/tests/ai/test_image_mime.py
+++ b/tests/ai/test_image_mime.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+
+import pytest
+
+from vane.ai.providers._mime import ImageMimePolicy, detect_image_mime_type
+from vane.ai.providers.anthropic import _IMAGE_MIME_POLICY as _ANTHROPIC_IMAGE_MIME_POLICY
+from vane.ai.providers.google import _IMAGE_MIME_POLICY as _GOOGLE_IMAGE_MIME_POLICY
+from vane.ai.providers.openai import _IMAGE_MIME_POLICY as _OPENAI_IMAGE_MIME_POLICY
+
+
+def _ftyp(
+    major_brand: bytes,
+    *compatible_brands: bytes,
+    extended_size: bool = False,
+) -> bytes:
+    assert len(major_brand) == 4
+    assert all(len(brand) == 4 for brand in compatible_brands)
+
+    body = major_brand + b"\x00\x00\x00\x00" + b"".join(compatible_brands)
+    if extended_size:
+        size = 16 + len(body)
+        return b"\x00\x00\x00\x01ftyp" + size.to_bytes(8, "big") + body
+    size = 8 + len(body)
+    return size.to_bytes(4, "big") + b"ftyp" + body
+
+
+def _has_module(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+_PNG = b"\x89PNG\r\n\x1a\nimage"
+_JPEG = b"\xff\xd8\xff\xe0image"
+_GIF = b"GIF89aimage"
+_WEBP_BODY = b"WEBPimage"
+_WEBP = b"RIFF" + len(_WEBP_BODY).to_bytes(4, "little") + _WEBP_BODY
+_AVIF = _ftyp(b"avif", b"avif", b"mif1")
+_HEIC = _ftyp(b"mif1", b"mif1", b"heic")
+_HEIF = _ftyp(b"mif1", b"mif1")
+_HEIC_SEQUENCE = _ftyp(b"msf1", b"msf1", b"hevc")
+_HEIF_SEQUENCE = _ftyp(b"msf1", b"msf1")
+
+_DETECTED_IMAGES = {
+    "image/avif": _AVIF,
+    "image/gif": _GIF,
+    "image/heic": _HEIC,
+    "image/heic-sequence": _HEIC_SEQUENCE,
+    "image/heif": _HEIF,
+    "image/heif-sequence": _HEIF_SEQUENCE,
+    "image/jpeg": _JPEG,
+    "image/png": _PNG,
+    "image/webp": _WEBP,
+}
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        pytest.param(_PNG, "image/png", id="png"),
+        pytest.param(_JPEG, "image/jpeg", id="jpeg"),
+        pytest.param(b"GIF87aimage", "image/gif", id="gif87a"),
+        pytest.param(_GIF, "image/gif", id="gif89a"),
+        pytest.param(_WEBP, "image/webp", id="webp"),
+    ],
+)
+def test_detect_image_mime_type_recognizes_image_signatures(data, expected):
+    assert detect_image_mime_type(data) == expected
+
+
+@pytest.mark.parametrize(
+    ("brand", "expected"),
+    [
+        pytest.param(b"heic", "image/heic", id="heic"),
+        pytest.param(b"heix", "image/heic", id="heix"),
+        pytest.param(b"heim", "image/heic", id="heim"),
+        pytest.param(b"heis", "image/heic", id="heis"),
+        pytest.param(b"mif1", "image/heif", id="mif1"),
+        pytest.param(b"hevc", "image/heic-sequence", id="hevc"),
+        pytest.param(b"hevx", "image/heic-sequence", id="hevx"),
+        pytest.param(b"hevm", "image/heic-sequence", id="hevm"),
+        pytest.param(b"hevs", "image/heic-sequence", id="hevs"),
+        pytest.param(b"msf1", "image/heif-sequence", id="msf1"),
+    ],
+)
+def test_detect_image_mime_type_uses_compatible_ftyp_brands(brand, expected):
+    assert detect_image_mime_type(_ftyp(b"isom", brand)) == expected
+
+
+@pytest.mark.parametrize(
+    "compatible_brands",
+    [
+        pytest.param((b"avif", b"mif1"), id="image-specific-first"),
+        pytest.param((b"mif1", b"avif"), id="image-generic-first"),
+        pytest.param((b"avis", b"msf1"), id="sequence-specific-first"),
+        pytest.param((b"msf1", b"avis"), id="sequence-generic-first"),
+        pytest.param((b"avio", b"mif1"), id="intra-only-specific-first"),
+        pytest.param((b"mif1", b"avio"), id="intra-only-generic-first"),
+    ],
+)
+def test_detect_image_mime_type_recognizes_avif_compatible_brands(compatible_brands):
+    assert detect_image_mime_type(_ftyp(b"isom", *compatible_brands)) == "image/avif"
+
+
+@pytest.mark.parametrize(
+    ("major_brand", "generic_brand"),
+    [
+        pytest.param(b"avif", b"mif1", id="image"),
+        pytest.param(b"avis", b"msf1", id="sequence"),
+        pytest.param(b"avio", b"mif1", id="intra-only"),
+    ],
+)
+def test_detect_image_mime_type_recognizes_avif_major_brands(major_brand, generic_brand):
+    assert detect_image_mime_type(_ftyp(major_brand, generic_brand)) == "image/avif"
+
+
+@pytest.mark.parametrize(
+    ("major_brand", "expected"),
+    [
+        pytest.param(b"avif", "image/avif", id="avif-major"),
+        pytest.param(b"heic", "image/heic", id="heic-major"),
+        pytest.param(b"isom", None, id="ambiguous-generic-major"),
+    ],
+)
+def test_detect_image_mime_type_handles_conflicting_codec_brands(major_brand, expected):
+    data = _ftyp(major_brand, b"avif", b"mif1", b"heic")
+    assert detect_image_mime_type(data) == expected
+
+
+def test_detect_image_mime_type_prefers_codec_specific_compatible_brand():
+    assert detect_image_mime_type(_ftyp(b"mif1", b"mif1", b"heic")) == "image/heic"
+    assert detect_image_mime_type(_ftyp(b"msf1", b"msf1", b"hevc")) == "image/heic-sequence"
+
+
+def test_detect_image_mime_type_prefers_still_brand_when_sequence_is_also_present():
+    # This brand combination is used by libheif's official example.heic.
+    assert detect_image_mime_type(_ftyp(b"mif1", b"mif1", b"heic", b"hevc")) == "image/heic"
+
+
+@pytest.mark.parametrize(
+    ("major_brand", "expected"),
+    [
+        pytest.param(b"mif1", "image/heic", id="still-major"),
+        pytest.param(b"hevc", "image/heic-sequence", id="sequence-major"),
+        pytest.param(b"isom", None, id="ambiguous-generic-major"),
+    ],
+)
+def test_detect_image_mime_type_uses_major_brand_to_choose_between_kinds(major_brand, expected):
+    data = _ftyp(major_brand, b"mif1", b"heic", b"msf1", b"hevc")
+    assert detect_image_mime_type(data) == expected
+
+
+def test_detect_image_mime_type_does_not_treat_major_brand_as_compatible():
+    assert detect_image_mime_type(_ftyp(b"heic", b"isom")) is None
+
+
+def test_detect_image_mime_type_supports_extended_size_ftyp_box():
+    assert detect_image_mime_type(_ftyp(b"mif1", b"mif1", b"heic", extended_size=True)) == "image/heic"
+
+
+def test_detect_image_mime_type_ignores_brands_after_ftyp_box():
+    data = _ftyp(b"isom", b"isom") + b"\x00\x00\x00\x0cmdatheic"
+    assert detect_image_mime_type(data) is None
+
+
+def test_detect_image_mime_type_requires_aligned_compatible_brand():
+    data = _ftyp(b"isom", b"Xhei", b"cYYY")
+    assert detect_image_mime_type(data) is None
+
+
+def test_detect_image_mime_type_bounds_ftyp_compatible_brand_scanning():
+    box_size = 64 * 1024 + 4
+    compatible_brand_count = (box_size - 16) // 4
+    data = (
+        box_size.to_bytes(4, "big")
+        + b"ftyp"
+        + b"isom"
+        + b"\x00\x00\x00\x00"
+        + b"heic"
+        + b"isom" * (compatible_brand_count - 1)
+    )
+    assert len(data) == box_size
+    assert detect_image_mime_type(data) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(b"", id="empty"),
+        pytest.param(b"not-an-image", id="unknown"),
+        pytest.param(b"%PDF-1.7", id="pdf"),
+        pytest.param(b"\xff\xd8", id="truncated-jpeg"),
+        pytest.param(b"GIF8", id="truncated-gif"),
+        pytest.param(b"RIFF\x00\x00\x00\x00NOPE", id="non-webp-riff"),
+        pytest.param(b"RIFF\x04\x00\x00\x00WEBPextra", id="webp-size-too-small"),
+        pytest.param(b"RIFF\xff\xff\xff\xffWEBP", id="webp-size-too-large"),
+        pytest.param(_ftyp(b"avc1", b"avc1"), id="unknown-ftyp-brand"),
+        pytest.param(b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00mif1", id="truncated-ftyp-box"),
+        pytest.param(b"\x00\x00\x00\x0cftypmif1\x00\x00\x00\x00mif1", id="undersized-ftyp-box"),
+        pytest.param(b"\x00\x00\x00\x15ftypmif1\x00\x00\x00\x00mif1x", id="misaligned-ftyp-brands"),
+        pytest.param(b"\x00\x00\x00\x00ftypmif1\x00\x00\x00\x00mif1", id="ftyp-extending-to-end"),
+        pytest.param(b"\x00\x00\x00\x01ftyp" + b"\x00" * 12, id="truncated-extended-size"),
+        pytest.param(
+            b"\x00\x00\x00\x01ftyp\x00\x00\x00\x00\x00\x00\x00\x14mif1\x00\x00\x00\x00",
+            id="undersized-extended-ftyp-box",
+        ),
+    ],
+)
+def test_detect_image_mime_type_rejects_unknown_or_malformed_data(data):
+    assert detect_image_mime_type(data) is None
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected_mime_types"),
+    [
+        pytest.param(
+            _ANTHROPIC_IMAGE_MIME_POLICY,
+            frozenset({"image/gif", "image/jpeg", "image/png", "image/webp"}),
+            id="anthropic",
+        ),
+        pytest.param(
+            _GOOGLE_IMAGE_MIME_POLICY,
+            frozenset({"image/heic", "image/heif", "image/jpeg", "image/png", "image/webp"}),
+            id="google",
+        ),
+        pytest.param(
+            _OPENAI_IMAGE_MIME_POLICY,
+            frozenset({"image/gif", "image/jpeg", "image/png", "image/webp"}),
+            id="openai",
+        ),
+    ],
+)
+def test_provider_image_mime_policy_matches_documented_formats(
+    policy: ImageMimePolicy,
+    expected_mime_types: frozenset[str],
+):
+    assert policy.supported_mime_types == expected_mime_types
+    for mime_type, data in _DETECTED_IMAGES.items():
+        if mime_type in expected_mime_types:
+            assert policy.require_supported(data) == mime_type
+        else:
+            with pytest.raises(ValueError, match=f"not supported by {policy.provider_name}"):
+                policy.require_supported(data)
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        pytest.param(_ANTHROPIC_IMAGE_MIME_POLICY, id="anthropic"),
+        pytest.param(_GOOGLE_IMAGE_MIME_POLICY, id="google"),
+        pytest.param(_OPENAI_IMAGE_MIME_POLICY, id="openai"),
+    ],
+)
+def test_provider_image_mime_policy_rejects_unrecognized_data(policy):
+    with pytest.raises(ValueError, match="unrecognized image format"):
+        policy.require_supported(b"not-an-image")
+
+
+def test_anthropic_message_processing_uses_provider_image_policy():
+    from vane.ai.providers.anthropic import AnthropicPrompter
+
+    image = AnthropicPrompter._process_message(_PNG)
+    assert image["source"] == {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": base64.b64encode(_PNG).decode("ascii"),
+    }
+    with pytest.raises(ValueError, match="not supported by Anthropic"):
+        AnthropicPrompter._process_message(_HEIC)
+
+
+def test_openai_message_processing_uses_provider_image_policy():
+    from vane.ai.providers.openai import OpenAIPrompter
+
+    prompter = OpenAIPrompter.__new__(OpenAIPrompter)
+    prompter._use_chat_completions = False
+    image = prompter._process_bytes(_PNG)
+    assert image["type"] == "input_image"
+    assert image["image_url"].startswith("data:image/png;base64,")
+    with pytest.raises(ValueError, match="not supported by OpenAI"):
+        prompter._process_bytes(_HEIC)
+
+
+@pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+def test_google_message_processing_uses_provider_image_policy():
+    from vane.ai.providers.google import GooglePrompter
+
+    prompter = GooglePrompter.__new__(GooglePrompter)
+    image = prompter._process_message(_HEIC)
+    assert image.inline_data.mime_type == "image/heic"
+    assert image.inline_data.data == _HEIC
+    with pytest.raises(ValueError, match="not supported by Google"):
+        prompter._process_message(_GIF)
+    with pytest.raises(ValueError, match="not supported by Google"):
+        prompter._process_message(_AVIF)

--- a/vane/ai/providers/_mime.py
+++ b/vane/ai/providers/_mime.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Image MIME detection and provider-level format policies.
+
+The detector identifies encoded image formats from their byte signatures. It
+does not decide whether an AI provider accepts the detected format; each
+provider owns that policy through :class:`ImageMimePolicy`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+_PNG_SIGNATURE: Final = b"\x89PNG\r\n\x1a\n"
+_GIF_SIGNATURES: Final = (b"GIF87a", b"GIF89a")
+_MAX_FTYP_BOX_SIZE: Final = 64 * 1024
+
+# AVIF brand and media-type specifications:
+# https://aomediacodec.github.io/av1-avif/#brands-overview
+# https://www.iana.org/assignments/media-types/image/avif
+# AVIF is a HEIF-based format and normally also advertises mif1 or msf1. Its
+# codec-specific brands must therefore be recognized before generic HEIF.
+_AVIF_BRANDS: Final = frozenset({b"avif", b"avis", b"avio"})
+
+# IANA registrations:
+# https://www.iana.org/assignments/media-types/image/heic
+# https://www.iana.org/assignments/media-types/image/heic-sequence
+# The image/heif pages share the corresponding registrations. All four media
+# types require one of these brands in the ftyp compatible-brands array.
+_HEIC_BRANDS: Final = frozenset({b"heic", b"heix", b"heim", b"heis"})
+_HEIF_BRANDS: Final = frozenset({b"mif1"})
+_HEIC_SEQUENCE_BRANDS: Final = frozenset({b"hevc", b"hevx", b"hevm", b"hevs"})
+_HEIF_SEQUENCE_BRANDS: Final = frozenset({b"msf1"})
+
+
+def _parse_ftyp_brands(data: bytes) -> tuple[bytes, int, int] | None:
+    """Return the major brand and compatible-brand range of an initial ftyp."""
+    if len(data) < 16 or data[4:8] != b"ftyp":
+        return None
+
+    box_size = int.from_bytes(data[:4], "big")
+    major_brand_start = 8
+    compatible_brands_start = 16
+    if box_size == 1:
+        if len(data) < 24:
+            return None
+        box_size = int.from_bytes(data[8:16], "big")
+        major_brand_start = 16
+        compatible_brands_start = 24
+    elif box_size == 0:
+        # ftyp must be followed by the boxes that carry the image. A box that
+        # extends to end-of-file cannot describe a usable HEIF payload.
+        return None
+
+    # Detection runs before a provider request is built. Bound work here so a
+    # malformed BLOB cannot turn its whole payload into a compatible-brand
+    # list and consume proportional CPU. Real ftyp boxes are tiny; 64 KiB still
+    # permits more than sixteen thousand brand entries.
+    if box_size > _MAX_FTYP_BOX_SIZE:
+        return None
+    if box_size < compatible_brands_start or box_size > len(data):
+        return None
+    if (box_size - compatible_brands_start) % 4 != 0:
+        return None
+    return data[major_brand_start : major_brand_start + 4], compatible_brands_start, box_size
+
+
+def _detect_iso_bmff_image_mime_type(data: bytes) -> str | None:
+    brands = _parse_ftyp_brands(data)
+    if brands is None:
+        return None
+    major_brand, start, end = brands
+
+    has_avif = False
+    has_heic = False
+    has_heif = False
+    has_heic_sequence = False
+    has_heif_sequence = False
+    for offset in range(start, end, 4):
+        brand = data[offset : offset + 4]
+        if brand in _AVIF_BRANDS:
+            has_avif = True
+        elif brand in _HEIC_BRANDS:
+            has_heic = True
+        elif brand in _HEIF_BRANDS:
+            has_heif = True
+        elif brand in _HEIC_SEQUENCE_BRANDS:
+            has_heic_sequence = True
+        elif brand in _HEIF_SEQUENCE_BRANDS:
+            has_heif_sequence = True
+
+    # The AVIF specification assigns image/avif whenever one of its brands is
+    # the major brand. AVIF compatible brands also take precedence over the
+    # generic HEIF brands they normally accompany. If the file advertises both
+    # AV1 and HEVC codec-specific brands, use a codec-specific major brand to
+    # disambiguate; otherwise fail closed instead of treating it as HEIF.
+    if major_brand in _AVIF_BRANDS:
+        return "image/avif"
+    if has_avif and (has_heic or has_heic_sequence):
+        major_selects_heic = major_brand in _HEIC_BRANDS and has_heic
+        major_selects_heic_sequence = major_brand in _HEIC_SEQUENCE_BRANDS and has_heic_sequence
+        if not major_selects_heic and not major_selects_heic_sequence:
+            return None
+    elif has_avif:
+        return "image/avif"
+
+    # A file may advertise both image-item and image-sequence profiles. The
+    # major brand expresses its best-use profile, but cannot establish MIME
+    # compatibility by itself. Use it only to choose between kinds that were
+    # independently established by compatible brands. Within either kind,
+    # prefer the codec-specific HEIC type over the generic HEIF type.
+    has_still = has_heic or has_heif
+    has_sequence = has_heic_sequence or has_heif_sequence
+    if has_still and has_sequence:
+        major_is_still = major_brand in _HEIC_BRANDS or major_brand in _HEIF_BRANDS
+        major_is_sequence = major_brand in _HEIC_SEQUENCE_BRANDS or major_brand in _HEIF_SEQUENCE_BRANDS
+        if not major_is_still and not major_is_sequence:
+            return None
+        has_still = major_is_still
+
+    if has_still:
+        return "image/heic" if has_heic else "image/heif"
+    if has_sequence:
+        return "image/heic-sequence" if has_heic_sequence else "image/heif-sequence"
+    return None
+
+
+def detect_image_mime_type(data: bytes) -> str | None:
+    """Detect a canonical image MIME type from encoded bytes.
+
+    The function validates the signature or container fields used for
+    detection, but leaves full image decoding and content validation to the
+    provider. Unknown and malformed inputs return ``None``.
+    """
+    if data.startswith(_PNG_SIGNATURE):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(_GIF_SIGNATURES):
+        return "image/gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        riff_size = int.from_bytes(data[4:8], "little")
+        if riff_size + 8 == len(data):
+            return "image/webp"
+    return _detect_iso_bmff_image_mime_type(data)
+
+
+@dataclass(frozen=True)
+class ImageMimePolicy:
+    """Provider-owned allowlist applied after format detection."""
+
+    provider_name: str
+    supported_mime_types: frozenset[str]
+
+    def require_supported(self, data: bytes) -> str:
+        """Return the detected MIME type or reject the input locally."""
+        mime_type = detect_image_mime_type(data)
+        if mime_type is None:
+            raise ValueError("Prompt image BLOB has an unrecognized image format")
+        if mime_type not in self.supported_mime_types:
+            supported = ", ".join(sorted(self.supported_mime_types))
+            raise ValueError(
+                f"Prompt image BLOB format {mime_type!r} is not supported by "
+                f"{self.provider_name}; supported MIME types: {supported}"
+            )
+        return mime_type

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -14,6 +14,7 @@ from vane.ai._schema import OutputValidationError, serialize_raw_response
 from vane.ai.options import validate_prompt_options
 from vane.ai.protocols import PrompterDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
+from vane.ai.providers._mime import ImageMimePolicy
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -26,18 +27,18 @@ if TYPE_CHECKING:
 _REQUEST_OPTIONS = frozenset({"max_tokens", "temperature", "top_p", "top_k", "stop_sequences"})
 _PROMPT_OPTIONS = _REQUEST_OPTIONS | frozenset({"base_url", "timeout"})
 _STRUCTURED_OUTPUT_TOOL = "vane_structured_output"
-
-
-def _guess_media_type(data: bytes) -> str | None:
-    if data[:8] == b"\x89PNG\r\n\x1a\n":
-        return "image/png"
-    if data[:2] == b"\xff\xd8":
-        return "image/jpeg"
-    if data[:4] == b"GIF8":
-        return "image/gif"
-    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
-        return "image/webp"
-    return None
+# https://platform.claude.com/docs/en/build-with-claude/vision#supported-formats
+_IMAGE_MIME_POLICY = ImageMimePolicy(
+    provider_name="Anthropic",
+    supported_mime_types=frozenset(
+        {
+            "image/gif",
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+        }
+    ),
+)
 
 
 def _is_prompt_capability_error(exc: Exception) -> bool:
@@ -201,9 +202,7 @@ class AnthropicPrompter:
         if isinstance(message, str):
             return {"type": "text", "text": message}
         if isinstance(message, bytes):
-            media_type = _guess_media_type(message)
-            if media_type is None:
-                raise ValueError("Prompt image BLOB has an unsupported or unrecognized image format")
+            media_type = _IMAGE_MIME_POLICY.require_supported(message)
             return {
                 "type": "image",
                 "source": {

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -33,6 +33,7 @@ from vane.ai.options import (
 )
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
+from vane.ai.providers._mime import ImageMimePolicy
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -42,17 +43,19 @@ if TYPE_CHECKING:
     from vane.ai.typing import Embedding, Options
 
 
-def _guess_media_type(data: bytes) -> str | None:
-    """Guess image MIME type from magic bytes."""
-    if data[:8] == b"\x89PNG\r\n\x1a\n":
-        return "image/png"
-    if data[:2] == b"\xff\xd8":
-        return "image/jpeg"
-    if data[:4] == b"GIF8":
-        return "image/gif"
-    if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
-        return "image/webp"
-    return None
+# https://ai.google.dev/gemini-api/docs/image-understanding#supported-image-formats
+_IMAGE_MIME_POLICY = ImageMimePolicy(
+    provider_name="Google",
+    supported_mime_types=frozenset(
+        {
+            "image/heic",
+            "image/heif",
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+        }
+    ),
+)
 
 
 def _retry_after_error_from_google_error(exc: Exception) -> Exception | None:
@@ -612,9 +615,7 @@ class GooglePrompter:
         if isinstance(msg, str):
             return types.Part.from_text(text=msg)
         if isinstance(msg, bytes):
-            media_type = _guess_media_type(msg)
-            if media_type is None:
-                raise ValueError("Prompt image BLOB has an unsupported or unrecognized image format")
+            media_type = _IMAGE_MIME_POLICY.require_supported(msg)
             return types.Part.from_bytes(data=msg, mime_type=media_type)
         raise TypeError(f"Unsupported Prompt content type: {type(msg).__name__}")
 

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -30,6 +30,7 @@ from vane.ai._schema import (
 from vane.ai.options import validate_embed_options, validate_prompt_options
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
+from vane.ai.providers._mime import ImageMimePolicy
 from vane.ai.typing import UDFOptions
 
 if TYPE_CHECKING:
@@ -74,6 +75,18 @@ _OPENAI_OFFICIAL_API_HOSTS = frozenset(
         "sg.api.openai.com",
         "us.api.openai.com",
     }
+)
+# https://developers.openai.com/api/docs/guides/images-vision#image-input-requirements
+_IMAGE_MIME_POLICY = ImageMimePolicy(
+    provider_name="OpenAI",
+    supported_mime_types=frozenset(
+        {
+            "image/gif",
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+        }
+    ),
 )
 
 _EMBED_CAPABILITY_ERROR_PARAMS = frozenset({"model", "dimensions", "encoding_format"})
@@ -821,9 +834,7 @@ class OpenAIPrompter:
     def _process_bytes(self, msg: bytes) -> dict[str, Any]:
         import base64
 
-        mime_type = _guess_mime_type(msg)
-        if mime_type is None:
-            raise ValueError("Prompt image BLOB has an unsupported or unrecognized image format")
+        mime_type = _IMAGE_MIME_POLICY.require_supported(msg)
         b64 = base64.b64encode(msg).decode("utf-8")
         data_url = f"data:{mime_type};base64,{b64}"
         return self._build_image_part(data_url)
@@ -964,16 +975,3 @@ class OpenAIPrompter:
         if self._use_chat_completions:
             return await self._prompt_chat_completions(chat_messages)
         return await self._prompt_responses(chat_messages)
-
-
-def _guess_mime_type(data: bytes) -> str | None:
-    """Guess a supported image MIME type from magic bytes."""
-    if data[:8] == b"\x89PNG\r\n\x1a\n":
-        return "image/png"
-    if data[:2] == b"\xff\xd8":
-        return "image/jpeg"
-    if data[:4] == b"GIF8":
-        return "image/gif"
-    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
-        return "image/webp"
-    return None


### PR DESCRIPTION
## Summary

- Separate byte-level image detection from provider-owned MIME allowlists, so adding Google support cannot silently broaden Anthropic or OpenAI behavior.
- Parse normal and extended ISO-BMFF `ftyp` boxes within declared and bounded ranges, require registered compatible brands, distinguish still-image and sequence MIME types, and fail closed on malformed or ambiguous containers.
- Recognize AVIF-specific `avif`/`avis`/`avio` brands before generic HEIF brands, so AVIF cannot be mislabeled as `image/heif` and bypass a provider allowlist.
- Allow HEIC/HEIF only for Google; retain the documented JPEG/PNG/GIF/WebP set for Anthropic and OpenAI; reject AVIF, image sequences, unknown input, and provider-unsupported BLOBs locally.
- Intentionally provide no compatibility alias or fallback. The private `_guess_media_type`/`_guess_mime_type` helpers are removed, signature checks are stricter, and Google GIF input is rejected because the current Gemini image contract does not list GIF.

## Related issue

close: #356

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The implementation links the current AOM, IANA, and provider format references next to the maintained mappings.

## Validation

- `scripts/format root --from-ref upstream/main --check` — passed
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed
- `python -m pytest -q tests/ai/test_ai_functions.py tests/ai/test_image_mime.py` — 246 passed
- `python -m pytest -q tests/ai -m 'not external_service'` — 602 passed, 6 deselected
- `scripts/run_release_tests.sh` — 509 passed, 1 skipped, 15 deselected, with one environment-only failure in `test_duckdb_source_id_matches_recorded_source_tree`: the shared virtual environment contains a native extension built from another checkout. This PR is Python-only, so no native rebuild is required by the development guide.
- Repeated the release non-Ray invocation excluding only that SourceID assertion — 509 passed, 1 skipped, 16 deselected
- Repeated the release real-Ray invocation — 11 passed, 515 deselected
- Exhaustive recognized-brand audit — 8,792 major/compatible-brand ordering cases passed; no AVIF brand combination fell through to a generic HEIF MIME type
- Random-input smoke test — 50,000 inputs completed without exceptions
- Current libheif `example.avif` detected as `image/avif`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
