### PR TITLE
[fix](ai) Reject negative Prompt temperatures during validation

### DIFF
--- a/tests/fast/test_ai_options_repr.py
+++ b/tests/fast/test_ai_options_repr.py
@@ -46,3 +46,14 @@ def test_prompt_options_reject_sensitive_values_before_repr_or_planning(options)
     with pytest.raises(ValueError, match="sensitive") as error:
         validate_prompt_options(family, options, relation=False)
     assert "plaintext-secret" not in str(error.value)
+
+
+@pytest.mark.parametrize("family", ["openai", "anthropic", "google", "vllm"])
+def test_prompt_options_reject_negative_temperature(family):
+    with pytest.raises(ValueError, match=r"temperature' must be >= 0"):
+        validate_prompt_options(family, {"temperature": -0.1}, relation=False)
+
+
+@pytest.mark.parametrize("family", ["openai", "anthropic", "google", "vllm"])
+def test_prompt_options_accept_zero_temperature(family):
+    assert validate_prompt_options(family, {"temperature": 0}, relation=False) == {"temperature": 0}

--- a/vane/ai/options.py
+++ b/vane/ai/options.py
@@ -405,7 +405,7 @@ def validate_prompt_options(
             f"Unsupported Prompt option(s) for provider {provider_family or 'custom'!r}: " + ", ".join(unknown)
         )
 
-    _require_prompt_number(copied, "temperature", nullable=True)
+    _require_prompt_number(copied, "temperature", minimum=0, nullable=True)
     for name in ("batch_size", "actor_number", "max_concurrency_per_actor"):
         _require_prompt_int(copied, name, minimum=1)
     _require_prompt_int(copied, "max_retries", minimum=0)


### PR DESCRIPTION
## Summary

`validate_prompt_options` checked `temperature` only for finiteness, so a negative value passed planning validation for every built-in provider and only failed later — in native vLLM's `SamplingParams` constructor on the worker, or at the remote provider. This turned a deterministic call-option error into a worker or provider failure.

This applies `minimum=0` at the existing `_require_prompt_number` call site, so the closed Prompt contract rejects negative temperatures during planning, as suggested in the follow-up from #397 (r3710038354). `temperature=0` (greedy/deterministic sampling) and `temperature=None` remain valid.

Note: a negative temperature nested in the raw vLLM pass-through (`generate_args.sampling_params.temperature`) still reaches the worker; `generate_args` is an intentional pass-through surface, so per-key semantics there are left as a possible follow-up rather than folded into this contract fix.

## Related issue

close: #467

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `pytest tests/fast/test_ai_options_repr.py` — 13 passed, including new regression tests: negative temperature rejected across all four provider families (`openai`, `anthropic`, `google`, `vllm`), zero temperature still accepted.
- Issue repro `validate_prompt_options("openai", {"temperature": -0.1}, relation=False)` now raises `ValueError: Prompt option 'temperature' must be >= 0`; `0.7` / `0` / `None` still pass.
- `ruff check` and `ruff format --check` clean on both touched files; pre-commit hooks passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyPevr7aJRqRcuxhfxb56q
