### PR TITLE
[perf](udf) Write terminal UDF output directly to Parquet

### DIFF
--- a/external/duckdb/extension/parquet/parquet_extension.cpp
+++ b/external/duckdb/extension/parquet/parquet_extension.cpp
@@ -88,6 +88,8 @@ struct ParquetWriteBindData : public TableFunctionData {
 	bool enable_bloom_filters = true;
 	//! What false positive rate are we willing to accept for bloom filters
 	double bloom_filter_false_positive_ratio = 0.01;
+	bool write_bloom_filter_option_set = false;
+	bool bloom_filter_false_positive_ratio_option_set = false;
 
 	//! After how many row groups to rotate to a new file
 	optional_idx row_groups_per_file;
@@ -102,6 +104,7 @@ struct ParquetWriteBindData : public TableFunctionData {
 
 	//! Which geo-parquet version to use when writing
 	GeoParquetVersion geoparquet_version = GeoParquetVersion::V1;
+	bool geoparquet_version_option_set = false;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<ParquetWriteBindData>();
@@ -116,12 +119,15 @@ struct ParquetWriteBindData : public TableFunctionData {
 		result->string_dictionary_page_size_limit = string_dictionary_page_size_limit;
 		result->enable_bloom_filters = enable_bloom_filters;
 		result->bloom_filter_false_positive_ratio = bloom_filter_false_positive_ratio;
+		result->write_bloom_filter_option_set = write_bloom_filter_option_set;
+		result->bloom_filter_false_positive_ratio_option_set = bloom_filter_false_positive_ratio_option_set;
 		result->row_groups_per_file = row_groups_per_file;
 		result->field_ids = field_ids.Copy();
 		result->shredding_types = shredding_types.Copy();
 		result->compression_level = compression_level;
 		result->parquet_version = parquet_version;
 		result->geoparquet_version = geoparquet_version;
+		result->geoparquet_version_option_set = geoparquet_version_option_set;
 		return unique_ptr<FunctionData>(std::move(result));
 	}
 };
@@ -317,12 +323,14 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 			bind_data->string_dictionary_page_size_limit = val;
 		} else if (loption == "write_bloom_filter") {
 			bind_data->enable_bloom_filters = BooleanValue::Get(option.second[0].DefaultCastAs(LogicalType::BOOLEAN));
+			bind_data->write_bloom_filter_option_set = true;
 		} else if (loption == "bloom_filter_false_positive_ratio") {
 			auto val = option.second[0].GetValue<double>();
 			if (val <= 0) {
 				throw BinderException("bloom_filter_false_positive_ratio must be greater than 0");
 			}
 			bind_data->bloom_filter_false_positive_ratio = val;
+			bind_data->bloom_filter_false_positive_ratio_option_set = true;
 		} else if (loption == "compression_level") {
 			const auto val = option.second[0].GetValue<int64_t>();
 			if (val < ZStdFileSystem::MinimumCompressionLevel() || val > ZStdFileSystem::MaximumCompressionLevel()) {
@@ -342,6 +350,7 @@ static unique_ptr<FunctionData> ParquetWriteBind(ClientContext &context, CopyFun
 				throw BinderException("Expected parquet_version 'V1' or 'V2'");
 			}
 		} else if (loption == "geoparquet_version") {
+			bind_data->geoparquet_version_option_set = true;
 			const auto roption = StringUtil::Upper(option.second[0].ToString());
 			if (roption == "NONE") {
 				bind_data->geoparquet_version = GeoParquetVersion::NONE;
@@ -394,6 +403,77 @@ static void ParquetWriteGetWrittenStatistics(ClientContext &context, FunctionDat
                                              GlobalFunctionData &gstate, CopyFunctionFileStatistics &statistics) {
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	global_state.writer->SetWrittenStatistics(statistics);
+}
+
+static Value ParquetArrowWriteOptions(const FunctionData &bind_data_p) {
+	auto &bind_data = bind_data_p.Cast<ParquetWriteBindData>();
+	if (!bind_data.kv_metadata.empty()) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support KV_METADATA");
+	}
+	if (bind_data.encryption_config) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support ENCRYPTION_CONFIG");
+	}
+	if (bind_data.field_ids.ids && !bind_data.field_ids.ids->empty()) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support FIELD_IDS");
+	}
+	if (bind_data.shredding_types.set) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support SHREDDING");
+	}
+	if (bind_data.row_group_size_bytes != NumericLimits<idx_t>::Maximum()) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support ROW_GROUP_SIZE_BYTES");
+	}
+	if (bind_data.row_groups_per_file.IsValid()) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support ROW_GROUPS_PER_FILE");
+	}
+	if (bind_data.dictionary_size_limit.IsValid()) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support DICTIONARY_SIZE_LIMIT");
+	}
+	if (bind_data.write_bloom_filter_option_set) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support WRITE_BLOOM_FILTER");
+	}
+	if (bind_data.bloom_filter_false_positive_ratio_option_set) {
+		throw NotImplementedException(
+		    "terminal UDF Arrow Parquet output does not support BLOOM_FILTER_FALSE_POSITIVE_RATIO");
+	}
+	if (bind_data.geoparquet_version_option_set) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support GEOPARQUET_VERSION");
+	}
+
+	string compression;
+	switch (bind_data.codec) {
+	case duckdb_parquet::CompressionCodec::UNCOMPRESSED:
+		compression = "none";
+		break;
+	case duckdb_parquet::CompressionCodec::SNAPPY:
+		compression = "snappy";
+		break;
+	case duckdb_parquet::CompressionCodec::GZIP:
+		compression = "gzip";
+		break;
+	case duckdb_parquet::CompressionCodec::ZSTD:
+		compression = "zstd";
+		break;
+	case duckdb_parquet::CompressionCodec::BROTLI:
+		compression = "brotli";
+		break;
+	case duckdb_parquet::CompressionCodec::LZ4_RAW:
+		compression = "lz4";
+		break;
+	default:
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support compression codec %d",
+		                              static_cast<int>(bind_data.codec));
+	}
+
+	child_list_t<Value> options;
+	options.emplace_back("compression", Value(compression));
+	options.emplace_back("row_group_size", Value::UBIGINT(bind_data.row_group_size));
+	options.emplace_back("dictionary_pagesize_limit", Value::UBIGINT(bind_data.string_dictionary_page_size_limit));
+	options.emplace_back("version", Value(bind_data.parquet_version == ParquetVersion::V2 ? "2.6" : "1.0"));
+	options.emplace_back("data_page_version", Value("1.0"));
+	if (bind_data.codec == duckdb_parquet::CompressionCodec::ZSTD) {
+		options.emplace_back("compression_level", Value::BIGINT(bind_data.compression_level));
+	}
+	return Value::STRUCT(std::move(options));
 }
 
 static void ParquetWriteSink(ExecutionContext &context, FunctionData &bind_data_p, GlobalFunctionData &gstate,
@@ -643,6 +723,12 @@ static void ParquetCopySerialize(Serializer &serializer, const FunctionData &bin
 	                                    default_value.geoparquet_version);
 	serializer.WritePropertyWithDefault<ShreddingType>(117, "shredding_types", bind_data.shredding_types,
 	                                                   default_value.shredding_types);
+	serializer.WritePropertyWithDefault(118, "write_bloom_filter_option_set", bind_data.write_bloom_filter_option_set,
+	                                    false);
+	serializer.WritePropertyWithDefault(119, "bloom_filter_false_positive_ratio_option_set",
+	                                    bind_data.bloom_filter_false_positive_ratio_option_set, false);
+	serializer.WritePropertyWithDefault(120, "geoparquet_version_option_set", bind_data.geoparquet_version_option_set,
+	                                    false);
 }
 
 static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserializer, CopyFunction &function) {
@@ -678,6 +764,12 @@ static unique_ptr<FunctionData> ParquetCopyDeserialize(Deserializer &deserialize
 	    deserializer.ReadPropertyWithExplicitDefault(116, "geoparquet_version", default_value.geoparquet_version);
 	data->shredding_types =
 	    deserializer.ReadPropertyWithExplicitDefault<ShreddingType>(117, "shredding_types", ShreddingType());
+	data->write_bloom_filter_option_set =
+	    deserializer.ReadPropertyWithExplicitDefault<bool>(118, "write_bloom_filter_option_set", false);
+	data->bloom_filter_false_positive_ratio_option_set =
+	    deserializer.ReadPropertyWithExplicitDefault<bool>(119, "bloom_filter_false_positive_ratio_option_set", false);
+	data->geoparquet_version_option_set =
+	    deserializer.ReadPropertyWithExplicitDefault<bool>(120, "geoparquet_version_option_set", false);
 
 	return std::move(data);
 }
@@ -914,6 +1006,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	function.copy_to_initialize_global = ParquetWriteInitializeGlobal;
 	function.copy_to_initialize_local = ParquetWriteInitializeLocal;
 	function.copy_to_get_written_statistics = ParquetWriteGetWrittenStatistics;
+	function.copy_to_get_arrow_write_options = ParquetArrowWriteOptions;
 	function.copy_to_sink = ParquetWriteSink;
 	function.copy_to_combine = ParquetWriteCombine;
 	function.copy_to_finalize = ParquetWriteFinalize;

--- a/external/duckdb/src/execution/distributed/pipeline_node/sink.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/sink.cpp
@@ -8,12 +8,124 @@
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/execution/operator/projection/physical_projection.hpp"
+#include "duckdb/execution/operator/projection/physical_udf_inout.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 #include <mutex>
 #include <unordered_map>
 
 namespace duckdb {
 namespace distributed {
+
+static bool ContainsStreamingUDF(const PhysicalOperator &op) {
+	if (op.type == PhysicalOperatorType::STREAMING_UDF) {
+		return true;
+	}
+	for (auto &child : op.children) {
+		if (ContainsStreamingUDF(child.get())) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool IsGeneratedUDFStructProjection(const PhysicalProjection &projection, const DistributedCopySpec &spec) {
+	if (projection.children.size() != 1 || projection.children[0].get().type != PhysicalOperatorType::STREAMING_UDF ||
+	    projection.select_list.size() != spec.names.size() || spec.names.size() != spec.expected_types.size()) {
+		return false;
+	}
+	for (idx_t i = 0; i < projection.select_list.size(); i++) {
+		auto &expression = projection.select_list[i];
+		if (!expression || expression->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION ||
+		    expression->return_type != spec.expected_types[i]) {
+			return false;
+		}
+		auto &function = expression->Cast<BoundFunctionExpression>();
+		if (!StringUtil::CIEquals(function.function.name, "struct_extract") || function.children.size() != 2 ||
+		    !function.children[0] || function.children[0]->GetExpressionClass() != ExpressionClass::BOUND_REF ||
+		    !function.children[1] || function.children[1]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+			return false;
+		}
+		auto &reference = function.children[0]->Cast<BoundReferenceExpression>();
+		auto &key = function.children[1]->Cast<BoundConstantExpression>().value;
+		if (reference.index != 0 || key.IsNull() || key.type().id() != LogicalTypeId::VARCHAR ||
+		    StringValue::Get(key) != spec.names[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static PhysicalStreamingUDF *FindTerminalStreamingUDF(PhysicalOperator &root, const DistributedCopySpec &spec) {
+	if (root.type == PhysicalOperatorType::STREAMING_UDF) {
+		return &root.Cast<PhysicalStreamingUDF>();
+	}
+	if (root.type == PhysicalOperatorType::PROJECTION) {
+		auto &projection = root.Cast<PhysicalProjection>();
+		if (IsGeneratedUDFStructProjection(projection, spec)) {
+			return &projection.children[0].get().Cast<PhysicalStreamingUDF>();
+		}
+	}
+	return nullptr;
+}
+
+static bool IsDefaultFilenamePattern(const FilenamePattern &pattern) {
+	static const string default_base = "data_";
+	return !pattern.HasUUID() && pattern.SerializeSegments().empty() && pattern.SerializeBase() == default_base &&
+	       pattern.SerializePos() == default_base.size();
+}
+
+static bool TryFuseTerminalUDFArrowSink(DuckPhysicalPlanRef &plan, DistributedCopySpec &spec,
+                                        const std::string &task_path) {
+	if (!spec.function.copy_to_get_arrow_write_options) {
+		return false;
+	}
+	auto &root = plan->Root();
+	auto terminal_udf = FindTerminalStreamingUDF(root, spec);
+	if (!terminal_udf) {
+		if (ContainsStreamingUDF(root)) {
+			throw NotImplementedException(
+			    "Arrow Parquet output requires the UDF to be the terminal relational operation");
+		}
+		return false;
+	}
+	if (spec.type != DistributedCopyType::COPY_TO_FILE) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support batch COPY");
+	}
+	if (spec.return_type == CopyFunctionReturnType::WRITTEN_FILE_STATISTICS) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support RETURN_STATS");
+	}
+	if (spec.partition_output) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support PARTITION_BY");
+	}
+	if (spec.rotate || spec.file_size_bytes.IsValid()) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support file rotation");
+	}
+	if (spec.overwrite_mode == CopyOverwriteMode::COPY_APPEND) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support APPEND");
+	}
+	if (!IsDefaultFilenamePattern(spec.filename_pattern)) {
+		throw NotImplementedException("terminal UDF Arrow Parquet output does not support FILENAME_PATTERN");
+	}
+	if (spec.file_extension.empty()) {
+		throw InvalidInputException("terminal UDF Arrow Parquet output requires a file extension");
+	}
+	if (!spec.bind_data) {
+		throw InvalidInputException("terminal UDF Arrow Parquet output requires copy bind data");
+	}
+	if (spec.names.empty() || spec.names.size() != spec.expected_types.size()) {
+		throw InvalidInputException("terminal UDF Arrow Parquet output requires a complete output schema");
+	}
+
+	auto writer_options = spec.function.copy_to_get_arrow_write_options(*spec.bind_data);
+	terminal_udf->ConfigureTerminalArrowParquetSink(task_path, spec.file_extension, std::move(writer_options),
+	                                                spec.names, spec.expected_types, spec.write_empty_file);
+	plan->SetRoot(*terminal_udf);
+	return true;
+}
 
 static DuckPhysicalPlanRef AppendCopyOperator(DuckPhysicalPlanRef plan, DistributedCopySpec spec,
                                               const std::string &task_path) {
@@ -22,6 +134,9 @@ static DuckPhysicalPlanRef AppendCopyOperator(DuckPhysicalPlanRef plan, Distribu
 	}
 	if (!spec.bind_data) {
 		throw InvalidInputException("CopySinkNode: copy bind_data is null");
+	}
+	if (TryFuseTerminalUDFArrowSink(plan, spec, task_path)) {
+		return plan;
 	}
 	auto &old_root = plan->Root();
 	auto worker_return_type = CopyFunctionReturnType::WRITTEN_FILE_STATISTICS;

--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -21,6 +21,7 @@
 #include "duckdb/execution/udf_executor.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/execution/external_block.hpp"
+#include "duckdb/function/copy_function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/function/function_serialization.hpp"
 #include "duckdb/function/scalar/udf_functions.hpp"
@@ -395,15 +396,21 @@ static bool IsRowPreservingPythonUDFLayoutPayload(const Value &payload);
 struct UDFOperatorState : public OperatorState {
 	UDFOperatorState(Value payload_p, shared_ptr<void> actor_handles_p = nullptr)
 	    : payload(std::move(payload_p)), actor_handles(std::move(actor_handles_p)) {
+		auto terminal_sink = GetStructBoolField(payload, "terminal_arrow_parquet_sink");
+		is_terminal_arrow_parquet_sink = terminal_sink.first && terminal_sink.second;
 		// is_flat_map = "result-only table UDF mode": no passthrough rows, output = UDF result only.
 		// row-preserving batch UDFs also carry output_schema, so classify by call_mode instead.
-		is_flat_map = ClassifyUDFMode(payload) == UDFMode::RESULT_ONLY_BATCH;
-		if (is_flat_map) {
+		is_flat_map = is_terminal_arrow_parquet_sink || ClassifyUDFMode(payload) == UDFMode::RESULT_ONLY_BATCH;
+		if (is_terminal_arrow_parquet_sink) {
+			output_names = GetCopyFunctionReturnNames(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
+			output_types_declared = GetCopyFunctionReturnLogicalTypes(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
+		} else if (is_flat_map) {
 			auto schema = ParsePayloadOutputSchema(payload);
 			output_names = std::move(schema.names);
 			output_types_declared = std::move(schema.types);
 		}
-		if (IsRowPreservingPythonUDFLayoutPayload(payload) && payload.type().id() == LogicalTypeId::STRUCT) {
+		if (!is_terminal_arrow_parquet_sink && IsRowPreservingPythonUDFLayoutPayload(payload) &&
+		    payload.type().id() == LogicalTypeId::STRUCT) {
 			auto &children = StructValue::GetChildren(payload);
 			auto child_count = StructType::GetChildCount(payload.type());
 			for (idx_t i = 0; i < child_count; i++) {
@@ -426,6 +433,7 @@ struct UDFOperatorState : public OperatorState {
 	idx_t submitted_batches = 0;
 	idx_t completed_batches = 0;
 	bool is_flat_map = false;
+	bool is_terminal_arrow_parquet_sink = false;
 	vector<string> output_names;
 	vector<LogicalType> output_types_declared;
 };
@@ -433,6 +441,9 @@ struct UDFOperatorState : public OperatorState {
 namespace {
 
 static bool UDFRequiresRowPreservingOutput(const UDFOperatorState &state) {
+	if (state.is_terminal_arrow_parquet_sink) {
+		return false;
+	}
 	if (!state.is_flat_map) {
 		return true;
 	}
@@ -2225,7 +2236,10 @@ static bool EnqueueStreamingDataEventLocked(StreamingUDFState &state, UDFOutputE
 		return false;
 	}
 
-	if (state.op->is_flat_map) {
+	if (state.op->is_terminal_arrow_parquet_sink) {
+		// The terminal writer already returns the six physical COPY statistics
+		// columns. Keep them flat so CopyFinishNode can parse them directly.
+	} else if (state.op->is_flat_map) {
 		PreserveFlatMapLazyOutputShape(*state.op, *event.ref_outputs);
 	} else {
 		PreserveScalarMapLazyOutputShape(*state.op, *event.ref_outputs);
@@ -2808,6 +2822,50 @@ static void FinishStreamingSubmissions(ClientContext &context, StreamingUDFState
 	state.op->executor->FinishedSubmitting(context);
 }
 
+static bool NeedsEmptyTerminalArrowParquetSink(const StreamingUDFState &state) {
+	if (state.submitted_batches.load(std::memory_order_relaxed) != 0 ||
+	    state.accepted_input_rows.load(std::memory_order_relaxed) != 0 || state.pending_rows != 0 ||
+	    state.reserved_rows != 0 || state.planned_submit.HasValue()) {
+		return false;
+	}
+	auto terminal_sink = GetStructBoolField(state.payload, "terminal_arrow_parquet_sink");
+	auto write_empty_file = GetStructBoolField(state.payload, "terminal_arrow_parquet_write_empty_file");
+	return terminal_sink.first && terminal_sink.second && write_empty_file.first && write_empty_file.second;
+}
+
+static bool TrySubmitEmptyTerminalArrowParquetSink(ExecutionContext &context, StreamingUDFState &state,
+                                                   const vector<LogicalType> &input_types,
+                                                   const unique_lock<mutex> &guard) {
+	state.VerifyLock(guard);
+	if (!NeedsEmptyTerminalArrowParquetSink(state)) {
+		return false;
+	}
+
+	EnsureStreamingExecutor(context, state, guard);
+	auto empty_input = make_uniq<DataChunk>();
+	empty_input->Initialize(context.client, input_types);
+	empty_input->SetCardinality(0);
+	vector<unique_ptr<DataChunk>> chunks;
+	chunks.push_back(std::move(empty_input));
+	idx_t submit_id = 0;
+	if (!TrySubmitMaterializedEnvelopeRaw(context, *state.op, chunks, 0, submit_id)) {
+		return false;
+	}
+
+	StreamingInflightBatch inflight;
+	inflight.submit_id = submit_id;
+	auto inserted = state.inflight_batches.emplace(submit_id, inflight);
+	if (!inserted.second) {
+		throw InternalException("streaming UDF duplicate empty sink submit_id %llu",
+		                        static_cast<unsigned long long>(submit_id));
+	}
+	state.max_active_batches =
+	    MaxValue<idx_t>(state.max_active_batches, static_cast<idx_t>(state.inflight_batches.size()));
+	state.submitted_batches.fetch_add(1);
+	StreamingUDFDebugState(state, "submit_empty_terminal_arrow_parquet_sink", true);
+	return true;
+}
+
 static void DriveStreamingAfterSinkFinished(ExecutionContext &context, StreamingUDFState &state,
                                             unique_lock<mutex> &guard) {
 	state.VerifyLock(guard);
@@ -2818,7 +2876,11 @@ static void DriveStreamingAfterSinkFinished(ExecutionContext &context, Streaming
 	ThrowIfStreamingError(state);
 	DriveStreamingSubmits(context, state, guard, true);
 	ThrowIfStreamingError(state);
-	if (state.pending_rows == 0) {
+	// An empty terminal COPY still owes one synthetic submit. Admission can
+	// temporarily block that submit, and the source may run while Finalize is
+	// asleep. Do not close the executor in that window: otherwise the
+	// dispatcher can report completion before the empty-file submit exists.
+	if (state.pending_rows == 0 && !NeedsEmptyTerminalArrowParquetSink(state)) {
 		FinishStreamingSubmissions(context.client, state);
 	}
 	if (StreamingTerminalReady(state)) {
@@ -2835,6 +2897,86 @@ PhysicalStreamingUDF::PhysicalStreamingUDF(PhysicalPlan &physical_plan, vector<L
     : PhysicalOperator(physical_plan, PhysicalOperatorType::STREAMING_UDF, std::move(types), estimated_cardinality),
       function(std::move(function_p)), bind_data(std::move(bind_data_p)), column_ids(std::move(column_ids_p)),
       projected_input(std::move(project_input_p)) {
+}
+
+void PhysicalStreamingUDF::ConfigureTerminalArrowParquetSink(string output_directory, string file_extension,
+                                                             Value writer_options, const vector<string> &expected_names,
+                                                             const vector<LogicalType> &expected_types,
+                                                             bool write_empty_file) {
+	if (!bind_data) {
+		throw InvalidInputException("terminal UDF Arrow Parquet sink requires UDF bind data");
+	}
+	if (expected_names.size() != expected_types.size()) {
+		throw InvalidInputException("terminal UDF Arrow Parquet sink schema name/type count mismatch");
+	}
+	auto &udf_bind = bind_data->Cast<UDFFunctionData>();
+	if (udf_bind.payload.IsNull() || udf_bind.payload.type().id() != LogicalTypeId::STRUCT) {
+		throw InvalidInputException("terminal UDF Arrow Parquet sink requires a STRUCT UDF payload");
+	}
+
+	auto sink_names = expected_names;
+	if (ClassifyUDFMode(udf_bind.payload) == UDFMode::RESULT_ONLY_BATCH) {
+		auto output_schema = ParsePayloadOutputSchema(udf_bind.payload);
+		if (output_schema.names.size() != expected_types.size() || output_schema.types != expected_types) {
+			throw InvalidInputException("terminal UDF Arrow Parquet sink output_schema does not match COPY types");
+		}
+		// A single-column result-only UDF can reach the physical root without
+		// the generated struct-extract projection. In that shape COPY's bound
+		// name is the UDF expression text, while the actual Arrow table uses
+		// the declared output_schema name.
+		sink_names = std::move(output_schema.names);
+	}
+
+	vector<Value> name_values;
+	vector<Value> type_values;
+	name_values.reserve(sink_names.size());
+	type_values.reserve(expected_types.size());
+	for (idx_t i = 0; i < sink_names.size(); i++) {
+		name_values.emplace_back(sink_names[i]);
+		type_values.emplace_back(expected_types[i].ToString());
+	}
+
+	udf_bind.payload = ReplaceStructFields(
+	    udf_bind.payload,
+	    {{"terminal_arrow_parquet_sink", Value::BOOLEAN(true)},
+	     {"terminal_arrow_parquet_output_directory", Value(std::move(output_directory))},
+	     {"terminal_arrow_parquet_file_extension", Value(std::move(file_extension))},
+	     {"terminal_arrow_parquet_writer_options", std::move(writer_options)},
+	     {"terminal_arrow_parquet_expected_names", Value::LIST(LogicalType::VARCHAR, std::move(name_values))},
+	     {"terminal_arrow_parquet_expected_types", Value::LIST(LogicalType::VARCHAR, std::move(type_values))},
+	     {"terminal_arrow_parquet_write_empty_file", Value::BOOLEAN(write_empty_file)}});
+	types = GetCopyFunctionReturnLogicalTypes(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
+	lock_guard<mutex> guard(streaming_state_lock);
+	streaming_state.reset();
+}
+
+bool PhysicalStreamingUDF::HasTerminalArrowParquetSink() const {
+	if (!bind_data) {
+		return false;
+	}
+	auto &payload = bind_data->Cast<UDFFunctionData>().payload;
+	auto value = GetStructBoolField(payload, "terminal_arrow_parquet_sink");
+	return value.first && value.second;
+}
+
+string PhysicalStreamingUDF::GetTerminalArrowParquetOutputDirectory() const {
+	if (!bind_data) {
+		return string();
+	}
+	auto &payload = bind_data->Cast<UDFFunctionData>().payload;
+	auto value = GetStructStringField(payload, "terminal_arrow_parquet_output_directory");
+	return value.first ? value.second : string();
+}
+
+void PhysicalStreamingUDF::SetTerminalArrowParquetOutputDirectory(string output_directory) {
+	if (!HasTerminalArrowParquetSink()) {
+		throw InvalidInputException("cannot patch output directory on a non-terminal UDF Arrow Parquet sink");
+	}
+	auto &udf_bind = bind_data->Cast<UDFFunctionData>();
+	udf_bind.payload = ReplaceStructFields(
+	    udf_bind.payload, {{"terminal_arrow_parquet_output_directory", Value(std::move(output_directory))}});
+	lock_guard<mutex> guard(streaming_state_lock);
+	streaming_state.reset();
 }
 
 std::shared_ptr<StreamingUDFState> PhysicalStreamingUDF::GetStreamingState(ClientContext &) const {
@@ -3049,6 +3191,11 @@ SinkFinalizeType PhysicalStreamingUDF::Finalize(Pipeline &pipeline, Event &, Cli
 	ThrowIfStreamingError(state);
 	state.sink_finished = true;
 	StreamingUDFDebugState(state, "finalize_sink", true);
+	if (NeedsEmptyTerminalArrowParquetSink(state) &&
+	    !TrySubmitEmptyTerminalArrowParquetSink(execution_context, state, children[0].get().types, guard)) {
+		StreamingUDFDebugState(state, "finalize_empty_terminal_arrow_parquet_sink_blocked", true);
+		return BlockStreamingFinalize(state, guard, input.interrupt_state);
+	}
 	DriveStreamingAfterSinkFinished(execution_context, state, guard);
 	if (StreamingTerminalReady(state)) {
 		PreventStreamingBlocking(state, guard);

--- a/external/duckdb/src/function/copy_function.cpp
+++ b/external/duckdb/src/function/copy_function.cpp
@@ -5,10 +5,10 @@ namespace duckdb {
 CopyFunction::CopyFunction(const string &name)
     : Function(name), plan(nullptr), copy_to_select(nullptr), copy_to_bind(nullptr), copy_options(nullptr),
       copy_to_initialize_local(nullptr), copy_to_initialize_global(nullptr), copy_to_get_written_statistics(nullptr),
-      copy_to_sink(nullptr), copy_to_combine(nullptr), copy_to_finalize(nullptr), execution_mode(nullptr),
-      initialize_operator(nullptr), prepare_batch(nullptr), flush_batch(nullptr), desired_batch_size(nullptr),
-      rotate_files(nullptr), rotate_next_file(nullptr), serialize(nullptr), deserialize(nullptr),
-      copy_from_bind(nullptr) {
+      copy_to_get_arrow_write_options(nullptr), copy_to_sink(nullptr), copy_to_combine(nullptr),
+      copy_to_finalize(nullptr), execution_mode(nullptr), initialize_operator(nullptr), prepare_batch(nullptr),
+      flush_batch(nullptr), desired_batch_size(nullptr), rotate_files(nullptr), rotate_next_file(nullptr),
+      serialize(nullptr), deserialize(nullptr), copy_from_bind(nullptr) {
 }
 
 CopyOption::CopyOption() : type(LogicalType::ANY), mode(CopyOptionMode::READ_WRITE) {

--- a/external/duckdb/src/include/duckdb/execution/operator/projection/physical_udf_inout.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/projection/physical_udf_inout.hpp
@@ -91,6 +91,13 @@ public:
 		return projected_input;
 	}
 
+	void ConfigureTerminalArrowParquetSink(string output_directory, string file_extension, Value writer_options,
+	                                       const vector<string> &expected_names,
+	                                       const vector<LogicalType> &expected_types, bool write_empty_file);
+	bool HasTerminalArrowParquetSink() const;
+	string GetTerminalArrowParquetOutputDirectory() const;
+	void SetTerminalArrowParquetOutputDirectory(string output_directory);
+
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
 	void SerializeOperatorData(Serializer &serializer) const override;
 

--- a/external/duckdb/src/include/duckdb/function/copy_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/copy_function.hpp
@@ -163,6 +163,10 @@ typedef bool (*copy_rotate_next_file_t)(GlobalFunctionData &gstate, FunctionData
 typedef void (*copy_to_get_written_statistics_t)(ClientContext &context, FunctionData &bind_data,
                                                  GlobalFunctionData &gstate, CopyFunctionFileStatistics &statistics);
 
+//! Return format-specific options for a terminal Arrow writer. Formats that
+//! do not support direct Arrow output leave this callback unset.
+typedef Value (*copy_to_get_arrow_write_options_t)(const FunctionData &bind_data);
+
 typedef vector<unique_ptr<Expression>> (*copy_to_select_t)(CopyToSelectInput &input);
 
 typedef void (*copy_to_initialize_operator_t)(GlobalFunctionData &gstate, const PhysicalOperator &op);
@@ -195,6 +199,7 @@ public:
 	copy_to_initialize_local_t copy_to_initialize_local;
 	copy_to_initialize_global_t copy_to_initialize_global;
 	copy_to_get_written_statistics_t copy_to_get_written_statistics;
+	copy_to_get_arrow_write_options_t copy_to_get_arrow_write_options;
 	copy_to_sink_t copy_to_sink;
 	copy_to_combine_t copy_to_combine;
 	copy_to_finalize_t copy_to_finalize;

--- a/src/vane_py/ray/native_fragment_executor.cpp
+++ b/src/vane_py/ray/native_fragment_executor.cpp
@@ -1006,9 +1006,13 @@ static void ApplyTaskLocalCopyOutput(duckdb::PhysicalPlan &plan, const CopyOutpu
 	// Determine which operator to modify
 	duckdb::PhysicalCopyToFile *copy_to_file = nullptr;
 	duckdb::PhysicalBatchCopyToFile *batch_copy = nullptr;
+	duckdb::PhysicalStreamingUDF *terminal_udf = nullptr;
 	std::string *file_path_ptr = nullptr;
 
-	if (root.type == duckdb::PhysicalOperatorType::COPY_TO_FILE) {
+	if (root.type == duckdb::PhysicalOperatorType::STREAMING_UDF &&
+	    root.Cast<duckdb::PhysicalStreamingUDF>().HasTerminalArrowParquetSink()) {
+		terminal_udf = &root.Cast<duckdb::PhysicalStreamingUDF>();
+	} else if (root.type == duckdb::PhysicalOperatorType::COPY_TO_FILE) {
 		copy_to_file = &root.Cast<duckdb::PhysicalCopyToFile>();
 		file_path_ptr = &copy_to_file->file_path;
 	} else if (root.type == duckdb::PhysicalOperatorType::BATCH_COPY_TO_FILE) {
@@ -1018,7 +1022,8 @@ static void ApplyTaskLocalCopyOutput(duckdb::PhysicalPlan &plan, const CopyOutpu
 		return; // Not a COPY operator
 	}
 
-	if (!duckdb::distributed::IsDistributedCopyOutputPlaceholder(*file_path_ptr)) {
+	auto template_path = terminal_udf ? terminal_udf->GetTerminalArrowParquetOutputDirectory() : *file_path_ptr;
+	if (!duckdb::distributed::IsDistributedCopyOutputPlaceholder(template_path)) {
 		return; // Not a distributed placeholder — nothing to do
 	}
 
@@ -1035,7 +1040,17 @@ static void ApplyTaskLocalCopyOutput(duckdb::PhysicalPlan &plan, const CopyOutpu
 
 	std::string task_dir;
 	if (direct_target_output) {
-		task_dir = info->remote_base;
+		if (terminal_udf) {
+			auto separator = std::string("/");
+			if (client_context) {
+				auto &fs = duckdb::FileSystem::GetFileSystem(*client_context);
+				separator = fs.PathSeparator(info->remote_base);
+			}
+			task_dir = duckdb::distributed::BuildCopyDirectWriteTaskDirectory(info->remote_base, info->run_id,
+			                                                                  worker_dir_name, separator);
+		} else {
+			task_dir = info->remote_base;
+		}
 	} else {
 		// Local FS: use staging directory
 		task_dir = info->base + "/" + info->run_id + "/" + worker_dir_name;
@@ -1047,6 +1062,11 @@ static void ApplyTaskLocalCopyOutput(duckdb::PhysicalPlan &plan, const CopyOutpu
 		if (!fs.DirectoryExists(task_dir)) {
 			fs.CreateDirectoriesRecursive(task_dir);
 		}
+	}
+
+	if (terminal_udf) {
+		terminal_udf->SetTerminalArrowParquetOutputDirectory(std::move(task_dir));
+		return;
 	}
 
 	// Build the actual output path (file or directory depending on spec)

--- a/src/vane_py/udf_executor.cpp
+++ b/src/vane_py/udf_executor.cpp
@@ -22,6 +22,7 @@
 #include "duckdb/common/types/arrow_aux_data.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/udf_executor.hpp"
+#include "duckdb/function/copy_function.hpp"
 #include "duckdb/function/scalar/udf_functions.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/main/config.hpp"
@@ -512,6 +513,7 @@ struct CollectorOutputLeaseCallbacks {
 
 struct PendingCollectorOutputLeaseCallback {
 	uint64_t slot_id;
+	bool completes_disposition = false;
 	std::function<void()> callback;
 };
 
@@ -1084,6 +1086,9 @@ struct ExecutorSlot {
 	// State flags
 	atomic<bool> finished_submitting_acked {false};
 	atomic<bool> all_tasks_finished {false};
+	// A collector DATA event cannot complete its slot until downstream has
+	// handed off its lease, or explicitly released an unconsumed lease.
+	atomic<idx_t> pending_output_lease_dispositions {0};
 	atomic<bool> cleanup_cancel_requested {false};
 	atomic<bool> collector_retired {false};
 	idx_t collector_cleanup_retry_count = 0;
@@ -1132,6 +1137,16 @@ static bool IsActiveSlotGeneration(const ExecutorSlot &slot, uint64_t generation
 static bool IsSlotRetiring(const ExecutorSlot &slot) {
 	auto state = slot.state.load();
 	return state == ExecutorSlotState::RETIRING || state == ExecutorSlotState::DETACHED;
+}
+
+static bool CompleteOutputLeaseDisposition(ExecutorSlot &slot) {
+	auto pending = slot.pending_output_lease_dispositions.load();
+	while (pending > 0) {
+		if (slot.pending_output_lease_dispositions.compare_exchange_weak(pending, pending - 1)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static void BeginSlotRetirement(ExecutorSlot &slot) {
@@ -1282,7 +1297,18 @@ public:
 		work_cv.notify_one();
 	}
 
-	void EnqueueOutputLeaseRelease(uint64_t slot_id, std::function<void()> release) {
+	bool TrackOutputLeaseDisposition(uint64_t slot_id) {
+		lock_guard<mutex> lifecycle_guard(global_lock);
+		auto entry = slots.find(slot_id);
+		if (entry == slots.end() || !IsSlotActive(*entry->second) ||
+		    !PayloadUsesRayStreamCollector(entry->second->payload)) {
+			return false;
+		}
+		entry->second->pending_output_lease_dispositions.fetch_add(1);
+		return true;
+	}
+
+	void EnqueueOutputLeaseRelease(uint64_t slot_id, bool completes_disposition, std::function<void()> release) {
 		if (!release) {
 			return;
 		}
@@ -1292,7 +1318,7 @@ public:
 				return;
 			}
 			lock_guard<mutex> lock(output_lease_release_lock);
-			output_lease_releases.push_back({slot_id, std::move(release)});
+			output_lease_releases.push_back({slot_id, completes_disposition, std::move(release)});
 		}
 		NotifyWork();
 	}
@@ -1408,7 +1434,11 @@ private:
 			releases.swap(output_lease_releases);
 		}
 		std::unordered_map<uint64_t, string> failures;
+		std::unordered_map<uint64_t, idx_t> completed_dispositions;
 		for (auto &release : releases) {
+			if (release.completes_disposition) {
+				completed_dispositions[release.slot_id]++;
+			}
 			if (!release.callback) {
 				continue;
 			}
@@ -1421,6 +1451,27 @@ private:
 			} catch (...) {
 				failures.emplace(release.slot_id, "udf output lease release failed with an unknown exception");
 			}
+		}
+		std::unordered_map<uint64_t, shared_ptr<ExecutorSlot>> disposition_slots;
+		for (auto &completion : completed_dispositions) {
+			shared_ptr<ExecutorSlot> slot;
+			{
+				lock_guard<mutex> guard(global_lock);
+				auto entry = slots.find(completion.first);
+				if (entry != slots.end()) {
+					slot = entry->second;
+				}
+			}
+			if (!slot) {
+				continue;
+			}
+			for (idx_t i = 0; i < completion.second; i++) {
+				if (!CompleteOutputLeaseDisposition(*slot) && IsSlotActive(*slot) && !slot->abort_requested.load()) {
+					failures.emplace(completion.first, "udf output lease disposition accounting underflow");
+					break;
+				}
+			}
+			disposition_slots.emplace(completion.first, std::move(slot));
 		}
 		for (auto &failure : failures) {
 			shared_ptr<ExecutorSlot> slot;
@@ -1437,6 +1488,11 @@ private:
 				// A retired slot has already fenced collector ownership. Its
 				// stale descriptor callback cannot affect a later query.
 				UDFDebugLog(failure.second);
+			}
+		}
+		for (auto &entry : disposition_slots) {
+			if (failures.find(entry.first) == failures.end() && entry.second && IsSlotActive(*entry.second)) {
+				MaybeMarkSlotFinished(*entry.second);
 			}
 		}
 		if (!releases.empty()) {
@@ -1575,7 +1631,7 @@ private:
 				if (!slot)
 					continue; // skip cleaned-up slots
 				if (IsSlotActive(*slot) && slot->finished_submitting_acked.load() && slot->inflight_count.load() == 0 &&
-				    !slot->all_tasks_finished.load()) {
+				    slot->pending_output_lease_dispositions.load() == 0 && !slot->all_tasks_finished.load()) {
 					slot->all_tasks_finished.store(true);
 					NotifySlotFinished(*slot);
 					did_work = true;
@@ -1956,6 +2012,7 @@ private:
 		slot.inflight_count.store(0);
 		slot.finished_submitting_acked.store(true);
 		slot.all_tasks_finished.store(true);
+		slot.pending_output_lease_dispositions.store(0);
 	}
 
 	bool CleanupSlot(uint64_t id) {
@@ -2211,6 +2268,7 @@ private:
 		slot.inflight_count.store(0);
 		slot.finished_submitting_acked.store(true);
 		slot.all_tasks_finished.store(true);
+		slot.pending_output_lease_dispositions.store(0);
 		slot.rows_by_submit_id.clear();
 		slot.ref_inputs_by_submit_id.clear();
 		return first_abort;
@@ -2241,7 +2299,8 @@ private:
 		if (slot.abort_requested.load() || slot.has_error.load()) {
 			return;
 		}
-		if (!slot.finished_submitting_acked.load() || slot.inflight_count.load() != 0) {
+		if (!slot.finished_submitting_acked.load() || slot.inflight_count.load() != 0 ||
+		    slot.pending_output_lease_dispositions.load() != 0) {
 			return;
 		}
 		bool expected = false;
@@ -3407,6 +3466,8 @@ struct CollectorOutputLeaseCallbackState {
 	mutex lock;
 	bool handed_off = false;
 	bool released = false;
+	bool disposition_callback_queued = false;
+	bool tracks_disposition = false;
 };
 
 static CollectorOutputLeaseCallbacks MakeCollectorOutputLeaseCallbacks(const py::object &collector, uint64_t slot_id,
@@ -3414,20 +3475,24 @@ static CollectorOutputLeaseCallbacks MakeCollectorOutputLeaseCallbacks(const py:
                                                                        const string &lease_id) {
 	auto collector_holder = MakePythonObjectHolder(py::reinterpret_borrow<py::object>(collector));
 	auto state = std::make_shared<CollectorOutputLeaseCallbackState>();
+	state->tracks_disposition = GlobalPythonDispatcher::Instance().TrackOutputLeaseDisposition(slot_id);
 	CollectorOutputLeaseCallbacks callbacks;
 	callbacks.handoff = [collector_holder, state, slot_id, request_id, lease_id]() {
+		bool completes_disposition = false;
 		{
 			lock_guard<mutex> guard(state->lock);
 			if (state->released || state->handed_off) {
 				return;
 			}
 			state->handed_off = true;
+			completes_disposition = state->tracks_disposition && !state->disposition_callback_queued;
+			state->disposition_callback_queued = true;
 		}
 		if (!PythonRuntimeUsableForUDFTeardown()) {
 			return;
 		}
 		GlobalPythonDispatcher::Instance().EnqueueOutputLeaseRelease(
-		    slot_id, [collector_holder, request_id, lease_id]() {
+		    slot_id, completes_disposition, [collector_holder, request_id, lease_id]() {
 			    auto collector_obj = BorrowPythonObjectHolder(collector_holder);
 			    if (collector_obj.is_none()) {
 				    return;
@@ -3436,18 +3501,21 @@ static CollectorOutputLeaseCallbacks MakeCollectorOutputLeaseCallbacks(const py:
 		    });
 	};
 	callbacks.release = [collector_holder, state, slot_id, request_id, lease_id]() {
+		bool completes_disposition = false;
 		{
 			lock_guard<mutex> guard(state->lock);
 			if (state->released) {
 				return;
 			}
 			state->released = true;
+			completes_disposition = state->tracks_disposition && !state->disposition_callback_queued;
+			state->disposition_callback_queued = true;
 		}
 		if (!PythonRuntimeUsableForUDFTeardown()) {
 			return;
 		}
 		GlobalPythonDispatcher::Instance().EnqueueOutputLeaseRelease(
-		    slot_id, [collector_holder, request_id, lease_id]() {
+		    slot_id, completes_disposition, [collector_holder, request_id, lease_id]() {
 			    auto collector_obj = BorrowPythonObjectHolder(collector_holder);
 			    if (collector_obj.is_none()) {
 				    return;
@@ -3877,8 +3945,15 @@ static unique_ptr<UDFExecutor> CreatePythonUDFExecutor(ClientContext &context, c
 	}
 
 	auto execution_payload = payload;
-	vector<LogicalType> output_types = ParseExpectedOutputTypes(execution_payload);
-	vector<LogicalType> ref_output_types = ParseStringListTypesField(execution_payload, "ref_output_types");
+	vector<LogicalType> output_types;
+	vector<LogicalType> ref_output_types;
+	if (GetStructBoolFlag(execution_payload, "terminal_arrow_parquet_sink")) {
+		output_types = GetCopyFunctionReturnLogicalTypes(CopyFunctionReturnType::WRITTEN_FILE_STATISTICS);
+		ref_output_types = output_types;
+	} else {
+		output_types = ParseExpectedOutputTypes(execution_payload);
+		ref_output_types = ParseStringListTypesField(execution_payload, "ref_output_types");
+	}
 	if (ref_output_types.empty()) {
 		throw InvalidInputException("UDF payload is missing ref_output_types");
 	}

--- a/tests/fast/test_function_udf_ray_task_resources.py
+++ b/tests/fast/test_function_udf_ray_task_resources.py
@@ -435,6 +435,68 @@ def test_materialized_task_publishes_unsplittable_row_for_soft_liveness():
     assert outputs[1]["block_id"] == "block:lease-oversized:0"
 
 
+def test_materialized_ray_task_writes_terminal_udf_output_with_arrow(tmp_path):
+    import pyarrow.parquet as pq
+
+    import vane.execution.udf_ray as fur
+    from vane import pickle as vane_pickle
+
+    def identity(table):
+        return table
+
+    output_directory = tmp_path / "ray-task-terminal-output"
+    payload = _distributed_payload(
+        function_pickle=vane_pickle.dumps(identity),
+        null_handling=1,
+        task_lease_id="lease-terminal-task",
+        attempt_id="attempt-terminal-task",
+        terminal_arrow_parquet_sink=True,
+        terminal_arrow_parquet_output_directory=str(output_directory),
+        terminal_arrow_parquet_file_extension="parquet",
+        terminal_arrow_parquet_writer_options={
+            "compression": "zstd",
+            "data_page_version": "1.0",
+            "dictionary_pagesize_limit": 1 << 20,
+            "row_group_size": 2,
+            "version": "1.0",
+        },
+        terminal_arrow_parquet_expected_names=["value"],
+        terminal_arrow_parquet_expected_types=["BIGINT"],
+        terminal_arrow_parquet_write_empty_file=True,
+    )
+
+    outputs = list(fur._iter_materialized_task_outputs(payload, [pa.table({"value": [1, 2, 3]})]))
+
+    assert len(outputs) == 2
+    statistics = outputs[0]
+    assert statistics.column("count").to_pylist() == [3]
+    output_path = statistics.column("filename")[0].as_py()
+    assert pq.read_table(output_path).to_pydict() == {"value": [1, 2, 3]}
+    assert "parquet-cpp-arrow" in str(pq.ParquetFile(output_path).metadata.created_by).lower()
+    assert outputs[1]["names"] == [
+        "filename",
+        "count",
+        "file_size_bytes",
+        "footer_size_bytes",
+        "column_statistics",
+        "partition_keys",
+    ]
+
+    empty_output_directory = tmp_path / "ray-task-terminal-empty-output"
+    empty_payload = dict(payload)
+    empty_payload["task_lease_id"] = "lease-terminal-task-empty"
+    empty_payload["terminal_arrow_parquet_output_directory"] = str(empty_output_directory)
+    empty_outputs = list(
+        fur._iter_materialized_task_outputs(
+            empty_payload,
+            [pa.table({"value": pa.array([], type=pa.int64())})],
+        )
+    )
+    assert len(empty_outputs) == 2
+    assert empty_outputs[0].column("count").to_pylist() == [0]
+    assert pq.read_table(empty_outputs[0].column("filename")[0].as_py()).schema == pa.schema([("value", pa.int64())])
+
+
 def test_actor_pool_requests_logical_memory_and_initializes_eagerly(monkeypatch):
     from vane.execution.udf_ray_actor_pool import UDFActorPoolBase
     from vane.runners.ray.query_runtime_protocol import RAY_ACTOR_INDEX_ENV

--- a/tests/fast/test_local_e2e.py
+++ b/tests/fast/test_local_e2e.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import builtins
 import sys
 
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
 import pytest
 
 import vane
@@ -59,6 +62,339 @@ def test_local_runner_write_parquet_e2e(local_runner, tmp_path, monkeypatch):
         con.close()
 
     assert rows == (80, 3960, 0, 4)
+
+
+@pytest.mark.parametrize("execution_backend", ["subprocess_task", "subprocess_actor"])
+def test_local_runner_terminal_udf_writes_parquet_with_arrow(local_runner, tmp_path, monkeypatch, execution_backend):
+    src = tmp_path / f"terminal_udf_input_{execution_backend}.parquet"
+    dst = tmp_path / f"terminal_udf_output_{execution_backend}.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(257) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def transform(table):
+        return pa.table(
+            {
+                "x": table["x"],
+                "doubled": pc.multiply(table["x"], pa.scalar(2, type=pa.int32())),
+            }
+        )
+
+    class Transform:
+        def __call__(self, table):
+            return transform(table)
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        udf_options = {"actor_number": 1, "gpus": 0.0} if execution_backend == "subprocess_actor" else {}
+        udf = Transform if execution_backend == "subprocess_actor" else transform
+        relation = (
+            con.read_parquet(str(src))
+            .repartition(4)
+            .map_batches(
+                udf,
+                schema={"x": vane.sqltypes.INTEGER, "doubled": vane.sqltypes.INTEGER},
+                execution_backend=execution_backend,
+                batch_size=64,
+                **udf_options,
+            )
+        )
+        relation.write_parquet(str(dst), compression="zstd", row_group_size=32)
+        rows = con.sql(f"select count(*), sum(x), sum(doubled) from read_parquet('{dst}')").fetchone()
+    finally:
+        con.close()
+
+    parquet_files = [dst] if dst.is_file() else sorted(dst.rglob("*.parquet"))
+    parquet_metadata = [pq.ParquetFile(path).metadata for path in parquet_files]
+    assert rows == (257, 32896, 65792)
+    assert len(parquet_files) >= 4
+    assert all(metadata.num_rows > 0 for metadata in parquet_metadata)
+    assert all("parquet-cpp-arrow" in str(metadata.created_by).lower() for metadata in parquet_metadata)
+    assert all(metadata.format_version == "1.0" for metadata in parquet_metadata)
+    assert all(
+        0 < metadata.row_group(index).num_rows <= 32
+        for metadata in parquet_metadata
+        for index in range(metadata.num_row_groups)
+    )
+    assert all(
+        metadata.row_group(index).column(0).compression == "ZSTD"
+        for metadata in parquet_metadata
+        for index in range(metadata.num_row_groups)
+    )
+
+
+@pytest.mark.parametrize("execution_backend", ["subprocess_task", "subprocess_actor"])
+def test_local_runner_terminal_flat_map_streams_to_parquet(local_runner, tmp_path, monkeypatch, execution_backend):
+    src = tmp_path / f"terminal_flat_map_input_{execution_backend}.parquet"
+    dst = tmp_path / f"terminal_flat_map_output_{execution_backend}.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(5) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def expand(row):
+        for value in range(row["x"] + 1):
+            yield {"x": row["x"], "value": value}
+
+    class Expand:
+        def __call__(self, row):
+            yield from expand(row)
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        udf_options = {"actor_number": 1, "gpus": 0.0} if execution_backend == "subprocess_actor" else {}
+        udf = Expand if execution_backend == "subprocess_actor" else expand
+        relation = con.read_parquet(str(src)).flat_map(
+            udf,
+            schema={"x": vane.sqltypes.INTEGER, "value": vane.sqltypes.INTEGER},
+            execution_backend=execution_backend,
+            **udf_options,
+        )
+        relation.write_parquet(str(dst), row_group_size=4)
+        rows = con.sql(f"select count(*), sum(x), sum(value) from read_parquet('{dst}')").fetchone()
+    finally:
+        con.close()
+
+    assert rows == (15, 40, 20)
+    parquet_files = [dst] if dst.is_file() else sorted(dst.rglob("*.parquet"))
+    assert parquet_files
+    assert all("parquet-cpp-arrow" in str(pq.ParquetFile(path).metadata.created_by).lower() for path in parquet_files)
+
+
+@pytest.mark.parametrize("execution_backend", ["subprocess_task", "subprocess_actor"])
+def test_local_runner_terminal_flat_map_writes_empty_parquet(local_runner, tmp_path, monkeypatch, execution_backend):
+    src = tmp_path / f"terminal_empty_flat_map_input_{execution_backend}.parquet"
+    dst = tmp_path / f"terminal_empty_flat_map_output_{execution_backend}.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(5) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def drop_all(row):
+        if False:
+            yield row
+
+    class DropAll:
+        def __call__(self, row):
+            if False:
+                yield row
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        udf_options = {"actor_number": 1, "gpus": 0.0} if execution_backend == "subprocess_actor" else {}
+        udf = DropAll if execution_backend == "subprocess_actor" else drop_all
+        relation = con.read_parquet(str(src)).flat_map(
+            udf,
+            schema={"x": vane.sqltypes.INTEGER},
+            execution_backend=execution_backend,
+            **udf_options,
+        )
+        relation.write_parquet(str(dst))
+        rows = con.sql(f"select count(*) from read_parquet('{dst}')").fetchone()
+    finally:
+        con.close()
+
+    parquet_files = [dst] if dst.is_file() else sorted(dst.rglob("*.parquet"))
+    assert rows == (0,)
+    assert parquet_files
+    assert all("parquet-cpp-arrow" in str(pq.ParquetFile(path).metadata.created_by).lower() for path in parquet_files)
+
+
+@pytest.mark.parametrize("execution_backend", ["subprocess_task", "subprocess_actor"])
+def test_local_runner_terminal_udf_writes_empty_parquet(local_runner, tmp_path, monkeypatch, execution_backend):
+    src = tmp_path / f"terminal_udf_empty_input_{execution_backend}.parquet"
+    dst = tmp_path / f"terminal_udf_empty_output_{execution_backend}.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(0) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def transform(table):
+        raise AssertionError("the UDF must not be called for empty input")
+
+    class Transform:
+        def __call__(self, table):
+            raise AssertionError("the UDF must not be called for empty input")
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        udf_options = {"actor_number": 1, "gpus": 0.0} if execution_backend == "subprocess_actor" else {}
+        udf = Transform if execution_backend == "subprocess_actor" else transform
+        relation = con.read_parquet(str(src)).map_batches(
+            udf,
+            schema={"x": vane.sqltypes.INTEGER},
+            execution_backend=execution_backend,
+            **udf_options,
+        )
+        relation.write_parquet(str(dst))
+        rows = con.sql(f"select count(*) from read_parquet('{dst}')").fetchone()
+    finally:
+        con.close()
+
+    parquet_files = [dst] if dst.is_file() else sorted(dst.rglob("*.parquet"))
+    assert rows == (0,)
+    assert len(parquet_files) == 1
+    assert "parquet-cpp-arrow" in str(pq.ParquetFile(parquet_files[0]).metadata.created_by).lower()
+    assert pq.read_schema(parquet_files[0]).names == ["x"]
+
+
+def test_local_runner_terminal_udf_writes_through_local_staging(local_runner, tmp_path, monkeypatch):
+    src = tmp_path / "terminal_udf_staging_input.parquet"
+    dst = tmp_path / "terminal_udf_staging_output.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(5) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def identity(table):
+        return table
+
+    monkeypatch.setenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", "1")
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        relation = con.read_parquet(str(src)).map_batches(
+            identity,
+            schema={"x": vane.sqltypes.INTEGER},
+            execution_backend="subprocess_task",
+            batch_size=2,
+        )
+        relation.write_parquet(str(dst))
+        rows = con.sql(f"select x from read_parquet('{dst}') order by x").fetchall()
+    finally:
+        con.close()
+
+    parquet_files = [dst] if dst.is_file() else sorted(dst.rglob("*.parquet"))
+    assert rows == [(0,), (1,), (2,), (3,), (4,)]
+    assert parquet_files
+    assert all("parquet-cpp-arrow" in str(pq.ParquetFile(path).metadata.created_by).lower() for path in parquet_files)
+    assert not (tmp_path / "terminal_udf_staging_output.parquet.duckdb_staging").exists()
+
+
+@pytest.mark.parametrize("execution_backend", ["subprocess_task", "subprocess_actor"])
+def test_local_runner_terminal_scalar_udf_writes_parquet(local_runner, tmp_path, monkeypatch, execution_backend):
+    src = tmp_path / f"terminal_scalar_udf_input_{execution_backend}.parquet"
+    dst = tmp_path / f"terminal_scalar_udf_output_{execution_backend}.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(5) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def plus_one(value):
+        return value + 1
+
+    class PlusOne:
+        def __call__(self, value):
+            return value + 1
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        udf_options = {"actor_number": 1, "gpus": 0.0} if execution_backend == "subprocess_actor" else {}
+        udf = PlusOne if execution_backend == "subprocess_actor" else plus_one
+        relation = con.read_parquet(str(src)).map(
+            udf,
+            return_type=vane.sqltypes.INTEGER,
+            execution_backend=execution_backend,
+            **udf_options,
+        )
+        relation.write_parquet(str(dst))
+        rows = con.sql(f"select x, value from read_parquet('{dst}') order by x").fetchall()
+    finally:
+        con.close()
+
+    assert rows == [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
+
+
+@pytest.mark.parametrize(
+    ("write_options", "message"),
+    [
+        ({"per_thread_output": True, "filename_pattern": "custom_{uuid}"}, "FILENAME_PATTERN"),
+        ({"append": True}, "APPEND"),
+        ({"field_ids": "auto"}, "FIELD_IDS"),
+        ({"partition_by": ["x"], "write_partition_columns": True}, "PARTITION_BY"),
+        ({"file_size_bytes": "1MB"}, "file rotation"),
+    ],
+)
+def test_local_runner_terminal_udf_rejects_unsupported_copy_options(
+    local_runner,
+    tmp_path,
+    monkeypatch,
+    write_options,
+    message,
+):
+    src = tmp_path / "terminal_udf_filename_pattern_input.parquet"
+    dst = tmp_path / "terminal_udf_filename_pattern_output"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(1) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def identity(table):
+        return table
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        relation = con.read_parquet(str(src)).map_batches(
+            identity,
+            schema={"x": vane.sqltypes.INTEGER},
+            execution_backend="subprocess_task",
+        )
+        with pytest.raises(ValueError, match=rf"does not support {message}"):
+            relation.write_parquet(str(dst), **write_options)
+    finally:
+        con.close()
+
+
+def test_local_runner_rejects_nonterminal_udf_arrow_parquet_output(local_runner, tmp_path, monkeypatch):
+    src = tmp_path / "nonterminal_udf_input.parquet"
+    dst = tmp_path / "nonterminal_udf_output.parquet"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    setup_conn = vane.connect()
+    try:
+        setup_conn.sql("select i::integer as x from range(2) tbl(i)").write_parquet(str(src))
+    finally:
+        setup_conn.close()
+
+    def identity(table):
+        return table
+
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    con = vane.connect()
+    try:
+        relation = (
+            con.read_parquet(str(src))
+            .map_batches(
+                identity,
+                schema={"x": vane.sqltypes.INTEGER},
+                execution_backend="subprocess_task",
+            )
+            .filter("x > 0")
+        )
+        with pytest.raises(ValueError, match="requires the UDF to be the terminal relational operation"):
+            relation.write_parquet(str(dst))
+    finally:
+        con.close()
 
 
 def test_local_runner_direct_target_per_thread_output_allows_sequential_partitions(tmp_path, monkeypatch):

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -2684,6 +2684,70 @@ def test_ray_python_udf_map_batches_arrow(ray_runner, duckdb_conn, parquet_path)
     _assert_results_match(duckdb_conn, sql, parts, label)
 
 
+@pytest.mark.parametrize("execution_backend", ["ray_task", "ray_actor"])
+def test_ray_terminal_udf_writes_parquet_with_arrow(
+    ray_runner,
+    duckdb_conn,
+    tmp_path,
+    execution_backend,
+):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    if ray is None:
+        pytest.skip("ray not installed")
+
+    input_path = tmp_path / f"terminal_udf_{execution_backend}_input.parquet"
+    output_path = tmp_path / f"terminal_udf_{execution_backend}_output.parquet"
+    duckdb_conn.execute(f"COPY (SELECT i::BIGINT AS x FROM range(17) t(i)) TO '{input_path!s}' (FORMAT PARQUET)")
+
+    def transform(table):
+        import pyarrow as worker_pa
+        import pyarrow.compute as pc
+
+        return worker_pa.table(
+            {
+                "x": table.column("x"),
+                "doubled": pc.multiply(table.column("x"), 2),
+            }
+        )
+
+    class Transform:
+        def __call__(self, table):
+            return transform(table)
+
+    udf = Transform if execution_backend == "ray_actor" else transform
+    backend_options = {"actor_number": 1} if execution_backend == "ray_actor" else {}
+    relation = (
+        duckdb_conn.read_parquet(str(input_path))
+        .repartition(2)
+        .map_batches(
+            udf,
+            schema={"x": vane.sqltypes.BIGINT, "doubled": vane.sqltypes.BIGINT},
+            execution_backend=execution_backend,
+            batch_size=4,
+            **backend_options,
+        )
+    )
+
+    relation.write_parquet(str(output_path), compression="zstd", row_group_size=3)
+
+    rows = duckdb_conn.sql(
+        f"SELECT count(*), sum(x)::BIGINT, sum(doubled)::BIGINT FROM read_parquet('{output_path!s}')"
+    ).fetchone()
+    parquet_files = [output_path] if output_path.is_file() else sorted(output_path.rglob("*.parquet"))
+    metadata = [pq.ParquetFile(path).metadata for path in parquet_files]
+    assert rows == (17, 136, 272)
+    assert parquet_files
+    assert all("parquet-cpp-arrow" in str(item.created_by).lower() for item in metadata)
+    assert all(0 < item.row_group(index).num_rows <= 3 for item in metadata for index in range(item.num_row_groups))
+    assert all(
+        item.row_group(index).column(0).compression == "ZSTD"
+        for item in metadata
+        for index in range(item.num_row_groups)
+    )
+    assert pa.concat_tables([pq.read_table(path) for path in parquet_files]).num_rows == 17
+
+
 def test_ray_task_credit_admission_runs_multiple_batches_concurrently(
     ray_runner,
     duckdb_conn,

--- a/tests/fast/test_udf_arrow_parquet_sink.py
+++ b/tests/fast/test_udf_arrow_parquet_sink.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from vane.execution.udf_arrow_parquet_sink import write_terminal_arrow_parquet_output
+
+
+def _sink_payload(output_directory, *, write_empty_file=True):
+    return {
+        "terminal_arrow_parquet_sink": True,
+        "terminal_arrow_parquet_output_directory": str(output_directory),
+        "terminal_arrow_parquet_file_extension": "parquet",
+        "terminal_arrow_parquet_writer_options": {
+            "compression": "zstd",
+            "compression_level": 3,
+            "data_page_version": "1.0",
+            "dictionary_pagesize_limit": 1 << 20,
+            "row_group_size": 2,
+            "version": "1.0",
+        },
+        "terminal_arrow_parquet_expected_names": ["x", "label"],
+        "terminal_arrow_parquet_expected_types": ["INTEGER", "VARCHAR"],
+        "terminal_arrow_parquet_write_empty_file": write_empty_file,
+    }
+
+
+def test_terminal_arrow_parquet_sink_writes_one_file_and_copy_statistics(tmp_path):
+    payload = _sink_payload(tmp_path / "output")
+    statistics = write_terminal_arrow_parquet_output(
+        payload,
+        (
+            pa.table({"x": pa.array([1], type=pa.int32()), "label": ["a"]}),
+            pa.table({"x": pa.array([2], type=pa.int32()), "label": ["b"]}),
+            pa.table({"x": pa.array([3], type=pa.int32()), "label": ["c"]}),
+        ),
+        invocation_id="lease:1",
+    )
+
+    assert statistics.schema.names == [
+        "filename",
+        "count",
+        "file_size_bytes",
+        "footer_size_bytes",
+        "column_statistics",
+        "partition_keys",
+    ]
+    assert statistics.column("count").to_pylist() == [3]
+    output_path = statistics.column("filename")[0].as_py()
+    assert statistics.column("file_size_bytes")[0].as_py() > 0
+    assert statistics.column("footer_size_bytes")[0].as_py() > 0
+    assert statistics.column("column_statistics")[0].as_py() == []
+    assert statistics.column("partition_keys")[0].as_py() == []
+    assert pq.read_table(output_path).to_pydict() == {"x": [1, 2, 3], "label": ["a", "b", "c"]}
+    metadata = pq.ParquetFile(output_path).metadata
+    assert "parquet-cpp-arrow" in str(metadata.created_by).lower()
+    assert metadata.format_version == "1.0"
+    assert metadata.num_row_groups == 2
+    assert [metadata.row_group(index).num_rows for index in range(metadata.num_row_groups)] == [2, 1]
+
+
+def test_terminal_arrow_parquet_sink_honors_no_empty_file(tmp_path):
+    output_directory = tmp_path / "empty-output"
+    payload = _sink_payload(output_directory, write_empty_file=False)
+    empty = pa.table(
+        {
+            "x": pa.array([], type=pa.int32()),
+            "label": pa.array([], type=pa.string()),
+        }
+    )
+
+    statistics = write_terminal_arrow_parquet_output(payload, (empty,), invocation_id="lease:empty")
+
+    assert statistics.num_rows == 0
+    assert not output_directory.exists()
+
+
+def test_terminal_arrow_parquet_sink_writes_schema_only_file_for_empty_input(tmp_path):
+    output_directory = tmp_path / "empty-output"
+    payload = _sink_payload(output_directory)
+
+    statistics = write_terminal_arrow_parquet_output(payload, (), invocation_id="lease:empty")
+
+    assert statistics.column("count").to_pylist() == [0]
+    output_path = statistics.column("filename")[0].as_py()
+    assert pq.read_schema(output_path) == pa.schema([("x", pa.int32()), ("label", pa.string())])
+    assert pq.read_table(output_path).num_rows == 0
+
+
+def test_terminal_arrow_parquet_sink_rejects_schema_mismatch(tmp_path):
+    payload = _sink_payload(tmp_path / "output")
+
+    with pytest.raises(ValueError, match="output columns do not match COPY schema"):
+        write_terminal_arrow_parquet_output(
+            payload,
+            (pa.table({"wrong": [1], "label": ["a"]}),),
+            invocation_id="lease:bad-schema",
+        )
+
+
+def test_terminal_arrow_parquet_sink_renames_internal_row_preserving_columns(tmp_path):
+    payload = _sink_payload(tmp_path / "output")
+    payload.update({"call_mode": "map", "scalar_arg_count": 1})
+
+    statistics = write_terminal_arrow_parquet_output(
+        payload,
+        (pa.table({"c1": pa.array([1], type=pa.int32()), "value": ["a"]}),),
+        invocation_id="lease:row-preserving",
+    )
+
+    output_path = statistics.column("filename")[0].as_py()
+    assert pq.read_table(output_path).to_pydict() == {"x": [1], "label": ["a"]}
+
+
+def test_terminal_arrow_parquet_sink_honors_file_extension(tmp_path):
+    payload = _sink_payload(tmp_path / "output")
+    payload["terminal_arrow_parquet_file_extension"] = "pq"
+
+    statistics = write_terminal_arrow_parquet_output(
+        payload,
+        (pa.table({"x": pa.array([1], type=pa.int32()), "label": ["a"]}),),
+        invocation_id="lease:extension",
+    )
+
+    output_path = statistics.column("filename")[0].as_py()
+    assert output_path.endswith(".pq")
+    assert pq.read_table(output_path).to_pydict() == {"x": [1], "label": ["a"]}

--- a/tests/fast/test_udf_process.py
+++ b/tests/fast/test_udf_process.py
@@ -1724,6 +1724,9 @@ def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
         from vane.execution.ref_bundle import make_local_shm_ref_bundle_result
 
         both_tracked = threading.Event()
+        bad_handoff_entered = threading.Event()
+        allow_bad_handoff_failure = threading.Event()
+        bad_query_finished = threading.Event()
         good_handoff = threading.Event()
 
 
@@ -1796,6 +1799,9 @@ def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
 
             def handoff_output_block_lease(self, request_id, _lease_id):
                 if str(request_id) == "output-request:bad":
+                    bad_handoff_entered.set()
+                    if not allow_bad_handoff_failure.wait(timeout=10):
+                        raise RuntimeError("timed out waiting to release bad output lease handoff")
                     raise RuntimeError("planned output lease handoff failure")
                 good_handoff.set()
                 return True
@@ -1891,6 +1897,8 @@ def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
                 bad_relation.fetchall()
             except BaseException as exc:
                 bad_errors.append(exc)
+            finally:
+                bad_query_finished.set()
 
 
         def run_good():
@@ -1906,9 +1914,14 @@ def test_output_lease_callback_failure_isolated_to_owning_ray_slot():
         bad_thread.start()
         good_thread.start()
         barrier.wait()
+        handoff_started = bad_handoff_entered.wait(timeout=10)
+        query_finished_before_handoff = bad_query_finished.wait(timeout=0.25)
+        allow_bad_handoff_failure.set()
         bad_thread.join(timeout=10)
         good_thread.join(timeout=10)
         try:
+            assert handoff_started, "failing output lease handoff did not start"
+            assert not query_finished_before_handoff, "bad query finished before its output lease handoff"
             assert not bad_thread.is_alive(), "failing Ray slot did not terminate"
             assert not good_thread.is_alive(), "healthy Ray slot did not terminate"
             assert bad_errors, (bad_errors, good_errors, good_results)

--- a/tests/fast/test_udf_ray_actor_row_preserving.py
+++ b/tests/fast/test_udf_ray_actor_row_preserving.py
@@ -228,6 +228,68 @@ def test_actor_rows_mode_reuses_executor_across_calls(fake_ray):
     assert second[0].to_pydict() == {"keep": ["b"], "y": [6]}
 
 
+def test_precreated_actor_uses_task_terminal_arrow_parquet_payload(fake_ray, tmp_path):
+    import pyarrow.parquet as pq
+
+    actor = _make_actor(_rows_payload(_AddOne))
+    output_directory = tmp_path / "ray-actor-terminal-output"
+    task_payload = {
+        "terminal_arrow_parquet_sink": True,
+        "terminal_arrow_parquet_output_directory": str(output_directory),
+        "terminal_arrow_parquet_file_extension": "parquet",
+        "terminal_arrow_parquet_writer_options": {
+            "compression": "zstd",
+            "data_page_version": "1.0",
+            "dictionary_pagesize_limit": 1 << 20,
+            "row_group_size": 2,
+            "version": "1.0",
+        },
+        "terminal_arrow_parquet_expected_names": ["keep", "y"],
+        "terminal_arrow_parquet_expected_types": ["VARCHAR", "INTEGER"],
+        "terminal_arrow_parquet_write_empty_file": True,
+    }
+
+    blocks = _data_blocks(
+        list(
+            actor.run_block_stream(
+                pa.table({"x": [1, 2, 3], "keep": ["a", "b", "c"]}),
+                payload=task_payload,
+            )
+        )
+    )
+
+    assert len(blocks) == 1
+    statistics = blocks[0]
+    assert statistics.column("count").to_pylist() == [3]
+    output_path = statistics.column("filename")[0].as_py()
+    assert str(output_path).startswith(str(output_directory))
+    assert pq.read_table(output_path).to_pydict() == {
+        "keep": ["a", "b", "c"],
+        "y": [2, 3, 4],
+    }
+
+    empty_output_directory = tmp_path / "ray-actor-terminal-empty-output"
+    empty_payload = dict(task_payload)
+    empty_payload["terminal_arrow_parquet_output_directory"] = str(empty_output_directory)
+    empty_blocks = _data_blocks(
+        list(
+            actor.run_block_stream(
+                pa.table(
+                    {
+                        "x": pa.array([], type=pa.int64()),
+                        "keep": pa.array([], type=pa.string()),
+                    }
+                ),
+                payload=empty_payload,
+            )
+        )
+    )
+    assert len(empty_blocks) == 1
+    assert empty_blocks[0].column("count").to_pylist() == [0]
+    empty_output_path = empty_blocks[0].column("filename")[0].as_py()
+    assert pq.read_table(empty_output_path).schema == pa.schema([("keep", pa.string()), ("y", pa.int32())])
+
+
 def test_reconstructed_actor_reconciles_new_node_before_user_code(fake_ray, monkeypatch):
     from vane.runners.ray.query_runtime_protocol import (
         RAY_ACTOR_GENERATION_CAPABILITY_ENV,

--- a/vane/execution/udf_arrow_parquet_sink.py
+++ b/vane/execution/udf_arrow_parquet_sink.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import itertools
+import os
+import posixpath
+import uuid
+from collections.abc import Iterable
+from typing import Any
+
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+from vane.execution._common import ensure_table
+from vane.execution.udf_output_schema import _arrow_type_from_name
+
+_SINK_FLAG = "terminal_arrow_parquet_sink"
+_OUTPUT_DIRECTORY = "terminal_arrow_parquet_output_directory"
+_FILE_EXTENSION = "terminal_arrow_parquet_file_extension"
+_WRITER_OPTIONS = "terminal_arrow_parquet_writer_options"
+_EXPECTED_NAMES = "terminal_arrow_parquet_expected_names"
+_EXPECTED_TYPES = "terminal_arrow_parquet_expected_types"
+_WRITE_EMPTY_FILE = "terminal_arrow_parquet_write_empty_file"
+_SINK_PAYLOAD_KEYS = (
+    _SINK_FLAG,
+    _OUTPUT_DIRECTORY,
+    _FILE_EXTENSION,
+    _WRITER_OPTIONS,
+    _EXPECTED_NAMES,
+    _EXPECTED_TYPES,
+    _WRITE_EMPTY_FILE,
+)
+
+_COLUMN_STATISTICS_TYPE = pa.map_(pa.string(), pa.map_(pa.string(), pa.string()))
+_PARTITION_KEYS_TYPE = pa.map_(pa.string(), pa.string())
+_COPY_STATISTICS_SCHEMA = pa.schema(
+    [
+        pa.field("filename", pa.string()),
+        pa.field("count", pa.uint64()),
+        pa.field("file_size_bytes", pa.uint64()),
+        pa.field("footer_size_bytes", pa.uint64()),
+        pa.field("column_statistics", _COLUMN_STATISTICS_TYPE),
+        pa.field("partition_keys", _PARTITION_KEYS_TYPE),
+    ]
+)
+
+
+def terminal_arrow_parquet_sink_enabled(payload: dict[str, Any] | None) -> bool:
+    return bool((payload or {}).get(_SINK_FLAG, False))
+
+
+def terminal_arrow_parquet_sink_payload(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not terminal_arrow_parquet_sink_enabled(payload):
+        return None
+    assert payload is not None
+    return {key: payload[key] for key in _SINK_PAYLOAD_KEYS if key in payload}
+
+
+def _expected_schema(payload: dict[str, Any]) -> pa.Schema:
+    names = [str(value) for value in payload.get(_EXPECTED_NAMES) or []]
+    type_names = [str(value) for value in payload.get(_EXPECTED_TYPES) or []]
+    if not names or len(names) != len(type_names):
+        raise ValueError("terminal Arrow Parquet sink requires matching expected names and types")
+    return pa.schema([pa.field(name, _arrow_type_from_name(type_name)) for name, type_name in zip(names, type_names)])
+
+
+def _row_preserving_output(payload: dict[str, Any]) -> bool:
+    call_mode = str(payload.get("call_mode") or "")
+    return call_mode == "map_batches_rows" or (call_mode == "map" and payload.get("scalar_arg_count") is not None)
+
+
+def _normalize_table(table: pa.Table, schema: pa.Schema, *, rename_columns: bool) -> pa.Table:
+    result = ensure_table(table)
+    if result.schema.names != schema.names:
+        if not rename_columns or result.num_columns != len(schema):
+            raise ValueError(
+                "terminal Arrow Parquet sink output columns do not match COPY schema: "
+                f"expected={schema.names!r} got={result.schema.names!r}"
+            )
+        result = result.rename_columns(schema.names)
+    if result.schema.types != schema.types:
+        result = result.cast(schema, safe=True)
+    return result
+
+
+def _output_location(output_directory: str, file_extension: str, invocation_id: str) -> tuple[Any, str, str]:
+    import pyarrow.fs as pafs  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+    directory = str(output_directory or "").strip()
+    if not directory:
+        raise ValueError("terminal Arrow Parquet sink requires an output directory")
+    extension = str(file_extension or "")
+    if not extension or "/" in extension or "\\" in extension:
+        raise ValueError("terminal Arrow Parquet sink requires a path-safe file extension")
+    identity = hashlib.sha256(str(invocation_id).encode("utf-8")).hexdigest()[:16]
+    file_name = f"part-{identity}-{uuid.uuid4().hex}.{extension}"
+
+    if "://" in directory or directory.startswith("file:"):
+        filesystem, filesystem_directory = pafs.FileSystem.from_uri(directory)
+        file_path = posixpath.join(filesystem_directory.rstrip("/"), file_name)
+        visible_path = directory.rstrip("/") + "/" + file_name
+    else:
+        filesystem = pafs.LocalFileSystem()
+        filesystem_directory = directory
+        file_path = os.path.join(filesystem_directory, file_name)
+        visible_path = file_path
+
+    filesystem.create_dir(filesystem_directory, recursive=True)
+    return filesystem, file_path, visible_path
+
+
+def _empty_copy_statistics() -> pa.Table:
+    return pa.Table.from_arrays(
+        [pa.array([], type=field.type) for field in _COPY_STATISTICS_SCHEMA],
+        schema=_COPY_STATISTICS_SCHEMA,
+    )
+
+
+def _copy_statistics(
+    *,
+    filename: str,
+    row_count: int,
+    file_size_bytes: int,
+    footer_size_bytes: int,
+) -> pa.Table:
+    return pa.Table.from_arrays(
+        [
+            pa.array([filename], type=pa.string()),
+            pa.array([row_count], type=pa.uint64()),
+            pa.array([file_size_bytes], type=pa.uint64()),
+            pa.array([footer_size_bytes], type=pa.uint64()),
+            pa.array([[]], type=_COLUMN_STATISTICS_TYPE),
+            pa.array([[]], type=_PARTITION_KEYS_TYPE),
+        ],
+        schema=_COPY_STATISTICS_SCHEMA,
+    )
+
+
+def _iter_row_group_tables(tables: Iterable[pa.Table], row_group_size: int) -> Iterable[pa.Table]:
+    pending: list[pa.Table] = []
+    pending_rows = 0
+    for table in tables:
+        offset = 0
+        while offset < table.num_rows:
+            remaining = table.num_rows - offset
+            if pending_rows == 0 and remaining >= row_group_size:
+                yield table.slice(offset, row_group_size)
+                offset += row_group_size
+                continue
+
+            take_rows = min(row_group_size - pending_rows, remaining)
+            pending.append(table.slice(offset, take_rows))
+            pending_rows += take_rows
+            offset += take_rows
+            if pending_rows == row_group_size:
+                yield pending[0] if len(pending) == 1 else pa.concat_tables(pending)
+                pending = []
+                pending_rows = 0
+
+    if pending:
+        yield pending[0] if len(pending) == 1 else pa.concat_tables(pending)
+
+
+def write_terminal_arrow_parquet_output(
+    payload: dict[str, Any],
+    tables: Iterable[pa.Table],
+    *,
+    invocation_id: str,
+) -> pa.Table:
+    import pyarrow.fs as pafs  # type: ignore[import-not-found, import-untyped, unused-ignore]
+    import pyarrow.parquet as pq  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+    if not terminal_arrow_parquet_sink_enabled(payload):
+        raise ValueError("terminal Arrow Parquet sink is not enabled")
+
+    schema = _expected_schema(payload)
+    rename_columns = _row_preserving_output(payload)
+    normalized_tables: Iterable[pa.Table] = (
+        _normalize_table(table, schema, rename_columns=rename_columns) for table in tables
+    )
+    write_empty_file = bool(payload.get(_WRITE_EMPTY_FILE, True))
+    if not write_empty_file:
+        first_non_empty = next((table for table in normalized_tables if table.num_rows > 0), None)
+        if first_non_empty is None:
+            return _empty_copy_statistics()
+        normalized_tables = itertools.chain((first_non_empty,), normalized_tables)
+
+    raw_options = payload.get(_WRITER_OPTIONS) or {}
+    if not isinstance(raw_options, dict):
+        raise TypeError("terminal Arrow Parquet writer options must be a dict")
+    writer_options = dict(raw_options)
+    row_group_size = int(writer_options.pop("row_group_size", 0) or 0)
+    if row_group_size <= 0:
+        raise ValueError("terminal Arrow Parquet row_group_size must be positive")
+
+    filesystem, file_path, visible_path = _output_location(
+        str(payload.get(_OUTPUT_DIRECTORY) or ""),
+        str(payload.get(_FILE_EXTENSION) or ""),
+        invocation_id,
+    )
+    row_count = 0
+    with filesystem.open_output_stream(file_path) as output_stream:
+        with pq.ParquetWriter(output_stream, schema, **writer_options) as writer:
+            for table in _iter_row_group_tables(normalized_tables, row_group_size):
+                row_count += table.num_rows
+                writer.write_table(table, row_group_size=row_group_size)
+
+    file_info = filesystem.get_file_info(file_path)
+    if file_info.type != pafs.FileType.File:
+        raise RuntimeError(f"terminal Arrow Parquet output is not a file: {visible_path}")
+    metadata = pq.ParquetFile(file_path, filesystem=filesystem).metadata
+    return _copy_statistics(
+        filename=visible_path,
+        row_count=row_count,
+        file_size_bytes=int(file_info.size),
+        footer_size_bytes=int(metadata.serialized_size),
+    )
+
+
+__all__ = [
+    "terminal_arrow_parquet_sink_enabled",
+    "terminal_arrow_parquet_sink_payload",
+    "write_terminal_arrow_parquet_output",
+]

--- a/vane/execution/udf_ray.py
+++ b/vane/execution/udf_ray.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 from collections import deque
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any
 
 import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
@@ -18,6 +18,10 @@ from vane.execution._common import callable_cache_enabled as _callable_cache_ena
 from vane.execution._common import ensure_table as _ensure_table
 from vane.execution._udf_runtime import UDFExecutor as RuntimeUDFExecutor
 from vane.execution.ray_stream_adapter import TaskLeaseObjectRefGenerator
+from vane.execution.udf_arrow_parquet_sink import (
+    terminal_arrow_parquet_sink_enabled,
+    write_terminal_arrow_parquet_output,
+)
 from vane.execution.udf_ray_actor_pool import (
     UDFActorPoolBase as _UDFActorPoolBase,
 )
@@ -807,45 +811,51 @@ def _iter_materialized_task_outputs(
             output_index += 1
             yield block, metadata
 
+    def execute_outputs() -> Iterator[pa.Table]:
+        call_mode = str(stream_payload.get("call_mode") or "")
+        if call_mode == "map":
+            for raw_table in tables:
+                yield _execute_scalar_map_layout(
+                    stream_payload,
+                    _ensure_table(raw_table),
+                    executor,
+                )
+            executor.finished_submitting()
+            return
+        if call_mode == "map_batches_rows":
+            for raw_table in tables:
+                yield _execute_row_preserving_batch_layout(
+                    stream_payload,
+                    _ensure_table(raw_table),
+                    executor,
+                )
+            executor.finished_submitting()
+            return
+        for raw_table in tables:
+            yield from executor.iter_submit(_ensure_table(raw_table))
+        executor.finished_submitting()
+        yield from executor.drain_outputs()
+
     # close() must run on every exit — errors and abandoned generators
     # included: with callable caching the AI wrapper outlives this executor,
     # and a skipped close would strand its provider client on a dead loop.
     try:
-        if str(stream_payload.get("call_mode") or "") == "map":
-            for raw_table in tables:
-                for block, metadata in emit(
-                    _execute_scalar_map_layout(
-                        stream_payload,
-                        _ensure_table(raw_table),
-                        executor,
-                    )
-                ):
-                    yield block
-                    yield metadata
-            executor.finished_submitting()
-            return
-
-        if str(stream_payload.get("call_mode") or "") == "map_batches_rows":
-            for raw_table in tables:
-                for block, metadata in emit(
-                    _execute_row_preserving_batch_layout(
-                        stream_payload,
-                        _ensure_table(raw_table),
-                        executor,
-                    )
-                ):
-                    yield block
-                    yield metadata
-            executor.finished_submitting()
-            return
-
-        for raw_table in tables:
-            for output in executor.iter_submit(_ensure_table(raw_table)):
-                for block, metadata in emit(output):
-                    yield block
-                    yield metadata
-        executor.finished_submitting()
-        for output in executor.drain_outputs():
+        outputs: Iterable[pa.Table]
+        if terminal_arrow_parquet_sink_enabled(stream_payload) and not any(
+            _ensure_table(table).num_rows for table in tables
+        ):
+            outputs = ()
+        else:
+            outputs = execute_outputs()
+        if terminal_arrow_parquet_sink_enabled(stream_payload):
+            outputs = (
+                write_terminal_arrow_parquet_output(
+                    stream_payload,
+                    outputs,
+                    invocation_id=str(stream_payload.get("task_lease_id") or ""),
+                ),
+            )
+        for output in outputs:
             for block, metadata in emit(output):
                 yield block
                 yield metadata
@@ -990,12 +1000,24 @@ def _iter_ref_bundle_task_outputs(
         # executor, and a skipped close would strand its provider client on
         # a dead loop.
         try:
-            for output in executor.iter_submit(table):
-                for block, output_metadata in emit_output(output):
-                    yield block
-                    yield output_metadata
-            executor.finished_submitting()
-            for output in executor.drain_outputs():
+
+            def execute_outputs() -> Iterator[pa.Table]:
+                if table.num_rows == 0 and terminal_arrow_parquet_sink_enabled(stream_payload):
+                    return
+                yield from executor.iter_submit(table)
+                executor.finished_submitting()
+                yield from executor.drain_outputs()
+
+            outputs: Iterable[pa.Table] = execute_outputs()
+            if terminal_arrow_parquet_sink_enabled(stream_payload):
+                outputs = (
+                    write_terminal_arrow_parquet_output(
+                        stream_payload,
+                        outputs,
+                        invocation_id=str(stream_payload.get("task_lease_id") or ""),
+                    ),
+                )
+            for output in outputs:
                 for block, output_metadata in emit_output(output):
                     yield block
                     yield output_metadata
@@ -1013,6 +1035,16 @@ def _iter_ref_bundle_task_outputs(
         return
 
     if call_mode == "map_batches_rows":
+        if table.num_rows == 0 and terminal_arrow_parquet_sink_enabled(payload):
+            statistics = write_terminal_arrow_parquet_output(
+                payload,
+                (),
+                invocation_id=str(payload.get("task_lease_id") or ""),
+            )
+            for output_index, block in enumerate(iter_bounded_stream_blocks(statistics, payload)):
+                yield block
+                yield make_stream_block_metadata(block, payload, output_index=output_index)
+            return
         executor = RuntimeUDFExecutor(payload, cache_callable=_callable_cache_enabled(payload))
         configure_loaded_torch_threads()
         try:
@@ -1020,6 +1052,12 @@ def _iter_ref_bundle_task_outputs(
             executor.finished_submitting()
         finally:
             executor.close()
+        if terminal_arrow_parquet_sink_enabled(payload):
+            fused = write_terminal_arrow_parquet_output(
+                payload,
+                (fused,),
+                invocation_id=str(payload.get("task_lease_id") or ""),
+            )
         for output_index, block in enumerate(iter_bounded_stream_blocks(fused, payload)):
             yield block
             yield make_stream_block_metadata(block, payload, output_index=output_index)
@@ -1028,12 +1066,29 @@ def _iter_ref_bundle_task_outputs(
     if call_mode != "map":
         raise RuntimeError("ray_task ref bundle input requires call_mode=map, map_batches, or flat_map")
 
+    if table.num_rows == 0 and terminal_arrow_parquet_sink_enabled(payload):
+        statistics = write_terminal_arrow_parquet_output(
+            payload,
+            (),
+            invocation_id=str(payload.get("task_lease_id") or ""),
+        )
+        for output_index, block in enumerate(iter_bounded_stream_blocks(statistics, payload)):
+            yield block
+            yield make_stream_block_metadata(block, payload, output_index=output_index)
+        return
+
     executor = RuntimeUDFExecutor(payload, cache_callable=_callable_cache_enabled(payload))
     configure_loaded_torch_threads()
     try:
         fused = _execute_scalar_map_layout(payload, table, executor)
     finally:
         executor.close()
+    if terminal_arrow_parquet_sink_enabled(payload):
+        fused = write_terminal_arrow_parquet_output(
+            payload,
+            (fused,),
+            invocation_id=str(payload.get("task_lease_id") or ""),
+        )
     for output_index, block in enumerate(iter_bounded_stream_blocks(fused, payload)):
         yield block
         yield make_stream_block_metadata(block, payload, output_index=output_index)

--- a/vane/execution/udf_ray_actor_runtime.py
+++ b/vane/execution/udf_ray_actor_runtime.py
@@ -13,6 +13,10 @@ import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ig
 
 from vane.execution._common import ensure_table as _ensure_table
 from vane.execution._udf_runtime import UDFExecutor as RuntimeUDFExecutor
+from vane.execution.udf_arrow_parquet_sink import (
+    terminal_arrow_parquet_sink_enabled,
+    write_terminal_arrow_parquet_output,
+)
 from vane.execution.udf_ray_config import (
     eager_actor_warm_up_enabled as _eager_actor_warm_up_enabled,
 )
@@ -325,38 +329,37 @@ def _actor_class(
                     )
                     output_count += 1
 
-            if str(effective_payload.get("call_mode") or "") == "map":
-                table = execute_scalar_map_layout(effective_payload, args, executor)
-                yield from emit(table)
-                _actor_debug_log(
-                    "run_block_stream_submit_done",
+            def execute_outputs() -> Iterator[pa.Table]:
+                call_mode = str(effective_payload.get("call_mode") or "")
+                if call_mode == "map":
+                    yield execute_scalar_map_layout(effective_payload, args, executor)
+                    return
+                if call_mode == "map_batches_rows":
+                    yield self._run_row_preserving_batch(args, effective_payload)
+                    return
+                for result in executor.iter_submit(args):
+                    table = _ensure_table(result)
+                    _actor_debug_log(
+                        "run_block_stream_output",
+                        effective_payload,
+                        output_index=output_count,
+                        rows=table.num_rows,
+                        columns=table.num_columns,
+                    )
+                    yield table
+
+            if terminal_arrow_parquet_sink_enabled(effective_payload):
+                statistics = write_terminal_arrow_parquet_output(
                     effective_payload,
-                    rows=args.num_rows,
-                    outputs=1,
+                    () if args.num_rows == 0 else execute_outputs(),
+                    invocation_id=str(effective_payload.get("task_lease_id") or ""),
                 )
-                return
-            if str(effective_payload.get("call_mode") or "") == "map_batches_rows":
-                yield from emit(self._run_row_preserving_batch(args, effective_payload))
-                _actor_debug_log(
-                    "run_block_stream_submit_done",
-                    effective_payload,
-                    rows=args.num_rows,
-                    outputs=1,
-                )
-                return
-            for result in executor.iter_submit(args):
-                table = _ensure_table(result)
-                _actor_debug_log(
-                    "run_block_stream_output",
-                    effective_payload,
-                    output_index=output_count,
-                    rows=table.num_rows,
-                    columns=table.num_columns,
-                )
-                yield from emit(table)
-            if output_count == 0:
-                table = _empty_output_table_from_payload(effective_payload)
-                yield from emit(table)
+                yield from emit(statistics)
+            else:
+                for table in execute_outputs():
+                    yield from emit(table)
+                if output_count == 0:
+                    yield from emit(_empty_output_table_from_payload(effective_payload))
             _actor_debug_log(
                 "run_block_stream_submit_done",
                 effective_payload,

--- a/vane/execution/udf_subprocess.py
+++ b/vane/execution/udf_subprocess.py
@@ -60,6 +60,7 @@ from vane.execution.udf_admission import (
     LocalExecutionSlotPool,
     LocalSlotAdmissionAuthority,
 )
+from vane.execution.udf_arrow_parquet_sink import terminal_arrow_parquet_sink_payload
 from vane.execution.udf_lifecycle import (
     ExecutionCancellationScope,
     ExecutionCancelledError,
@@ -86,6 +87,8 @@ _MSG_OUTPUT_GRANT_GRANTED = 0x0D
 _MSG_OUTPUT_GRANT_CANCELLED = 0x0E
 _MSG_OUTPUT_GRANT_RELEASE = 0x0F
 _MSG_TASK_CANCELLED = 0x10
+
+_TERMINAL_ARROW_PARQUET_PAYLOAD_KEY = "_vane_terminal_arrow_parquet_payload"
 
 _HEADER = struct.Struct("=BI")
 _IPC_HEADER = struct.Struct("<Q")
@@ -336,6 +339,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         self._wakeup: Callable[[], None] | None = None
         self._wakeup_error: BaseException | None = None
         self._ref_bundle_output = payload_requests_local_ref_bundle_output(payload)
+        self._terminal_arrow_parquet_payload = terminal_arrow_parquet_sink_payload(payload)
         self._worker_env = dict(worker_env or {})
         self._session_config = (
             None if session_config is None else {str(key): str(value) for key, value in session_config.items()}
@@ -742,9 +746,18 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
         if self._broken_error is None:
             self._broken_error = f"UDF subprocess wakeup callback failed: {exc}"
 
-    def _submit_table(self, args: pa.Table) -> Any | None:
+    def _submit_table(
+        self,
+        args: pa.Table,
+        terminal_arrow_parquet_payload: dict[str, Any] | None = None,
+    ) -> Any | None:
         args = _ensure_table(args)
-        if args.num_rows == 0:
+        terminal_payload = (
+            terminal_arrow_parquet_payload
+            if terminal_arrow_parquet_payload is not None
+            else self._terminal_arrow_parquet_payload
+        )
+        if args.num_rows == 0 and terminal_payload is None:
             return None
 
         scope = self._current_execution_scope()
@@ -763,10 +776,12 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
                 names,
                 submit_id=None,
                 name="udf-materialized-input",
-                reserve_output_credit=self._ref_bundle_output,
+                reserve_output_credit=self._ref_bundle_output and terminal_payload is None,
             )
             if worker_payload is None:
                 raise RuntimeError("local_shm descriptor creation failed for subprocess submit")
+            if terminal_payload is not None:
+                worker_payload[_TERMINAL_ARROW_PARQUET_PAYLOAD_KEY] = terminal_payload
             return self._submit_ref_bundle_direct(worker_payload)
         except BaseException as submit_error:
             cleanup_error: BaseException | None = None
@@ -949,7 +964,7 @@ class _SingleSubprocessExecutor(BaseUDFExecutor):
 
     def _submit_ref_bundle_direct(self, payload: dict[str, Any]) -> Any | None:
         lease_id_raw = payload.get("input_lease_id")
-        if payload.get("estimated_num_rows") == 0:
+        if payload.get("estimated_num_rows") == 0 and payload.get(_TERMINAL_ARROW_PARQUET_PAYLOAD_KEY) is None:
             # The worker will never receive this bundle and therefore cannot
             # acknowledge its lease. Cancel rather than consume it so an empty
             # result does not leave behind unused output credit.
@@ -2576,7 +2591,10 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         self._pending_lock = threading.Lock()
         self._pending_batches = 0
         self._ref_bundle_output = payload_requests_local_ref_bundle_output(payload)
-        self._output_row_budget_bytes = _payload_output_row_budget_bytes(payload)
+        self._terminal_arrow_parquet_payload = terminal_arrow_parquet_sink_payload(payload)
+        self._output_row_budget_bytes = (
+            0 if self._terminal_arrow_parquet_payload is not None else _payload_output_row_budget_bytes(payload)
+        )
         self._learned_output_budget_bytes = 0
         self._last_output_budget_estimate_bytes = 0
         self._output_budget_lock = threading.Lock()
@@ -3007,7 +3025,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         admission = self._take_task_admission()
         self._submit_async(
             None,
-            lambda worker: worker._submit_table(table),
+            lambda worker: worker._submit_table(table, self._terminal_arrow_parquet_payload),
             admission,
         )
 
@@ -3016,7 +3034,7 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
         admission = self._take_task_admission()
         self._submit_async(
             int(submit_id),
-            lambda worker: worker._submit_table(table),
+            lambda worker: worker._submit_table(table, self._terminal_arrow_parquet_payload),
             admission,
         )
 
@@ -3035,10 +3053,12 @@ class UDFExecutor(AdmissionExecutorMixin, BaseUDFExecutor):
             names,
             submit_id=int(submit_id),
             name=f"udf-input-{int(submit_id)}",
-            reserve_output_credit=self._ref_bundle_output,
+            reserve_output_credit=self._ref_bundle_output and self._terminal_arrow_parquet_payload is None,
         )
         if worker_payload is not None:
             assert lease_id is not None
+            if self._terminal_arrow_parquet_payload is not None:
+                worker_payload[_TERMINAL_ARROW_PARQUET_PAYLOAD_KEY] = self._terminal_arrow_parquet_payload
             self._track_input_lease(lease_id)
 
             def submit_worker(

--- a/vane/execution/udf_subprocess_worker.py
+++ b/vane/execution/udf_subprocess_worker.py
@@ -10,6 +10,7 @@ import os
 import socket
 import struct
 import sys
+from collections.abc import Iterable
 from traceback import TracebackException
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +29,10 @@ from vane.execution.ref_bundle import (
     materialize_ref_bundle,
     payload_requests_local_ref_bundle_output,
     release_local_shm_ref_bundle_descriptor,
+)
+from vane.execution.udf_arrow_parquet_sink import (
+    terminal_arrow_parquet_sink_enabled,
+    write_terminal_arrow_parquet_output,
 )
 from vane.execution.udf_row_preserving import (
     fuse_row_preserving_output,
@@ -51,6 +56,8 @@ _MSG_OUTPUT_GRANT_GRANTED = 0x0D
 _MSG_OUTPUT_GRANT_CANCELLED = 0x0E
 _MSG_OUTPUT_GRANT_RELEASE = 0x0F
 _MSG_TASK_CANCELLED = 0x10
+
+_TERMINAL_ARROW_PARQUET_PAYLOAD_KEY = "_vane_terminal_arrow_parquet_payload"
 
 _HEADER = struct.Struct("=BI")
 _IPC_HEADER = struct.Struct("<Q")
@@ -362,10 +369,11 @@ def _execute_submit(
     submit_count: int,
     input_lease_id: int | None = None,
     finish_before_drain: bool = False,
+    execution_payload: dict[str, Any] | None = None,
 ) -> tuple[shared_memory.SharedMemory, int, bytes]:
-    if input_table.num_rows == 0:
+    payload = execution_payload or getattr(executor, "_payload", {}) or {}
+    if input_table.num_rows == 0 and not terminal_arrow_parquet_sink_enabled(payload):
         return data_shm, _MSG_OK, struct.pack("<Q", 0)
-    payload = getattr(executor, "_payload", {}) or {}
     call_mode = str(payload.get("call_mode") or "")
     row_preserving = call_mode == "map_batches_rows" or (
         call_mode == "map" and payload.get("scalar_arg_count") is not None
@@ -373,18 +381,49 @@ def _execute_submit(
     passthrough_table = None
     if row_preserving:
         input_table, passthrough_table = split_row_preserving_input(payload, input_table)
-    executor.submit(input_table)
-    if finish_before_drain:
-        executor.finished_submitting()
-    output_tables = _drain_executor_outputs(executor)
-    if row_preserving:
+    output_tables: Iterable[pa.Table]
+    if input_table.num_rows == 0:
+        output_tables = []
+    elif terminal_arrow_parquet_sink_enabled(payload) and not row_preserving:
+
+        def iter_terminal_outputs() -> Iterable[pa.Table]:
+            emitted = False
+            for output in executor.iter_submit(input_table):
+                emitted = True
+                yield output
+            if finish_before_drain:
+                executor.finished_submitting()
+            for output in executor.drain_outputs():
+                emitted = True
+                yield output
+            if not emitted:
+                raise RuntimeError("UDF returned no result")
+
+        output_tables = iter_terminal_outputs()
+    else:
+        executor.submit(input_table)
+        if finish_before_drain:
+            executor.finished_submitting()
+        output_tables = _drain_executor_outputs(executor)
+    if row_preserving and input_table.num_rows > 0:
+        output_tables = list(output_tables)
         if len(output_tables) != 1:
             raise RuntimeError(
                 "%s subprocess produced %d outputs, expected exactly 1" % (call_mode, len(output_tables))
             )
         output_tables = [fuse_row_preserving_output(payload, passthrough_table, output_tables[0])]
+    if terminal_arrow_parquet_sink_enabled(payload):
+        result_tables = [
+            write_terminal_arrow_parquet_output(
+                payload,
+                output_tables,
+                invocation_id=f"subprocess:{os.getpid()}:{submit_count}",
+            )
+        ]
+    else:
+        result_tables = list(output_tables)
     if produce_ref_bundle_output:
-        required = sum(_ipc_response_size(output_table) for output_table in output_tables)
+        required = sum(_ipc_response_size(output_table) for output_table in result_tables)
         grant_id = _request_output_grant(
             sock,
             submit_count=submit_count,
@@ -393,7 +432,7 @@ def _execute_submit(
         )
         descriptor = None
         try:
-            descriptor = _make_local_shm_ref_bundle_descriptor_for_tables(output_tables, grant_id=grant_id)
+            descriptor = _make_local_shm_ref_bundle_descriptor_for_tables(result_tables, grant_id=grant_id)
             result_payload = vane_pickle.dumps(descriptor)
         except Exception:
             if descriptor is not None:
@@ -407,7 +446,7 @@ def _execute_submit(
                 pass
             raise
         return data_shm, _MSG_REF_BUNDLE_RESULT, result_payload
-    output_table = _concat_executor_outputs(output_tables)
+    output_table = _concat_executor_outputs(result_tables)
     output_ipc = _arrow_table_to_ipc_bytes(output_table)
     required = _IPC_HEADER.size + len(output_ipc)
     data_shm = _resize_shm(data_shm, required)
@@ -425,7 +464,7 @@ def _execute_task_submit(
     sock: socket.socket,
     input_lease_id: int | None = None,
 ) -> tuple[shared_memory.SharedMemory, int, bytes]:
-    if input_table.num_rows == 0:
+    if input_table.num_rows == 0 and not terminal_arrow_parquet_sink_enabled(payload):
         return data_shm, _MSG_OK, struct.pack("<Q", 0)
     executor = RuntimeUDFExecutor(payload, cache_callable=_callable_cache_enabled(payload))
     configure_loaded_torch_threads()
@@ -512,6 +551,7 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
 
             try:
                 input_lease_id = None
+                terminal_arrow_parquet_payload = None
                 if msg_type == _MSG_SUBMIT:
                     input_size = struct.unpack("<Q", payload_data)[0]
                     if input_size > len(_require_shm_buffer(data_shm)):
@@ -522,6 +562,11 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
                     input_table = _arrow_table_from_ipc_bytes(input_ipc)
                 else:
                     ref_bundle = vane_pickle.loads(payload_data)
+                    terminal_arrow_parquet_payload = ref_bundle.pop(_TERMINAL_ARROW_PARQUET_PAYLOAD_KEY, None)
+                    if terminal_arrow_parquet_payload is not None and not isinstance(
+                        terminal_arrow_parquet_payload, dict
+                    ):
+                        raise TypeError("terminal Arrow Parquet submit payload must be a dict")
                     lease_id_raw = ref_bundle.get("input_lease_id")
                     input_lease_id = int(lease_id_raw) if lease_id_raw is not None else None
                     try:
@@ -535,6 +580,10 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
                         _send_input_consume_failed(sock, ref_bundle, exc)
                         raise
                     _send_input_consumed(sock, ref_bundle, input_table)
+                execution_payload = payload
+                if terminal_arrow_parquet_payload is not None:
+                    execution_payload = dict(payload)
+                    execution_payload.update(terminal_arrow_parquet_payload)
                 submit_count += 1
                 log_submit = _should_log_submit(submit_count)
                 if log_submit:
@@ -548,7 +597,7 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
                     )
                 if subprocess_mode == "task":
                     data_shm, result_msg_type, result_payload = _execute_task_submit(
-                        payload,
+                        execution_payload,
                         input_table,
                         data_shm,
                         produce_ref_bundle_output,
@@ -568,6 +617,7 @@ def worker_main(sock_fd: int, payload_shm_name: str, payload_size: int, data_shm
                         sock=sock,
                         submit_count=submit_count,
                         input_lease_id=input_lease_id,
+                        execution_payload=execution_payload,
                     )
                 if log_submit:
                     _worker_thread_log(


### PR DESCRIPTION
## Summary

- Fuse a terminal distributed Python UDF with Parquet `COPY` and stream its Arrow output directly into a PyArrow `ParquetWriter`, avoiding the Arrow-to-DuckDB-to-Parquet round trip.
- Preserve declared schemas, empty-file behavior, six-column worker COPY statistics, and staging/direct-write/retry cleanup across subprocess task/actor and Ray task/actor backends.
- Propagate equivalent compression, row-group, dictionary-page, and Parquet-version settings. Non-terminal UDF plans and COPY options that cannot be represented by the direct writer now fail explicitly; there is intentionally no compatibility fallback.
- Fence Ray output-lease disposition callbacks so a handoff/release failure cannot be overtaken by successful query completion or affect another query slot.

## Related issue

N/A

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public `Relation.write_parquet` API is unchanged. The intentional behavior change for unsupported terminal-UDF COPY shapes/options is documented in the summary above.

## Validation

- Incremental Release native install: `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`.
- Affected UDF, Arrow Parquet sink, local task/actor, and Ray task/actor tests: 82 passed.
- Output-lease callback race test: 20 consecutive passes.
- Native distributed suite: `VCPKG_INSTALLED_DIR="$PWD/vcpkg_installed" scripts/run_native_tests.sh "[distributed]"` — 187 test cases and 7,988 assertions passed.
- Release suite: `scripts/run_release_tests.sh` — 538 passed (15 deselected), plus 11 real-Ray tests passed (542 deselected).
- Complete fast suite: `scripts/run_fast_tests.sh` — 6,206 passed, 602 skipped, 120 deselected, 7 xfailed, and 1 xpassed in the non-Ray shard; 103 passed and 6 skipped in the shared-Ray shard; all seven CPU-only Ray-owner tests passed, with the unavailable vLLM test skipped.
- Formatting and static checks: `scripts/format workspace --changed --check`, pre-commit on every changed file, and `git diff --check` passed.
- Environment: CPU-only local and local-Ray runners. Direct-write E2E coverage used synthetic 257-row local input (`batch_size=64`, `row_group_size=32`) and 17-row Ray input (`batch_size=4`, `row_group_size=3`) across task and actor backends.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
