### PR TITLE
[chore](release) Prepare Vane Data 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "vane-ai"
-version = "0.1.0a1"
+version = "0.1.0"
 description = "A distributed, multimodal data engine built on DuckDB and Ray"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -296,10 +296,10 @@ def _requirement_for_extra(extra, package, environment=None):
     return selected[0]
 
 
-def test_distribution_declares_alpha_version_and_apache_license_expression():
+def test_distribution_declares_release_version_and_apache_license_expression():
     package_metadata = metadata("vane-ai")
 
-    assert version("vane-ai") == "0.1.0a1"
+    assert version("vane-ai") == "0.1.0"
     assert package_metadata["License-Expression"] == "Apache-2.0"
     assert SpecifierSet(package_metadata["Requires-Python"]) == SpecifierSet(">=3.10,<3.15")
 


### PR DESCRIPTION
## Summary

- Set the final PEP 440 package version to `0.1.0` and synchronize the installed-distribution metadata assertion.
- Review the canonical public Release notes in this pull-request description before creating any release tag.
- Keep the repository free of `CHANGELOG.md` and `RELEASE_NOTES*.md` files; the approved GitHub Release body remains the public change record.

## Related issue

N/A

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The reviewed Release notes below are the user-facing documentation for this version and will be copied without semantic changes into the Draft GitHub Release.

## Release provenance

- Release base on `main`: `a8ed920485b027dc099eaf92a779ccdbdef77941`.
- Candidate commit: `ce6bf14ffefa8f3879603a17d42df90fb95bfed5`.
- `external/duckdb` tree ID / DuckDB SourceID: `0c2adbf409e29d268c695598f25983d82468ebfa`.
- Full Vane DuckDB fork revision: `b1c745e9c45b0a1d065aa71b346fac44a26ddf4f`.
- `vane-ai 0.1.0` returned HTTP 404 from both TestPyPI and PyPI immediately before opening this PR.
- No imported dependency, native source, license, notice, or source-provenance file changes are part of this PR.
- Clean candidate sdist: `vane_ai-0.1.0.tar.gz`, SHA-256 `41de1e1ea2ed7e6ca2d0a1ac83d1d458feb02de099b9c8dd97d78f5d9100d803`.

## Security triage

- There are no open first-party critical or high-severity CodeQL findings. [CodeQL #156](https://github.com/AstroVela/vane/security/code-scanning/156) was dismissed as a documented false positive: stdout is a captured private subprocess IPC channel and is never forwarded to logs.
- The remaining 154 open critical/high CodeQL findings are confined to the inherited `external/duckdb` subtree (74 critical and 80 high). This two-file PR does not change that subtree. Because the embedded engine is shipped, this is an explicit inherited-risk record rather than a claim that those findings are irrelevant; they remain open for upstream-oriented triage, and reviewers explicitly review that baseline for `0.1.0`.
- [Dependabot #2](https://github.com/AstroVela/vane/security/dependabot/2) was dismissed as `inaccurate`: [GHSA-rgxp-2hwp-jwgg](https://github.com/advisories/GHSA-rgxp-2hwp-jwgg) states that the affected C++ pre-buffering API is not exposed through Python bindings, while the flagged dependency is used by a Python benchmark.
- The remaining Moderate pytest alert is confined to `benchmarking/parquet/benchmark-requirements.txt`, is not part of the package runtime or release artifacts, and is tracked by [PR #529](https://github.com/AstroVela/vane/pull/529).
- Both secret-scanning findings were inherited DuckDB test fixtures, were verified absent from the release sdist, and were resolved as `used in tests`. There are no open secret-scanning alerts.

## Release notes

# Vane Data 0.1.0

Vane Data is a high-performance, multimodal-native data engine for AI workloads. Built on a fork of [DuckDB](https://duckdb.org/), it extends the core execution engine with native multimodal processing and a unified framework for local and distributed execution.

## Core Features

- **Distributed DuckDB execution engine**  
  Extends DuckDB with distributed physical plans, distributed Plan Fragments, FTE (Fault-Tolerant Execution) scheduling, and distributed operator execution, with Arrow Flight providing cross-worker Exchange/Shuffle data transport.

- **Python UDFs**  
  Relation UDFs support row-wise `map`, Arrow Table-based `map_batches`, and one-to-many `flat_map`. Expression UDFs provide `@vane.func`, `@vane.cls`, and their corresponding `.batch` forms. Scalar, batch, and class UDFs can all be registered as SQL functions through `vane.attach_function()`.

- **AI Functions**  
  Provides typed `Prompt` and `Embed` APIs across the Python Expression API, Relation API, and SQL. `Prompt` integrates with OpenAI, Anthropic, Google, and the native vLLM backend, while `Embed` supports OpenAI, Google, and SentenceTransformers. Structured outputs and image Prompt inputs are available where supported by the provider.

- **Native vLLM batch execution**  
  Implements a native `PhysicalVLLM` operator and Actor Pool, with bounded task submission enforced through in-flight limits. Prompts are bucketed by shared prefixes and routed to actors using prefix-aware routing to improve opportunities for reusing the vLLM Prefix Cache.  
  **The native vLLM `Prompt` path currently supports text input only.**

- **Adaptive multimodal batching and backpressure**  
  The UDF and vLLM execution paths dynamically split or combine batches according to row count, data size, and in-flight limits. Resource admission control and object-stream backpressure limit the number of queued tasks and their memory consumption.

- **Fault-Tolerant Execution**  
  Supports task retries, Worker failure detection and replacement, Split reassignment, Attempt Fencing, cancellation, and resource cleanup.

- **Ray Runner and Local Runner**  
  The same SQL and Relation plan model can run through either the distributed Ray Runner or the local In-Process FTE Runner. Ray Runner is the default execution path and supports both single-machine and distributed execution. Local Runner targets lightweight, lower-overhead local execution without Ray.  
  **Local Runner is currently experimental.**

- **Multimodal benchmarks**  
  Provides comparable Vane, Ray Data, and Daft pipelines covering audio transcription, document embedding, image classification, and video object detection.  
  **The current benchmarks use local files on a single-GPU machine. They represent a single-node environment and are not a direct reproduction of the original distributed Ray Data benchmark.**

## Contributor Acknowledgements

Thank you to all authors and co-authors whose non-automated contributions supported this release across [Vane](https://github.com/AstroVela/vane), [vane-website](https://github.com/AstroVela/vane-website), and [demo-scene](https://github.com/AstroVela/demo-scene):

[@kaka11chen](https://github.com/kaka11chen), [@QuakeWang](https://github.com/QuakeWang), [@caomaocao](https://github.com/caomaocao), [@hubgeter](https://github.com/hubgeter), [@liwuhen](https://github.com/liwuhen), [@pollychen-lab](https://github.com/pollychen-lab), [@figurant](https://github.com/figurant), [@zy-kkk](https://github.com/zy-kkk), [@suxiaogang223](https://github.com/suxiaogang223), [@jingdaws](https://github.com/jingdaws), [@freemandealer](https://github.com/freemandealer), [@liujiwen-up](https://github.com/liujiwen-up), and [@StanleyXu512](https://github.com/StanleyXu512).

## Validation

- `scripts/format root --changed`
- `pre-commit run --files pyproject.toml tests/fast/test_package_metadata.py`
- `git diff --check`
- Clean `python -m build --sdist`, followed by `python scripts/check_release_artifacts.py <sdist>` and an independent version/file-list check; the package version is `0.1.0` and `CHANGELOG.md` plus both `RELEASE_NOTES` names are absent.
- `python -m pytest -q tests/fast/test_build_backend.py tests/fast/test_release_artifact_security.py` in the release launcher's isolated import mode: 73 passed.
- `tests/fast/test_package_metadata.py` checks that do not require the newly built candidate wheel: 23 passed, 1 artifact-only skip. The version, embedded DuckDB identity, and self-contained runtime assertions are intentionally left to PR CI, which builds and installs the clean candidate wheel; the shared local environment belongs to a different native worktree and was not treated as release evidence.
- [Build-only Release workflow #31360517097](https://github.com/AstroVela/vane/actions/runs/31360517097) passed on the release-process base commit, producing one sdist and five CPython 3.10–3.14 manylinux wheels with valid checksums, Sigstore bundles, SBOM, and provenance. A fresh candidate build-only run is required again after this PR merges.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
