### PR TITLE
[fix](ai) Guard malformed Retry-After delays before retry sleeps

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -1737,6 +1737,72 @@ class TestRetryAfterError:
         assert exc_info.value.__cause__ is None
         assert exc_info.value.__context__ is None
 
+    @pytest.mark.parametrize("bad", [-1.0, -0.001, float("nan"), float("inf"), 10**400, -(10**400)])
+    def test_retry_wait_seconds_rejects_malformed_retry_after(self, bad):
+        """A non-finite or negative retry_after never becomes the sleep value (issue #469)."""
+        from vane.ai.functions import RetryAfterError, _retry_wait_seconds
+
+        # Falls back to exponential backoff (1, 2, 4, ... capped at 30) rather
+        # than passing a value that time.sleep/asyncio.sleep would choke on.
+        # The 10**400 cases also pin that the guard itself must not raise
+        # OverflowError converting an int beyond float range.
+        assert _retry_wait_seconds(RetryAfterError(retry_after=bad), attempt=0) == 1
+        assert _retry_wait_seconds(RetryAfterError(retry_after=bad), attempt=2) == 4
+
+    def test_retry_wait_seconds_honors_valid_retry_after(self):
+        from vane.ai.functions import RetryAfterError, _retry_wait_seconds
+
+        assert _retry_wait_seconds(RetryAfterError(retry_after=7.0), attempt=0) == 7.0
+        assert _retry_wait_seconds(RetryAfterError(retry_after=0.0), attempt=0) == 0.0
+        assert _retry_wait_seconds(RetryAfterError(retry_after=999.0), attempt=0) == 120  # capped
+
+    @pytest.mark.parametrize("bad", [-1.0, float("nan"), float("inf")])
+    def test_retry_call_malformed_retry_after_does_not_break_sleep(self, monkeypatch, bad):
+        """Sync retry with a malformed delay retries and honours on_error, never ValueError."""
+        from vane.ai import functions
+        from vane.ai.functions import RetryAfterError, _retry_call
+
+        slept: list[float] = []
+        monkeypatch.setattr(functions.time, "sleep", lambda seconds: slept.append(seconds))
+
+        calls: list[int] = []
+
+        def fn():
+            calls.append(1)
+            raise RetryAfterError(retry_after=bad, original=RuntimeError("429"))
+
+        result = _retry_call(fn, max_retries=3, on_error="ignore", default="fallback")
+
+        assert result == "fallback"  # on_error honoured, not bypassed by a sleep crash
+        assert len(calls) == 4  # first attempt + 3 retries all ran
+        assert slept == [1, 2, 4]  # fell back to exponential backoff
+
+    def test_retry_call_async_malformed_retry_after_does_not_hang(self, monkeypatch):
+        """Async retry with retry_after=NaN must not deadlock on asyncio.sleep(nan) (issue #469)."""
+        import asyncio
+
+        from vane.ai import functions
+        from vane.ai.functions import RetryAfterError, _retry_call_async
+
+        slept: list[float] = []
+
+        async def fake_sleep(seconds):
+            slept.append(seconds)
+
+        monkeypatch.setattr(functions.asyncio, "sleep", fake_sleep)
+
+        calls: list[int] = []
+
+        async def fn():
+            calls.append(1)
+            raise RetryAfterError(retry_after=float("nan"), original=ValueError("503"))
+
+        result = asyncio.run(_retry_call_async(fn, max_retries=3, on_error="ignore", default="fb"))
+
+        assert result == "fb"
+        assert len(calls) == 4
+        assert slept == [1, 2, 4]
+
 
 class TestGoogleRetryHandling:
     """Tests for Google provider 429/503 → RetryAfterError conversion."""
@@ -1805,6 +1871,43 @@ class TestGoogleRetryHandling:
         exc = RuntimeError("random error")
         # No .code attribute → should not raise
         _raise_retry_after_on_google_error(exc)
+
+    @pytest.mark.parametrize("bad_header", ["-1", "-0.5", "nan", "NaN", "inf", "1e999"])
+    def test_google_malformed_retry_after_header_uses_default(self, bad_header):
+        """Parseable-but-invalid Retry-After (negative/NaN/inf) falls back to 5s (issue #469)."""
+        from unittest.mock import MagicMock
+
+        from vane.ai.functions import RetryAfterError
+        from vane.ai.providers.google import _raise_retry_after_on_google_error
+
+        mock_response = MagicMock()
+        mock_response.headers = {"Retry-After": bad_header}
+
+        exc = Exception("rate limited")
+        exc.code = 429
+        exc.response = mock_response
+
+        with pytest.raises(RetryAfterError) as ctx:
+            _raise_retry_after_on_google_error(exc)
+        assert ctx.value.retry_after == 5.0
+
+    def test_google_valid_decimal_retry_after_header(self):
+        """A well-formed fractional Retry-After is still honoured verbatim."""
+        from unittest.mock import MagicMock
+
+        from vane.ai.functions import RetryAfterError
+        from vane.ai.providers.google import _raise_retry_after_on_google_error
+
+        mock_response = MagicMock()
+        mock_response.headers = {"Retry-After": "3.5"}
+
+        exc = Exception("rate limited")
+        exc.code = 429
+        exc.response = mock_response
+
+        with pytest.raises(RetryAfterError) as ctx:
+            _raise_retry_after_on_google_error(exc)
+        assert ctx.value.retry_after == 3.5
 
 
 class TestEmbedProviderCapabilityErrors:

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import math
 import time
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, overload
@@ -140,7 +141,9 @@ class RetryAfterError(Exception):
 
     Providers raise this when they receive a rate-limit (429) or
     service-unavailable (503) response with a ``Retry-After`` header.
-    The retry helpers honour :attr:`retry_after` for the sleep duration.
+    The retry helpers honour :attr:`retry_after` for the sleep duration when
+    it is a finite, non-negative number (capped at 120s); any other value
+    falls back to exponential backoff (see :func:`_retry_wait_seconds`).
     """
 
     def __init__(self, retry_after: float, original: Exception | None = None) -> None:
@@ -156,6 +159,31 @@ class RetryAfterError(Exception):
                 continue
             if type(value) is int and -999_999 <= value <= 999_999:
                 setattr(self, name, value)
+
+
+def _retry_wait_seconds(exc: Exception, attempt: int) -> float:
+    """Seconds to sleep before the next retry attempt.
+
+    A :class:`RetryAfterError` whose ``retry_after`` is a finite, non-negative
+    number is honoured, capped at 120s. Any other value falls back to
+    exponential backoff: a negative, NaN, or infinite delay — reachable from a
+    malformed but parseable provider ``Retry-After`` header (Google parses the
+    header with ``float()``) or a misbehaving custom provider — must never reach
+    ``time.sleep``/``asyncio.sleep``, where a negative or NaN value raises
+    ``ValueError`` (sync) or can hang the retry forever (async NaN), replacing
+    the provider's retry/``on_error`` behaviour with a spurious sleep failure
+    (issue #469).
+    """
+    if isinstance(exc, RetryAfterError):
+        retry_after = exc.retry_after
+        if isinstance(retry_after, (int, float)) and not isinstance(retry_after, bool):
+            try:
+                wait = float(retry_after)
+            except OverflowError:  # int beyond float range — not a usable delay
+                wait = math.inf
+            if math.isfinite(wait) and wait >= 0:
+                return min(wait, 120)
+    return min(2**attempt, 30)  # 1, 2, 4, 8, ... capped at 30s
 
 
 _TRANSIENT_HTTP_STATUS_CODES = frozenset({408, 409, 425, 429})
@@ -262,10 +290,7 @@ def _retry_call(
             if not _is_transient_provider_error(exc):
                 break
             if attempt < max_retries:
-                if isinstance(exc, RetryAfterError):
-                    wait = min(exc.retry_after, 120)
-                else:
-                    wait = min(2**attempt, 30)  # 1, 2, 4, 8, ... capped at 30s
+                wait = _retry_wait_seconds(exc, attempt)
         # Do not sleep while the provider exception is the active exception.
         # Otherwise an interrupt can retain the raw SDK error as its context.
         if wait is not None:
@@ -313,10 +338,7 @@ async def _retry_call_async(
             if not _is_transient_provider_error(exc):
                 break
             if attempt < max_retries:
-                if isinstance(exc, RetryAfterError):
-                    wait = min(exc.retry_after, 120)
-                else:
-                    wait = min(2**attempt, 30)
+                wait = _retry_wait_seconds(exc, attempt)
         # Keep cancellation outside the raw provider exception handler so the
         # provider error cannot become CancelledError.__context__.
         if wait is not None:

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -18,6 +18,7 @@ Requires::
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -58,8 +59,9 @@ def _guess_media_type(data: bytes) -> str | None:
 def _retry_after_error_from_google_error(exc: Exception) -> Exception | None:
     """Build a safe retry signal for Google 429/503 responses, if applicable.
 
-    Parses the ``Retry-After`` header if present; otherwise falls back to
-    a 5-second default wait.
+    Parses the ``Retry-After`` header if present; a missing, unparseable, or
+    malformed (negative or non-finite) header falls back to a 5-second
+    default wait.
     """
     from vane.ai.functions import RetryAfterError
 
@@ -75,9 +77,15 @@ def _retry_after_error_from_google_error(exc: Exception) -> Exception | None:
         raw = headers.get("Retry-After") or headers.get("retry-after")
         if raw is not None:
             try:
-                retry_after = float(raw)
+                parsed = float(raw)
             except (TypeError, ValueError):
-                pass
+                parsed = None
+            # A negative, NaN, or infinite header (all parseable by float(),
+            # e.g. "-1", "nan", "1e999") is malformed: ignore it and fall back
+            # to the default wait rather than passing it to a retry sleep that
+            # would raise or hang (issue #469).
+            if parsed is not None and math.isfinite(parsed) and parsed >= 0:
+                retry_after = parsed
     if retry_after is None:
         retry_after = 5.0  # default wait for 429/503
 


### PR DESCRIPTION
## Summary

A `RetryAfterError` carrying a negative, NaN, or infinite `retry_after` reached `time.sleep()`/`asyncio.sleep()` unchecked. The sync Embed retry path raised `ValueError` (`sleep length must be non-negative` / `Invalid value NaN (not a number)`) after the **first** attempt, bypassing the remaining retries and the `on_error="ignore"` policy and replacing the original 429/503 with a spurious sleep failure. The async Prompt path was worse than the issue describes: `asyncio.sleep(nan)` creates a timer that never fires on Python ≤ 3.12, hanging the retry forever (reproduced locally on 3.12.2; 3.13+ raises `ValueError` instead).

Both values are reachable from a misbehaving custom provider (`RetryAfterError` is public API) and from Google's `Retry-After` header, which is parsed with bare `float()` and therefore accepts `"-1"`, `"nan"`, and `"1e999"` (→ `inf`).

The fix guards both ends:

- **Consumption** (`vane/ai/functions.py`): the wait computation duplicated across `_retry_call` / `_retry_call_async` is extracted into `_retry_wait_seconds`, which honours a finite non-negative `retry_after` (capped at 120s, as before) and falls back to the normal exponential backoff for anything else, so no malformed delay can reach a sleep. An int beyond float range is treated as infinite rather than letting the conversion itself raise `OverflowError`.
- **Construction** (`vane/ai/providers/google.py`): a parsed header value that is negative or non-finite is treated the same as a missing/unparseable header and falls back to the documented 5-second default.

**Design note:** the originating review comment (#397, r3711116179) suggested *clamping* the delay to a finite non-negative range. This PR instead **discards** malformed values (5s default on the Google parse side, exponential backoff on the consumer side), on the grounds that a garbage value should not be partially trusted — e.g. clamping `Retry-After: -1` to 0 would produce an immediate hot retry. Happy to switch to clamping if you prefer the letter of the suggestion.

Valid inputs are unchanged: header `"0"`, `retry_after=0.0`, fractional values, and the 120s cap all behave exactly as before.

## Related issue

close: #469

## Documentation impact

- [x] No user-facing documentation update is required.

Behaviour is documented in the `RetryAfterError` and `_retry_wait_seconds` docstrings; internal retry mechanics are not part of the public docs.

## Validation

- Reproduced all three failure modes on the pre-fix code via the real `_retry_call` / `_retry_call_async` paths (Python 3.12.2): sync `retry_after=-1.0` → `ValueError` after 1 attempt; sync NaN → `ValueError`; async NaN → hang (confirmed via 10s `wait_for` timeout).
- `pytest tests/ai/test_ai_functions.py -k "TestRetryAfterError or TestGoogleRetryHandling"` — **27 passed** (16 new: helper unit cases incl. `±10**400` overflow pins, sync/async end-to-end with monkeypatched sleeps asserting `[1, 2, 4]` backoff and `on_error` honoured, Google header cases for `-1`/`-0.5`/`nan`/`NaN`/`inf`/`1e999`/`3.5`). The new tests fail on the pre-fix code.
- Local environment cannot build the native `_duckdb` extension, so the suite was run with the `vane`-package import stubbed; engine-dependent tests are covered by CI.
- `ruff check` / `ruff format` clean via pre-commit.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (This change hardens handling of
      an untrusted HTTP header.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyPevr7aJRqRcuxhfxb56q
