### PR TITLE
[fix](ray) Bound provider capability stream metadata

### DIFF
--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -3136,7 +3136,14 @@ def test_explicit_remote_error_pair_preserves_cause_without_output_lease():
         collector.shutdown()
 
 
-def test_remote_provider_capability_error_preserves_safe_details():
+@pytest.mark.parametrize(
+    ("provider", "expected_provider"),
+    [
+        pytest.param("openai-compatible", "openai-compatible", id="unchanged"),
+        pytest.param("p" * 17_000, "…<truncated>", id="truncated"),
+    ],
+)
+def test_remote_provider_capability_error_preserves_safe_details(provider, expected_provider):
     from vane.ai.provider import ProviderCapabilityError
     from vane.execution.udf_ray_stream_protocol import make_stream_error_pair
 
@@ -3151,7 +3158,7 @@ def test_remote_provider_capability_error_preserves_safe_details():
             "attempt_id": lease["attempt_id"],
         }
         error = ProviderCapabilityError(
-            "openai-compatible",
+            provider,
             "chat-only-model",
             "structured Prompt generation",
             original_error=RuntimeError("endpoint rejected schema"),
@@ -3174,13 +3181,55 @@ def test_remote_provider_capability_error_preserves_safe_details():
         assert [item[2] for item in events] == ["error"]
         message = events[0][3]
         assert "ProviderCapabilityError" in message
-        assert "openai-compatible" in message
+        assert expected_provider in message
         assert "chat-only-model" in message
         assert "structured Prompt generation" in message
         assert "RuntimeError" in message
         assert "endpoint rejected schema" not in message
     finally:
         collector.shutdown()
+
+
+@pytest.mark.parametrize("detail_name", ["provider", "model", "capability", "original_error_summary"])
+def test_provider_capability_error_metadata_bounds_text_details(detail_name):
+    from vane.ai.provider import ProviderCapabilityError
+    from vane.execution import udf_ray_stream_protocol as stream_protocol
+
+    payload = {
+        "query_id": "query",
+        "resource_unit_id": "resource:query:node:1:udf",
+        "task_lease_id": "lease",
+        "attempt_id": "attempt",
+    }
+
+    def encode_detail(value):
+        details = {
+            "provider": "provider",
+            "model": "model",
+            "capability": "capability",
+        }
+        original_error_summary = "RuntimeError"
+        if detail_name == "original_error_summary":
+            original_error_summary = value
+        else:
+            details[detail_name] = value
+        error = ProviderCapabilityError._from_safe_summary(
+            details["provider"],
+            details["model"],
+            details["capability"],
+            original_error_summary,
+        )
+        _, metadata = stream_protocol.make_stream_error_pair(payload, error)
+        validated = stream_protocol.validate_stream_error_metadata(metadata)
+        return validated["exception_details"][detail_name]
+
+    limit = stream_protocol._MAX_ERROR_TEXT_CHARS
+    at_limit = "a" * limit
+    assert encode_detail(at_limit) == at_limit
+
+    suffix = "…<truncated>"
+    oversized = "b" * (limit + 1)
+    assert encode_detail(oversized) == oversized[: limit - len(suffix)] + suffix
 
 
 def test_malformed_metadata_fails_only_its_stream_without_output_admission():

--- a/vane/execution/udf_ray_stream_protocol.py
+++ b/vane/execution/udf_ray_stream_protocol.py
@@ -53,6 +53,7 @@ _ERROR_METADATA_FIELDS = {
     "exception_details",
 }
 _MAX_ERROR_TEXT_CHARS = 16 * 1024
+_ERROR_TEXT_TRUNCATION_SUFFIX = "…<truncated>"
 _PROVIDER_CAPABILITY_DETAIL_FIELDS = {
     "kind",
     "provider",
@@ -60,6 +61,13 @@ _PROVIDER_CAPABILITY_DETAIL_FIELDS = {
     "capability",
     "original_error_summary",
 }
+
+
+def _truncate_error_detail(value: str) -> str:
+    if len(value) <= _MAX_ERROR_TEXT_CHARS:
+        return value
+    retained_chars = _MAX_ERROR_TEXT_CHARS - len(_ERROR_TEXT_TRUNCATION_SUFFIX)
+    return value[:retained_chars] + _ERROR_TEXT_TRUNCATION_SUFFIX
 
 
 def _stream_identity(payload: dict[str, Any]) -> tuple[str, str, str, str]:
@@ -230,17 +238,19 @@ def make_stream_error_pair(
     exception_type = type(exc).__name__[:256] or "Exception"
     exception_message = str(exc)
     if len(exception_message) > _MAX_ERROR_TEXT_CHARS:
-        exception_message = exception_message[:_MAX_ERROR_TEXT_CHARS] + "…<truncated>"
+        exception_message = exception_message[:_MAX_ERROR_TEXT_CHARS] + _ERROR_TEXT_TRUNCATION_SUFFIX
     exception_details = None
     from vane.ai.provider import ProviderCapabilityError
 
     if isinstance(exc, ProviderCapabilityError):
         exception_details = {
             "kind": "provider_capability",
-            "provider": exc.provider,
-            "model": exc.model,
-            "capability": exc.capability,
-            "original_error_summary": exc.original_error_summary,
+            "provider": _truncate_error_detail(exc.provider),
+            "model": _truncate_error_detail(exc.model),
+            "capability": _truncate_error_detail(exc.capability),
+            "original_error_summary": (
+                _truncate_error_detail(exc.original_error_summary) if exc.original_error_summary is not None else None
+            ),
         }
     sentinel = pa.table({})
     return sentinel, {
@@ -322,7 +332,7 @@ def validate_stream_error_metadata(metadata: Any) -> dict[str, Any]:
             raise ValueError(f"Ray UDF stream error metadata {name} must be non-empty")
         result[name] = value
     result["exception_message"] = str(result["exception_message"] or "")
-    if len(result["exception_message"]) > _MAX_ERROR_TEXT_CHARS + len("…<truncated>"):
+    if len(result["exception_message"]) > _MAX_ERROR_TEXT_CHARS + len(_ERROR_TEXT_TRUNCATION_SUFFIX):
         raise ValueError("Ray UDF stream error metadata exception_message is too large")
     details = result["exception_details"]
     if details is not None:


### PR DESCRIPTION
<!-- Title format: [type](scope) Subject -->

## Summary

<!-- Describe the user-visible or architectural change and why it is needed. -->

`make_stream_error_pair` bounded the generic exception message but copied `ProviderCapabilityError` details unchanged. The consumer rejected details longer than 16 KiB, replacing the original capability error with a metadata `ValueError`.

  - truncate provider capability details before emitting Ray stream metadata
  - keep normal values unchanged and preserve strict consumer validation
  - preserve `ProviderCapabilityError` identity for oversized details
  - add end-to-end and per-field boundary regressions

## Related issue

Close: #470

<!-- Link the issue or write `N/A` for a small, self-contained change. -->

## Documentation impact

<!-- Select exactly one option. -->

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

<!-- Link the documentation PR or add follow-up notes here. -->

## Validation

<!-- List the exact checks you ran. Include relevant hardware, dataset, runner, and batch settings for performance changes. -->

## Checklist

<!-- Check each applicable item, or explain why it does not apply. -->

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
