### PR TITLE
[fix](execution) Reject zero partitions in RepartitionNode

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -212,6 +212,9 @@ RepartitionNode::RepartitionNode(PipelineNodeConfig config, PipelineNodeContext 
                                  std::shared_ptr<ExchangeManager> exchange_mgr)
     : config_(std::move(config)), context_(std::move(context)), repartition_spec_(std::move(repartition_spec)),
       num_partitions_(num_partitions), child_(std::move(child)), exchange_mgr_(std::move(exchange_mgr)) {
+	if (num_partitions_ == 0) {
+		throw InvalidInputException("RepartitionNode requires at least one partition");
+	}
 }
 
 // Static factory method.
@@ -220,6 +223,9 @@ std::shared_ptr<RepartitionNode> RepartitionNode::create(NodeID node_id, const s
                                                          size_t num_partitions, SchemaRef schema,
                                                          std::shared_ptr<DistributedPipelineNode> child,
                                                          std::shared_ptr<ExchangeManager> exchange_mgr) {
+	if (num_partitions == 0) {
+		throw InvalidInputException("RepartitionNode requires at least one partition");
+	}
 	PipelineNodeContext context(plan_config->query_idx, plan_config->query_id, node_id, NODE_NAME);
 	auto upstream_num = child ? child->config().clustering_spec()->num_partitions() : 1;
 	// Use num_partitions (not the node-count-capped remote_partitions) for the


### PR DESCRIPTION
## Summary

RepartitionNode previously accepted `num_partitions == 0`, which created a bounded channel with capacity 0. Since `ChannelState::send()` waits for `queue_.size() < capacity`, that predicate can never be true when capacity is zero — causing a permanent deadlock on the first send.

The fix adds an `InvalidInputException` guard in both the private constructor and the static factory `create()`, matching the existing validation pattern in `PhysicalRemoteExchangeSink` (`physical_remote_exchange_sink.cpp:130`).

## Related issue

close: #427

## Documentation impact

- [x] No user-facing documentation update is required.

## Validation

- Static validation: the guard fires at plan construction time, before any channel or exchange resources are allocated.
- The factory check acts as a fast path (rejects before PipelineNodeContext / ClusteringSpec allocation); the constructor check is the structural invariant against future bypass.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.