### PR TITLE
[fix](ci) Gate on complete DuckDB unit suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,9 +166,9 @@ jobs:
             "pydantic>=2" \
             pytest
 
-      - name: Build and run native distributed tests
+      - name: Build and run DuckDB unit tests
         if: matrix.python-version == '3.12'
-        run: scripts/run_native_tests.sh "[distributed]"
+        run: scripts/run_native_tests.sh
 
       - name: Build release artifacts
         env:

--- a/external/duckdb/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
+++ b/external/duckdb/src/execution/operator/persistent/physical_batch_copy_to_file.cpp
@@ -7,9 +7,7 @@
 #include "duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp"
 
 #include "duckdb/common/allocator.hpp"
-#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/queue.hpp"
-#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/batched_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/operator/persistent/batch_memory_manager.hpp"
@@ -23,16 +21,6 @@
 #include <algorithm>
 
 namespace duckdb {
-
-static void EnsureBatchCopyOutputParentExists(FileSystem &fs, const string &path) {
-	auto parent_dir = StringUtil::GetFilePath(path);
-	if (parent_dir.empty()) {
-		return;
-	}
-	if (!fs.DirectoryExists(parent_dir)) {
-		fs.CreateDirectoriesRecursive(parent_dir);
-	}
-}
 
 struct ActiveFlushGuard {
 	explicit ActiveFlushGuard(atomic<bool> &bool_value_p) : bool_value(bool_value_p) {
@@ -149,8 +137,6 @@ public:
 			return;
 		}
 		// initialize writing to the file
-		auto &fs = FileSystem::GetFileSystem(context);
-		EnsureBatchCopyOutputParentExists(fs, op.file_path);
 		global_state = op.function.copy_to_initialize_global(context, *op.bind_data, op.file_path);
 		if (op.function.initialize_operator) {
 			op.function.initialize_operator(*global_state, op);

--- a/external/duckdb/src/execution/operator/persistent/physical_copy_to_file.cpp
+++ b/external/duckdb/src/execution/operator/persistent/physical_copy_to_file.cpp
@@ -21,16 +21,6 @@
 
 namespace duckdb {
 
-static void EnsureCopyOutputParentExists(FileSystem &fs, const string &path) {
-	auto parent_dir = StringUtil::GetFilePath(path);
-	if (parent_dir.empty()) {
-		return;
-	}
-	if (!fs.DirectoryExists(parent_dir)) {
-		fs.CreateDirectoriesRecursive(parent_dir);
-	}
-}
-
 struct PartitionWriteInfo {
 	unique_ptr<GlobalFunctionData> global_state;
 	idx_t active_writes = 0;
@@ -104,8 +94,6 @@ public:
 		}
 		// initialize writing to the file
 		created_files.push_back(op.file_path);
-		auto &fs = FileSystem::GetFileSystem(context);
-		EnsureCopyOutputParentExists(fs, op.file_path);
 		global_state = op.function.copy_to_initialize_global(context, *op.bind_data, op.file_path);
 		if (op.function.initialize_operator) {
 			op.function.initialize_operator(*global_state, op);
@@ -404,7 +392,6 @@ unique_ptr<GlobalFunctionData> PhysicalCopyToFile::CreateFileState(ClientContext
 	idx_t this_file_offset = g.last_file_offset++;
 	auto &fs = FileSystem::GetFileSystem(context);
 	string output_path(filename_pattern.CreateFilename(fs, file_path, file_extension, this_file_offset));
-	EnsureCopyOutputParentExists(fs, output_path);
 	g.created_files.push_back(output_path);
 	optional_ptr<CopyToFileInfo> written_file_info;
 	if (return_type != CopyFunctionReturnType::CHANGED_ROWS) {

--- a/external/duckdb/src/planner/operator/logical_get.cpp
+++ b/external/duckdb/src/planner/operator/logical_get.cpp
@@ -245,9 +245,9 @@ void LogicalGet::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty(204, "projection_ids", projection_ids);
 	serializer.WriteProperty(205, "table_filters", table_filters);
 	FunctionSerializer::Serialize(serializer, function, bind_data.get());
-	if (!function.serialize) {
-		D_ASSERT(!function.serialize);
-		// no serialize method: serialize input values and named_parameters for rebinding purposes
+	if (!function.serialize || function.in_out_function) {
+		// Functions without custom serialization need these values for rebinding. In-out functions also need them
+		// during execution.
 		serializer.WriteProperty(206, "parameters", parameters);
 		serializer.WriteProperty(207, "named_parameters", named_parameters);
 		serializer.WriteProperty(208, "input_table_types", input_table_types);
@@ -277,13 +277,14 @@ unique_ptr<LogicalOperator> LogicalGet::Deserialize(Deserializer &deserializer) 
 	auto &function = result->function;
 	auto has_serialize = entry.second;
 	unique_ptr<FunctionData> bind_data;
-	if (!has_serialize) {
+	if (has_serialize) {
+		bind_data = FunctionSerializer::FunctionDeserialize(deserializer, function);
+	}
+	if (!has_serialize || function.in_out_function) {
 		deserializer.ReadProperty(206, "parameters", result->parameters);
 		deserializer.ReadProperty(207, "named_parameters", result->named_parameters);
 		deserializer.ReadProperty(208, "input_table_types", result->input_table_types);
 		deserializer.ReadProperty(209, "input_table_names", result->input_table_names);
-	} else {
-		bind_data = FunctionSerializer::FunctionDeserialize(deserializer, function);
 	}
 	deserializer.ReadProperty(210, "projected_input", result->projected_input);
 	deserializer.ReadPropertyWithDefault(211, "column_indexes", result->column_ids);

--- a/external/duckdb/test/api/test_reset.cpp
+++ b/external/duckdb/test/api/test_reset.cpp
@@ -89,6 +89,8 @@ OptionValueSet GetValueForOption(const string &name, const LogicalType &type) {
 	    {"max_expression_depth", {50}},
 	    {"max_memory", {"4.0 GiB"}},
 	    {"max_temp_directory_size", {"10.0 GiB"}},
+	    {"local_exchange_buffer_bytes", {"64.0 MiB"}},
+	    {"local_exchange_streaming", {false}},
 	    {"merge_join_threshold", {73}},
 	    {"nested_loop_join_threshold", {73}},
 	    {"memory_limit", {"4.0 GiB"}},

--- a/external/duckdb/test/execution/distributed/test_physical_repartition.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_repartition.cpp
@@ -23,5 +23,7 @@ TEST_CASE("PhysicalRepartition: basic construction", "[execution]") {
 	REQUIRE(rep_ptr != nullptr);
 
 	REQUIRE(rep_ptr->repartition_spec != nullptr);
-	REQUIRE(rep_ptr->ParamsToString().contains("__repartition_spec__"));
+	auto params = rep_ptr->ParamsToString();
+	REQUIRE(params.at("repartition_type") == "Random");
+	REQUIRE(params.at("lazy_ref_local_exchange") == "whole_block");
 }

--- a/scripts/run_native_tests.sh
+++ b/scripts/run_native_tests.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 usage() {
   echo "Usage: scripts/run_native_tests.sh [unittest arguments...]"
   echo
-  echo "Build Vane's Arrow/Flight native tests with pinned dependencies and C++20."
+  echo "Build and run Vane's complete DuckDB unit test suite with pinned Arrow/Flight dependencies and C++20."
 }
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -78,7 +78,12 @@ cmake --fresh \
   -B "$build_dir" \
   -G "$generator" \
   "${cmake_args[@]}"
-cmake --build "$build_dir" --target unittest --parallel "$build_jobs"
+cmake --build "$build_dir" \
+  --target \
+  unittest \
+  loadable_extension_demo_loadable_extension \
+  loadable_extension_optimizer_demo_loadable_extension \
+  --parallel "$build_jobs"
 
 test_binary="$build_dir/test/unittest"
 if [[ ! -x "$test_binary" ]]; then


### PR DESCRIPTION
## Summary

- Run the complete DuckDB/Vane native unit suite in the required Python 3.12 CI job instead of filtering it to `[distributed]` tests.
- Build the loadable-extension fixtures required by the complete suite before launching `unittest`.
- Fix the latent failures exposed by the new gate: preserve table in-out execution parameters across logical-plan serialization, restore COPY target permission and extension-resolution semantics, cover the local-exchange RESET settings, and update the stale repartition diagnostics assertion.
- COPY no longer creates a missing parent directory implicitly before the copy function opens its target. Callers that need a new parent directory must create it explicitly; this intentionally restores DuckDB's target-path behavior and exact-path allowlist semantics.

## Related issue

N/A

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The native test entrypoint's `--help` text now describes the complete suite.

## Validation

- Focused rerun of all 17 failures found by the first complete-suite run: 17 test cases and 699 assertions passed.
- `VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh`: 4,288 test cases and 1,116,946 assertions passed; 354 tests skipped by their existing requirements.
- Non-editable Python 3.12 Release install from the worktree with `SKBUILD_BUILD_DIR=build/python-release`; the embedded DuckDB SourceID matched the current source tree.
- `scripts/run_release_tests.sh`: 510 passed, 1 skipped in the non-Ray shard; 11 passed in the real-Ray shard.
- `scripts/format workspace --changed --check`
- `pre-commit run --files <changed files>`
- `actionlint .github/workflows/ci.yml`
- `bash -n scripts/run_native_tests.sh`
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
