### PR TITLE
[fix](distributed) Keep queued UDF events live

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -90,6 +90,12 @@ static bool InjectEarlyStreamingWakeupForTesting() {
 	return injected.compare_exchange_strong(expected, true);
 }
 
+static bool IsolateQueuedStreamingControlWakeupForTesting() {
+	static const bool enabled = DebugEnvFlagEnabled("VANE_ENABLE_UDF_TEST_HOOKS") &&
+	                            DebugEnvFlagEnabled("VANE_TEST_ISOLATE_QUEUED_UDF_CONTROL_WAKEUP");
+	return enabled;
+}
+
 static void StreamingUDFDebugLog(const string &message) {
 	if (!StreamingUDFDebugEnabled()) {
 		return;
@@ -1539,9 +1545,15 @@ static void NotifyStreamingDispatcherFinished(StreamingUDFState &state);
 
 static void TryWakeStreamingTasksForQueuedEvent(StreamingUDFState &state) {
 	auto guard = state.Lock();
-	// DATA events are consumed by the source side. Waking control tasks here can
-	// race with task descheduling and strand the dispatcher in RescheduleTask.
-	WakeOneStreamingSource(state, guard);
+	// Queue insertion is a real state transition for both sides. The source is
+	// the normal DATA consumer, but its task can already be gone after a
+	// downstream LIMIT finishes and a task-mode callback is then a no-op. Keep
+	// Finalize as the durable fallback consumer so it can drain DATA and terminal
+	// events, advance submission state, and wake a live source task if needed.
+	WakeStreamingUDFTasks(state, guard);
+	if (!IsolateQueuedStreamingControlWakeupForTesting()) {
+		WakeOneStreamingSource(state, guard);
+	}
 }
 
 static void QueueStreamingOutputEvent(StreamingUDFState &state, UDFOutputEvent &&event) {
@@ -1571,6 +1583,10 @@ static void EnsureStreamingExecutor(ExecutionContext &context, StreamingUDFState
 		state.op->executor->RegisterWakeupCallback([weak_state]() {
 			auto shared = weak_state.lock();
 			if (!shared) {
+				return;
+			}
+			if (IsolateQueuedStreamingControlWakeupForTesting() &&
+			    shared->queued_output_events.load(std::memory_order_relaxed) > 0) {
 				return;
 			}
 			auto guard = shared->Lock();

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -327,6 +327,131 @@ def test_streaming_task_wakeup_epoch_handles_early_and_duplicate_callbacks():
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_streaming_control_task_drains_event_after_source_wakeup_is_lost():
+    """Finalize must keep output-event progress alive after a stale source callback."""
+    import os
+    import subprocess
+    import sys
+    import textwrap
+
+    script = textwrap.dedent(
+        """
+        import threading
+        import time
+
+        import duckdb
+        import duckdb.execution.udf as udf_exec
+        import pyarrow as pa
+        from duckdb.execution.ref_bundle import make_local_shm_ref_bundle_result
+
+
+        class DelayedExecutor:
+            def __init__(self):
+                self._lock = threading.Lock()
+                self._wakeup = None
+                self._state = "idle"
+                self._retained_input_bytes = 0
+                self._output = None
+                self._finished = False
+                self._producer = None
+
+            def register_wakeup(self, callback):
+                self._wakeup = callback
+
+            def request_task_admission(self, retained_input_bytes):
+                with self._lock:
+                    self._retained_input_bytes = int(retained_input_bytes)
+                    self._state = "ready"
+                return True
+
+            def task_admission_state(self):
+                with self._lock:
+                    return {
+                        "state": self._state,
+                        "available": self._state == "ready",
+                        "retained_input_bytes": self._retained_input_bytes,
+                    }
+
+            def submit_with_id(self, submit_id, table):
+                values = table.column(0).to_pylist()
+                output = (
+                    "__vane_submit_result__",
+                    int(submit_id),
+                    make_local_shm_ref_bundle_result(pa.table({"y": [value + 1 for value in values]})),
+                )
+                with self._lock:
+                    self._state = "idle"
+
+                def publish():
+                    time.sleep(0.25)
+                    with self._lock:
+                        self._output = output
+                    self._wakeup()
+
+                self._producer = threading.Thread(target=publish, daemon=True)
+                self._producer.start()
+
+            def take_ready_result(self):
+                with self._lock:
+                    output = self._output
+                    self._output = None
+                    return output
+
+            def finished_submitting(self):
+                with self._lock:
+                    self._finished = True
+
+            def all_tasks_finished(self):
+                with self._lock:
+                    return self._finished and self._output is None
+
+            def close(self):
+                if self._producer is not None:
+                    self._producer.join(timeout=2)
+
+
+        def build_executor(_payload, options=None):
+            del options
+            return DelayedExecutor()
+
+
+        def add_one(table):
+            return pa.table({"y": [value + 1 for value in table.column(0).to_pylist()]})
+
+
+        udf_exec.build_executor = build_executor
+        connection = duckdb.connect()
+        try:
+            relation = connection.sql("select i::INTEGER as x from range(4) t(i)").map_batches(
+                add_one,
+                schema={"y": duckdb.sqltypes.INTEGER},
+                execution_backend="subprocess_task",
+                batch_size=4,
+            )
+            rows = relation.limit(1).fetchall()
+            assert len(rows) == 1, rows
+            assert rows[0][0] in {1, 2, 3, 4}, rows
+        finally:
+            connection.close()
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+        env={
+            **os.environ,
+            "VANE_ENABLE_UDF_TEST_HOOKS": "1",
+            "VANE_TEST_ISOLATE_QUEUED_UDF_CONTROL_WAKEUP": "1",
+            "VANE_RUNNER": "local-fast",
+        },
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
 def test_native_dispatcher_shutdown_closes_active_executor():
     """Terminal shutdown must close Python ownership before it returns."""
     import os


### PR DESCRIPTION
## Summary

- Wake the streaming UDF control task whenever an output event is queued, while
  retaining the normal source wakeup.
- Keep `Finalize` available as the durable fallback consumer when a downstream
  `LIMIT` has already removed the original source task.
- Add a deterministic regression that isolates the lost-source-wakeup path and
  verifies queued output still drains to completion.

## Related issue

close: #520

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This is an internal scheduler-liveness fix with no public API or configuration
change.

## Validation

- `scripts/format duckdb --changed --check`
- `ruff format --check tests/fast/test_udf_process.py`
- `ruff check tests/fast/test_udf_process.py`
- `python -m pytest tests/fast/test_udf_process.py` — 21 passed
- `RAY_OVERRIDE_RESOURCES='{"CPU":4}' VANE_TEST_RAY_OBJECT_STORE_BYTES=4294967296 python -m pytest --import-mode=importlib -vv --count=30 tests/fast/test_ray_e2e.py::test_ray_row_preserving_batch_udf_limit_preserves_output_schema` — 30 passed in 196.48s
- `scripts/run_release_tests.sh` — 510 passed, 1 skipped; real-Ray phase 11 passed
- `RAY_OVERRIDE_RESOURCES='{"CPU":4}' VANE_TEST_RAY_OBJECT_STORE_BYTES=4294967296 VANE_FAST_TEST_ARTIFACT_MODE=1 VANE_FAST_TEST_EXCLUDE_GPU=1 scripts/run_fast_tests.sh shared-ray` — 98 passed, 2 skipped
- Latest-`main` release wheel built and installed with the repository-pinned
  Arrow, Flight, and OpenSSL dependencies.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
