### PR TITLE
[fix](ray) Release the caller's GIL across Python-backend poll sleeps

### DIFF
--- a/src/vane_py/include/vane_python/pybind11/gil_wrapper.hpp
+++ b/src/vane_py/include/vane_python/pybind11/gil_wrapper.hpp
@@ -8,6 +8,9 @@
 
 #include "vane_python/pybind11/pybind_wrapper.hpp"
 
+#include <chrono>
+#include <thread>
+
 #if PY_VERSION_HEX < 0x030D0000 && !defined(Py_LIMITED_API)
 extern "C" int _Py_IsFinalizing(void);
 #endif
@@ -72,5 +75,29 @@ private:
 		return true;
 	}
 };
+
+//! Sleep for `duration`, temporarily releasing the GIL if — and only if — the
+//! current thread holds it.
+//!
+//! `PythonGILWrapper` / `PyGILState_Ensure` RESTORE (not release) a GIL the
+//! caller already owned, so a poll loop entered GIL-held would otherwise keep
+//! the GIL for the whole inter-poll sleep and starve the Python threads that
+//! must make progress for the poll to ever observe it. Releasing here keeps
+//! such waits self-contained regardless of the caller's incoming GIL state.
+//!
+//! When the interpreter is unavailable or finalizing, or the GIL is not held,
+//! this is a plain sleep that never touches GIL state. The guard is evaluated
+//! at entry only: if finalization begins while a released sleep is in flight,
+//! the release's destructor still re-acquires the GIL on wake — the same
+//! behavior as the inline guard this helper centralizes.
+template <typename Rep, typename Period>
+inline void SleepWithGILReleasedIfHeld(std::chrono::duration<Rep, Period> duration) {
+	if (Py_IsInitialized() && !PythonIsFinalizing() && PyGILState_Check()) {
+		py::gil_scoped_release release;
+		std::this_thread::sleep_for(duration);
+		return;
+	}
+	std::this_thread::sleep_for(duration);
+}
 
 } // namespace duckdb

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -1428,7 +1428,7 @@ public:
 				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
 				    DuckDBError::external_error("timed out waiting for Python backend FTE query: " + status_message));
 			}
-			std::this_thread::sleep_for(std::chrono::milliseconds(10));
+			duckdb::SleepWithGILReleasedIfHeld(std::chrono::milliseconds(10));
 		}
 
 		const double remaining_timeout_s =
@@ -2400,7 +2400,7 @@ private:
 				    DuckDBError("timed out draining Python backend FTE result handles"));
 			}
 			pending = std::move(still_pending);
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+			duckdb::SleepWithGILReleasedIfHeld(std::chrono::milliseconds(1));
 		}
 		RetainPythonTaskResultHandles(query_id, std::move(retained_handles));
 		return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::ok(std::move(outputs));
@@ -2450,6 +2450,22 @@ struct PyPhysicalPlanWrapperRunner {
 	void register_query_owner(const string &query_id, const string &owner_query_id) {
 		if (py_backend_worker_manager_) {
 			py_backend_worker_manager_->register_query_owner(query_id, owner_query_id);
+		}
+	}
+
+	// Test-only: drive the Python-backend FTE wait WITHOUT releasing the GIL.
+	// Production reaches wait_fte_query under a py::gil_scoped_release taken
+	// upstream (this file's run_plan implementation releases around
+	// runner->run_plan), which is what currently masks the poll loops' GIL
+	// retention. Entering here GIL-held lets a regression test observe
+	// whether the inter-poll sleeps still starve concurrent Python threads.
+	void wait_fte_query_gil_held_for_test(const string &query_id, double timeout_s) {
+		if (!py_backend_worker_manager_) {
+			throw std::runtime_error("wait_fte_query_gil_held_for_test requires a Python-backend runner");
+		}
+		auto res = py_backend_worker_manager_->wait_fte_query(query_id, timeout_s);
+		if (res.is_err()) {
+			throw duckdb::InternalException(res.error().what());
 		}
 	}
 

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -1141,6 +1141,10 @@ void register_ray_bindings(py::module_ &mod) {
 	    .def("drop_query_fragments", &PyPhysicalPlanWrapperRunner::drop_query_fragments, py::arg("query_id"))
 	    .def("_register_query_owner_for_test", &PyPhysicalPlanWrapperRunner::register_query_owner, py::arg("query_id"),
 	         py::arg("owner_query_id"))
+	    // timeout_s is deliberately required: 0.0 means "no deadline", and a
+	    // defaulted infinite wait against a never-finishing test fake hangs CI.
+	    .def("_wait_fte_query_gil_held_for_test", &PyPhysicalPlanWrapperRunner::wait_fte_query_gil_held_for_test,
+	         py::arg("query_id"), py::arg("timeout_s"))
 	    .def("close_session", &PyPhysicalPlanWrapperRunner::close_session, py::arg("session_id"))
 	    .def("warm_up", &PyPhysicalPlanWrapperRunner::warm_up)
 	    .def("shutdown",

--- a/src/vane_py/ray/worker_manager.cpp
+++ b/src/vane_py/ray/worker_manager.cpp
@@ -385,12 +385,7 @@ DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>> RayWorkerMana
 				return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
 				    DuckDBError::external_error("timed out draining FTE result handles"));
 			}
-			if (PyGILState_Check()) {
-				py::gil_scoped_release gil_release;
-				std::this_thread::sleep_for(std::chrono::milliseconds(1));
-			} else {
-				std::this_thread::sleep_for(std::chrono::milliseconds(1));
-			}
+			duckdb::SleepWithGILReleasedIfHeld(std::chrono::milliseconds(1));
 		}
 	}
 	std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>> retained_handles;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -4597,3 +4597,99 @@ def test_execute_native_roundtrip_hash_join_plan_no_crash():
     assert "rows 1" in proc.stdout
     assert "status ok" in proc.stdout
     assert "ok" in proc.stdout
+
+
+def test_python_backend_wait_releases_gil_during_poll_sleeps():
+    """Regression for #456: the Python-backend FTE poll loop must release the GIL
+    while it sleeps between polls, so a concurrent Python thread keeps running.
+
+    The wait is entered GIL-held via a test-only binding — production callers wrap
+    it in ``py::gil_scoped_release``, which is exactly what masks the bug on the
+    live path.
+
+    Making this a true discriminator requires care: CPython voluntarily hands the
+    GIL off at bytecode boundaries roughly every ``switchinterval`` seconds, so a
+    spinner thread would advance a little during the Python status callbacks even
+    if the sleeps held the GIL. We raise ``switchinterval`` far above the total
+    duration of the (short) GIL-held wait, so voluntary hand-offs never trigger:
+    the spinner can then only advance if the inter-poll sleep *explicitly* releases
+    the GIL. With the guard in place the spinner runs during the sleep; without it
+    the spinner is provably never scheduled and the delta is exactly zero.
+    """
+    spinner_counter = [0]
+    stop = threading.Event()
+
+    def spin():
+        while not stop.is_set():
+            spinner_counter[0] += 1  # pure-Python work; only advances while holding the GIL
+            # Cooperatively drop the GIL so the main thread re-acquires promptly
+            # after each released sleep; keeps the test fast despite the high
+            # switchinterval. When the GIL is held across the sleep the spinner is
+            # blocked here and this line never runs, so it cannot mask the bug.
+            time.sleep(0.0001)
+
+    class NeverFinishesBackend:
+        def __init__(self):
+            self.counter_at_first_poll = None
+            self.counter_at_last_poll = None
+
+        def register_query_owner(self, query_id, owner_query_id):
+            return None
+
+        def fte_query_status(self, query_id):
+            if self.counter_at_first_poll is None:
+                self.counter_at_first_poll = spinner_counter[0]
+            self.counter_at_last_poll = spinner_counter[0]
+            return {"failed": False, "finished": False}
+
+    backend = NeverFinishesBackend()
+    runner = vane.ray_cxx.DistributedPhysicalPlanRunner(backend)
+    runner._register_query_owner_for_test("query-gil-poll", "query-gil-poll")
+
+    old_interval = sys.getswitchinterval()
+    spinner = threading.Thread(target=spin, daemon=True)
+    spinner.start()
+    try:
+        # Inside the try so the long-lived shared pytest process gets the
+        # interval restored even if anything below raises.
+        sys.setswitchinterval(1.0)
+        with pytest.raises(Exception) as exc_info:
+            # Never finishes + a short deadline => the loop sleeps several times and
+            # then times out. The deadline (0.2 s) sits well above a single poll but
+            # far below switchinterval, so an unfixed loop never yields the GIL.
+            runner._wait_fte_query_gil_held_for_test("query-gil-poll", timeout_s=0.2)
+        assert "timed out" in str(exc_info.value).lower()
+    finally:
+        stop.set()
+        sys.setswitchinterval(old_interval)
+        spinner.join()
+
+    assert backend.counter_at_first_poll is not None
+    progress = backend.counter_at_last_poll - backend.counter_at_first_poll
+    assert progress > 0, "concurrent Python thread was starved: the poll loop held the GIL across its sleep"
+
+
+def test_python_backend_wait_gil_held_completes_when_backend_finishes():
+    """Entered GIL-held, the wait still completes normally once the backend reports
+    finished — exercising the status loop's sleep on the success path without
+    altering functional behavior."""
+
+    class FinishingBackend:
+        def __init__(self):
+            self.polls = 0
+
+        def register_query_owner(self, query_id, owner_query_id):
+            return None
+
+        def fte_query_status(self, query_id):
+            self.polls += 1
+            # A few not-finished polls force the loop through its inter-poll sleep
+            # before it succeeds; no stored result handles => an empty drain.
+            return {"failed": False, "finished": self.polls >= 3}
+
+    backend = FinishingBackend()
+    runner = vane.ray_cxx.DistributedPhysicalPlanRunner(backend)
+    runner._register_query_owner_for_test("query-gil-finish", "query-gil-finish")
+
+    runner._wait_fte_query_gil_held_for_test("query-gil-finish", timeout_s=0.0)
+    assert backend.polls >= 3


### PR DESCRIPTION
## What & why

Closes #456.

The Python-backend FTE worker manager polls a Python backend in a loop, sleeping between polls. `PythonGILWrapper` (`PyGILState_Ensure`/`PyGILState_Release`) **restores** — it does not **release** — a GIL the caller already held. So a wait entered while holding the GIL keeps the GIL across every inter-poll `sleep_for`, which can starve the Python backend thread that must make progress for the poll to ever observe it.

This is **latent today**: every pybind entry point releases the GIL before reaching the wait (this file's `run_plan` releases around `runner->run_plan`), so no current caller arrives GIL-held. The masking is incidental — a new direct caller or a refactor that drops an outer `gil_scoped_release` would turn an ordinary poll into interpreter-wide starvation. This change makes the wait self-contained instead.

## Changes

- **New shared helper** `SleepWithGILReleasedIfHeld` in `gil_wrapper.hpp` — sleeps while releasing the GIL only when the thread actually holds it, guarded by the most defensive form already used in this tree (`Py_IsInitialized() && !PythonIsFinalizing() && PyGILState_Check()`); a plain sleep otherwise.
- **Both Python-backend poll-loop sleeps** now route through it: the `wait_fte_query` status-wait loop and the `DrainResultHandles` drain loop.
- **De-duplication:** the existing Ray poll-loop guard in `worker_manager.cpp` (which already open-coded this exact release-if-held pattern) now calls the shared helper. Behavior-preserving; the condition is widened from GIL-held-only to also short-circuit during finalization (strictly safer, unreachable-in-practice difference).
- Per-poll Python callbacks still acquire the GIL exactly as before via `PythonGILWrapper`; only the *waiting* portion changes.

No public API, SQL, or backend-protocol surface changes — the only new symbols are a test-only pybind method/binding.

## Testing

A new test-only `_wait_fte_query_gil_held_for_test` binding enters the wait **without** releasing the GIL (the inverse of the existing `_wait_fte_query_scoped_for_test`), against a fake Python backend. The regression test raises `sys.setswitchinterval` above the wait's total duration, so CPython's voluntary GIL hand-offs during the status callbacks cannot fire: a concurrent Python thread then advances **only** if the inter-poll sleep explicitly releases the GIL. Unfixed ⇒ the spinner's progress is exactly zero; fixed ⇒ it advances. A second test covers the success path (completes once the backend reports finished).

> **CI is the gate.** The native extension cannot be built on the author's machine, so these tests were **not** run locally — please rely on CI. The test is designed to fail deterministically (a threshold-free `progress > 0` under a suppressed switch interval, not a timing race) so a red result unambiguously means the guard is missing.

## Known gap (deferred follow-up)

The drain-loop sleep routes through the same one-line helper but is **not independently exercised** by a test — reaching it requires stored result handles, and `submit_fte_task_events` is not exposed to Python, so a dedicated test would need a second `_for_test` submit binding plus fake pending-then-ready result-handle machinery that can't be validated on the local (unbuildable) native extension. Both sleeps are the identical helper call, proven by the status-loop discriminator; independent drain-loop coverage is left as a follow-up. Happy to add it in this PR if a reviewer prefers.

Also intentionally **out of scope**: the sibling unguarded sleep on the non-Python-backend Ray status path (`worker_manager.cpp`, the FTE status wait loop) — same bug class, but not one of the two sites named in #456. Flagged for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxNrziiFp5FDEJpGUPX9NK
