### PR TITLE
[feat](udf) Add dynamic GPU batch sizing

### DIFF
--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "duckdb/execution/operator/projection/physical_udf_inout.hpp"
+#include "duckdb/execution/operator/projection/udf_dynamic_batching.hpp"
 #include "duckdb/execution/distributed/common_types.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -30,6 +31,8 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <chrono>
+#include <cmath>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
@@ -817,6 +820,19 @@ static void AppendUDFExecutionConfigParams(InsertionOrderPreservingMap<string> &
 	if (preserve_compute_batch_boundaries.first && preserve_compute_batch_boundaries.second) {
 		result["preserve_compute_batch_boundaries"] = "true";
 	}
+	auto dynamic_batching = GetStructBoolField(payload, "dynamic_batching");
+	if (dynamic_batching.first && dynamic_batching.second) {
+		result["dynamic_batching"] = "true";
+		for (const auto &name :
+		     {"dynamic_batch_size_min_rows", "dynamic_batch_size_max_rows", "dynamic_batch_size_initial_rows",
+		      "dynamic_batch_target_latency_ms", "dynamic_batch_latency_tolerance_ms", "dynamic_batch_step_size",
+		      "dynamic_batch_correction", "dynamic_batch_history_size"}) {
+			auto value = GetStructIntField(payload, name);
+			if (value.first && value.second > 0) {
+				result[name] = std::to_string(value.second);
+			}
+		}
+	}
 	auto target_max_batch_bytes = GetStructIntField(payload, "udf_target_max_batch_bytes");
 	if (target_max_batch_bytes.first && target_max_batch_bytes.second > 0) {
 		result["udf_target_max_batch_bytes"] = std::to_string(target_max_batch_bytes.second);
@@ -910,6 +926,7 @@ static InsertionOrderPreservingMap<string> UDFTableFunctionDynamicToString(Table
 
 struct StreamingUDFConfig {
 	idx_t compute_batch_rows = 0;
+	UDFDynamicBatchingConfig dynamic_batching;
 	// Soft lower bound matching Ray Data's min_rows_per_bundle: preserve
 	// complete upstream blocks and coalesce only undersized blocks until this
 	// row count is reached. EOS and byte pressure may still submit a short tail.
@@ -1066,6 +1083,7 @@ struct StreamingInflightBatch {
 	idx_t total_rows = 0;
 	idx_t bytes = 0;
 	idx_t emitted_rows = 0;
+	std::chrono::steady_clock::time_point submitted_at;
 };
 
 struct StreamingReadyOutput {
@@ -1092,6 +1110,7 @@ struct StreamingUDFState : public StateWithBlockableTasks {
 	    : original_payload(std::move(payload_p)), actor_handles(std::move(actor_handles_p)) {
 		payload = original_payload;
 		config = ResolveStreamingUDFConfig(original_payload);
+		dynamic_batch_sizer.Reset(config.dynamic_batching);
 		UDFWorkerSlotDebugLog(StringUtil::Format("streaming_ctor_unresolved udf_name=%s initial_config_width=1",
 		                                         UDFDebugNameFromPayload(original_payload).c_str()));
 	}
@@ -1149,6 +1168,7 @@ struct StreamingUDFState : public StateWithBlockableTasks {
 		    operator_width_resolved ? "true" : "false", static_cast<unsigned long long>(resolved_task_operator_width)));
 		payload = ResolveUDFRuntimePayload(original_payload, task_operator_width);
 		config = ResolveStreamingUDFConfig(payload, task_operator_width);
+		dynamic_batch_sizer.Reset(config.dynamic_batching);
 		resolved_task_operator_width = task_operator_width;
 		runtime_resolved = true;
 		runtime_operator_width_resolved = operator_width_resolved;
@@ -1158,6 +1178,7 @@ struct StreamingUDFState : public StateWithBlockableTasks {
 	Value payload;
 	shared_ptr<void> actor_handles;
 	StreamingUDFConfig config;
+	UDFDynamicBatchSizer dynamic_batch_sizer;
 	idx_t resolved_task_operator_width = 0;
 	bool runtime_resolved = false;
 	bool runtime_operator_width_resolved = false;
@@ -1285,7 +1306,8 @@ static void StreamingUDFDebugState(StreamingUDFState &state, const char *where, 
 	    "result_callbacks=%llu notify_space=%llu source_calls=%llu sink_calls=%llu blocked_sources=%llu "
 	    "blocked_sinks=%llu source_have_more=%llu source_blocked_empty=%llu wake_one=%llu wake_all=%llu "
 	    "blocked_source_tasks=%llu blocked_control_tasks=%llu max_pending_rows=%llu max_ready_rows=%llu "
-	    "max_active_batches=%llu config_compute_batch_rows=%llu config_min_task_batch_rows=%llu "
+	    "max_active_batches=%llu dynamic_batching=%s current_compute_batch_rows=%llu "
+	    "config_min_task_batch_rows=%llu "
 	    "config_task_input_max_bytes=%llu "
 	    "config_output_target_bytes=%llu",
 	    static_cast<unsigned long long>(tick), UDFDebugNameFromPayload(state.original_payload).c_str(), where,
@@ -1326,7 +1348,10 @@ static void StreamingUDFDebugState(StreamingUDFState &state, const char *where, 
 	    static_cast<unsigned long long>(state.blocked_control_tasks.size()),
 	    static_cast<unsigned long long>(state.max_pending_rows), static_cast<unsigned long long>(state.max_ready_rows),
 	    static_cast<unsigned long long>(state.max_active_batches),
-	    static_cast<unsigned long long>(state.config.compute_batch_rows),
+	    state.dynamic_batch_sizer.Enabled() ? "true" : "false",
+	    static_cast<unsigned long long>(state.dynamic_batch_sizer.Enabled()
+	                                        ? state.dynamic_batch_sizer.CurrentBatchRows()
+	                                        : state.config.compute_batch_rows),
 	    static_cast<unsigned long long>(state.config.min_task_batch_rows),
 	    static_cast<unsigned long long>(state.config.task_input_max_bytes),
 	    static_cast<unsigned long long>(state.config.output_target_bytes)));
@@ -1377,6 +1402,89 @@ static idx_t StreamingOutputByteCapacity(const StreamingUDFState &state);
 static idx_t StreamingOutputItemByteCapacity(const StreamingUDFState &state);
 static idx_t StreamingOutputEventCapacity(const StreamingUDFState &state);
 
+static idx_t RequirePositiveDynamicBatchField(const Value &payload, const string &name) {
+	auto child = GetStructChild(payload, name);
+	if (!child) {
+		throw InvalidInputException("dynamic GPU UDF batching requires payload.%s", name);
+	}
+	int64_t value = 0;
+	switch (child->type().id()) {
+	case LogicalTypeId::INTEGER:
+		value = IntegerValue::Get(*child);
+		break;
+	case LogicalTypeId::BIGINT:
+		value = BigIntValue::Get(*child);
+		break;
+	default:
+		throw InvalidInputException("dynamic GPU UDF payload.%s must be an integer", name);
+	}
+	if (value <= 0) {
+		throw InvalidInputException("dynamic GPU UDF payload.%s must be positive", name);
+	}
+	return NumericCast<idx_t>(value);
+}
+
+static std::chrono::microseconds DynamicBatchMilliseconds(idx_t milliseconds, const string &name) {
+	if (milliseconds > NumericLimits<int64_t>::Maximum() / 1000) {
+		throw InvalidInputException("dynamic GPU UDF payload.%s is too large", name);
+	}
+	return std::chrono::microseconds(static_cast<int64_t>(milliseconds * 1000));
+}
+
+static void ValidateDynamicBatchingExecution(const Value &payload, const string &execution_backend) {
+	if (execution_backend != "ray_task" && execution_backend != "ray_actor") {
+		throw InvalidInputException("dynamic GPU UDF batching requires a Ray execution backend");
+	}
+	auto call_mode = GetStructStringField(payload, "call_mode");
+	if (!call_mode.first || (call_mode.second != "map_batches" && call_mode.second != "map_batches_rows")) {
+		throw InvalidInputException("dynamic GPU UDF batching requires a batch UDF");
+	}
+	auto gpus = GetStructChild(payload, "gpus");
+	if (!gpus) {
+		throw InvalidInputException("dynamic GPU UDF batching requires positive payload.gpus");
+	}
+	switch (gpus->type().id()) {
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		break;
+	default:
+		throw InvalidInputException("dynamic GPU UDF payload.gpus must be numeric");
+	}
+	const auto gpu_count = gpus->DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+	if (!std::isfinite(gpu_count) || gpu_count <= 0.0) {
+		throw InvalidInputException("dynamic GPU UDF batching requires positive payload.gpus");
+	}
+}
+
+static bool IsRayGPUBatchPayload(const Value &payload, const string &execution_backend) {
+	if (execution_backend != "ray_task" && execution_backend != "ray_actor") {
+		return false;
+	}
+	auto call_mode = GetStructStringField(payload, "call_mode");
+	if (!call_mode.first || (call_mode.second != "map_batches" && call_mode.second != "map_batches_rows")) {
+		return false;
+	}
+	auto gpus = GetStructChild(payload, "gpus");
+	if (!gpus) {
+		return false;
+	}
+	switch (gpus->type().id()) {
+	case LogicalTypeId::INTEGER:
+	case LogicalTypeId::BIGINT:
+	case LogicalTypeId::FLOAT:
+	case LogicalTypeId::DOUBLE:
+	case LogicalTypeId::DECIMAL:
+		break;
+	default:
+		return false;
+	}
+	const auto gpu_count = gpus->DefaultCastAs(LogicalType::DOUBLE).GetValue<double>();
+	return std::isfinite(gpu_count) && gpu_count > 0.0;
+}
+
 static StreamingUDFConfig ResolveStreamingUDFConfig(const Value &payload, idx_t task_operator_width) {
 	StreamingUDFConfig config;
 	auto async_mode = GetStructBoolField(payload, "async_mode");
@@ -1395,12 +1503,46 @@ static StreamingUDFConfig ResolveStreamingUDFConfig(const Value &payload, idx_t 
 	if (ClassifyUDFMode(payload) != UDFMode::SCALAR_MAP && !HasStructField(payload, "output_schema")) {
 		throw InvalidInputException("non-scalar streaming UDF execution requires payload.output_schema");
 	}
-	auto batch_size = GetStructIntField(payload, "batch_size");
-	if (batch_size.first && batch_size.second > 0) {
-		config.compute_batch_rows = batch_size.second;
+	auto dynamic_batching_child = GetStructChild(payload, "dynamic_batching");
+	if (dynamic_batching_child && dynamic_batching_child->type().id() != LogicalTypeId::BOOLEAN) {
+		throw InvalidInputException("dynamic GPU UDF payload.dynamic_batching must be boolean");
+	}
+	auto dynamic_batching = GetStructBoolField(payload, "dynamic_batching");
+	if (IsRayGPUBatchPayload(payload, execution_backend.second) &&
+	    (!dynamic_batching.first || !dynamic_batching.second)) {
+		throw InvalidInputException("Ray GPU batch UDF payload requires dynamic_batching=true");
+	}
+	if (dynamic_batching.first && dynamic_batching.second) {
+		ValidateDynamicBatchingExecution(payload, execution_backend.second);
+		config.dynamic_batching.enabled = true;
+		config.dynamic_batching.min_batch_rows =
+		    RequirePositiveDynamicBatchField(payload, "dynamic_batch_size_min_rows");
+		config.dynamic_batching.max_batch_rows =
+		    RequirePositiveDynamicBatchField(payload, "dynamic_batch_size_max_rows");
+		config.dynamic_batching.initial_batch_rows =
+		    RequirePositiveDynamicBatchField(payload, "dynamic_batch_size_initial_rows");
+		config.dynamic_batching.target_batch_latency =
+		    DynamicBatchMilliseconds(RequirePositiveDynamicBatchField(payload, "dynamic_batch_target_latency_ms"),
+		                             "dynamic_batch_target_latency_ms");
+		config.dynamic_batching.latency_tolerance =
+		    DynamicBatchMilliseconds(RequirePositiveDynamicBatchField(payload, "dynamic_batch_latency_tolerance_ms"),
+		                             "dynamic_batch_latency_tolerance_ms");
+		config.dynamic_batching.step_size_alpha = RequirePositiveDynamicBatchField(payload, "dynamic_batch_step_size");
+		config.dynamic_batching.correction_delta =
+		    RequirePositiveDynamicBatchField(payload, "dynamic_batch_correction");
+		config.dynamic_batching.history_size = RequirePositiveDynamicBatchField(payload, "dynamic_batch_history_size");
+		config.dynamic_batching.Validate();
+	} else {
+		auto batch_size = GetStructIntField(payload, "batch_size");
+		if (batch_size.first && batch_size.second > 0) {
+			config.compute_batch_rows = batch_size.second;
+		}
 	}
 	auto min_task_batch_size = GetStructIntField(payload, "min_task_batch_size");
 	if (min_task_batch_size.first && min_task_batch_size.second > 0) {
+		if (config.dynamic_batching.enabled) {
+			throw InvalidInputException("streaming UDF min_task_batch_size is not valid with dynamic batching");
+		}
 		if (config.compute_batch_rows == 0) {
 			throw InvalidInputException("streaming UDF min_task_batch_size requires batch_size");
 		}
@@ -1955,6 +2097,13 @@ static bool StreamingHasLazyInput(const StreamingUDFState &state) {
 	return state.planned_submit.IsLazy() || !state.pending_lazy_inputs.empty();
 }
 
+static idx_t StreamingComputeBatchRows(const StreamingUDFState &state) {
+	if (state.dynamic_batch_sizer.Enabled()) {
+		return state.dynamic_batch_sizer.CurrentBatchRows();
+	}
+	return state.config.compute_batch_rows;
+}
+
 static idx_t NextStreamingPlannedSubmitSequence(StreamingUDFState &state) {
 	auto sequence = state.next_planned_submit_sequence++;
 	if (state.next_planned_submit_sequence == 0) {
@@ -1985,6 +2134,15 @@ static StreamingSubmitPlan PlanStreamingLazySubmit(const StreamingUDFState &stat
 	if (state.pending_rows == 0 || state.pending_lazy_inputs.empty()) {
 		return plan;
 	}
+	const auto compute_batch_rows = StreamingComputeBatchRows(state);
+	if (state.dynamic_batch_sizer.Enabled()) {
+		// Match Daft's Flexible(min, current_max) contract: the adaptive
+		// batch size is an upper bound, not a watermark that delays available
+		// GPU work until a full batch can be assembled.
+		plan.target_rows = MinValue<idx_t>(state.pending_rows, compute_batch_rows);
+		plan.allow_incomplete_compute_batch = true;
+		return plan;
+	}
 	idx_t rows_through_boundary = 0;
 	for (const auto &entry : state.pending_lazy_inputs) {
 		if (!entry.bundle || entry.rows == 0) {
@@ -2006,11 +2164,11 @@ static StreamingSubmitPlan PlanStreamingLazySubmit(const StreamingUDFState &stat
 			continue;
 		}
 		rows_through_boundary = SaturatingAdd(rows_through_boundary, entry.rows);
-		if (state.config.compute_batch_rows == 0) {
+		if (compute_batch_rows == 0) {
 			plan.target_rows = rows_through_boundary;
 			return plan;
 		}
-		const auto aligned_rows = rows_through_boundary - (rows_through_boundary % state.config.compute_batch_rows);
+		const auto aligned_rows = rows_through_boundary - (rows_through_boundary % compute_batch_rows);
 		if (aligned_rows > 0) {
 			plan.target_rows = aligned_rows;
 			return plan;
@@ -2022,6 +2180,12 @@ static StreamingSubmitPlan PlanStreamingLazySubmit(const StreamingUDFState &stat
 static StreamingSubmitPlan PlanStreamingMaterializedSubmit(const StreamingUDFState &state, bool flush_tail) {
 	StreamingSubmitPlan plan;
 	if (state.pending_rows == 0 || state.pending_inputs.empty()) {
+		return plan;
+	}
+	const auto compute_batch_rows = StreamingComputeBatchRows(state);
+	if (state.dynamic_batch_sizer.Enabled()) {
+		plan.target_rows = MinValue<idx_t>(state.pending_rows, compute_batch_rows);
+		plan.allow_incomplete_compute_batch = true;
 		return plan;
 	}
 	idx_t rows_through_boundary = 0;
@@ -2038,11 +2202,11 @@ static StreamingSubmitPlan PlanStreamingMaterializedSubmit(const StreamingUDFSta
 			}
 			continue;
 		}
-		if (state.config.compute_batch_rows == 0) {
+		if (compute_batch_rows == 0) {
 			plan.target_rows = rows_through_boundary;
 			return plan;
 		}
-		const auto aligned_rows = rows_through_boundary - (rows_through_boundary % state.config.compute_batch_rows);
+		const auto aligned_rows = rows_through_boundary - (rows_through_boundary % compute_batch_rows);
 		if (aligned_rows > 0) {
 			plan.target_rows = aligned_rows;
 			return plan;
@@ -2318,6 +2482,11 @@ static bool CompleteStreamingSubmitLocked(StreamingUDFState &state, unique_lock<
 		                       static_cast<unsigned long long>(submit_id)));
 		return false;
 	}
+	if (state.dynamic_batch_sizer.Enabled()) {
+		const auto batch_latency = std::chrono::duration_cast<std::chrono::microseconds>(
+		    std::chrono::steady_clock::now() - inflight_ref.submitted_at);
+		state.dynamic_batch_sizer.Record(inflight_ref.total_rows, batch_latency);
+	}
 	AtomicAddStreamingCounter(state.completed_input_rows, inflight_ref.total_rows);
 	AtomicAddStreamingCounter(state.completed_input_bytes, inflight_ref.bytes);
 	state.completed_batches.fetch_add(1);
@@ -2355,7 +2524,7 @@ static bool TrySubmitStreamingLazyInput(ExecutionContext &context, StreamingUDFS
 		if (!plan) {
 			return false;
 		}
-		candidate = TakeStreamingLazyInputBatch(state, plan, state.config.compute_batch_rows,
+		candidate = TakeStreamingLazyInputBatch(state, plan, StreamingComputeBatchRows(state),
 		                                        state.config.task_input_max_bytes);
 		pending = &candidate;
 	}
@@ -2381,6 +2550,7 @@ static bool TrySubmitStreamingLazyInput(ExecutionContext &context, StreamingUDFS
 	inflight.submit_id = submit_id;
 	inflight.total_rows = submitted_rows;
 	inflight.bytes = submitted_bytes;
+	inflight.submitted_at = std::chrono::steady_clock::now();
 	auto inserted = state.inflight_batches.emplace(submit_id, inflight);
 	if (!inserted.second) {
 		throw InternalException("streaming UDF duplicate lazy submit_id %llu",
@@ -2689,7 +2859,7 @@ static bool TrySubmitStreamingMaterializedInput(ExecutionContext &context, Strea
 		if (!plan) {
 			return false;
 		}
-		candidate = TakeStreamingMaterializedEnvelope(context, state, plan, state.config.compute_batch_rows,
+		candidate = TakeStreamingMaterializedEnvelope(context, state, plan, StreamingComputeBatchRows(state),
 		                                              state.config.task_input_max_bytes);
 		envelope = &candidate;
 	}
@@ -2721,6 +2891,7 @@ static bool TrySubmitStreamingMaterializedInput(ExecutionContext &context, Strea
 	inflight.submit_id = submit_id;
 	inflight.total_rows = rows;
 	inflight.bytes = bytes;
+	inflight.submitted_at = std::chrono::steady_clock::now();
 	auto inserted = state.inflight_batches.emplace(submit_id, inflight);
 	if (!inserted.second) {
 		throw InternalException("streaming UDF duplicate submit_id %llu", static_cast<unsigned long long>(submit_id));

--- a/external/duckdb/src/include/duckdb/execution/operator/projection/udf_dynamic_batching.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/projection/udf_dynamic_batching.hpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/exception.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <deque>
+#include <limits>
+
+namespace duckdb {
+
+struct UDFDynamicBatchingConfig {
+	bool enabled = false;
+	idx_t min_batch_rows = 1;
+	idx_t max_batch_rows = 1;
+	idx_t initial_batch_rows = 1;
+	std::chrono::microseconds target_batch_latency {0};
+	std::chrono::microseconds latency_tolerance {0};
+	idx_t step_size_alpha = 1;
+	idx_t correction_delta = 1;
+	idx_t history_size = 1;
+
+	void Validate() const {
+		if (!enabled) {
+			return;
+		}
+		if (min_batch_rows == 0 || max_batch_rows == 0 || initial_batch_rows == 0) {
+			throw InvalidInputException("dynamic UDF batch sizes must be positive");
+		}
+		if (min_batch_rows > max_batch_rows) {
+			throw InvalidInputException("dynamic UDF min batch rows must not exceed max batch rows");
+		}
+		if (initial_batch_rows < min_batch_rows || initial_batch_rows > max_batch_rows) {
+			throw InvalidInputException("dynamic UDF initial batch rows must be within the configured bounds");
+		}
+		if (target_batch_latency.count() <= 0) {
+			throw InvalidInputException("dynamic UDF target batch latency must be positive");
+		}
+		if (latency_tolerance.count() < 0 || latency_tolerance >= target_batch_latency) {
+			throw InvalidInputException(
+			    "dynamic UDF latency tolerance must be non-negative and below the target latency");
+		}
+		using latency_rep = std::chrono::microseconds::rep;
+		if (target_batch_latency.count() > std::numeric_limits<latency_rep>::max() - latency_tolerance.count()) {
+			throw InvalidInputException("dynamic UDF target latency plus tolerance is too large");
+		}
+		if (step_size_alpha == 0 || correction_delta == 0 || history_size == 0) {
+			throw InvalidInputException("dynamic UDF adjustment and history sizes must be positive");
+		}
+	}
+};
+
+// Latency-constrained batching follows Algorithm 2 in "Optimizing LLM Inference
+// Throughput via Memory-aware and SLA-constrained Dynamic Batching". Its
+// parameter defaults and flexible upper-bound semantics match Daft. The current
+// row limit is the upper bound for the next UDF submission; byte pressure and
+// end-of-stream may still produce a shorter batch.
+class UDFDynamicBatchSizer {
+public:
+	UDFDynamicBatchSizer() = default;
+
+	explicit UDFDynamicBatchSizer(const UDFDynamicBatchingConfig &config) {
+		Reset(config);
+	}
+
+	void Reset(const UDFDynamicBatchingConfig &config) {
+		config.Validate();
+		config_ = config;
+		recent_batch_rows_.clear();
+		recent_latencies_.clear();
+		if (!config_.enabled) {
+			current_batch_rows_ = 0;
+			search_low_ = 0;
+			search_high_ = 0;
+			return;
+		}
+		current_batch_rows_ = config_.initial_batch_rows;
+		search_low_ = config_.min_batch_rows;
+		search_high_ = config_.initial_batch_rows;
+	}
+
+	bool Enabled() const {
+		return config_.enabled;
+	}
+
+	idx_t CurrentBatchRows() const {
+		return current_batch_rows_;
+	}
+
+	idx_t SearchLow() const {
+		return search_low_;
+	}
+
+	idx_t SearchHigh() const {
+		return search_high_;
+	}
+
+	idx_t ObservationCount() const {
+		return recent_batch_rows_.size();
+	}
+
+	void Record(idx_t batch_rows, std::chrono::microseconds duration) {
+		if (!config_.enabled) {
+			return;
+		}
+		if (batch_rows == 0) {
+			throw InternalException("cannot record an empty dynamic UDF batch");
+		}
+		if (duration.count() < 0) {
+			throw InternalException("cannot record a negative dynamic UDF batch latency");
+		}
+
+		recent_batch_rows_.push_back(batch_rows);
+		recent_latencies_.push_back(duration);
+		while (recent_batch_rows_.size() > config_.history_size) {
+			recent_batch_rows_.pop_front();
+			recent_latencies_.pop_front();
+		}
+		Recalculate();
+	}
+
+private:
+	static idx_t SaturatingAdd(idx_t left, idx_t right) {
+		if (right > std::numeric_limits<idx_t>::max() - left) {
+			return std::numeric_limits<idx_t>::max();
+		}
+		return left + right;
+	}
+
+	static idx_t SaturatingSubtract(idx_t left, idx_t right) {
+		return left > right ? left - right : 0;
+	}
+
+	static idx_t Midpoint(idx_t left, idx_t right) {
+		return left / 2 + right / 2 + (left % 2 + right % 2) / 2;
+	}
+
+	void Recalculate() {
+		if (recent_batch_rows_.empty()) {
+			return;
+		}
+
+		idx_t total_rows = 0;
+		int64_t total_latency_us = 0;
+		for (auto rows : recent_batch_rows_) {
+			total_rows = SaturatingAdd(total_rows, rows);
+		}
+		for (auto latency : recent_latencies_) {
+			if (latency.count() > std::numeric_limits<int64_t>::max() - total_latency_us) {
+				total_latency_us = std::numeric_limits<int64_t>::max();
+				break;
+			}
+			total_latency_us += latency.count();
+		}
+
+		const auto observation_count = recent_batch_rows_.size();
+		const auto average_rows = std::max<idx_t>(1, total_rows / observation_count);
+		const auto average_latency = std::chrono::microseconds(total_latency_us / observation_count);
+		const auto upper_latency = config_.target_batch_latency + config_.latency_tolerance;
+		const auto lower_latency = config_.target_batch_latency - config_.latency_tolerance;
+
+		if (average_latency > upper_latency) {
+			search_high_ =
+			    std::max(average_rows, SaturatingAdd(SaturatingSubtract(search_low_, 1), config_.step_size_alpha));
+			search_low_ = std::max(SaturatingSubtract(SaturatingSubtract(search_low_, 1), config_.correction_delta),
+			                       config_.min_batch_rows);
+		} else if (average_latency < lower_latency) {
+			search_low_ = std::max(average_rows,
+			                       SaturatingSubtract(SaturatingSubtract(search_high_, 1), config_.step_size_alpha));
+			search_high_ = std::min(config_.max_batch_rows,
+			                        SaturatingAdd(SaturatingSubtract(search_high_, 1), config_.correction_delta));
+		} else {
+			const auto tighten_amount = config_.step_size_alpha / 2;
+			search_high_ = std::min(SaturatingAdd(average_rows, tighten_amount), config_.max_batch_rows);
+			search_low_ = std::max(SaturatingSubtract(average_rows, tighten_amount), config_.min_batch_rows);
+		}
+
+		// Out-of-order completions can temporarily cross the two search
+		// endpoints. Daft still takes their midpoint instead of collapsing the
+		// search to the latest observed batch size.
+		current_batch_rows_ = Midpoint(search_low_, search_high_);
+		current_batch_rows_ = std::min(std::max(current_batch_rows_, config_.min_batch_rows), config_.max_batch_rows);
+	}
+
+	UDFDynamicBatchingConfig config_;
+	idx_t current_batch_rows_ = 0;
+	idx_t search_low_ = 0;
+	idx_t search_high_ = 0;
+	std::deque<idx_t> recent_batch_rows_;
+	std::deque<std::chrono::microseconds> recent_latencies_;
+};
+
+} // namespace duckdb

--- a/external/duckdb/test/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/test/execution/distributed/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_EXECUTION_DISTRIBUTED_SOURCES
     test_aggregate_node.cpp
     test_udf_per_thread.cpp
     test_udf_serialization.cpp
+    test_udf_dynamic_batching.cpp
     test_clustering_spec.cpp
     test_copy_finalize.cpp
     test_execute_plan.cpp

--- a/external/duckdb/test/execution/distributed/test_udf_dynamic_batching.cpp
+++ b/external/duckdb/test/execution/distributed/test_udf_dynamic_batching.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "catch.hpp"
+
+#include "duckdb/execution/operator/projection/udf_dynamic_batching.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+UDFDynamicBatchingConfig TestConfig() {
+	UDFDynamicBatchingConfig config;
+	config.enabled = true;
+	config.min_batch_rows = 1;
+	config.max_batch_rows = 512;
+	config.initial_batch_rows = 256;
+	config.target_batch_latency = std::chrono::milliseconds(100);
+	config.latency_tolerance = std::chrono::milliseconds(10);
+	config.step_size_alpha = 20;
+	config.correction_delta = 5;
+	config.history_size = 16;
+	return config;
+}
+
+} // namespace
+
+TEST_CASE("Dynamic UDF batching starts with a bounded exploratory batch", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	UDFDynamicBatchSizer sizer(config);
+
+	REQUIRE(sizer.Enabled());
+	REQUIRE(sizer.CurrentBatchRows() == 256);
+	REQUIRE(sizer.SearchLow() == 1);
+	REQUIRE(sizer.SearchHigh() == 256);
+	REQUIRE(sizer.ObservationCount() == 0);
+}
+
+TEST_CASE("Dynamic UDF batching expands after low latency", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	UDFDynamicBatchSizer sizer(config);
+
+	sizer.Record(256, std::chrono::milliseconds(50));
+
+	REQUIRE(sizer.SearchLow() == 256);
+	REQUIRE(sizer.SearchHigh() == 260);
+	REQUIRE(sizer.CurrentBatchRows() == 258);
+}
+
+TEST_CASE("Dynamic UDF batching contracts after high latency", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	UDFDynamicBatchSizer sizer(config);
+
+	sizer.Record(256, std::chrono::milliseconds(150));
+
+	REQUIRE(sizer.SearchLow() == 1);
+	REQUIRE(sizer.SearchHigh() == 256);
+	REQUIRE(sizer.CurrentBatchRows() == 128);
+}
+
+TEST_CASE("Dynamic UDF batching tightens around target latency", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	UDFDynamicBatchSizer sizer(config);
+
+	sizer.Record(80, std::chrono::milliseconds(100));
+
+	REQUIRE(sizer.SearchLow() == 70);
+	REQUIRE(sizer.SearchHigh() == 90);
+	REQUIRE(sizer.CurrentBatchRows() == 80);
+}
+
+TEST_CASE("Dynamic UDF batching respects its maximum and rolling window", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	config.max_batch_rows = 100;
+	config.initial_batch_rows = 100;
+	UDFDynamicBatchSizer sizer(config);
+
+	for (idx_t observation = 0; observation < 32; observation++) {
+		sizer.Record(100, std::chrono::milliseconds(50));
+	}
+
+	REQUIRE(sizer.CurrentBatchRows() == 100);
+	REQUIRE(sizer.SearchLow() == 100);
+	REQUIRE(sizer.SearchHigh() == 100);
+	REQUIRE(sizer.ObservationCount() == 16);
+}
+
+TEST_CASE("Dynamic UDF batching handles crossed search endpoints from out-of-order completions",
+          "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	config.history_size = 1;
+	UDFDynamicBatchSizer sizer(config);
+
+	// A short, slow batch can complete before an earlier full, fast batch.
+	sizer.Record(1, std::chrono::milliseconds(150));
+	sizer.Record(256, std::chrono::milliseconds(50));
+
+	REQUIRE(sizer.SearchLow() == 256);
+	REQUIRE(sizer.SearchHigh() == 24);
+	REQUIRE(sizer.CurrentBatchRows() == 140);
+}
+
+TEST_CASE("Dynamic UDF batching rejects invalid bounds", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	config.min_batch_rows = 20;
+	config.max_batch_rows = 10;
+
+	REQUIRE_THROWS_WITH(UDFDynamicBatchSizer(config),
+	                    Catch::Matchers::Contains("min batch rows must not exceed max batch rows"));
+}
+
+TEST_CASE("Dynamic UDF batching rejects latency-bound overflow", "[execution][udf][dynamic-batching]") {
+	auto config = TestConfig();
+	config.target_batch_latency =
+	    std::chrono::microseconds(std::numeric_limits<std::chrono::microseconds::rep>::max() - 5);
+	config.latency_tolerance = std::chrono::microseconds(10);
+
+	REQUIRE_THROWS_WITH(UDFDynamicBatchSizer(config),
+	                    Catch::Matchers::Contains("target latency plus tolerance is too large"));
+}

--- a/src/vane_py/pyrelation/initialize.cpp
+++ b/src/vane_py/pyrelation/initialize.cpp
@@ -329,7 +329,9 @@ void DuckDBPyRelation::Initialize(py::handle &m) {
 	    "a call after failure; exactly-once execution is not provided, so external effects must be idempotent. "
 	    "Callable classes use Actor backends: "
 	    "actor_number creates independent ephemeral instances, work has no Actor affinity or global ordering, and "
-	    "failures may reconstruct an Actor and reset its local state.",
+	    "failures may reconstruct an Actor and reset its local state. GPU UDFs use latency-constrained dynamic "
+	    "batching; batch_size is the maximum row count rather than a fixed size, and min_task_batch_size cannot be "
+	    "combined with it.",
 	    py::arg("function"), py::arg("schema") = py::none(), py::kw_only(), py::arg("batch_size") = py::none(),
 	    py::arg("output_batch_size") = py::none(), py::arg("min_task_batch_size") = py::none(),
 	    py::arg("preserve_compute_batch_boundaries") = py::none(), py::arg("cpus") = py::none(),

--- a/src/vane_py/python_udf_utils.cpp
+++ b/src/vane_py/python_udf_utils.cpp
@@ -29,6 +29,13 @@ namespace {
 
 constexpr idx_t DEFAULT_UDF_TARGET_MAX_BATCH_BYTES = 134217728;
 constexpr const char *UDF_TARGET_MAX_BATCH_BYTES_ENV = "VANE_UDF_TARGET_MAX_BATCH_BYTES";
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_MAX_ROWS = 128 * 1024;
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_INITIAL_ROWS = 256;
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_TARGET_LATENCY_MS = 5000;
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_LATENCY_TOLERANCE_MS = 1000;
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_STEP_SIZE = 16;
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_CORRECTION = 4;
+constexpr idx_t DEFAULT_DYNAMIC_BATCH_HISTORY_SIZE = 16;
 static std::atomic<uint64_t> registered_expression_sequence {0};
 
 static Value BuildShapeValue(const vector<idx_t> &shape) {
@@ -357,9 +364,16 @@ Value BuildPythonUDFPayload(
 	auto batch_size_value = ParseOptionalPositiveIdx(batch_size, "batch_size");
 	auto output_batch_size_value = ParseOptionalPositiveIdx(output_batch_size, "output_batch_size");
 	auto min_task_batch_size_value = ParseOptionalPositiveIdx(min_task_batch_size, "min_task_batch_size");
+	const bool dynamic_batching = is_ray_backend && gpus_value.first && gpus_value.second > 0.0 && !flat_map;
+	const auto dynamic_batch_max_rows =
+	    batch_size_value.first ? batch_size_value.second : DEFAULT_DYNAMIC_BATCH_MAX_ROWS;
+	const auto dynamic_batch_initial_rows = MinValue<idx_t>(DEFAULT_DYNAMIC_BATCH_INITIAL_ROWS, dynamic_batch_max_rows);
 	const bool preserve_compute_boundaries_value =
 	    !preserve_compute_batch_boundaries.is_none() && py::cast<bool>(preserve_compute_batch_boundaries);
 	if (min_task_batch_size_value.first) {
+		if (dynamic_batching) {
+			throw InvalidInputException("min_task_batch_size is not valid for dynamically batched GPU UDFs");
+		}
 		if (!batch_size_value.first) {
 			throw InvalidInputException("min_task_batch_size requires batch_size");
 		}
@@ -432,6 +446,24 @@ Value BuildPythonUDFPayload(
 	}
 	if (batch_size_value.first) {
 		children.emplace_back("batch_size", Value::BIGINT(static_cast<int64_t>(batch_size_value.second)));
+	}
+	if (dynamic_batching) {
+		children.emplace_back("dynamic_batching", Value::BOOLEAN(true));
+		children.emplace_back("dynamic_batch_size_min_rows", Value::BIGINT(1));
+		children.emplace_back("dynamic_batch_size_max_rows",
+		                      Value::BIGINT(static_cast<int64_t>(dynamic_batch_max_rows)));
+		children.emplace_back("dynamic_batch_size_initial_rows",
+		                      Value::BIGINT(static_cast<int64_t>(dynamic_batch_initial_rows)));
+		children.emplace_back("dynamic_batch_target_latency_ms",
+		                      Value::BIGINT(static_cast<int64_t>(DEFAULT_DYNAMIC_BATCH_TARGET_LATENCY_MS)));
+		children.emplace_back("dynamic_batch_latency_tolerance_ms",
+		                      Value::BIGINT(static_cast<int64_t>(DEFAULT_DYNAMIC_BATCH_LATENCY_TOLERANCE_MS)));
+		children.emplace_back("dynamic_batch_step_size",
+		                      Value::BIGINT(static_cast<int64_t>(DEFAULT_DYNAMIC_BATCH_STEP_SIZE)));
+		children.emplace_back("dynamic_batch_correction",
+		                      Value::BIGINT(static_cast<int64_t>(DEFAULT_DYNAMIC_BATCH_CORRECTION)));
+		children.emplace_back("dynamic_batch_history_size",
+		                      Value::BIGINT(static_cast<int64_t>(DEFAULT_DYNAMIC_BATCH_HISTORY_SIZE)));
 	}
 	if (output_batch_size_value.first) {
 		children.emplace_back("output_batch_size", Value::BIGINT(static_cast<int64_t>(output_batch_size_value.second)));

--- a/tests/fast/test_expression_udf_contracts.py
+++ b/tests/fast/test_expression_udf_contracts.py
@@ -443,6 +443,15 @@ def test_ray_actor_pool_size_and_gpu_options_follow_physical_payload(monkeypatch
     assert "stateful" not in nodes[0]["payload"]
     assert "side_effects" not in nodes[0]["payload"]
     assert nodes[0]["payload"]["expression_id"]
+    assert nodes[0]["payload"]["dynamic_batching"] is True
+    assert nodes[0]["payload"]["dynamic_batch_size_min_rows"] == 1
+    assert nodes[0]["payload"]["dynamic_batch_size_max_rows"] == 2
+    assert nodes[0]["payload"]["dynamic_batch_size_initial_rows"] == 2
+    assert nodes[0]["payload"]["dynamic_batch_target_latency_ms"] == 5000
+    assert nodes[0]["payload"]["dynamic_batch_latency_tolerance_ms"] == 1000
+    assert nodes[0]["payload"]["dynamic_batch_step_size"] == 16
+    assert nodes[0]["payload"]["dynamic_batch_correction"] == 4
+    assert nodes[0]["payload"]["dynamic_batch_history_size"] == 16
 
     calls = []
 
@@ -541,7 +550,21 @@ def test_expression_and_relation_class_udfs_share_actor_resource_contract(monkey
 
     relation_payload = relation_node["payload"]
     expression_payload = expression_node["payload"]
-    for field in ("execution_backend", "actor_number", "gpus", "batch_size"):
+    for field in (
+        "execution_backend",
+        "actor_number",
+        "gpus",
+        "batch_size",
+        "dynamic_batching",
+        "dynamic_batch_size_min_rows",
+        "dynamic_batch_size_max_rows",
+        "dynamic_batch_size_initial_rows",
+        "dynamic_batch_target_latency_ms",
+        "dynamic_batch_latency_tolerance_ms",
+        "dynamic_batch_step_size",
+        "dynamic_batch_correction",
+        "dynamic_batch_history_size",
+    ):
         assert relation_payload[field] == expression_payload[field]
     assert relation_node["actor_pool_size"] == expression_node["actor_pool_size"] == 3
     assert relation_payload["call_mode"] == "map_batches"

--- a/tests/fast/test_expression_udf_map_batches.py
+++ b/tests/fast/test_expression_udf_map_batches.py
@@ -426,11 +426,44 @@ def test_vane_function_batch_gpu_zero_stays_streaming():
 
         assert "STREAMING_UDF" in plan
         assert "ray_block_stream_output:" in plan
+        assert "dynamic_batching:" not in plan
     finally:
         if old_runner is None:
             os.environ.pop("VANE_RUNNER", None)
         else:
             os.environ["VANE_RUNNER"] = old_runner
+
+
+def test_vane_function_batch_gpu_payload_uses_dynamic_batch_defaults(monkeypatch):
+    import uuid
+
+    import pyarrow as pa
+
+    import vane
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    @vane.func.batch(return_dtype=pa.int32(), gpus=1)
+    def identity(values):
+        return values
+
+    con = vane.connect()
+    try:
+        relation = con.sql("select i::INTEGER as x from range(3) t(i)").select(identity(vane.col("x")))
+        payload = (
+            vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, str(uuid.uuid4()))
+            .to_physical_plan(con)
+            .collect_udf_nodes(conn=con)[0]["payload"]
+        )
+    finally:
+        con.close()
+
+    assert payload["execution_backend"] == "ray_task"
+    assert payload["dynamic_batching"] is True
+    assert payload["dynamic_batch_size_min_rows"] == 1
+    assert payload["dynamic_batch_size_max_rows"] == 128 * 1024
+    assert payload["dynamic_batch_size_initial_rows"] == 256
+    assert "batch_size" not in payload
 
 
 def test_vane_function_batch_descriptor_binds_instance():

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -708,6 +708,69 @@ def test_ray_udf_lazy_output_defaults_to_enabled(duckdb_conn):
 
 
 @pytest.mark.gpu
+def test_ray_gpu_batch_udf_adapts_batch_limit_from_completion_latency(ray_runner, duckdb_conn, tmp_path):
+    pytest.importorskip("pyarrow")
+    import pyarrow as pa
+
+    if ray is None:
+        pytest.skip("ray not installed")
+    if float(ray.cluster_resources().get("GPU", 0.0)) < 1.0:
+        pytest.skip("requires a Ray cluster with at least one GPU resource")
+
+    class ObserveBatchRows:
+        def __call__(self, table):
+            rows = table.num_rows
+            return pa.table(
+                {
+                    "id": table.column("id"),
+                    "batch_rows": [rows] * rows,
+                }
+            )
+
+    input_path = tmp_path / "gpu_dynamic_batching.parquet"
+    duckdb_conn.execute(
+        f"""
+        COPY (
+            SELECT i::INTEGER AS id
+            FROM range(4096) t(i)
+        ) TO '{input_path!s}' (FORMAT PARQUET)
+        """
+    )
+    df = (
+        duckdb_conn.read_parquet(str(input_path))
+        .repartition(1)
+        .map_batches(
+            ObserveBatchRows,
+            schema={
+                "id": vane.sqltypes.INTEGER,
+                "batch_rows": vane.sqltypes.INTEGER,
+            },
+            execution_backend="ray_actor",
+            actor_number=1,
+            gpus=1,
+            batch_size=512,
+        )
+    )
+
+    parts = _run_iter_tables(ray_runner, df, "test_ray_e2e: GPU dynamic batching", timeout_s=60.0)
+    observed_batch_rows = set()
+    total_rows = 0
+    for part in parts:
+        table = part.to_arrow() if hasattr(part, "to_arrow") else part
+        if table.num_rows == 0:
+            continue
+        total_rows += table.num_rows
+        observed_batch_rows.update(table.column(1).to_pylist())
+
+    assert total_rows == 4096
+    assert 256 in observed_batch_rows
+    assert max(observed_batch_rows) <= 512
+    # A cold worker may initially contract while a warm worker expands. Either
+    # direction proves that a completion changed the initial 256-row limit.
+    assert observed_batch_rows != {256}
+
+
+@pytest.mark.gpu
 def test_ray_udf_lazy_output_input_passthrough_distributed(ray_runner, duckdb_conn, tmp_path):
     pytest.importorskip("pyarrow")
     import pyarrow as pa

--- a/tests/fast/test_udf.py
+++ b/tests/fast/test_udf.py
@@ -1032,6 +1032,15 @@ def test_map_batches_minimum_task_batch_size_validates_contract():
             batch_size=32,
             min_task_batch_size=16,
         )
+    with pytest.raises(vane.InvalidInputException, match="dynamically batched GPU UDFs"):
+        rel.map_batches(
+            identity,
+            schema={"x": vane.sqltypes.INTEGER},
+            execution_backend="ray_task",
+            gpus=1,
+            batch_size=32,
+            min_task_batch_size=32,
+        )
 
 
 def test_map_batches_can_preserve_compute_batch_output_boundaries():

--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -2628,6 +2628,66 @@ def test_udf_runtime_stream_output_default_uses_runtime_batch_size():
     assert executor.take_ready_result() is None
 
 
+@pytest.mark.parametrize(
+    ("extra", "match"),
+    [
+        ({"execution_backend": "subprocess_task", "gpus": 1.0}, "Ray execution backend"),
+        ({"execution_backend": "ray_task", "gpus": 0.0}, "positive 'gpus' value"),
+    ],
+)
+def test_udf_runtime_dynamic_batching_rejects_non_gpu_ray_contract(extra, match):
+    from vane.execution._udf_runtime import UDFExecutor
+
+    payload = _subprocess_map_payload(lambda table: table, dynamic_batching=True, **extra)
+
+    with pytest.raises(ValueError, match=match):
+        UDFExecutor(payload)
+
+
+def test_udf_runtime_ray_gpu_batch_rejects_static_fallback():
+    from vane.execution._udf_runtime import UDFExecutor
+
+    payload = _subprocess_map_payload(
+        lambda table: table,
+        execution_backend="ray_task",
+        gpus=1.0,
+    )
+
+    with pytest.raises(ValueError, match="requires dynamic_batching=True"):
+        UDFExecutor(payload)
+
+
+def test_udf_runtime_dynamic_batching_treats_scheduler_envelope_as_one_compute_batch():
+    from vane.execution._udf_runtime import UDFExecutor
+
+    def identity(table):
+        return pa.table(
+            {
+                "result": table.column("x"),
+                "batch_rows": [table.num_rows] * table.num_rows,
+            }
+        )
+
+    payload = _subprocess_map_payload(
+        identity,
+        execution_backend="ray_task",
+        gpus=1.0,
+        batch_size=10,
+        prebatched_input=False,
+        stream_output=True,
+        dynamic_batching=True,
+    )
+    executor = UDFExecutor(payload)
+    executor.submit(pa.table({"x": list(range(25))}))
+
+    output = executor.take_ready_result()
+
+    assert output is not None
+    assert output.num_rows == 25
+    assert output.column("batch_rows").to_pylist() == [25] * 25
+    assert executor.take_ready_result() is None
+
+
 def test_udf_runtime_stream_output_default_ignores_submit_and_method_batch_size():
     from vane.execution._udf_runtime import UDFExecutor
 

--- a/vane/_expression_udf.py
+++ b/vane/_expression_udf.py
@@ -1410,7 +1410,8 @@ def _func_batch(
     value with multiple fields and ``unnest=True`` to project those fields as
     separate columns. Retrying distributed backends may replay a batch after a
     failure. Exactly-once execution is not provided, so external effects must
-    be idempotent.
+    be idempotent. GPU execution uses latency-constrained dynamic batching;
+    ``batch_size`` is its maximum row count rather than a fixed batch size.
     """
     return lambda actual_fn: VaneBatchFunction(
         actual_fn,
@@ -1476,7 +1477,9 @@ def _cls_batch(
     retried after a failure; Actor reconstruction can additionally reset local
     state. Instance state is consequently reconstructible cache state rather
     than durable query state, and external effects must be idempotent because
-    execution is not exactly once.
+    execution is not exactly once. GPU execution uses latency-constrained
+    dynamic batching; ``batch_size`` is its maximum row count rather than a
+    fixed batch size.
     """
     return lambda actual_class: VaneClassBatch(
         actual_class,

--- a/vane/execution/_udf_runtime.py
+++ b/vane/execution/_udf_runtime.py
@@ -10,6 +10,7 @@ Supports ``map``, ``flat_map``, ``map_batches``, and ``map_batches_rows`` modes.
 from __future__ import annotations
 
 import inspect
+import math
 import os
 from collections import deque
 from collections.abc import Iterable
@@ -444,6 +445,37 @@ class UDFExecutor:
         self._call_mode = str(payload.get("call_mode") or "")
         if self._call_mode not in ("map_batches", "map_batches_rows", "flat_map", "map"):
             raise ValueError("UDF payload.call_mode must be one of: map_batches, map_batches_rows, flat_map, map")
+        self._execution_backend = str(payload.get("execution_backend") or "").strip().lower()
+        dynamic_batching = payload.get("dynamic_batching", False)
+        if not isinstance(dynamic_batching, bool):
+            raise ValueError("UDF payload field 'dynamic_batching' must be boolean")
+        gpus = payload.get("gpus")
+        is_positive_gpu = (
+            not isinstance(gpus, bool)
+            and isinstance(gpus, (int, float))
+            and math.isfinite(float(gpus))
+            and float(gpus) > 0.0
+        )
+        if (
+            self._call_mode in ("map_batches", "map_batches_rows")
+            and self._execution_backend in ("ray_task", "ray_actor")
+            and is_positive_gpu
+            and not dynamic_batching
+        ):
+            raise ValueError("Ray GPU batch UDF payload requires dynamic_batching=True")
+        if dynamic_batching:
+            if self._call_mode not in ("map_batches", "map_batches_rows"):
+                raise ValueError("dynamic GPU UDF batching requires a batch UDF")
+            if self._execution_backend not in ("ray_task", "ray_actor"):
+                raise ValueError("dynamic GPU UDF batching requires a Ray execution backend")
+            if (
+                isinstance(gpus, bool)
+                or not isinstance(gpus, (int, float))
+                or not math.isfinite(float(gpus))
+                or float(gpus) <= 0.0
+            ):
+                raise ValueError("dynamic GPU UDF batching requires a positive 'gpus' value")
+        self._dynamic_batching = dynamic_batching
 
         if self._call_mode == "map":
             self._init_scalar(payload, cache_callable=cache_callable, cache_max_entries=cache_max_entries)
@@ -484,9 +516,10 @@ class UDFExecutor:
         if not isinstance(preserve_compute_boundaries, bool):
             raise ValueError("UDF payload field 'preserve_compute_batch_boundaries' must be boolean")
         self._preserve_compute_batch_boundaries = preserve_compute_boundaries
-        # When C++ pre-batches input, skip Python re-batching.
-        self._prebatched_input = bool(payload.get("prebatched_input", False))
-        self._execution_backend = str(payload.get("execution_backend") or "").strip().lower()
+        # Dynamic GPU batches are sized by the C++ streaming scheduler. Treat
+        # every submitted envelope as one compute batch so the Python runtime
+        # cannot split it again using the configured maximum batch size.
+        self._prebatched_input = self._dynamic_batching or bool(payload.get("prebatched_input", False))
         can_flush_compute_tail = self._execution_backend in ("ray_task", "subprocess_task")
         self._input_batcher = (
             RuntimeInputBatcher(self._batch_size)


### PR DESCRIPTION
## Summary

- Add latency-constrained dynamic row batching for Ray task and Ray actor batch UDFs that request GPU resources. The scheduler starts with an exploratory envelope of up to 256 rows, learns from accepted-submission-to-completion latency, and adjusts toward a 5 s target within the user-provided `batch_size` upper bound (or the 131,072-row default). Existing hard byte limits remain in force.
- Carry a strict dynamic-batching contract through the physical payload and treat scheduler envelopes as prebatched in the Python executor, so a GPU UDF invocation is not split again below the scheduler. Reject `min_task_batch_size` and malformed/legacy Ray GPU batch payloads instead of silently using static batching; this intentionally provides no compatibility fallback.
- Document the new `batch_size` semantics and cover controller bounds, overflow, out-of-order completion, payload validation, executor behavior, CPU isolation, and a real-GPU end-to-end path.

The controller was independently implemented from Algorithm 2 in [Optimizing LLM Inference Throughput via Memory-aware and SLA-constrained Dynamic Batching](https://arxiv.org/abs/2503.05248). [Daft's controller](https://github.com/Eventual-Inc/Daft/blob/b2fba655a96fe8f2cc5c21915ddc81dbe9610d3a/src/daft-local-execution/src/dynamic_batching/latency_constrained_strategy.rs) and [UDF defaults](https://github.com/Eventual-Inc/Daft/blob/b2fba655a96fe8f2cc5c21915ddc81dbe9610d3a/src/daft-local-execution/src/intermediate_ops/udf.rs) at commit `b2fba655a96fe8f2cc5c21915ddc81dbe9610d3a` were used as behavioral references; no source code was copied.

Implementation and review were AI-assisted. The complete diff was iteratively reviewed, provenance was checked, and the behavior was independently validated with the checks below.

## Related issue

N/A

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Public Python docstrings for relation `map_batches` and batch-UDF decorators now describe `batch_size` as the dynamic GPU upper bound.

## Validation

- `export SKBUILD_BUILD_DIR="$PWD/build/python-release"; export SKBUILD_CMAKE_BUILD_TYPE=Release; uv pip install . --no-build-isolation` — incremental native build and non-editable install passed.
- `python -m pytest tests/fast/test_udf_process.py tests/fast/test_expression_udf_contracts.py tests/fast/test_expression_udf_map_batches.py tests/fast/test_udf.py tests/fast/test_udf_executor_lifecycle.py` — 504 passed.
- Focused strict-payload contract selection after the final validation change — 9 passed, 495 deselected.
- `build/native-cxx20/test/unittest '[dynamic-batching]'` — 8 test cases and 23 assertions passed.
- `python -m pytest tests/fast/test_ray_e2e.py::test_ray_gpu_batch_udf_adapts_batch_limit_from_completion_latency -m gpu` — passed on an NVIDIA GeForce RTX 2080 Ti (22,528 MiB, driver 570.207), using 4,096 rows, one Ray actor, one GPU, and a 512-row maximum.
- `scripts/run_release_tests.sh` — non-Ray shard: 517 passed, 4 skipped, 15 deselected; real-Ray shard: 11 passed, 525 deselected.
- `scripts/format workspace --changed --check` — passed.
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed, including Ruff, clang-format, mypy, secret, artifact, and conflict checks.
- `git diff --check` — passed.
- The root license policy reported `missing=0`. The full license helper then hit its existing DuckDB-path issue at `external/duckdb/benchmarking/__init__.py`; both new DuckDB files were manually verified to carry MIT SPDX headers, and the root changes retain Apache headers where required.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
