### PR TITLE
[fix](ai) Reject negative Prompt temperatures

### DIFF
--- a/tests/ai/test_descriptors.py
+++ b/tests/ai/test_descriptors.py
@@ -101,6 +101,25 @@ class TestProviderLoading:
         with pytest.raises(ValueError, match=message):
             OpenAIProvider().get_prompter(model=model, options=options)
 
+    def test_builtin_provider_factories_reject_negative_temperature(self):
+        from vane.ai.providers.anthropic import AnthropicProvider
+        from vane.ai.providers.google import GoogleProvider
+        from vane.ai.providers.openai import OpenAIProvider
+        from vane.ai.providers.vllm import VLLMProvider
+
+        factories = [
+            lambda: OpenAIProvider().get_prompter(options={"temperature": -0.1}),
+            lambda: AnthropicProvider(prompt_model="claude-test").get_prompter(
+                options={"max_tokens": 8, "temperature": -0.1}
+            ),
+            lambda: GoogleProvider(prompt_model="gemini-test").get_prompter(options={"temperature": -0.1}),
+            lambda: VLLMProvider().get_prompter(options={"temperature": -0.1}),
+        ]
+
+        for factory in factories:
+            with pytest.raises(ValueError, match=r"Prompt option 'temperature' must be >= 0"):
+                factory()
+
     @pytest.mark.parametrize(
         ("operation", "options"),
         [

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -1469,6 +1469,45 @@ def test_ai_prompt_options_are_provider_closed(provider, options, offending):
 
 
 @pytest.mark.parametrize(
+    ("provider", "model", "required_options"),
+    [
+        ("openai", None, {}),
+        ("anthropic", "claude-test", {"max_tokens": 8}),
+        ("google", "gemini-test", {}),
+        ("vllm", None, {}),
+    ],
+)
+def test_builtin_prompt_rejects_negative_temperature_during_planning(provider, model, required_options):
+    with pytest.raises(ValueError, match=r"Prompt option 'temperature' must be >= 0"):
+        vane.ai.prompt(
+            vane.col("text"),
+            provider=provider,
+            model=model,
+            temperature=-0.1,
+            **required_options,
+        )
+
+
+@pytest.mark.parametrize(
+    ("provider", "model", "required_options"),
+    [
+        ("openai", None, {}),
+        ("anthropic", "claude-test", {"max_tokens": 8}),
+        ("google", "gemini-test", {}),
+        ("vllm", None, {}),
+    ],
+)
+def test_builtin_prompt_accepts_zero_temperature_during_planning(provider, model, required_options):
+    vane.ai.prompt(
+        vane.col("text"),
+        provider=provider,
+        model=model,
+        temperature=0,
+        **required_options,
+    )
+
+
+@pytest.mark.parametrize(
     "options",
     [
         {"api_key": "secret"},

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -597,6 +597,19 @@ def test_ai_prompt_sql_options_must_be_a_foldable_struct_or_null():
         """).fetchall()
 
 
+def test_ai_prompt_sql_rejects_negative_temperature_during_planning():
+    conn = vane.connect()
+
+    with pytest.raises(Exception, match=r"Prompt option 'temperature' must be >= 0"):
+        conn.sql("""
+            SELECT ai_prompt(
+                'alpha',
+                provider := 'openai',
+                options := struct_pack(temperature := -0.1)
+            )
+        """).fetchall()
+
+
 @pytest.mark.parametrize("argument", ["system_message", "provider", "model", "on_error"])
 def test_ai_prompt_sql_call_level_configuration_must_be_foldable(argument):
     values = {

--- a/tests/fast/test_ai_options_repr.py
+++ b/tests/fast/test_ai_options_repr.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import pytest
 
 import vane
-from vane.ai.options import PromptOptions, validate_prompt_options
+from vane.ai.options import PromptOptions, normalize_prompt_options
 
 
 def test_prompt_options_is_the_only_public_prompt_option_type():
@@ -30,7 +30,13 @@ def test_prompt_options_are_plain_closed_mappings():
         "actor_number": 2,
         "max_concurrency_per_actor": 7,
     }
-    assert validate_prompt_options("openai", options, relation=False) == options
+    assert normalize_prompt_options("openai", options, relation=False) == options
+
+
+def test_prompt_outer_normalization_leaves_provider_values_for_adapter_validation():
+    options: PromptOptions = {"temperature": -0.1}
+
+    assert normalize_prompt_options("openai", options, relation=False) == options
 
 
 @pytest.mark.parametrize(
@@ -44,5 +50,5 @@ def test_prompt_options_are_plain_closed_mappings():
 def test_prompt_options_reject_sensitive_values_before_repr_or_planning(options):
     family = "vllm" if "engine_args" in options or "generate_args" in options else "openai"
     with pytest.raises(ValueError, match="sensitive") as error:
-        validate_prompt_options(family, options, relation=False)
+        normalize_prompt_options(family, options, relation=False)
     assert "plaintext-secret" not in str(error.value)

--- a/tests/fast/test_vllm_sampling_param_fold.py
+++ b/tests/fast/test_vllm_sampling_param_fold.py
@@ -162,6 +162,19 @@ def test_public_vllm_rejects_guided_decoding_alias_mapping():
         _plan_from_prompt_options({"generate_args": {"sampling_params": {"guided_decoding": {"regex": ".*"}}}})
 
 
+@pytest.mark.parametrize("sampling_params", [{"temperature": -0.1}, '{"temperature":-0.1}'])
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(_plan_from_prompt_options, id="prompt-entry-point"),
+        pytest.param(lambda options: VLLMProvider().get_prompter(options=options), id="provider-factory"),
+    ],
+)
+def test_public_vllm_rejects_negative_nested_temperature_during_planning(sampling_params, factory):
+    with pytest.raises(ValueError, match=r"sampling_params\.temperature.*>= 0"):
+        factory({"generate_args": {"sampling_params": sampling_params}})
+
+
 @pytest.mark.parametrize(
     "engine_args",
     [

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -52,8 +52,8 @@ from vane.ai._schema import (
 from vane.ai.options import (
     EmbedOptions,
     PromptOptions,
+    normalize_prompt_options,
     validate_embed_options,
-    validate_prompt_options,
 )
 from vane.ai.protocols import NativePrompterPlan
 from vane.ai.provider import (
@@ -1487,7 +1487,7 @@ def _prepare_prompt_call(
     if not isinstance(resolved_provider, Provider):
         raise TypeError("provider must be a provider name or Provider object")
     family = _prompt_provider_family(resolved_provider)
-    prepared = validate_prompt_options(family, options, relation=relation)
+    prepared = normalize_prompt_options(family, options, relation=relation)
 
     execution_backend = prepared.pop("execution_backend", None)
     batch_size = prepared.pop("batch_size", None)

--- a/vane/ai/options.py
+++ b/vane/ai/options.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 import math
 import re
 from collections.abc import Mapping
@@ -21,8 +20,10 @@ VLLMJSONValue: TypeAlias = VLLMJSONPrimitive | list["VLLMJSONValue"] | dict[str,
 class PromptOptions(TypedDict, total=False):
     """Closed keyword surface shared by the Python Prompt entry points."""
 
-    # Common generation and execution options.
+    # Provider request option shared by every built-in Prompt adapter.
     temperature: float | None
+
+    # Vane Prompt execution options.
     batch_size: int
     actor_number: int
     max_concurrency_per_actor: int
@@ -41,7 +42,7 @@ class PromptOptions(TypedDict, total=False):
     max_tokens: int | None
     top_k: int | None
 
-    # Native vLLM execution options.
+    # Native vLLM provider options.
     gpus_per_actor: float
     engine_args: Mapping[str, VLLMJSONValue]
     generate_args: Mapping[str, VLLMJSONValue]
@@ -118,17 +119,6 @@ _GOOGLE_EMBED_TASK_TYPES = frozenset(
 _EXECUTION_BACKENDS = frozenset({"subprocess_task", "subprocess_actor", "ray_task", "ray_actor"})
 _OPENAI_EXTRA_SENSITIVE_KEYS = frozenset({"organization"})
 _HUGGING_FACE_COMMIT_SHA = re.compile(r"[0-9a-fA-F]{40}")
-_VLLM_REMOTE_CODE_SPECULATIVE_METHODS = frozenset(
-    {
-        "mtp",
-        "deepseek_mtp",
-        "mimo_mtp",
-        "glm4_moe_mtp",
-        "ernie_mtp",
-        "qwen3_next_mtp",
-        "longcat_flash_mtp",
-    }
-)
 
 
 def _is_hugging_face_commit_sha(value: Any) -> bool:
@@ -273,9 +263,10 @@ def validate_embed_options(
     return copied
 
 
-_PROMPT_COMMON_OPTIONS = frozenset({"temperature", "batch_size", "actor_number", "max_retries"})
-_PROMPT_RELATION_OPTIONS = frozenset({"execution_backend"})
-_PROMPT_REMOTE_OPTIONS = frozenset({"max_concurrency_per_actor"})
+_PROMPT_SHARED_PROVIDER_OPTIONS = frozenset({"temperature"})
+_PROMPT_BASE_EXECUTION_OPTIONS = frozenset({"batch_size", "actor_number", "max_retries"})
+_PROMPT_RELATION_EXECUTION_OPTIONS = frozenset({"execution_backend"})
+_PROMPT_REMOTE_EXECUTION_OPTIONS = frozenset({"max_concurrency_per_actor"})
 _PROMPT_PROVIDER_OPTIONS = {
     "openai": frozenset(
         {"use_chat_completions", "max_output_tokens", "top_p", "stop_sequences", "base_url", "timeout"}
@@ -361,51 +352,37 @@ def _validate_prompt_stop_sequences(options: Mapping[str, Any]) -> None:
         raise ValueError("Prompt option 'stop_sequences' must contain only non-empty strings")
 
 
-def _validate_vllm_json(value: Any, path: str) -> None:
-    if value is None or isinstance(value, (str, bool, int)):
-        return
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError(f"Prompt option {path} must contain only finite numbers")
-        return
-    if isinstance(value, Mapping):
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise TypeError(f"Prompt option {path} must use string keys; got {type(key).__name__}")
-            if key in {"structured_outputs", "guided_decoding"}:
-                raise ValueError(f"Prompt option generate_args cannot configure {key} directly; use return_format")
-            _validate_vllm_json(item, f"{path}.{key}")
-        return
-    if isinstance(value, list):
-        for index, item in enumerate(value):
-            _validate_vllm_json(item, f"{path}[{index}]")
-        return
-    raise TypeError(f"Prompt option {path} must be JSON-compatible; got {type(value).__name__}")
-
-
-def validate_prompt_options(
+def normalize_prompt_options(
     provider_family: str | None,
     options: Mapping[str, Any],
     *,
     relation: bool,
 ) -> dict[str, Any]:
-    """Validate and copy the closed Prompt options for one entry point."""
+    """Copy and validate the outer Prompt option envelope.
+
+    Provider adapters own the semantics of every option they consume. This
+    outer normalization boundary only applies Vane-wide safety and closed-key
+    checks, then validates the execution fields consumed by Prompt planning.
+    """
 
     copied = dict(options)
     _reject_sensitive_prompt_options(copied)
     family = (provider_family or "").casefold()
-    allowed = _PROMPT_COMMON_OPTIONS | _PROMPT_PROVIDER_OPTIONS.get(family, frozenset())
+    allowed = (
+        _PROMPT_SHARED_PROVIDER_OPTIONS
+        | _PROMPT_BASE_EXECUTION_OPTIONS
+        | _PROMPT_PROVIDER_OPTIONS.get(family, frozenset())
+    )
     if family != "vllm":
-        allowed |= _PROMPT_REMOTE_OPTIONS
+        allowed |= _PROMPT_REMOTE_EXECUTION_OPTIONS
     if relation and family != "vllm":
-        allowed |= _PROMPT_RELATION_OPTIONS
+        allowed |= _PROMPT_RELATION_EXECUTION_OPTIONS
     unknown = sorted(set(copied) - allowed)
     if unknown:
         raise TypeError(
             f"Unsupported Prompt option(s) for provider {provider_family or 'custom'!r}: " + ", ".join(unknown)
         )
 
-    _require_prompt_number(copied, "temperature", nullable=True)
     for name in ("batch_size", "actor_number", "max_concurrency_per_actor"):
         _require_prompt_int(copied, name, minimum=1)
     _require_prompt_int(copied, "max_retries", minimum=0)
@@ -420,83 +397,7 @@ def validate_prompt_options(
         if "actor_number" in copied and backend in {"subprocess_task", "ray_task"}:
             raise ValueError("Prompt option 'actor_number' requires an actor execution backend")
 
-    if family == "openai":
-        if "use_chat_completions" in copied and not isinstance(copied["use_chat_completions"], bool):
-            raise ValueError("Prompt option 'use_chat_completions' must be a bool")
-        _require_prompt_int(copied, "max_output_tokens", minimum=1, nullable=True)
-    elif family == "anthropic":
-        _require_prompt_int(copied, "max_tokens", minimum=0, nullable=True)
-        _require_prompt_int(copied, "top_k", minimum=0, nullable=True)
-    elif family == "google":
-        _require_prompt_int(copied, "max_output_tokens", minimum=1, nullable=True)
-        _require_prompt_int(copied, "top_k", minimum=0, nullable=True)
-    elif family == "vllm":
-        _require_prompt_int(copied, "max_tokens", minimum=1, nullable=True)
-        for name in ("max_buffer_size", "min_bucket_size", "load_balance_threshold", "inflight_limit"):
-            _require_prompt_int(copied, name, minimum=0)
-        _require_prompt_number(copied, "prefix_match_threshold", minimum=0, maximum=1)
-        _require_prompt_number(copied, "engine_init_timeout_s", minimum=0, nullable=True)
-        if "gpus_per_actor" in copied:
-            _require_prompt_number(copied, "gpus_per_actor", minimum=0)
-            value = float(copied["gpus_per_actor"])
-            if value <= 0 or (value >= 1 and not value.is_integer()):
-                raise ValueError("Prompt option 'gpus_per_actor' must be positive and must be an integer when >= 1")
-        if "do_prefix_routing" in copied and not isinstance(copied["do_prefix_routing"], bool):
-            raise ValueError("Prompt option 'do_prefix_routing' must be a bool")
-        for name in ("engine_args", "generate_args"):
-            if name in copied:
-                value = copied[name]
-                if not isinstance(value, Mapping):
-                    raise TypeError(f"Prompt option {name!r} must be a mapping")
-                _validate_vllm_json(value, name)
-        generate_args = copied.get("generate_args", {})
-        sampling_params = generate_args.get("sampling_params")
-        if isinstance(sampling_params, str):
-            try:
-                decoded_sampling_params = json.loads(sampling_params)
-            except json.JSONDecodeError as exc:
-                raise ValueError("Prompt option 'generate_args.sampling_params' must be valid JSON") from exc
-            if not isinstance(decoded_sampling_params, Mapping):
-                raise ValueError("Prompt option 'generate_args.sampling_params' JSON must decode to a mapping")
-            _reject_sensitive_prompt_options(
-                decoded_sampling_params,
-                path="options.generate_args.sampling_params",
-            )
-            _validate_vllm_json(decoded_sampling_params, "generate_args.sampling_params")
-        engine_args = copied.get("engine_args", {})
-        if "trust_remote_code" in engine_args and not isinstance(engine_args["trust_remote_code"], bool):
-            raise ValueError("Prompt option 'engine_args.trust_remote_code' must be a bool")
-        if engine_args.get("trust_remote_code") is True:
-            for revision_name in ("code_revision", "tokenizer_revision"):
-                if not _is_hugging_face_commit_sha(engine_args.get(revision_name)):
-                    raise ValueError(
-                        "Prompt option 'engine_args.trust_remote_code=True' requires "
-                        f"engine_args.{revision_name} as a full 40-character commit SHA"
-                    )
-            speculative_config = engine_args.get("speculative_config")
-            speculative_model = speculative_config.get("model") if isinstance(speculative_config, Mapping) else None
-            speculative_method = speculative_config.get("method") if isinstance(speculative_config, Mapping) else None
-            if (
-                isinstance(speculative_config, Mapping)
-                and (
-                    (speculative_model is not None and speculative_model not in {"ngram", "[ngram]"})
-                    or speculative_method in _VLLM_REMOTE_CODE_SPECULATIVE_METHODS
-                )
-                and not _is_hugging_face_commit_sha(speculative_config.get("code_revision"))
-            ):
-                raise ValueError(
-                    "Prompt option 'engine_args.trust_remote_code=True' with a speculative model requires "
-                    "engine_args.speculative_config.code_revision as a full 40-character commit SHA"
-                )
-        if copied.get("max_retries", 0) != 0:
-            raise ValueError("native vLLM prompting only accepts max_retries=0")
-
-    if family in {"openai", "anthropic", "google"}:
-        _require_prompt_number(copied, "top_p", minimum=0, maximum=1, nullable=True)
-        _validate_prompt_stop_sequences(copied)
-        _validate_base_url_option(copied, api="Prompt")
-        _require_prompt_number(copied, "timeout", minimum=0, nullable=True)
-        if copied.get("timeout") == 0:
-            raise ValueError("Prompt option 'timeout' must be a finite positive number or None")
+    if family == "vllm" and copied.get("max_retries", 0) != 0:
+        raise ValueError("native vLLM prompting only accepts max_retries=0")
 
     return copied

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -11,7 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import OutputValidationError, serialize_raw_response
-from vane.ai.options import validate_prompt_options
+from vane.ai.options import (
+    _require_prompt_int,
+    _require_prompt_number,
+    _validate_base_url_option,
+    _validate_prompt_stop_sequences,
+)
 from vane.ai.protocols import PrompterDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
 from vane.ai.typing import UDFOptions
@@ -108,6 +113,25 @@ class AnthropicProvider(Provider):
         )
 
 
+def _validate_anthropic_prompt_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate options owned by the Anthropic Prompt adapter."""
+
+    copied = dict(options)
+    unknown = sorted(set(copied) - _PROMPT_OPTIONS)
+    if unknown:
+        raise TypeError(f"Unsupported Anthropic Prompt option(s): {', '.join(unknown)}")
+    _require_prompt_number(copied, "temperature", minimum=0, nullable=True)
+    _require_prompt_int(copied, "max_tokens", minimum=0, nullable=True)
+    _require_prompt_int(copied, "top_k", minimum=0, nullable=True)
+    _require_prompt_number(copied, "top_p", minimum=0, maximum=1, nullable=True)
+    _validate_prompt_stop_sequences(copied)
+    _validate_base_url_option(copied, api="Prompt")
+    _require_prompt_number(copied, "timeout", minimum=0, nullable=True)
+    if copied.get("timeout") == 0:
+        raise ValueError("Prompt option 'timeout' must be a finite positive number or None")
+    return copied
+
+
 @dataclass
 class AnthropicPrompterDescriptor(PrompterDescriptor):
     """Serializable factory for the Anthropic Messages API."""
@@ -122,10 +146,7 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
     def __post_init__(self) -> None:
         if not isinstance(self.model_name, str) or not self.model_name.strip():
             raise ValueError("Anthropic prompt model must be a non-empty string")
-        unknown = sorted(set(self.options) - _PROMPT_OPTIONS)
-        if unknown:
-            raise TypeError(f"Unsupported Anthropic Prompt option(s): {', '.join(unknown)}")
-        validated_options = validate_prompt_options("anthropic", self.options, relation=False)
+        validated_options = _validate_anthropic_prompt_options(self.options)
         if validated_options.get("max_tokens") is None:
             raise ValueError(
                 "No max_tokens configured for the Anthropic provider. Pass max_tokens=... on the Prompt call."

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -26,10 +26,12 @@ import numpy as np
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import serialize_raw_response
 from vane.ai.options import (
-    validate_embed_options as validate_closed_embed_options,
+    _require_prompt_int,
+    _require_prompt_number,
+    _validate_prompt_stop_sequences,
 )
 from vane.ai.options import (
-    validate_prompt_options as validate_closed_prompt_options,
+    validate_embed_options as validate_closed_embed_options,
 )
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
@@ -195,7 +197,7 @@ def _canonical_model_id(model_name: str) -> str:
     return model_name.removeprefix("models/")
 
 
-def _validate_prompt_options(model_name: str, options: Mapping[str, Any]) -> None:
+def _validate_google_prompt_model_options(model_name: str, options: Mapping[str, Any]) -> None:
     """Reject request options the selected model is documented not to support.
 
     Raises:
@@ -518,6 +520,21 @@ class GoogleTextEmbedder:
 # ---------------------------------------------------------------------------
 
 
+def _validate_google_prompt_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate options owned by the Google Prompt adapter."""
+
+    copied = dict(options)
+    unknown = sorted(set(copied) - _PROMPT_REQUEST_OPTIONS)
+    if unknown:
+        raise TypeError(f"Unsupported Google Prompt option(s): {', '.join(unknown)}")
+    _require_prompt_number(copied, "temperature", minimum=0, nullable=True)
+    _require_prompt_int(copied, "max_output_tokens", minimum=1, nullable=True)
+    _require_prompt_int(copied, "top_k", minimum=0, nullable=True)
+    _require_prompt_number(copied, "top_p", minimum=0, maximum=1, nullable=True)
+    _validate_prompt_stop_sequences(copied)
+    return copied
+
+
 @dataclass
 class GooglePrompterDescriptor(PrompterDescriptor):
     """Serializable factory for a basic Gemini text/image prompter."""
@@ -532,13 +549,10 @@ class GooglePrompterDescriptor(PrompterDescriptor):
     def __post_init__(self) -> None:
         if not isinstance(self.model_name, str) or not self.model_name.strip():
             raise ValueError("Google prompt model must be a non-empty string")
-        unknown = sorted(set(self.options) - _PROMPT_REQUEST_OPTIONS)
-        if unknown:
-            raise TypeError(f"Unsupported Google Prompt option(s): {', '.join(unknown)}")
-        validated_options = validate_closed_prompt_options("google", self.options, relation=False)
+        validated_options = _validate_google_prompt_options(self.options)
         if _canonical_model_id(self.model_name) in _EMBEDDING_DIMS:
             raise ValueError(f"Google model {self.model_name!r} supports Embed, not Prompt")
-        _validate_prompt_options(self.model_name, validated_options)
+        _validate_google_prompt_model_options(self.model_name, validated_options)
         self.options = wrap_sensitive_options(validated_options)
 
     def get_provider(self) -> str:

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -27,7 +27,13 @@ from vane.ai._schema import (
     _uses_openai_strict_structured_outputs,
     serialize_raw_response,
 )
-from vane.ai.options import validate_embed_options, validate_prompt_options
+from vane.ai.options import (
+    _require_prompt_int,
+    _require_prompt_number,
+    _validate_base_url_option,
+    _validate_prompt_stop_sequences,
+    validate_embed_options,
+)
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultError
 from vane.ai.typing import UDFOptions
@@ -684,6 +690,26 @@ class OpenAITextEmbedder:
 # ---------------------------------------------------------------------------
 
 
+def _validate_openai_prompt_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate options owned by the OpenAI Prompt adapter."""
+
+    copied = dict(options)
+    unknown = sorted(set(copied) - OpenAIProvider._PROMPT_OPTIONS)
+    if unknown:
+        raise TypeError(f"Unsupported OpenAI Prompt option(s): {', '.join(unknown)}")
+    if "use_chat_completions" in copied and not isinstance(copied["use_chat_completions"], bool):
+        raise ValueError("Prompt option 'use_chat_completions' must be a bool")
+    _require_prompt_number(copied, "temperature", minimum=0, nullable=True)
+    _require_prompt_int(copied, "max_output_tokens", minimum=1, nullable=True)
+    _require_prompt_number(copied, "top_p", minimum=0, maximum=1, nullable=True)
+    _validate_prompt_stop_sequences(copied)
+    _validate_base_url_option(copied, api="Prompt")
+    _require_prompt_number(copied, "timeout", minimum=0, nullable=True)
+    if copied.get("timeout") == 0:
+        raise ValueError("Prompt option 'timeout' must be a finite positive number or None")
+    return copied
+
+
 @dataclass
 class OpenAIPrompterDescriptor(PrompterDescriptor):
     """Serializable factory for a basic text/image OpenAI prompter."""
@@ -698,10 +724,7 @@ class OpenAIPrompterDescriptor(PrompterDescriptor):
     def __post_init__(self) -> None:
         if not isinstance(self.model_name, str) or not self.model_name.strip():
             raise ValueError("OpenAI prompt model must be a non-empty string")
-        unknown = sorted(set(self.options) - OpenAIProvider._PROMPT_OPTIONS)
-        if unknown:
-            raise TypeError(f"Unsupported OpenAI Prompt option(s): {', '.join(unknown)}")
-        validated_options = validate_prompt_options("openai", self.options, relation=False)
+        validated_options = _validate_openai_prompt_options(self.options)
         if validated_options.get("stop_sequences") is not None and not validated_options.get(
             "use_chat_completions", False
         ):

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -40,12 +41,146 @@ from duckdb.execution._vllm_options_protocol import (
     _dump_vllm_protocol_json,
 )
 from vane.ai._redaction import Secret, wrap_sensitive_options
-from vane.ai.options import validate_prompt_options
+from vane.ai.options import (
+    _reject_sensitive_prompt_options,
+    _require_prompt_int,
+    _require_prompt_number,
+    normalize_prompt_options,
+)
 from vane.ai.protocols import NativePrompterPlan
 from vane.ai.provider import Provider
 
 if TYPE_CHECKING:
     from vane.ai.typing import Options
+
+
+_VLLM_PROVIDER_OPTIONS = frozenset(
+    {
+        "temperature",
+        "max_tokens",
+        "gpus_per_actor",
+        "engine_args",
+        "generate_args",
+        "do_prefix_routing",
+        "max_buffer_size",
+        "min_bucket_size",
+        "prefix_match_threshold",
+        "load_balance_threshold",
+        "inflight_limit",
+        "engine_init_timeout_s",
+    }
+)
+_VLLM_EXECUTION_OPTIONS = frozenset({"batch_size", "actor_number", "max_retries"})
+_HUGGING_FACE_COMMIT_SHA = re.compile(r"[0-9a-fA-F]{40}")
+_REMOTE_CODE_SPECULATIVE_METHODS = frozenset(
+    {
+        "mtp",
+        "deepseek_mtp",
+        "mimo_mtp",
+        "glm4_moe_mtp",
+        "ernie_mtp",
+        "qwen3_next_mtp",
+        "longcat_flash_mtp",
+    }
+)
+
+
+def _is_hugging_face_commit_sha(value: Any) -> bool:
+    return isinstance(value, str) and _HUGGING_FACE_COMMIT_SHA.fullmatch(value) is not None
+
+
+def _validate_vllm_json(value: Any, path: str) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"Prompt option {path} must contain only finite numbers")
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"Prompt option {path} must use string keys; got {type(key).__name__}")
+            if key in {"structured_outputs", "guided_decoding"}:
+                raise ValueError(f"Prompt option generate_args cannot configure {key} directly; use return_format")
+            _validate_vllm_json(item, f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_vllm_json(item, f"{path}[{index}]")
+        return
+    raise TypeError(f"Prompt option {path} must be JSON-compatible; got {type(value).__name__}")
+
+
+def _validate_vllm_prompt_options(options: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate options owned by the native vLLM Prompt adapter."""
+
+    copied = dict(options)
+    unknown = sorted(set(copied) - _VLLM_PROVIDER_OPTIONS - _VLLM_EXECUTION_OPTIONS)
+    if unknown:
+        raise TypeError(f"Unsupported vLLM Prompt option(s): {', '.join(unknown)}")
+
+    _require_prompt_number(copied, "temperature", minimum=0, nullable=True)
+    _require_prompt_int(copied, "max_tokens", minimum=1, nullable=True)
+    for name in ("max_buffer_size", "min_bucket_size", "load_balance_threshold", "inflight_limit"):
+        _require_prompt_int(copied, name, minimum=0)
+    _require_prompt_number(copied, "prefix_match_threshold", minimum=0, maximum=1)
+    _require_prompt_number(copied, "engine_init_timeout_s", minimum=0, nullable=True)
+    if "gpus_per_actor" in copied:
+        _require_prompt_number(copied, "gpus_per_actor", minimum=0)
+        value = float(copied["gpus_per_actor"])
+        if value <= 0 or (value >= 1 and not value.is_integer()):
+            raise ValueError("Prompt option 'gpus_per_actor' must be positive and must be an integer when >= 1")
+    if "do_prefix_routing" in copied and not isinstance(copied["do_prefix_routing"], bool):
+        raise ValueError("Prompt option 'do_prefix_routing' must be a bool")
+
+    for name in ("engine_args", "generate_args"):
+        if name in copied:
+            value = copied[name]
+            if not isinstance(value, Mapping):
+                raise TypeError(f"Prompt option {name!r} must be a mapping")
+            _validate_vllm_json(value, name)
+
+    generate_args = copied.get("generate_args", {})
+    sampling_params = generate_args.get("sampling_params")
+    if isinstance(sampling_params, str):
+        try:
+            sampling_params = json.loads(sampling_params)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Prompt option 'generate_args.sampling_params' must be valid JSON") from exc
+        if not isinstance(sampling_params, Mapping):
+            raise ValueError("Prompt option 'generate_args.sampling_params' JSON must decode to a mapping")
+        _reject_sensitive_prompt_options(sampling_params, path="options.generate_args.sampling_params")
+        _validate_vllm_json(sampling_params, "generate_args.sampling_params")
+    if isinstance(sampling_params, Mapping) and "temperature" in sampling_params:
+        nested_name = "generate_args.sampling_params.temperature"
+        _require_prompt_number({nested_name: sampling_params["temperature"]}, nested_name, minimum=0, nullable=True)
+
+    engine_args = copied.get("engine_args", {})
+    if "trust_remote_code" in engine_args and not isinstance(engine_args["trust_remote_code"], bool):
+        raise ValueError("Prompt option 'engine_args.trust_remote_code' must be a bool")
+    if engine_args.get("trust_remote_code") is True:
+        for revision_name in ("code_revision", "tokenizer_revision"):
+            if not _is_hugging_face_commit_sha(engine_args.get(revision_name)):
+                raise ValueError(
+                    "Prompt option 'engine_args.trust_remote_code=True' requires "
+                    f"engine_args.{revision_name} as a full 40-character commit SHA"
+                )
+        speculative_config = engine_args.get("speculative_config")
+        speculative_model = speculative_config.get("model") if isinstance(speculative_config, Mapping) else None
+        speculative_method = speculative_config.get("method") if isinstance(speculative_config, Mapping) else None
+        if (
+            isinstance(speculative_config, Mapping)
+            and (
+                (speculative_model is not None and speculative_model not in {"ngram", "[ngram]"})
+                or speculative_method in _REMOTE_CODE_SPECULATIVE_METHODS
+            )
+            and not _is_hugging_face_commit_sha(speculative_config.get("code_revision"))
+        ):
+            raise ValueError(
+                "Prompt option 'engine_args.trust_remote_code=True' with a speculative model requires "
+                "engine_args.speculative_config.code_revision as a full 40-character commit SHA"
+            )
+    return copied
 
 
 def _canonicalize_native_json(value: Any, path: str = "options") -> Any:
@@ -159,7 +294,8 @@ class VLLMProvider(Provider):
     ) -> NativeVLLMPromptPlan:
         if return_raw_response:
             raise ValueError("Provider 'vllm' does not support return_raw_response")
-        prepared = validate_prompt_options("vllm", options or {}, relation=False)
+        prepared = normalize_prompt_options("vllm", options or {}, relation=False)
+        prepared = _validate_vllm_prompt_options(prepared)
         model_name = model or self.DEFAULT_MODEL
         if not isinstance(model_name, str) or not model_name.strip():
             raise ValueError("vLLM prompt model must be a non-empty string")


### PR DESCRIPTION
## Summary

- Split Prompt option handling by ownership: the outer Vane boundary copies options, rejects sensitive or unknown fields, and validates execution controls; each built-in provider validates the request fields it consumes.
- Reject negative `temperature` values during planning for OpenAI, Anthropic, Google, and native vLLM, including vLLM `generate_args.sampling_params` mappings and JSON strings.
- Remove the old central Prompt semantic validator without a compatibility facade or custom-provider fallback.

## Related issue

close: #467

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change affects invalid-option error timing and internal validation ownership only.

## Validation

- `scripts/format root --changed`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Targeted Prompt/provider/security suite: 363 passed
- `scripts/run_release_tests.sh`: 509 passed and 1 skipped in the non-Ray phase; the SourceID identity check failed because the reused native installation was built from another worktree, and the script stopped before its Ray phase
- Complete fast launcher with only the mismatched SourceID identity test excluded on this CPU host: 6637 non-Ray, 98 shared-Ray, and 7 test-owned-Ray tests passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.