### PR TITLE
[feat](udf) Add configurable Python batch formats

### DIFF
--- a/src/vane_py/include/vane_python/pyrelation.hpp
+++ b/src/vane_py/include/vane_python/pyrelation.hpp
@@ -222,8 +222,9 @@ public:
 	                                 const Optional<py::object> &gpus, const Optional<py::object> &execution_backend,
 	                                 const Optional<py::object> &actor_number);
 	unique_ptr<DuckDBPyRelation>
-	MapBatches(py::function fun, Optional<py::object> schema, const Optional<py::object> &batch_size,
-	           const Optional<py::object> &output_batch_size, const Optional<py::object> &min_task_batch_size,
+	MapBatches(py::function fun, Optional<py::object> schema, const string &batch_format,
+	           const Optional<py::object> &batch_size, const Optional<py::object> &output_batch_size,
+	           const Optional<py::object> &min_task_batch_size,
 	           const Optional<py::object> &preserve_compute_batch_boundaries, const Optional<py::object> &cpus,
 	           const Optional<py::object> &gpus, const Optional<py::object> &memory_bytes,
 	           const Optional<py::object> &execution_backend, const Optional<py::object> &actor_number,

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -2104,6 +2104,13 @@ static bool IsSubprocessExecutionBackend(const string &backend) {
 	return backend == "subprocess_task" || backend == "subprocess_actor";
 }
 
+static string ResolveBatchFormat(const string &batch_format) {
+	if (batch_format != "pyarrow" && batch_format != "numpy" && batch_format != "pandas" && batch_format != "cudf") {
+		throw InvalidInputException("batch_format must be one of: cudf, numpy, pandas, pyarrow");
+	}
+	return batch_format;
+}
+
 static string ResolveRayActorThreadPolicy(const Optional<py::object> &thread_policy, const string &execution_backend,
                                           const string &operation_name) {
 	if (thread_policy.is_none()) {
@@ -2182,7 +2189,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Map(py::function fun, const share
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyRelation::MapBatches(
-    py::function fun, Optional<py::object> schema, const Optional<py::object> &batch_size,
+    py::function fun, Optional<py::object> schema, const string &batch_format, const Optional<py::object> &batch_size,
     const Optional<py::object> &output_batch_size, const Optional<py::object> &min_task_batch_size,
     const Optional<py::object> &preserve_compute_batch_boundaries, const Optional<py::object> &cpus,
     const Optional<py::object> &gpus, const Optional<py::object> &memory_bytes,
@@ -2193,6 +2200,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::MapBatches(
 	if (schema.is_none() || !py::isinstance<py::dict>(schema)) {
 		throw InvalidInputException("map_batches requires a schema dict");
 	}
+	auto resolved_batch_format = ResolveBatchFormat(batch_format);
 	auto resolved_execution_backend = ResolveUDFExecutionBackend(execution_backend, fun, ResolveRunnerType());
 	auto resolved_ray_actor_thread_policy =
 	    ResolveRayActorThreadPolicy(ray_actor_thread_policy, resolved_execution_backend, "map_batches");
@@ -2218,6 +2226,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::MapBatches(
 		auto child_name = StructType::GetChildName(existing_type, i);
 		new_children.emplace_back(child_name, existing_children[i]);
 	}
+	new_children.emplace_back("batch_format", Value(resolved_batch_format));
 	if (!resolved_ray_actor_thread_policy.empty()) {
 		new_children.emplace_back("ray_actor_thread_policy", Value(resolved_ray_actor_thread_policy));
 	}

--- a/src/vane_py/pyrelation/initialize.cpp
+++ b/src/vane_py/pyrelation/initialize.cpp
@@ -310,7 +310,7 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 	                    py::arg("filter_expr"));
 	relation_module.def(
 	    "map_batches",
-	    [](DuckDBPyRelation &self, py::function fun, Optional<py::object> schema,
+	    [](DuckDBPyRelation &self, py::function fun, Optional<py::object> schema, const string &batch_format,
 	       const Optional<py::object> &batch_size, const Optional<py::object> &output_batch_size,
 	       const Optional<py::object> &min_task_batch_size,
 	       const Optional<py::object> &preserve_compute_batch_boundaries, const Optional<py::object> &cpus,
@@ -320,23 +320,28 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 	       const Optional<py::object> &task_input_max_bytes, const Optional<py::object> &output_target_max_bytes,
 	       py::kwargs kwargs) {
 		    RejectMapBatchesUnsupportedKwargs(kwargs);
-		    return self.MapBatches(fun, schema, batch_size, output_batch_size, min_task_batch_size,
+		    return self.MapBatches(fun, schema, batch_format, batch_size, output_batch_size, min_task_batch_size,
 		                           preserve_compute_batch_boundaries, cpus, gpus, memory_bytes, execution_backend,
 		                           actor_number, ray_actor_thread_policy, target_max_batch_bytes, task_input_max_bytes,
 		                           output_target_max_bytes);
 	    },
-	    "Apply a Python function or callable class to batches of rows. Retrying Task and Actor backends may replay "
+	    "Apply a Python function or callable class to batches of rows. batch_format selects pyarrow.Table, "
+	    "dict[str, numpy.ndarray], pandas.DataFrame, or cudf.DataFrame input and output. Non-null fixed-shape tensor "
+	    "columns are N-D arrays in NumPy batches; nullable tensor columns are object arrays containing per-row "
+	    "ndarrays or None. pandas tensor columns use per-row ndarrays. Nullable ordinary NumPy columns use "
+	    "numpy.ma.MaskedArray. The UDF must return batches in the selected batch_format. Retrying Task and Actor "
+	    "backends may replay "
 	    "a call after failure; exactly-once execution is not provided, so external effects must be idempotent. "
 	    "Callable classes use Actor backends: "
 	    "actor_number creates independent ephemeral instances, work has no Actor affinity or global ordering, and "
 	    "failures may reconstruct an Actor and reset its local state.",
-	    py::arg("function"), py::arg("schema") = py::none(), py::kw_only(), py::arg("batch_size") = py::none(),
-	    py::arg("output_batch_size") = py::none(), py::arg("min_task_batch_size") = py::none(),
-	    py::arg("preserve_compute_batch_boundaries") = py::none(), py::arg("cpus") = py::none(),
-	    py::arg("gpus") = py::none(), py::arg("memory_bytes") = py::none(), py::arg("execution_backend") = py::none(),
-	    py::arg("actor_number") = py::none(), py::arg("ray_actor_thread_policy") = py::none(),
-	    py::arg("target_max_batch_bytes") = py::none(), py::arg("task_input_max_bytes") = py::none(),
-	    py::arg("output_target_max_bytes") = py::none());
+	    py::arg("function"), py::arg("schema") = py::none(), py::kw_only(), py::arg("batch_format") = "pyarrow",
+	    py::arg("batch_size") = py::none(), py::arg("output_batch_size") = py::none(),
+	    py::arg("min_task_batch_size") = py::none(), py::arg("preserve_compute_batch_boundaries") = py::none(),
+	    py::arg("cpus") = py::none(), py::arg("gpus") = py::none(), py::arg("memory_bytes") = py::none(),
+	    py::arg("execution_backend") = py::none(), py::arg("actor_number") = py::none(),
+	    py::arg("ray_actor_thread_policy") = py::none(), py::arg("target_max_batch_bytes") = py::none(),
+	    py::arg("task_input_max_bytes") = py::none(), py::arg("output_target_max_bytes") = py::none());
 	relation_module.def(
 	    "flat_map",
 	    [](DuckDBPyRelation &self, py::function fun, Optional<py::object> schema,

--- a/tests/fast/test_udf.py
+++ b/tests/fast/test_udf.py
@@ -2429,6 +2429,108 @@ def test_map_batches_tensor_through_local_exchange():
     assert out.fetchall() == [(1, 10.0), (3, 18.0), (5, 26.0), (7, 34.0)]
 
 
+def test_map_batches_numpy_batch_format_end_to_end():
+    import numpy as np
+
+    import vane
+
+    def add_columns(batch):
+        assert set(batch) == {"x", "label"}
+        assert all(isinstance(column, np.ndarray) for column in batch.values())
+        assert batch["label"].tolist() == [f"item-{value}" for value in batch["x"]]
+        return {"x": batch["x"], "score": batch["x"] * 3}
+
+    con = vane.connect()
+    out = (
+        con.sql("select i::BIGINT as x, ('item-' || i)::VARCHAR as label from range(4) t(i)")
+        .map_batches(
+            add_columns,
+            schema={"x": vane.sqltypes.BIGINT, "score": vane.sqltypes.BIGINT},
+            batch_format="numpy",
+            batch_size=2,
+            execution_backend="subprocess_task",
+        )
+        .order("x")
+    )
+    assert out.fetchall() == [(0, 0), (1, 3), (2, 6), (3, 9)]
+
+
+def test_map_batches_pandas_batch_format_end_to_end():
+    pd = pytest.importorskip("pandas")
+
+    import vane
+
+    def transform(frame):
+        assert isinstance(frame, pd.DataFrame)
+        return pd.DataFrame({"x": frame["x"], "label": frame["label"].str.upper()})
+
+    con = vane.connect()
+    out = (
+        con.sql("select i::BIGINT as x, ('item-' || i)::VARCHAR as label from range(3) t(i)")
+        .map_batches(
+            transform,
+            schema={"x": vane.sqltypes.BIGINT, "label": vane.sqltypes.VARCHAR},
+            batch_format="pandas",
+            batch_size=2,
+            execution_backend="subprocess_task",
+        )
+        .order("x")
+    )
+    assert out.fetchall() == [(0, "ITEM-0"), (1, "ITEM-1"), (2, "ITEM-2")]
+
+
+def test_map_batches_numpy_tensor_round_trip_end_to_end():
+    import numpy as np
+
+    import vane
+
+    tensor_type = vane.tensor_type(vane.sqltypes.FLOAT, (2, 2))
+
+    def build_tensor(batch):
+        values = batch["x"].astype(np.float32)
+        tensors = np.stack([np.array([[x, x + 1], [x + 2, x + 3]], dtype=np.float32) for x in values])
+        return {"x": batch["x"], "embedding": tensors}
+
+    def reduce_tensor(batch):
+        assert batch["embedding"].shape == (2, 2, 2)
+        return {"x": batch["x"], "total": batch["embedding"].sum(axis=(1, 2), dtype=np.float32)}
+
+    con = vane.connect()
+    out = (
+        con.sql("select i::BIGINT as x from range(1, 5) t(i)")
+        .map_batches(
+            build_tensor,
+            schema={"x": vane.sqltypes.BIGINT, "embedding": tensor_type},
+            batch_format="numpy",
+            batch_size=2,
+            execution_backend="subprocess_task",
+        )
+        .map_batches(
+            reduce_tensor,
+            schema={"x": vane.sqltypes.BIGINT, "total": vane.sqltypes.FLOAT},
+            batch_format="numpy",
+            batch_size=2,
+            execution_backend="subprocess_task",
+        )
+        .order("x")
+    )
+    assert out.fetchall() == [(1, 10.0), (2, 14.0), (3, 18.0), (4, 22.0)]
+
+
+def test_map_batches_rejects_unknown_batch_format():
+    import pyarrow as pa
+
+    import vane
+
+    con = vane.connect()
+    with pytest.raises(vane.InvalidInputException, match="batch_format must be one of"):
+        con.sql("select 1::BIGINT as x").map_batches(
+            lambda table: pa.table({"x": table.column("x")}),
+            schema={"x": vane.sqltypes.BIGINT},
+            batch_format="polars",
+        )
+
+
 def test_subprocess_streaming_tensor_uses_batch_sized_chunks_under_low_memory():
     """Large tensor intermediates should not force STANDARD_VECTOR_SIZE capacity."""
     pytest.importorskip("pyarrow")

--- a/tests/fast/test_udf_batch_format.py
+++ b/tests/fast/test_udf_batch_format.py
@@ -1,0 +1,446 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import datetime
+import sys
+import types
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from vane.execution._udf_runtime import UDFExecutor
+from vane.execution.udf_batch_format import format_udf_input, iter_udf_output_tables
+
+
+def _duckdb_field(name: str, type_name: str) -> dict[str, object]:
+    return {"name": name, "kind": "duckdb_type", "type": type_name, "dtype": "", "shape": []}
+
+
+def _tensor_field(name: str, dtype: str, shape: tuple[int, ...]) -> dict[str, object]:
+    return {"name": name, "kind": "tensor", "type": "", "dtype": dtype, "shape": list(shape)}
+
+
+def _runtime_payload(fn, *, batch_format: str, output_schema: list[dict[str, object]]) -> dict[str, object]:
+    import cloudpickle
+
+    return {
+        "function_pickle": cloudpickle.dumps(fn),
+        "call_mode": "map_batches",
+        "execution_backend": "subprocess_task",
+        "batch_format": batch_format,
+        "output_schema": output_schema,
+        "input_names": ["x", "embedding"],
+    }
+
+
+def _tensor_input_table(*, nullable: bool = False) -> pa.Table:
+    dense = np.arange(12, dtype=np.float32).reshape(3, 2, 2)
+    tensor_type = pa.fixed_shape_tensor(pa.float32(), (2, 2))
+    if nullable:
+        storage = pa.array(
+            [dense[0].reshape(-1).tolist(), None, dense[2].reshape(-1).tolist()],
+            type=tensor_type.storage_type,
+        )
+        tensors = pa.ExtensionArray.from_storage(tensor_type, storage)
+    else:
+        tensors = pa.FixedShapeTensorArray.from_numpy_ndarray(dense)
+    return pa.table({"x": pa.array([1, 2, 3], type=pa.int64()), "embedding": tensors})
+
+
+def test_numpy_batch_format_runtime_round_trip_preserves_tensor_shape():
+    def transform(batch):
+        assert set(batch) == {"x", "embedding"}
+        assert all(isinstance(column, np.ndarray) for column in batch.values())
+        assert all(column.flags.writeable for column in batch.values())
+        assert batch["embedding"].shape == (3, 2, 2)
+        return {"x": batch["x"] + 10, "embedding": batch["embedding"] * np.float32(2)}
+
+    executor = UDFExecutor(
+        _runtime_payload(
+            transform,
+            batch_format="numpy",
+            output_schema=[_duckdb_field("x", "BIGINT"), _tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )
+    executor.submit(_tensor_input_table())
+    result = executor.take_ready_result()
+
+    assert result is not None
+    assert result.column("x").to_pylist() == [11, 12, 13]
+    tensor = result.column("embedding").combine_chunks()
+    assert tensor.type == pa.fixed_shape_tensor(pa.float32(), (2, 2))
+    np.testing.assert_array_equal(
+        tensor.to_numpy_ndarray(),
+        np.arange(12, dtype=np.float32).reshape(3, 2, 2) * np.float32(2),
+    )
+
+
+def test_numpy_batch_format_runtime_builds_declared_empty_output():
+    def drop_batch(_batch):
+        return None
+
+    executor = UDFExecutor(
+        _runtime_payload(
+            drop_batch,
+            batch_format="numpy",
+            output_schema=[_duckdb_field("x", "BIGINT"), _tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )
+    executor.submit(_tensor_input_table())
+    result = executor.take_ready_result()
+
+    assert result is not None
+    assert result.num_rows == 0
+    assert result.schema == pa.schema(
+        [
+            pa.field("x", pa.int64()),
+            pa.field("embedding", pa.fixed_shape_tensor(pa.float32(), (2, 2))),
+        ]
+    )
+
+
+def test_numpy_batch_format_preserves_nullable_tensor_rows_as_object_array():
+    batch = format_udf_input(_tensor_input_table(nullable=True), "numpy")
+
+    assert batch["embedding"].dtype == object
+    assert batch["embedding"][1] is None
+    np.testing.assert_array_equal(batch["embedding"][0], np.arange(4, dtype=np.float32).reshape(2, 2))
+
+
+def test_numpy_batch_format_round_trips_null_mask_separately_from_nan():
+    table = pa.table(
+        {
+            "integer": pa.array([1, None, 3], type=pa.int64()),
+            "floating": pa.array([1.0, np.nan, None], type=pa.float64()),
+        }
+    )
+
+    batch = format_udf_input(table, "numpy")
+    assert isinstance(batch["integer"], np.ma.MaskedArray)
+    assert isinstance(batch["floating"], np.ma.MaskedArray)
+    assert batch["integer"].dtype == np.dtype(np.int64)
+    assert batch["integer"].mask.tolist() == [False, True, False]
+    assert batch["floating"].mask.tolist() == [False, False, True]
+    assert np.isnan(batch["floating"][1])
+
+    output = list(
+        iter_udf_output_tables(
+            batch,
+            batch_format="numpy",
+            output_schema=[_duckdb_field("integer", "BIGINT"), _duckdb_field("floating", "DOUBLE")],
+        )
+    )[0]
+    assert output.column("integer").to_pylist() == [1, None, 3]
+    floating = output.column("floating")
+    assert floating.null_count == 1
+    assert np.isnan(floating[1].as_py())
+
+
+def test_numpy_batch_output_requires_ndarrays_and_declared_columns():
+    schema = [_duckdb_field("x", "BIGINT")]
+
+    with pytest.raises(TypeError, match="must be numpy.ndarray"):
+        list(iter_udf_output_tables({"x": [1, 2]}, batch_format="numpy", output_schema=schema))
+    with pytest.raises(ValueError, match="missing=.*x.*extra=.*y"):
+        list(
+            iter_udf_output_tables(
+                {"y": np.array([1, 2], dtype=np.int64)},
+                batch_format="numpy",
+                output_schema=schema,
+            )
+        )
+
+
+def test_non_tensor_output_type_is_left_for_native_schema_validation():
+    identifier = "550e8400-e29b-41d4-a716-446655440000"
+    output = list(
+        iter_udf_output_tables(
+            {"identifier": np.array([identifier], dtype=object)},
+            batch_format="numpy",
+            output_schema=[_duckdb_field("identifier", "UUID")],
+        )
+    )
+
+    assert output[0].schema.field("identifier").type == pa.string()
+    assert output[0].column("identifier").to_pylist() == [identifier]
+
+
+def test_numpy_output_iterator_yields_multiple_batches():
+    def batches():
+        yield {"x": np.array([1, 2], dtype=np.int64)}
+        yield {"x": np.array([3], dtype=np.int64)}
+
+    output = list(
+        iter_udf_output_tables(
+            batches(),
+            batch_format="numpy",
+            output_schema=[_duckdb_field("x", "BIGINT")],
+        )
+    )
+
+    assert [table.column("x").to_pylist() for table in output] == [[1, 2], [3]]
+
+
+def test_numpy_tensor_output_safely_casts_to_declared_dtype():
+    output = list(
+        iter_udf_output_tables(
+            {"embedding": np.arange(8, dtype=np.float64).reshape(2, 2, 2)},
+            batch_format="numpy",
+            output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )[0]
+
+    tensor = output.column("embedding").combine_chunks()
+    assert tensor.type == pa.fixed_shape_tensor(pa.float32(), (2, 2))
+    np.testing.assert_array_equal(tensor.to_numpy_ndarray(), np.arange(8, dtype=np.float32).reshape(2, 2, 2))
+
+
+def test_numpy_tensor_output_does_not_confuse_date_with_timestamp_dtype():
+    values = np.array(
+        [["2026-01-01", "2026-01-02"], ["2026-01-03", "2026-01-04"]],
+        dtype="datetime64[ms]",
+    )
+
+    output = list(
+        iter_udf_output_tables(
+            {"dates": values},
+            batch_format="numpy",
+            output_schema=[_tensor_field("dates", "DATE", (2,))],
+        )
+    )[0]
+
+    tensor = output.column("dates").combine_chunks()
+    assert tensor.type == pa.fixed_shape_tensor(pa.date32(), (2,))
+    assert tensor.storage.to_pylist() == [
+        [datetime.date(2026, 1, 1), datetime.date(2026, 1, 2)],
+        [datetime.date(2026, 1, 3), datetime.date(2026, 1, 4)],
+    ]
+
+
+def test_numpy_tensor_output_converts_non_native_byte_order():
+    values = np.arange(8, dtype=np.float32).astype(">f4").reshape(2, 2, 2)
+
+    output = list(
+        iter_udf_output_tables(
+            {"embedding": values},
+            batch_format="numpy",
+            output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )[0]
+
+    tensor = output.column("embedding").combine_chunks()
+    assert tensor.type == pa.fixed_shape_tensor(pa.float32(), (2, 2))
+    np.testing.assert_array_equal(tensor.to_numpy_ndarray(), np.arange(8, dtype=np.float32).reshape(2, 2, 2))
+
+
+def test_numpy_object_tensor_output_safely_casts_to_declared_dtype():
+    output = list(
+        iter_udf_output_tables(
+            {"embedding": np.arange(8).reshape(2, 2, 2).astype(object)},
+            batch_format="numpy",
+            output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )[0]
+
+    tensor = output.column("embedding").combine_chunks()
+    assert tensor.type == pa.fixed_shape_tensor(pa.float32(), (2, 2))
+    np.testing.assert_array_equal(tensor.to_numpy_ndarray(), np.arange(8, dtype=np.float32).reshape(2, 2, 2))
+
+
+@pytest.mark.parametrize("masked", [False, True])
+def test_numpy_empty_tensor_output_preserves_declared_type(masked):
+    values = np.empty((0, 2, 2), dtype=np.float32)
+    if masked:
+        values = np.ma.MaskedArray(values, mask=np.empty((0, 2, 2), dtype=bool))
+
+    output = list(
+        iter_udf_output_tables(
+            {"embedding": values},
+            batch_format="numpy",
+            output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )[0]
+
+    assert output.num_rows == 0
+    assert output.schema.field("embedding").type == pa.fixed_shape_tensor(pa.float32(), (2, 2))
+
+
+def test_numpy_masked_tensor_output_preserves_whole_row_nulls():
+    values = np.ma.MaskedArray(
+        np.arange(8, dtype=np.float32).reshape(2, 2, 2),
+        mask=np.array([np.zeros((2, 2), dtype=bool), np.ones((2, 2), dtype=bool)]),
+    )
+
+    output = list(
+        iter_udf_output_tables(
+            {"embedding": values},
+            batch_format="numpy",
+            output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )[0]
+
+    tensor = output.column("embedding").combine_chunks()
+    assert tensor.null_count == 1
+    np.testing.assert_array_equal(tensor.to_numpy_ndarray()[0], np.arange(4, dtype=np.float32).reshape(2, 2))
+
+
+def test_numpy_masked_tensor_output_rejects_partial_row_masks():
+    mask = np.zeros((2, 2, 2), dtype=bool)
+    mask[1, 0, 0] = True
+    values = np.ma.MaskedArray(np.arange(8, dtype=np.float32).reshape(2, 2, 2), mask=mask)
+
+    with pytest.raises(ValueError, match="row 1 has a partial mask"):
+        list(
+            iter_udf_output_tables(
+                {"embedding": values},
+                batch_format="numpy",
+                output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+            )
+        )
+
+
+def test_numpy_object_tensor_output_rejects_partial_row_masks():
+    values = np.empty(1, dtype=object)
+    values[0] = np.ma.MaskedArray(
+        np.arange(4, dtype=np.float32).reshape(2, 2),
+        mask=[[True, False], [False, False]],
+    )
+
+    with pytest.raises(ValueError, match="row 0 has a partial mask"):
+        list(
+            iter_udf_output_tables(
+                {"embedding": values},
+                batch_format="numpy",
+                output_schema=[_tensor_field("embedding", "FLOAT", (2, 2))],
+            )
+        )
+
+
+def test_batch_output_does_not_fall_back_across_formats():
+    schema = [_duckdb_field("x", "BIGINT")]
+
+    with pytest.raises(TypeError, match=r"batch_format='numpy'.*dict\[str, numpy.ndarray\]"):
+        list(iter_udf_output_tables(pa.table({"x": [1]}), batch_format="numpy", output_schema=schema))
+    with pytest.raises(TypeError, match="batch_format='pyarrow'.*pyarrow.Table"):
+        list(
+            iter_udf_output_tables(
+                {"x": np.array([1], dtype=np.int64)},
+                batch_format="pyarrow",
+                output_schema=schema,
+            )
+        )
+
+
+def test_batch_format_rejects_duplicate_input_column_names():
+    table = pa.Table.from_arrays([pa.array([1]), pa.array([2])], names=["x", "x"])
+
+    with pytest.raises(ValueError, match="requires unique column names"):
+        format_udf_input(table, "numpy")
+
+
+def test_pandas_batch_format_round_trip_preserves_tensor_cells():
+    pandas = pytest.importorskip("pandas")
+    table = _tensor_input_table(nullable=True)
+
+    frame = format_udf_input(table, "pandas")
+    assert isinstance(frame, pandas.DataFrame)
+    assert frame.loc[1, "embedding"] is None
+    assert frame.loc[0, "embedding"].shape == (2, 2)
+
+    frame["x"] += 5
+    output = list(
+        iter_udf_output_tables(
+            frame,
+            batch_format="pandas",
+            output_schema=[_duckdb_field("x", "BIGINT"), _tensor_field("embedding", "FLOAT", (2, 2))],
+        )
+    )
+    assert len(output) == 1
+    assert output[0].column("x").to_pylist() == [6, 7, 8]
+    assert output[0].column("embedding").null_count == 1
+    np.testing.assert_array_equal(
+        output[0].column("embedding").combine_chunks().to_numpy_ndarray()[0],
+        np.arange(4, dtype=np.float32).reshape(2, 2),
+    )
+
+
+def test_pandas_batch_format_preserves_nulls_separately_from_nan():
+    pytest.importorskip("pandas")
+    table = pa.table(
+        {
+            "integer": pa.array([1, None, 3], type=pa.int64()),
+            "floating": pa.array([1.0, np.nan, None], type=pa.float64()),
+        }
+    )
+
+    frame = format_udf_input(table, "pandas")
+    assert str(frame["integer"].dtype) == "int64[pyarrow]"
+    assert frame["integer"].isna().tolist() == [False, True, False]
+    assert frame["floating"].isna().tolist() == [False, False, True]
+    assert np.isnan(frame.loc[1, "floating"])
+
+    output = list(
+        iter_udf_output_tables(
+            frame,
+            batch_format="pandas",
+            output_schema=[_duckdb_field("integer", "BIGINT"), _duckdb_field("floating", "DOUBLE")],
+        )
+    )[0]
+    assert output.column("integer").to_pylist() == [1, None, 3]
+    assert output.column("floating").null_count == 1
+    assert np.isnan(output.column("floating")[1].as_py())
+
+
+def test_cudf_batch_format_uses_arrow_boundary(monkeypatch):
+    class FakeDataFrame:
+        def __init__(self, table):
+            self.table = table
+
+        @classmethod
+        def from_arrow(cls, table):
+            return cls(table)
+
+        def to_arrow(self, *, preserve_index):
+            assert preserve_index is False
+            return self.table
+
+    fake_cudf = types.ModuleType("cudf")
+    fake_cudf.DataFrame = FakeDataFrame
+    monkeypatch.setitem(sys.modules, "cudf", fake_cudf)
+
+    frame = format_udf_input(pa.table({"x": [1, 2]}), "cudf")
+    assert isinstance(frame, FakeDataFrame)
+    output = list(
+        iter_udf_output_tables(
+            frame,
+            batch_format="cudf",
+            output_schema=[_duckdb_field("x", "BIGINT")],
+        )
+    )
+    assert output[0].to_pydict() == {"x": [1, 2]}
+
+
+@pytest.mark.gpu
+def test_cudf_batch_format_round_trip():
+    cudf = pytest.importorskip("cudf")
+    table = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
+
+    frame = format_udf_input(table, "cudf")
+    assert isinstance(frame, cudf.DataFrame)
+    frame["x"] += 4
+    output = list(
+        iter_udf_output_tables(
+            frame,
+            batch_format="cudf",
+            output_schema=[_duckdb_field("x", "BIGINT")],
+        )
+    )
+    assert output[0].column("x").to_pylist() == [5, 6, 7]
+
+
+def test_unknown_batch_format_is_rejected():
+    with pytest.raises(ValueError, match="batch_format must be one of"):
+        format_udf_input(pa.table({"x": [1]}), "polars")

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -557,6 +557,7 @@ class DuckDBPyRelation:
         function: Callable[..., typing.Any],
         schema: dict[str, sqltypes.DuckDBPyType] | None = None,
         *,
+        batch_format: typing.Literal["pyarrow", "numpy", "pandas", "cudf"] = "pyarrow",
         batch_size: int | None = None,
         output_batch_size: int | None = None,
         min_task_batch_size: int | None = None,

--- a/vane/execution/_udf_runtime.py
+++ b/vane/execution/_udf_runtime.py
@@ -33,6 +33,10 @@ from vane.execution._common import (
     load_udf_from_payload_cached,
 )
 from vane.execution._udf_validation import ensure_synchronous_udf_result, validate_synchronous_udf_callable
+from vane.execution.udf_batch_format import format_udf_input as _format_udf_input
+from vane.execution.udf_batch_format import iter_udf_output_tables as _iter_udf_output_tables
+from vane.execution.udf_batch_format import normalize_batch_format as _normalize_batch_format
+from vane.execution.udf_batch_format import resolve_udf_output_schema as _resolve_udf_output_schema
 from vane.execution.udf_output_schema import empty_output_table_from_payload as _empty_output_table_from_payload
 from vane.execution.udf_ray_config import stream_output_enabled as _stream_output_enabled
 from vane.udf import FunctionNullHandling
@@ -232,34 +236,6 @@ def _effective_output_batch_size(payload: dict[str, Any]) -> int | None:
     return None
 
 
-def _iter_output_tables(result: Any) -> Iterable[pa.Table]:
-    """Iterate over output batches from a stream UDF result."""
-    result = ensure_synchronous_udf_result(result)
-    if result is None:
-        return
-
-    if isinstance(result, pa.RecordBatchReader):
-        raise TypeError("UDF output must be materialized; RecordBatchReader is not supported")
-    if isinstance(result, pa.Table):
-        yield result
-        return
-    if isinstance(result, pa.RecordBatch):
-        yield pa.Table.from_batches([result])
-        return
-    if isinstance(result, dict):
-        yield pa.table(result)
-        return
-
-    if isinstance(result, Iterable) and not isinstance(result, (str, bytes, bytearray)):
-        for item in result:
-            if item is None:
-                continue
-            yield from _iter_output_tables(item)
-        return
-
-    raise TypeError("udf output must be Table/RecordBatch/dict, or an iterable yielding those types")
-
-
 def _iter_table_row_dicts(table: pa.Table) -> Iterable[dict[str, Any]]:
     names = table.schema.names
     columns = table.columns
@@ -422,7 +398,7 @@ class UDFExecutor:
     """Execute a Python UDF locally according to payload.call_mode.
 
     Supported call modes:
-    - ``map_batches``: ``fn(pa.Table) → pa.Table | Iterator[pa.Table]``
+    - ``map_batches``: formatted batch-to-batch calls selected by ``payload.batch_format``.
     - ``map_batches_rows``: ``fn(pa.Table) → pa.Table`` with one output row per input row.
     - ``flat_map``:    ``fn(dict) → dict | Iterator[dict]``
     - ``map``:
@@ -475,6 +451,12 @@ class UDFExecutor:
         self._is_map_batches_rows = self._call_mode == "map_batches_rows"
         self._is_flat_map = self._call_mode == "flat_map"
         self._is_map = False
+        self._batch_format = (
+            _normalize_batch_format(payload.get("batch_format", "pyarrow")) if self._is_map_batches else "pyarrow"
+        )
+        self._batch_output_schema = (
+            _resolve_udf_output_schema(self._batch_format, output_schema) if self._is_map_batches else None
+        )
 
         # Batch size for splitting input
         self._batch_size = _effective_batch_size(payload)
@@ -555,19 +537,14 @@ class UDFExecutor:
         return args
 
     def _iter_map_batches_output_tables(self, result: Any) -> Iterable[pa.Table]:
-        if result is None:
-            return
-
         try:
-            tables = _iter_output_tables(result)
-            for table in tables:
-                if table is not None:
-                    yield table
-            return
+            yield from _iter_udf_output_tables(
+                result,
+                batch_format=self._batch_format,
+                resolved_output_schema=self._batch_output_schema,
+            )
         except TypeError as exc:
-            raise TypeError(
-                f"map_batches UDF must return pa.Table or Iterator[pa.Table], got {type(result)}: {exc}"
-            ) from exc
+            raise TypeError(f"map_batches UDF returned an invalid {self._batch_format!r} batch: {exc}") from exc
 
     def _coerce_row_preserving_batch_output(self, result: Any, expected_rows: int) -> pa.Table:
         if isinstance(result, pa.Table):
@@ -615,7 +592,8 @@ class UDFExecutor:
         )
         for batch in batches:
             saw_compute_batch = True
-            result = ensure_synchronous_udf_result(self._map_fn(batch))
+            udf_batch = _format_udf_input(batch, self._batch_format) if self._is_map_batches else batch
+            result = ensure_synchronous_udf_result(self._map_fn(udf_batch))
             if self._is_map_batches_rows:
                 results.append(self._coerce_row_preserving_batch_output(result, batch.num_rows))
                 continue
@@ -672,7 +650,7 @@ class UDFExecutor:
             shared_output_buffer = RuntimeOutputBuffer(self._output_batch_size, self._output_target_max_bytes)
             for batch in batches:
                 saw_compute_batch = True
-                result = ensure_synchronous_udf_result(self._map_fn(batch))
+                result = ensure_synchronous_udf_result(self._map_fn(_format_udf_input(batch, self._batch_format)))
                 output_buffer = (
                     RuntimeOutputBuffer(self._output_batch_size, self._output_target_max_bytes)
                     if self._preserve_compute_batch_boundaries

--- a/vane/execution/udf_batch_format.py
+++ b/vane/execution/udf_batch_format.py
@@ -1,0 +1,445 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Strict batch-format adapters for relation-level ``map_batches`` UDFs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+from numpy.typing import NDArray
+
+from vane.execution._udf_validation import ensure_synchronous_udf_result
+from vane.execution.udf_output_schema import arrow_type_from_output_schema_entry, normalize_output_schema_entries
+
+VALID_BATCH_FORMATS = frozenset({"pyarrow", "numpy", "pandas", "cudf"})
+
+
+@dataclass(frozen=True)
+class _OutputColumnSchema:
+    name: str
+    tensor_type: pa.DataType | None
+
+
+_OutputSchema = tuple[_OutputColumnSchema, ...]
+
+
+def normalize_batch_format(value: Any) -> str:
+    if not isinstance(value, str) or value not in VALID_BATCH_FORMATS:
+        choices = ", ".join(sorted(VALID_BATCH_FORMATS))
+        raise ValueError(f"batch_format must be one of: {choices}")
+    return value
+
+
+def format_udf_input(table: pa.Table, batch_format: str) -> Any:
+    """Convert an internal Arrow table to the exact format requested by a UDF."""
+    batch_format = normalize_batch_format(batch_format)
+    if batch_format == "pyarrow":
+        return table
+
+    _require_unique_column_names(table.schema.names, batch_format)
+    if batch_format == "numpy":
+        return {
+            name: _arrow_column_to_numpy(table.column(index))
+            for index, name in enumerate(table.schema.names)
+        }
+    if batch_format == "pandas":
+        return _arrow_table_to_pandas(table)
+    return _arrow_table_to_cudf(table)
+
+
+def iter_udf_output_tables(
+    result: Any,
+    *,
+    batch_format: str,
+    output_schema: Any = None,
+    resolved_output_schema: _OutputSchema | None = None,
+) -> Iterable[pa.Table]:
+    """Normalize UDF output batches back to Arrow without cross-format fallback."""
+    batch_format = normalize_batch_format(batch_format)
+    if output_schema is not None and resolved_output_schema is not None:
+        raise ValueError("provide output_schema or resolved_output_schema, not both")
+    if resolved_output_schema is None:
+        resolved_output_schema = resolve_udf_output_schema(batch_format, output_schema)
+    yield from _iter_udf_output_tables(result, batch_format=batch_format, output_schema=resolved_output_schema)
+
+
+def resolve_udf_output_schema(batch_format: str, output_schema: Any) -> _OutputSchema | None:
+    """Resolve the declared output schema once for a worker-side format adapter."""
+    batch_format = normalize_batch_format(batch_format)
+    if batch_format == "pyarrow":
+        return None
+    columns: list[_OutputColumnSchema] = []
+    for name, entry in normalize_output_schema_entries(output_schema):
+        kind = str(entry.get("kind") or "").strip().lower()
+        tensor_type = arrow_type_from_output_schema_entry(entry) if kind == "tensor" else None
+        columns.append(_OutputColumnSchema(name=name, tensor_type=tensor_type))
+    return tuple(columns)
+
+
+def _iter_udf_output_tables(
+    result: Any,
+    *,
+    batch_format: str,
+    output_schema: _OutputSchema | None,
+) -> Iterable[pa.Table]:
+    result = ensure_synchronous_udf_result(result)
+    if result is None:
+        return
+
+    if batch_format == "pyarrow":
+        if isinstance(result, pa.RecordBatchReader):
+            raise TypeError("pyarrow map_batches output must be materialized; RecordBatchReader is not supported")
+        if isinstance(result, pa.Table):
+            yield result
+            return
+        if isinstance(result, pa.RecordBatch):
+            yield pa.Table.from_batches([result])
+            return
+    elif batch_format == "numpy":
+        if type(result) is dict:
+            assert output_schema is not None
+            yield _numpy_batch_to_arrow(result, output_schema)
+            return
+    elif batch_format == "pandas":
+        pandas = _import_pandas()
+        if isinstance(result, pandas.DataFrame):
+            assert output_schema is not None
+            yield _pandas_batch_to_arrow(result, output_schema)
+            return
+    else:
+        cudf = _import_cudf()
+        if isinstance(result, cudf.DataFrame):
+            assert output_schema is not None
+            yield _cudf_batch_to_arrow(result, output_schema)
+            return
+
+    if _is_batch_like(result):
+        raise TypeError(
+            f"map_batches(batch_format={batch_format!r}) UDF must return {_output_type_name(batch_format)}, "
+            f"got {type(result)}"
+        )
+    if isinstance(result, Iterable) and not isinstance(result, (str, bytes, bytearray)):
+        for item in result:
+            if item is None:
+                continue
+            yield from _iter_udf_output_tables(item, batch_format=batch_format, output_schema=output_schema)
+        return
+
+    raise TypeError(
+        f"map_batches(batch_format={batch_format!r}) UDF must return {_output_type_name(batch_format)} "
+        f"or an iterator yielding that type, got {type(result)}"
+    )
+
+
+def _is_batch_like(value: Any) -> bool:
+    if isinstance(value, (pa.Table, pa.RecordBatch, pa.RecordBatchReader, np.ndarray, Mapping)):
+        return True
+    module = type(value).__module__.partition(".")[0]
+    return module in {"pandas", "cudf"}
+
+
+def _output_type_name(batch_format: str) -> str:
+    return {
+        "pyarrow": "pyarrow.Table or pyarrow.RecordBatch",
+        "numpy": "dict[str, numpy.ndarray]",
+        "pandas": "pandas.DataFrame",
+        "cudf": "cudf.DataFrame",
+    }[batch_format]
+
+
+def _require_unique_column_names(names: list[str], batch_format: str) -> None:
+    seen = set()
+    duplicates = set()
+    for name in names:
+        if name in seen:
+            duplicates.add(name)
+        seen.add(name)
+    if duplicates:
+        rendered = ", ".join(repr(name) for name in sorted(duplicates))
+        raise ValueError(f"batch_format={batch_format!r} requires unique column names; duplicates: {rendered}")
+
+
+def _is_fixed_shape_tensor(data_type: pa.DataType) -> bool:
+    return getattr(data_type, "extension_name", None) == "arrow.fixed_shape_tensor"
+
+
+def _arrow_column_to_numpy(column: pa.ChunkedArray) -> np.ndarray:
+    array = column.combine_chunks()
+    if not _is_fixed_shape_tensor(array.type):
+        if array.null_count == 0:
+            return np.array(array.to_numpy(zero_copy_only=False), copy=True)
+        valid = array.is_valid().to_numpy(zero_copy_only=False)
+        valid_array = array.filter(pa.array(valid))
+        valid_values = valid_array.to_numpy(zero_copy_only=False)
+        nullable_values: NDArray[Any] = np.zeros(len(array), dtype=valid_values.dtype)
+        nullable_values[valid] = valid_values
+        return np.ma.MaskedArray(  # type: ignore[no-untyped-call]
+            nullable_values,
+            mask=np.logical_not(valid),
+            copy=False,
+        )
+
+    dense = array.to_numpy_ndarray()
+    if array.null_count == 0:
+        return np.array(dense, copy=True)
+
+    valid = array.is_valid().to_numpy(zero_copy_only=False)
+    nullable: NDArray[np.object_] = np.empty(len(array), dtype=object)
+    for index, is_valid in enumerate(valid):
+        nullable[index] = np.array(dense[index], copy=True) if is_valid else None
+    return nullable
+
+
+def _arrow_table_to_pandas(table: pa.Table) -> Any:
+    pandas = _import_pandas()
+    tensor_indices = [index for index, field in enumerate(table.schema) if _is_fixed_shape_tensor(field.type)]
+    if not tensor_indices:
+        return _arrow_regular_table_to_pandas(table, pandas)
+
+    tensor_index_set = set(tensor_indices)
+    regular_columns = [index for index in range(table.num_columns) if index not in tensor_index_set]
+    if regular_columns:
+        frame = _arrow_regular_table_to_pandas(table.select(regular_columns), pandas)
+    else:
+        frame = pandas.DataFrame(index=pandas.RangeIndex(table.num_rows))
+    for index, field in enumerate(table.schema):
+        if not _is_fixed_shape_tensor(field.type):
+            continue
+        tensor_values = _tensor_column_to_object_array(table.column(index))
+        frame.insert(index, field.name, pandas.Series(tensor_values, index=frame.index, dtype=object))
+    return frame
+
+
+def _arrow_regular_table_to_pandas(table: pa.Table, pandas: Any) -> Any:
+    def types_mapper(data_type: pa.DataType) -> Any:
+        if isinstance(data_type, pa.BaseExtensionType) or pa.types.is_dictionary(data_type):
+            return None
+        return pandas.ArrowDtype(data_type)
+
+    return table.to_pandas(types_mapper=types_mapper)
+
+
+def _tensor_column_to_object_array(column: pa.ChunkedArray) -> np.ndarray:
+    array = column.combine_chunks()
+    dense = array.to_numpy_ndarray()
+    valid = array.is_valid().to_numpy(zero_copy_only=False) if array.null_count else None
+    values: NDArray[np.object_] = np.empty(len(array), dtype=object)
+    for index in range(len(array)):
+        values[index] = None if valid is not None and not valid[index] else np.array(dense[index], copy=True)
+    return values
+
+
+def _arrow_table_to_cudf(table: pa.Table) -> Any:
+    cudf = _import_cudf()
+    return cudf.DataFrame.from_arrow(table)
+
+
+def _numpy_batch_to_arrow(batch: dict[Any, Any], schema: _OutputSchema) -> pa.Table:
+    _validate_output_names(list(batch.keys()), schema)
+    arrays: list[pa.Array] = []
+    row_count: int | None = None
+    for column_schema in schema:
+        value = batch[column_schema.name]
+        if not isinstance(value, np.ndarray):
+            raise TypeError(
+                f"numpy batch column {column_schema.name!r} must be numpy.ndarray, got {type(value)}"
+            )
+        if value.ndim == 0:
+            raise ValueError(f"numpy batch column {column_schema.name!r} must include a row dimension")
+        if row_count is None:
+            row_count = len(value)
+        elif len(value) != row_count:
+            raise ValueError(
+                f"numpy batch columns must have the same row count; {column_schema.name!r} has {len(value)}, "
+                f"expected {row_count}"
+            )
+        arrays.append(_numpy_column_to_arrow(value, column_schema))
+    return pa.Table.from_arrays(arrays, names=[column.name for column in schema])
+
+
+def _numpy_column_to_arrow(value: np.ndarray, column_schema: _OutputColumnSchema) -> pa.Array:
+    if column_schema.tensor_type is not None:
+        return _tensor_values_to_arrow(value, column_schema)
+    if value.ndim != 1:
+        return pa.array(value.tolist())
+    return pa.array(value)
+
+
+def _pandas_batch_to_arrow(frame: Any, schema: _OutputSchema) -> pa.Table:
+    _validate_output_names(list(frame.columns), schema)
+    arrays = []
+    for column_schema in schema:
+        series = frame[column_schema.name]
+        if column_schema.tensor_type is not None:
+            arrays.append(_tensor_values_to_arrow(series.tolist(), column_schema))
+        else:
+            arrays.append(pa.array(series, from_pandas=True))
+    return pa.Table.from_arrays(arrays, names=[column.name for column in schema])
+
+
+def _cudf_batch_to_arrow(frame: Any, schema: _OutputSchema) -> pa.Table:
+    table = frame.to_arrow(preserve_index=False)
+    if not isinstance(table, pa.Table):
+        raise TypeError(f"cudf.DataFrame.to_arrow() must return pyarrow.Table, got {type(table)}")
+    _validate_output_names(table.schema.names, schema)
+    return table.select([column.name for column in schema])
+
+
+def _validate_output_names(actual_names: list[Any], schema: _OutputSchema) -> None:
+    if not all(isinstance(name, str) for name in actual_names):
+        raise TypeError("map_batches output column names must be strings")
+    names = list(actual_names)
+    if len(names) != len(set(names)):
+        raise ValueError("map_batches output column names must be unique")
+    expected = [column.name for column in schema]
+    missing = [name for name in expected if name not in names]
+    extra = [name for name in names if name not in expected]
+    if missing or extra:
+        raise ValueError(f"map_batches output columns do not match schema; missing={missing}, extra={extra}")
+
+
+def _tensor_values_to_arrow(values: Any, column_schema: _OutputColumnSchema) -> pa.Array:
+    tensor_type = column_schema.tensor_type
+    assert tensor_type is not None
+    shape = tuple(int(dim) for dim in tensor_type.shape)
+    if np.ma.isMaskedArray(values):  # type: ignore[no-untyped-call]
+        return _masked_tensor_values_to_arrow(values, column_schema, shape)
+    if isinstance(values, np.ndarray) and values.ndim == len(shape) + 1 and values.dtype != object:
+        return _dense_tensor_values_to_arrow(values, column_schema, shape)
+
+    rows = list(values)
+    tensor_rows: list[np.ndarray | None] = []
+    dense_rows: list[np.ndarray] = []
+    has_null = False
+    for index, value in enumerate(rows):
+        if np.ma.isMaskedArray(value):  # type: ignore[no-untyped-call]
+            row_mask = np.ma.getmaskarray(value)  # type: ignore[no-untyped-call]
+            if row_mask.all():
+                tensor_rows.append(None)
+                has_null = True
+                continue
+            if row_mask.any():
+                raise ValueError(
+                    f"tensor output column {column_schema.name!r} row {index} has a partial mask; "
+                    "only whole tensor rows may be null"
+                )
+            value = value.data
+        if _is_null_tensor_value(value):
+            tensor_rows.append(None)
+            has_null = True
+            continue
+        tensor = np.asarray(value)
+        if tensor.shape != shape:
+            raise ValueError(
+                f"tensor output column {column_schema.name!r} row {index} has shape {tensor.shape}, expected {shape}"
+            )
+        tensor_rows.append(tensor)
+        dense_rows.append(tensor)
+    if rows and not has_null:
+        return _dense_tensor_values_to_arrow(np.stack(dense_rows), column_schema, shape)
+    storage_rows = [None if tensor is None else tensor.reshape(-1).tolist() for tensor in tensor_rows]
+    storage = pa.array(storage_rows, type=tensor_type.storage_type, safe=True)
+    return pa.ExtensionArray.from_storage(tensor_type, storage)
+
+
+def _masked_tensor_values_to_arrow(
+    values: np.ma.MaskedArray,
+    column_schema: _OutputColumnSchema,
+    shape: tuple[int, ...],
+) -> pa.Array:
+    if len(values) == 0:
+        return _dense_tensor_values_to_arrow(np.asarray(values.data), column_schema, shape)
+    if values.ndim == 1 and values.dtype == object:
+        row_mask = np.ma.getmaskarray(values)  # type: ignore[no-untyped-call]
+        rows = [None if row_mask[index] else values.data[index] for index in range(len(values))]
+        return _tensor_values_to_arrow(rows, column_schema)
+
+    if values.ndim != len(shape) + 1 or tuple(values.shape[1:]) != shape:
+        raise ValueError(
+            f"tensor output column {column_schema.name!r} has shape {values.shape[1:]}, expected {shape}"
+        )
+
+    element_mask = np.ma.getmaskarray(values).reshape(  # type: ignore[no-untyped-call]
+        len(values),
+        -1,
+    )
+    masked_rows = element_mask.all(axis=1)
+    partially_masked_rows = element_mask.any(axis=1) & ~masked_rows
+    if partially_masked_rows.any():
+        first_row = int(np.flatnonzero(partially_masked_rows)[0])
+        raise ValueError(
+            f"tensor output column {column_schema.name!r} row {first_row} has a partial mask; "
+            "only whole tensor rows may be null"
+        )
+    if not masked_rows.any():
+        return _dense_tensor_values_to_arrow(np.asarray(values.data), column_schema, shape)
+
+    rows = [None if masked_rows[index] else np.asarray(values.data[index]) for index in range(len(values))]
+    return _tensor_values_to_arrow(rows, column_schema)
+
+
+def _dense_tensor_values_to_arrow(
+    values: np.ndarray,
+    column_schema: _OutputColumnSchema,
+    shape: tuple[int, ...],
+) -> pa.Array:
+    tensor_type = column_schema.tensor_type
+    assert tensor_type is not None
+    if tuple(values.shape[1:]) != shape:
+        raise ValueError(
+            f"tensor output column {column_schema.name!r} has shape {values.shape[1:]}, expected {shape}"
+        )
+    if len(values) == 0:
+        storage = pa.array([], type=tensor_type.storage_type)
+        return pa.ExtensionArray.from_storage(tensor_type, storage)
+    contiguous = np.ascontiguousarray(values)
+    try:
+        source_value_type = pa.from_numpy_dtype(contiguous.dtype)
+    except pa.ArrowNotImplementedError:
+        source_value_type = None
+    if contiguous.dtype.isnative and source_value_type == tensor_type.value_type:
+        return pa.FixedShapeTensorArray.from_numpy_ndarray(contiguous)
+
+    flattened = pa.array(contiguous.reshape(-1).tolist(), type=tensor_type.value_type, safe=True)
+    storage = pa.FixedSizeListArray.from_arrays(flattened, tensor_type.storage_type.list_size)
+    return pa.ExtensionArray.from_storage(tensor_type, storage)
+
+
+def _is_null_tensor_value(value: Any) -> bool:
+    if value is None:
+        return True
+    if value is np.ma.masked:
+        return True
+    if isinstance(value, (float, np.floating)):
+        return bool(np.isnan(value))
+    return type(value).__name__ == "NAType" and type(value).__module__.partition(".")[0] == "pandas"
+
+
+def _import_pandas() -> Any:
+    try:
+        import pandas
+    except ImportError as exc:
+        raise ImportError("batch_format='pandas' requires pandas to be installed") from exc
+    return pandas
+
+
+def _import_cudf() -> Any:
+    try:
+        import cudf  # type: ignore[import-not-found, import-untyped, unused-ignore]
+    except ImportError as exc:
+        raise ImportError("batch_format='cudf' requires cuDF and a CUDA-capable environment") from exc
+    return cudf
+
+
+__all__ = [
+    "VALID_BATCH_FORMATS",
+    "format_udf_input",
+    "iter_udf_output_tables",
+    "normalize_batch_format",
+    "resolve_udf_output_schema",
+]

--- a/vane/execution/udf_batch_format.py
+++ b/vane/execution/udf_batch_format.py
@@ -43,10 +43,7 @@ def format_udf_input(table: pa.Table, batch_format: str) -> Any:
 
     _require_unique_column_names(table.schema.names, batch_format)
     if batch_format == "numpy":
-        return {
-            name: _arrow_column_to_numpy(table.column(index))
-            for index, name in enumerate(table.schema.names)
-        }
+        return {name: _arrow_column_to_numpy(table.column(index)) for index, name in enumerate(table.schema.names)}
     if batch_format == "pandas":
         return _arrow_table_to_pandas(table)
     return _arrow_table_to_cudf(table)
@@ -246,9 +243,7 @@ def _numpy_batch_to_arrow(batch: dict[Any, Any], schema: _OutputSchema) -> pa.Ta
     for column_schema in schema:
         value = batch[column_schema.name]
         if not isinstance(value, np.ndarray):
-            raise TypeError(
-                f"numpy batch column {column_schema.name!r} must be numpy.ndarray, got {type(value)}"
-            )
+            raise TypeError(f"numpy batch column {column_schema.name!r} must be numpy.ndarray, got {type(value)}")
         if value.ndim == 0:
             raise ValueError(f"numpy batch column {column_schema.name!r} must include a row dimension")
         if row_count is None:
@@ -360,9 +355,7 @@ def _masked_tensor_values_to_arrow(
         return _tensor_values_to_arrow(rows, column_schema)
 
     if values.ndim != len(shape) + 1 or tuple(values.shape[1:]) != shape:
-        raise ValueError(
-            f"tensor output column {column_schema.name!r} has shape {values.shape[1:]}, expected {shape}"
-        )
+        raise ValueError(f"tensor output column {column_schema.name!r} has shape {values.shape[1:]}, expected {shape}")
 
     element_mask = np.ma.getmaskarray(values).reshape(  # type: ignore[no-untyped-call]
         len(values),
@@ -391,9 +384,7 @@ def _dense_tensor_values_to_arrow(
     tensor_type = column_schema.tensor_type
     assert tensor_type is not None
     if tuple(values.shape[1:]) != shape:
-        raise ValueError(
-            f"tensor output column {column_schema.name!r} has shape {values.shape[1:]}, expected {shape}"
-        )
+        raise ValueError(f"tensor output column {column_schema.name!r} has shape {values.shape[1:]}, expected {shape}")
     if len(values) == 0:
         storage = pa.array([], type=tensor_type.storage_type)
         return pa.ExtensionArray.from_storage(tensor_type, storage)

--- a/vane/execution/udf_output_schema.py
+++ b/vane/execution/udf_output_schema.py
@@ -56,7 +56,7 @@ def _arrow_type_from_name(type_name: str) -> pa.DataType:
     try:
         return _arrow_type_from_duckdb_type(type_name)
     except Exception as exc:
-        raise ValueError(f"unsupported UDF output type for empty output: {type_name!r}") from exc
+        raise ValueError(f"unsupported UDF output type: {type_name!r}") from exc
 
 
 def _arrow_type_from_duckdb_type(type_name: str) -> pa.DataType:
@@ -112,10 +112,10 @@ def _arrow_type_from_duckdb_pytype(dt: Any) -> pa.DataType:
             _arrow_type_from_duckdb_pytype(children["value"]),
         )
 
-    raise ValueError(f"unsupported DuckDB type id for empty UDF output: {type_id!r}")
+    raise ValueError(f"unsupported DuckDB type id for UDF output: {type_id!r}")
 
 
-def _arrow_type_from_output_schema_entry(entry: dict[str, Any]) -> pa.DataType:
+def arrow_type_from_output_schema_entry(entry: dict[str, Any]) -> pa.DataType:
     kind = str(entry.get("kind") or "").strip().lower()
     if kind == "tensor":
         dtype = _arrow_type_from_name(str(entry.get("dtype") or ""))
@@ -129,15 +129,33 @@ def _arrow_type_from_output_schema_entry(entry: dict[str, Any]) -> pa.DataType:
 
 
 def empty_output_table_from_schema(output_schema: Any) -> pa.Table:
+    schema = arrow_schema_from_output_schema(output_schema)
+    return pa.Table.from_arrays([pa.array([], type=field.type) for field in schema], schema=schema)
+
+
+def arrow_schema_from_output_schema(output_schema: Any) -> pa.Schema:
+    fields = []
+    for name, entry in normalize_output_schema_entries(output_schema):
+        fields.append(pa.field(name, arrow_type_from_output_schema_entry(entry)))
+    return pa.schema(fields)
+
+
+def normalize_output_schema_entries(output_schema: Any) -> tuple[tuple[str, dict[str, Any]], ...]:
     if not output_schema:
-        raise ValueError("empty UDF output requires payload.output_schema")
-    arrays = {}
+        raise ValueError("UDF output conversion requires payload.output_schema")
+    normalized: list[tuple[str, dict[str, Any]]] = []
+    names = set()
     for entry in output_schema:
         if not isinstance(entry, dict):
             raise ValueError("payload.output_schema entries must be dicts")
         name = str(entry.get("name") or "")
-        arrays[name] = pa.array([], type=_arrow_type_from_output_schema_entry(entry))
-    return pa.table(arrays)
+        if not name:
+            raise ValueError("payload.output_schema entries require non-empty names")
+        if name in names:
+            raise ValueError(f"payload.output_schema contains duplicate name {name!r}")
+        names.add(name)
+        normalized.append((name, entry))
+    return tuple(normalized)
 
 
 def empty_output_table_from_payload(payload: dict[str, Any] | None) -> pa.Table:
@@ -145,4 +163,10 @@ def empty_output_table_from_payload(payload: dict[str, Any] | None) -> pa.Table:
     return empty_output_table_from_schema(payload.get("output_schema"))
 
 
-__all__ = ["empty_output_table_from_payload", "empty_output_table_from_schema"]
+__all__ = [
+    "arrow_schema_from_output_schema",
+    "arrow_type_from_output_schema_entry",
+    "empty_output_table_from_payload",
+    "empty_output_table_from_schema",
+    "normalize_output_schema_entries",
+]


### PR DESCRIPTION
## Summary

- Add a strict `batch_format` option to relation-level `map_batches` for
  `pyarrow`, NumPy dictionaries, pandas DataFrames, and cuDF DataFrames.
- Preserve fixed-shape tensor dimensions and nullable validity across NumPy and
  pandas conversions, including a separate NumPy mask for ordinary nullable
  columns.
- Normalize selected-format outputs back to Arrow with strict column names, row
  counts, and tensor dtype/shape validation, without cross-format fallback.

`batch_format="pyarrow"` remains the default. Input and output must both use the
selected format; output dictionaries previously accepted by the default Arrow
path are intentionally rejected by the new strict contract.

## Related issue

N/A

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public native docstring and type stub document the supported formats,
defaults, nullable NumPy representation, and tensor representation.

## Validation

CPU-only Linux host; the real cuDF test is marked `gpu` and was deselected
because CUDA hardware was unavailable. The fake-cuDF Arrow-boundary test passed.

- Incremental Release native install with `uv pip install . --no-build-isolation`
- `scripts/format root --changed`
- Affected UDF suites: 205 passed, 1 GPU test deselected
- `scripts/run_fast_tests.sh` with `VANE_FAST_TEST_EXCLUDE_GPU=1`:
  - non-Ray: 6207 passed, 602 skipped, 7 xfailed, 1 xpassed, 119 deselected
  - shared-cluster Ray: 98 passed, 2 skipped, 6836 deselected
  - test-owned Ray clusters: 7 passed across 7 isolated pytest processes
- `scripts/run_release_tests.sh`:
  - non-Ray: 521 passed, 15 deselected
  - real Ray: 11 passed, 525 deselected
- `pre-commit run --all-files`
- `pre-commit run --all-files --hook-stage manual`
- `python scripts/check_source_license_headers.py --repo root`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
