### PR TITLE
[feat](csv) Distribute CSV reads and writes

### DIFF
--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
@@ -4,12 +4,17 @@
 #include "duckdb/execution/distributed/pipeline_node/translator_scan.hpp"
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/enums/file_compression_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 #include "duckdb/common/multi_file/multi_file_states.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/physical_plan.hpp"
+#include "duckdb/execution/operator/csv_scanner/csv_scan_range.hpp"
+#include "duckdb/execution/operator/csv_scanner/scanner_boundary.hpp"
 #include "duckdb/function/extension_file_list_provider.hpp"
+#include "duckdb/function/table/read_csv.hpp"
 #include "duckdb/main/database.hpp"
 
 #include <algorithm>
@@ -124,6 +129,46 @@ size_t ResolveScanTaskTargetCount(size_t source_count, const DuckDBExecutionConf
 	return target;
 }
 
+size_t ResolveSingleCSVTaskCount(uint64_t file_size, const DuckDBExecutionConfig &exec_cfg,
+                                 const CSVReaderOptions &options) {
+	auto target = ResolveScanTaskTargetCount(1, exec_cfg);
+	if (target <= 1) {
+		return 1;
+	}
+	if (exec_cfg.scan_task_size_grouping_enabled() && exec_cfg.scan_task_min_partition_num() == 0 &&
+	    exec_cfg.scan_task_min_bytes() > 0) {
+		const auto size_limited_tasks = MaxValue<uint64_t>(1, file_size / exec_cfg.scan_task_min_bytes());
+		target = MinValue<uint64_t>(target, size_limited_tasks);
+	}
+	const auto minimum_range_size = MaxValue<idx_t>(2, CSVIterator::BytesPerThread(options));
+	const auto safe_range_count = MaxValue<uint64_t>(1, file_size / minimum_range_size);
+	return static_cast<size_t>(MinValue<uint64_t>(target, safe_range_count));
+}
+
+void ValidateSingleCSVSplit(const OpenFileInfo &file, const ReadCSVData &csv_data) {
+	if (!csv_data.options.parallel) {
+		throw InvalidInputException("Distributed byte-range scanning of CSV file \"%s\" requires parallel=true",
+		                            file.path);
+	}
+	if (csv_data.options.GetSkipRows() > 0) {
+		throw InvalidInputException("Distributed byte-range scanning of CSV file \"%s\" does not support skip_rows",
+		                            file.path);
+	}
+	if (StringUtil::Lower(csv_data.options.encoding) != "utf-8") {
+		throw InvalidInputException("Distributed byte-range scanning of CSV file \"%s\" requires UTF-8 input",
+		                            file.path);
+	}
+	const auto compression = csv_data.options.compression;
+	const bool compressed =
+	    compression == FileCompressionType::GZIP || compression == FileCompressionType::ZSTD ||
+	    (compression == FileCompressionType::AUTO_DETECT && (IsFileCompressed(file.path, FileCompressionType::GZIP) ||
+	                                                         IsFileCompressed(file.path, FileCompressionType::ZSTD)));
+	if (compressed) {
+		throw InvalidInputException("Distributed byte-range scanning requires an uncompressed CSV file: \"%s\"",
+		                            file.path);
+	}
+}
+
 std::vector<std::vector<idx_t>> GroupIndexesByCount(idx_t count, size_t max_tasks) {
 	std::vector<std::vector<idx_t>> groups;
 	if (count == 0) {
@@ -220,6 +265,24 @@ std::vector<uint64_t> GetFileSizesFromDB(const std::vector<OpenFileInfo> &files,
 	return sizes;
 }
 
+uint64_t GetRequiredFileSizeFromDB(const OpenFileInfo &file, const shared_ptr<DatabaseInstance> &db) {
+	if (!db) {
+		throw InvalidInputException("Distributed byte-range scanning requires database file-system access for \"%s\"",
+		                            file.path);
+	}
+	auto &fs = FileSystem::GetFileSystem(*db);
+	auto handle = fs.OpenFile(file, FileOpenFlags::FILE_FLAGS_READ);
+	if (!handle) {
+		throw IOException("Could not open CSV file \"%s\" while creating byte-range scan tasks", file.path);
+	}
+	const auto size = fs.GetFileSize(*handle);
+	if (size <= 0) {
+		throw InvalidInputException(
+		    "Distributed byte-range scanning requires a non-empty CSV file with a known size: \"%s\"", file.path);
+	}
+	return static_cast<uint64_t>(size);
+}
+
 } // namespace
 
 DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
@@ -248,6 +311,11 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 
 	vector<OpenFileInfo> files;
 	auto *multi_bind = dynamic_cast<MultiFileBindData *>(scan.bind_data.get());
+	auto *csv_data =
+	    multi_bind && multi_bind->bind_data ? dynamic_cast<ReadCSVData *>(multi_bind->bind_data.get()) : nullptr;
+	if (csv_data && csv_data->options.store_rejects.GetValue()) {
+		throw InvalidInputException("Distributed CSV scanning does not support store_rejects");
+	}
 	if (multi_bind && multi_bind->file_list) {
 		files = multi_bind->file_list->GetAllFiles();
 	} else {
@@ -317,6 +385,38 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 	};
 	if (files.size() == 1) {
 		ensure_file_sizes();
+		const auto requested_task_count = ResolveScanTaskTargetCount(1, exec_cfg);
+		if (csv_data && requested_task_count > 1) {
+			ValidateSingleCSVSplit(files.front(), *csv_data);
+			if (file_sizes.size() != 1 || total_file_bytes == 0) {
+				total_file_bytes = GetRequiredFileSizeFromDB(files.front(), db);
+				file_sizes = {total_file_bytes};
+			}
+			const auto task_count = ResolveSingleCSVTaskCount(total_file_bytes, exec_cfg, csv_data->options);
+			if (task_count > 1) {
+				const auto scan_unit_bytes = MaxValue<idx_t>(2, CSVIterator::BytesPerThread(csv_data->options));
+				const auto scan_unit_count = total_file_bytes / scan_unit_bytes;
+				const auto units_per_task = scan_unit_count / task_count;
+				const auto extra_units = scan_unit_count % task_count;
+				const auto rows_per_task = estimated_scan_rows / task_count;
+				const auto extra_rows = estimated_scan_rows % task_count;
+				uint64_t start = 0;
+				for (size_t task_idx = 0; task_idx < task_count; ++task_idx) {
+					const auto task_units = units_per_task + (task_idx < extra_units ? 1 : 0);
+					const auto end =
+					    task_idx + 1 == task_count ? total_file_bytes : start + task_units * scan_unit_bytes;
+					const auto task_bytes = end - start;
+					ScanTaskDescriptor task;
+					task.files.push_back(CSVScanRange::Set(files.front(), start, end));
+					task.estimated_cardinality = rows_per_task + (task_idx < extra_rows ? 1 : 0);
+					task.estimated_bytes = static_cast<idx_t>(task_bytes);
+					task.source_task_partition_id = task_idx;
+					tasks.push_back(std::move(task));
+					start = end;
+				}
+				return tasks;
+			}
+		}
 		ScanTaskDescriptor task;
 		task.files = std::move(files);
 		task.estimated_cardinality = estimated_scan_rows;

--- a/external/duckdb/src/execution/distributed/plan/scan_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/scan_task.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/distributed/common_types.hpp"
 #include "duckdb/execution/distributed/plan/fte_split_queue.hpp"
+#include "duckdb/function/table/read_csv.hpp"
 
 #include <mutex>
 
@@ -42,6 +43,62 @@ struct ApplyScanTasksStats {
 	idx_t copied_tasks = 0;
 	idx_t missing_group_id = 0;
 };
+
+ReadCSVData *GetCSVBindData(MultiFileBindData &bind_data) {
+	if (!bind_data.bind_data) {
+		return nullptr;
+	}
+	return dynamic_cast<ReadCSVData *>(bind_data.bind_data.get());
+}
+
+void ResetCSVProcessLocalReaderState(MultiFileBindData &bind_data) {
+	auto *csv_data = GetCSVBindData(bind_data);
+	if (!csv_data) {
+		return;
+	}
+	bind_data.initial_reader.reset();
+	for (auto &reader : bind_data.union_readers) {
+		if (reader) {
+			reader->reader.reset();
+		}
+	}
+	csv_data->buffer_manager.reset();
+}
+
+void ReconcileCachedCSVReaders(MultiFileBindData &bind_data, const vector<OpenFileInfo> &task_files) {
+	if (!GetCSVBindData(bind_data)) {
+		return;
+	}
+	// A process-local reader may already own an open file handle and buffered bytes. Once a task supplies its own
+	// OpenFileInfo (including CSV byte ranges or remote open options), only cached metadata remains reusable.
+	ResetCSVProcessLocalReaderState(bind_data);
+	if (bind_data.union_readers.empty()) {
+		return;
+	}
+
+	vector<shared_ptr<BaseUnionData>> selected_readers;
+	selected_readers.reserve(task_files.size());
+	vector<bool> used(bind_data.union_readers.size(), false);
+	for (const auto &task_file : task_files) {
+		idx_t matching_reader = DConstants::INVALID_INDEX;
+		for (idx_t reader_idx = 0; reader_idx < bind_data.union_readers.size(); ++reader_idx) {
+			if (!used[reader_idx] && bind_data.union_readers[reader_idx] &&
+			    bind_data.union_readers[reader_idx]->GetFileName() == task_file.path) {
+				matching_reader = reader_idx;
+				break;
+			}
+		}
+		if (matching_reader == DConstants::INVALID_INDEX) {
+			bind_data.union_readers.clear();
+			return;
+		}
+		used[matching_reader] = true;
+		auto reader = bind_data.union_readers[matching_reader];
+		reader->file = task_file;
+		selected_readers.push_back(std::move(reader));
+	}
+	bind_data.union_readers = std::move(selected_readers);
+}
 
 class FteDynamicScanFileList : public MultiFileList {
 private:
@@ -290,6 +347,7 @@ static bool ApplyScanTasksToOperator(PhysicalOperator &op, const std::unordered_
 						stats.non_multi_bind++;
 					}
 				} else {
+					ReconcileCachedCSVReaders(*multi_bind, it->second.files);
 					multi_bind->file_list = duckdb::make_shared_ptr<SimpleMultiFileList>(it->second.files);
 					const idx_t file_count = it->second.file_count();
 					scan.extra_info.total_files = optional_idx(file_count);
@@ -481,6 +539,13 @@ bool ApplyFteScanSourceQueuesToOperator(PhysicalOperator &op,
 					scan.extra_info.filtered_files = optional_idx(file_count);
 					applied++;
 				} else {
+					// The queue can supply a subset of the original files or multiple byte ranges for the same
+					// file. Bind-time readers do not carry those task-specific OpenFileInfo values, so they must
+					// not be reused for a dynamic scan.
+					if (GetCSVBindData(*multi_bind)) {
+						ResetCSVProcessLocalReaderState(*multi_bind);
+						multi_bind->union_readers.clear();
+					}
 					multi_bind->file_list = make_shared_ptr<FteDynamicScanFileList>(entry->second);
 					scan.extra_info.total_files = optional_idx();
 					scan.extra_info.filtered_files = optional_idx();

--- a/external/duckdb/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
+++ b/external/duckdb/src/execution/operator/csv_scanner/buffer_manager/csv_buffer_manager.cpp
@@ -1,5 +1,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_buffer_manager.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_buffer.hpp"
+#include "duckdb/execution/operator/csv_scanner/csv_scan_range.hpp"
+#include "duckdb/execution/operator/csv_scanner/scanner_boundary.hpp"
 #include "duckdb/function/table/read_csv.hpp"
 namespace duckdb {
 
@@ -9,10 +11,29 @@ CSVBufferManager::CSVBufferManager(ClientContext &context_p, const CSVReaderOpti
     : context(context_p), per_file_single_threaded(per_file_single_threaded_p), file(file_p),
       buffer_size(options.buffer_size_option.GetValue()) {
 	D_ASSERT(!file.path.empty());
+	CSVScanRange scan_range;
+	const bool has_scan_range = CSVScanRange::TryGet(file, scan_range);
+	if (has_scan_range) {
+		if (!options.parallel) {
+			throw InvalidInputException("Distributed byte-range scanning of CSV file \"%s\" requires parallel=true",
+			                            file.path);
+		}
+		if (options.GetSkipRows() > 0) {
+			throw InvalidInputException("Distributed byte-range scanning of CSV file \"%s\" does not support skip_rows",
+			                            file.path);
+		}
+		if (options.store_rejects.GetValue()) {
+			throw InvalidInputException("Distributed CSV scanning does not support store_rejects");
+		}
+	}
 	if (file_handle_p) {
 		file_handle = std::move(file_handle_p);
 	} else {
-		file_handle = ReadCSV::OpenCSV(file, options, context);
+		file_handle = ReadCSV::OpenCSV(CSVScanRange::Strip(file), options, context);
+	}
+	if (has_scan_range) {
+		file_handle->SetScanRange(scan_range.start, scan_range.end,
+		                          MaxValue<idx_t>(2, CSVIterator::BytesPerThread(options)));
 	}
 	is_pipe = file_handle->IsPipe();
 	skip_rows = options.dialect_options.skip_rows.GetValue();
@@ -154,6 +175,18 @@ bool CSVBufferManager::IsBlockUnloaded(idx_t block_idx) {
 
 idx_t CSVBufferManager::GetBytesRead() const {
 	return bytes_read;
+}
+
+bool CSVBufferManager::HasScanRange() const {
+	return file_handle->HasScanRange();
+}
+
+idx_t CSVBufferManager::GetScanRangeStart() const {
+	return file_handle->ScanRangeStart();
+}
+
+idx_t CSVBufferManager::GetScanRangeSize() const {
+	return file_handle->FileSize();
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
+++ b/external/duckdb/src/execution/operator/csv_scanner/buffer_manager/csv_file_handle.cpp
@@ -50,7 +50,14 @@ void CSVFileHandle::Seek(const idx_t position) const {
 		}
 		throw InternalException("Trying to seek a compressed CSV File.");
 	}
-	file_handle->Seek(position);
+	if (has_scan_range) {
+		if (position > scan_read_end - scan_range_start) {
+			throw InternalException("Trying to seek past a CSV scan task's byte range");
+		}
+		file_handle->Seek(scan_range_start + position);
+	} else {
+		file_handle->Seek(position);
+	}
 }
 
 bool CSVFileHandle::OnDiskFile() const {
@@ -58,9 +65,48 @@ bool CSVFileHandle::OnDiskFile() const {
 }
 
 void CSVFileHandle::Reset() {
-	file_handle->Reset();
+	if (has_scan_range) {
+		file_handle->Seek(scan_range_start);
+	} else {
+		file_handle->Reset();
+	}
 	finished = false;
 	requested_bytes = 0;
+}
+
+void CSVFileHandle::SetScanRange(const idx_t start, const idx_t end, const idx_t overlap) {
+	if (compression_type != FileCompressionType::UNCOMPRESSED) {
+		throw InvalidInputException("CSV byte-range scans require an uncompressed input file");
+	}
+	if (!can_seek || is_pipe) {
+		throw InvalidInputException("CSV byte-range scans require a seekable input file");
+	}
+	if (encoder.encoding_name != "utf-8") {
+		throw InvalidInputException("CSV byte-range scans require UTF-8 input");
+	}
+	if (start >= end || end > file_size) {
+		throw InvalidInputException("CSV byte range [%llu, %llu) is outside file of size %llu", start, end, file_size);
+	}
+	idx_t aligned_start = start;
+	if (start > 0) {
+		char boundary_bytes[2];
+		file_handle->Read(context, boundary_bytes, sizeof(boundary_bytes), start - 1);
+		if (boundary_bytes[0] == '\r' && boundary_bytes[1] == '\n') {
+			// Starting on the LF half of CRLF leaves the strict CSV state machine without the preceding CR.
+			// Start after the complete delimiter. The preceding task's overlap owns the boundary row, while this
+			// task's normal row synchronization skips that already-owned row.
+			aligned_start++;
+		}
+	}
+	if (aligned_start >= end) {
+		throw InvalidInputException("CSV byte range [%llu, %llu) cannot be aligned to a complete record delimiter",
+		                            start, end);
+	}
+	has_scan_range = true;
+	scan_range_start = aligned_start;
+	scan_range_end = end;
+	scan_read_end = end > file_size - MinValue<idx_t>(overlap, file_size) ? file_size : end + overlap;
+	Reset();
 }
 
 bool CSVFileHandle::IsPipe() const {
@@ -68,7 +114,15 @@ bool CSVFileHandle::IsPipe() const {
 }
 
 idx_t CSVFileHandle::FileSize() const {
-	return file_size;
+	return has_scan_range ? scan_range_end - scan_range_start : file_size;
+}
+
+bool CSVFileHandle::HasScanRange() const {
+	return has_scan_range;
+}
+
+idx_t CSVFileHandle::ScanRangeStart() const {
+	return scan_range_start;
 }
 
 bool CSVFileHandle::FinishedReading() const {
@@ -81,7 +135,9 @@ idx_t CSVFileHandle::Read(void *buffer, idx_t nr_bytes) {
 	// in csv format while logging is enabled
 	if (file_handle->GetFileCompressionType() == FileCompressionType::UNCOMPRESSED && file_handle->CanSeek() &&
 	    encoder.encoding_name == "utf-8") {
-		nr_bytes = MinValue<idx_t>(nr_bytes, file_size - file_handle->SeekPosition());
+		const auto read_end = has_scan_range ? scan_read_end : file_size;
+		const auto current_position = file_handle->SeekPosition();
+		nr_bytes = current_position >= read_end ? 0 : MinValue<idx_t>(nr_bytes, read_end - current_position);
 	}
 
 	requested_bytes += nr_bytes;
@@ -93,7 +149,7 @@ idx_t CSVFileHandle::Read(void *buffer, idx_t nr_bytes) {
 		bytes_read = encoder.Encode(*file_handle, static_cast<char *>(buffer), nr_bytes);
 	}
 	if (!finished) {
-		finished = bytes_read == 0;
+		finished = bytes_read == 0 || (has_scan_range && file_handle->SeekPosition() >= scan_read_end);
 	}
 	uncompressed_bytes_read += static_cast<idx_t>(bytes_read);
 	return UnsafeNumericCast<idx_t>(bytes_read);
@@ -114,7 +170,7 @@ string CSVFileHandle::ReadLine() {
 					throw BinderException(
 					    "Carriage return newlines not supported when reading CSV files in which we cannot seek");
 				}
-				file_handle->Seek(file_handle->SeekPosition() - 1);
+				Seek(file_handle->SeekPosition() - scan_range_start - 1);
 				return result;
 			}
 		}

--- a/external/duckdb/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
+++ b/external/duckdb/src/execution/operator/csv_scanner/table_function/csv_file_scanner.cpp
@@ -1,10 +1,27 @@
 #include "duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp"
 
 #include "duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp"
+#include "duckdb/execution/operator/csv_scanner/csv_scan_range.hpp"
 #include "duckdb/execution/operator/csv_scanner/skip_scanner.hpp"
 #include "duckdb/function/table/read_csv.hpp"
 
 namespace duckdb {
+
+static void DetectNewLineFromFileStartForScanRange(ClientContext &context, const OpenFileInfo &file,
+                                                   CSVReaderOptions &options, bool per_file_single_threaded) {
+	CSVScanRange scan_range;
+	if (options.dialect_options.state_machine_options.new_line != NewLineIdentifier::NOT_SET ||
+	    !CSVScanRange::TryGet(file, scan_range)) {
+		return;
+	}
+
+	// A byte-range task can begin immediately before an embedded newline in a quoted value. Detecting the newline
+	// convention from that range would incorrectly classify a CRLF file as LF-only, so always inspect the beginning
+	// of the original file before narrowing the reader to the task range.
+	auto detection_manager =
+	    make_shared_ptr<CSVBufferManager>(context, options, CSVScanRange::Strip(file), per_file_single_threaded);
+	options.dialect_options.state_machine_options.new_line = CSVSniffer::DetectNewLineDelimiter(*detection_manager);
+}
 
 CSVFileScan::CSVFileScan(ClientContext &context, const OpenFileInfo &file_p, CSVReaderOptions options_p,
                          const MultiFileOptions &file_options, const vector<string> &names,
@@ -13,6 +30,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, const OpenFileInfo &file_p, CSV
     : BaseFileReader(file_p), buffer_manager(std::move(buffer_manager_p)),
       error_handler(make_shared_ptr<CSVErrorHandler>(options_p.ignore_errors.GetValue())),
       options(std::move(options_p)) {
+	DetectNewLineFromFileStartForScanRange(context, file, options, per_file_single_threaded);
 	// Initialize Buffer Manager
 	if (!buffer_manager) {
 		buffer_manager = make_shared_ptr<CSVBufferManager>(context, options, file, per_file_single_threaded);
@@ -53,6 +71,7 @@ CSVFileScan::CSVFileScan(ClientContext &context, const OpenFileInfo &file_p, con
                          const MultiFileOptions &file_options)
     : BaseFileReader(file_p), error_handler(make_shared_ptr<CSVErrorHandler>(options_p.ignore_errors.GetValue())),
       options(options_p) {
+	DetectNewLineFromFileStartForScanRange(context, file, options, false);
 	buffer_manager = make_shared_ptr<CSVBufferManager>(context, options, file);
 	// Initialize On Disk and Size of file
 	on_disk_file = buffer_manager->file_handle->OnDiskFile();
@@ -82,6 +101,10 @@ CSVUnionData::~CSVUnionData() {
 }
 
 void CSVFileScan::SetStart() {
+	if (buffer_manager->HasScanRange() && buffer_manager->GetScanRangeStart() > 0) {
+		start_iterator.first_one = false;
+		return;
+	}
 	idx_t rows_to_skip = options.GetSkipRows() + state_machine->dialect_options.header.GetValue();
 
 	if (rows_to_skip == 0) {

--- a/external/duckdb/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
+++ b/external/duckdb/src/execution/operator/csv_scanner/table_function/csv_multi_file_info.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_file_scanner.hpp"
 #include "duckdb/execution/operator/csv_scanner/global_csv_state.hpp"
+#include "duckdb/execution/operator/csv_scanner/csv_scan_range.hpp"
 #include "duckdb/execution/operator/csv_scanner/sniffer/csv_sniffer.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_buffer.hpp"
 #include "duckdb/execution/operator/persistent/csv_rejects_table.hpp"
@@ -188,10 +189,12 @@ void CSVMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &r
 		CSVFileReaderOptions csv_options(options);
 		bind_data.reader_bind = bind_data.multi_file_reader->BindUnionReader(
 		    context, return_types, names, multi_file_list, bind_data, csv_options, bind_data.file_options);
-		if (bind_data.union_readers.size() > 1) {
+		if (!bind_data.union_readers.empty()) {
 			for (idx_t i = 0; i < bind_data.union_readers.size(); i++) {
 				auto &csv_union_data = bind_data.union_readers[i]->Cast<CSVUnionData>();
-				csv_data.column_info.emplace_back(csv_union_data.names, csv_union_data.types);
+				csv_data.column_info.emplace_back(
+				    csv_union_data.names, csv_union_data.types, csv_union_data.GetFileName(),
+				    SerializedCSVReaderOptions(csv_union_data.options, bind_data.file_options));
 			}
 		}
 		if (!options.sql_types_per_column.empty()) {
@@ -297,9 +300,8 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 	auto options = union_data.options;
 	options.auto_detect = false;
 	D_ASSERT(csv_data.csv_schema.Empty());
-	return make_shared_ptr<CSVFileScan>(context, union_data.GetFileName(), std::move(options), bind_data.file_options,
-	                                    csv_names, csv_types, csv_data.csv_schema, gstate.SingleThreadedRead(), nullptr,
-	                                    false);
+	return make_shared_ptr<CSVFileScan>(context, union_data.file, std::move(options), bind_data.file_options, csv_names,
+	                                    csv_types, csv_data.csv_schema, gstate.SingleThreadedRead(), nullptr, false);
 }
 
 shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context, GlobalTableFunctionState &gstate_p,
@@ -309,7 +311,29 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 	auto &csv_data = bind_data.bind_data->Cast<ReadCSVData>();
 
 	auto options = csv_data.options;
-	if (bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE) {
+	const vector<string> *csv_names = &bind_data.names;
+	const vector<LogicalType> *csv_types = &bind_data.types;
+	if (bind_data.file_options.union_by_name) {
+		if (csv_data.column_info.empty()) {
+			throw InternalException("CSV union-by-name scan has no per-file reader information");
+		}
+		optional_ptr<const ColumnInfo> file_info;
+		for (const auto &info : csv_data.column_info) {
+			if (info.file_path == file.path) {
+				file_info = info;
+				break;
+			}
+		}
+		if (!file_info) {
+			throw InternalException("Missing CSV union reader information for file \"%s\"", file.path);
+		}
+		options = file_info->options.options;
+		csv_names = &file_info->names;
+		csv_types = &file_info->types;
+	}
+	CSVScanRange scan_range;
+	if (bind_data.file_list->GetExpandResult() == FileExpandResult::SINGLE_FILE ||
+	    CSVScanRange::TryGet(file, scan_range)) {
 		options.auto_detect = false;
 	}
 
@@ -320,8 +344,8 @@ shared_ptr<BaseFileReader> CSVMultiFileInfo::CreateReader(ClientContext &context
 			buffer_manager.reset();
 		}
 	}
-	return make_shared_ptr<CSVFileScan>(context, file, std::move(options), bind_data.file_options, bind_data.names,
-	                                    bind_data.types, csv_data.csv_schema, gstate.SingleThreadedRead(),
+	return make_shared_ptr<CSVFileScan>(context, file, std::move(options), bind_data.file_options, *csv_names,
+	                                    *csv_types, csv_data.csv_schema, gstate.SingleThreadedRead(),
 	                                    std::move(buffer_manager), false);
 }
 
@@ -344,6 +368,10 @@ shared_ptr<BaseUnionData> CSVFileScan::GetUnionData(idx_t file_idx) {
 	}
 	data->options.auto_detect = false;
 	return data;
+}
+
+unique_ptr<MultiFileReaderInterface> CSVMultiFileInfo::Copy() {
+	return make_uniq<CSVMultiFileInfo>();
 }
 
 void CSVFileScan::PrepareReader(ClientContext &context, GlobalTableFunctionState &) {

--- a/external/duckdb/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
+++ b/external/duckdb/src/execution/operator/csv_scanner/table_function/global_csv_state.cpp
@@ -44,10 +44,13 @@ void CSVGlobalState::FinishScan(unique_ptr<StringValueScanner> scanner) {
 
 unique_ptr<StringValueScanner> CSVGlobalState::Next(shared_ptr<CSVFileScan> &current_file_ptr) {
 	auto &current_file = *current_file_ptr;
+	const bool has_scan_range = current_file.buffer_manager->HasScanRange();
+	const auto buffer_size = current_file.options.buffer_size_option.GetValue();
 	if (!initialized) {
 		// initialize the boundary for this file
 		current_boundary = current_file.start_iterator;
-		current_boundary.SetCurrentBoundaryToPosition(single_threaded, current_file.options);
+		current_boundary.buffer_size = buffer_size;
+		current_boundary.SetCurrentBoundaryToPosition(single_threaded && !has_scan_range, current_file.options);
 		if (current_boundary.done && context.client_data->debug_set_max_line_length) {
 			context.client_data->debug_max_line_length =
 			    MaxValue<idx_t>(context.client_data->debug_max_line_length, current_boundary.pos.buffer_pos);
@@ -60,6 +63,17 @@ unique_ptr<StringValueScanner> CSVGlobalState::Next(shared_ptr<CSVFileScan> &cur
 		if (current_boundary.done || !current_boundary.Next(*current_file.buffer_manager, current_file.options)) {
 			// finished processing this file - return
 			return nullptr;
+		}
+	}
+	if (has_scan_range) {
+		const auto scan_end = current_file.buffer_manager->GetScanRangeSize();
+		if (current_boundary.GetGlobalCurrentPos() >= scan_end) {
+			return nullptr;
+		}
+		const auto end_buffer_idx = (scan_end - 1) / buffer_size;
+		const auto end_buffer_pos = (scan_end - 1) % buffer_size + 1;
+		if (current_boundary.GetBufferIdx() == end_buffer_idx && current_boundary.GetEndPos() > end_buffer_pos) {
+			current_boundary.SetEnd(end_buffer_pos);
 		}
 	}
 	// create the scanner for this file

--- a/external/duckdb/src/function/table/copy_csv.cpp
+++ b/external/duckdb/src/function/table/copy_csv.cpp
@@ -3,7 +3,9 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/multi_file/multi_file_function.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
@@ -116,6 +118,23 @@ void BaseCSVData::Finalize() {
 	}
 }
 
+unique_ptr<FunctionData> WriteCSVData::Copy() const {
+	auto result = make_uniq<WriteCSVData>(options.name_list);
+	result->options = options;
+	result->filename_col_idx = filename_col_idx;
+	result->hive_partition_col_idx = hive_partition_col_idx;
+	result->flush_size = flush_size;
+	result->sql_types = sql_types;
+	result->cast_expressions.reserve(cast_expressions.size());
+	for (auto &expression : cast_expressions) {
+		if (!expression) {
+			throw InternalException("Cannot copy CSV writer bind data with a null cast expression");
+		}
+		result->cast_expressions.push_back(expression->Copy());
+	}
+	return std::move(result);
+}
+
 static vector<unique_ptr<Expression>> CreateCastExpressions(WriteCSVData &bind_data, ClientContext &context,
                                                             const vector<string> &names,
                                                             const vector<LogicalType> &sql_types) {
@@ -206,8 +225,39 @@ static unique_ptr<FunctionData> WriteCSVBind(ClientContext &context, CopyFunctio
 
 	auto expressions = CreateCastExpressions(*bind_data, context, names, sql_types);
 	bind_data->cast_expressions = std::move(expressions);
+	bind_data->sql_types = sql_types;
 
 	return std::move(bind_data);
+}
+
+static void WriteCSVSerialize(Serializer &serializer, const FunctionData &bind_data_p, const CopyFunction &function) {
+	auto &bind_data = bind_data_p.Cast<WriteCSVData>();
+	serializer.WriteProperty(100, "options", SerializedCSVReaderOptions(bind_data.options, MultiFileOptions()));
+	serializer.WriteProperty(101, "sql_types", bind_data.sql_types);
+	serializer.WriteProperty(102, "flush_size", bind_data.flush_size);
+}
+
+static unique_ptr<FunctionData> WriteCSVDeserialize(Deserializer &deserializer, CopyFunction &function) {
+	auto &context = deserializer.Get<ClientContext &>();
+	auto serialized_options = deserializer.ReadProperty<SerializedCSVReaderOptions>(100, "options");
+	auto sql_types = deserializer.ReadProperty<vector<LogicalType>>(101, "sql_types");
+	auto flush_size = deserializer.ReadProperty<idx_t>(102, "flush_size");
+	if (serialized_options.options.name_list.size() != sql_types.size()) {
+		throw SerializationException("CSV COPY bind data has %llu names but %llu types",
+		                             serialized_options.options.name_list.size(), sql_types.size());
+	}
+
+	auto result = make_uniq<WriteCSVData>(serialized_options.options.name_list);
+	result->options = std::move(serialized_options.options);
+	result->sql_types = std::move(sql_types);
+	result->flush_size = flush_size;
+	result->cast_expressions = CreateCastExpressions(*result, context, result->options.name_list, result->sql_types);
+	for (auto &expression : result->cast_expressions) {
+		if (!expression) {
+			throw InternalException("CSV writer deserialization produced a null cast expression");
+		}
+	}
+	return std::move(result);
 }
 
 static void CSVListCopyOptions(ClientContext &context, CopyOptionsInput &input) {
@@ -273,9 +323,9 @@ public:
 };
 
 struct GlobalWriteCSVData : public GlobalFunctionData {
-	GlobalWriteCSVData(CSVReaderOptions &options, FileSystem &fs, const string &file_path,
+	GlobalWriteCSVData(CSVReaderOptions &options, FileSystem &fs_p, const string &file_path_p,
 	                   FileCompressionType compression)
-	    : writer(options, fs, file_path, compression) {
+	    : writer(options, fs_p, file_path_p, compression), fs(fs_p), file_path(file_path_p) {
 	}
 
 	idx_t FileSize() {
@@ -302,15 +352,61 @@ struct GlobalWriteCSVData : public GlobalFunctionData {
 		local_states.push_back(std::move(lstate));
 	}
 
+	void SetWrittenStatistics(CopyFunctionFileStatistics &statistics) {
+		auto file_size = writer.FileSize();
+		lock_guard<mutex> guard(statistics_lock);
+		written_statistics = &statistics;
+		written_statistics->row_count = rows_written;
+		written_statistics->file_size_bytes = file_size;
+	}
+
+	void AddRows(idx_t count) {
+		lock_guard<mutex> guard(statistics_lock);
+		rows_written += count;
+		if (written_statistics) {
+			written_statistics->row_count = rows_written;
+		}
+	}
+
+	void FinalizeWrittenStatistics() {
+		{
+			lock_guard<mutex> guard(statistics_lock);
+			if (!written_statistics) {
+				return;
+			}
+		}
+		auto handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
+		auto file_size = handle->GetFileSize();
+		lock_guard<mutex> guard(statistics_lock);
+		if (written_statistics) {
+			written_statistics->row_count = rows_written;
+			written_statistics->file_size_bytes = file_size;
+		}
+	}
+
 	CSVWriter writer;
 
 private:
+	FileSystem &fs;
+	string file_path;
 	mutex local_state_lock;
 	vector<unique_ptr<CSVWriterState>> local_states;
+	mutex statistics_lock;
+	idx_t rows_written = 0;
+	CopyFunctionFileStatistics *written_statistics = nullptr;
 };
 
 static unique_ptr<LocalFunctionData> WriteCSVInitializeLocal(ExecutionContext &context, FunctionData &bind_data) {
 	auto &csv_data = bind_data.Cast<WriteCSVData>();
+	if (csv_data.cast_expressions.size() != csv_data.options.name_list.size()) {
+		throw InternalException("CSV writer has %llu columns but %llu cast expressions",
+		                        csv_data.options.name_list.size(), csv_data.cast_expressions.size());
+	}
+	for (auto &expression : csv_data.cast_expressions) {
+		if (!expression) {
+			throw InternalException("CSV writer local initialization received a null cast expression");
+		}
+	}
 	auto local_data = make_uniq<LocalWriteCSVData>(context.client, csv_data.cast_expressions, csv_data.flush_size);
 
 	// create the chunk with VARCHAR types
@@ -353,6 +449,7 @@ static void WriteCSVSink(ExecutionContext &context, FunctionData &bind_data, Glo
 
 	WriteCSVChunkInternal(global_state.writer, local_data.writer_local_state, local_data.cast_chunk, input,
 	                      local_data.executor);
+	global_state.AddRows(input.size());
 }
 
 //===--------------------------------------------------------------------===//
@@ -379,6 +476,13 @@ void WriteCSVFinalize(ClientContext &context, FunctionData &bind_data, GlobalFun
 		global_state.writer.WriteRawString(global_state.writer.writer_options.newline);
 	}
 	global_state.writer.Close();
+	global_state.FinalizeWrittenStatistics();
+}
+
+static void WriteCSVGetWrittenStatistics(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate,
+                                         CopyFunctionFileStatistics &statistics) {
+	auto &global_state = gstate.Cast<GlobalWriteCSVData>();
+	global_state.SetWrittenStatistics(statistics);
 }
 
 //===--------------------------------------------------------------------===//
@@ -423,9 +527,11 @@ unique_ptr<PreparedBatchData> WriteCSVPrepareBatch(ClientContext &context, Funct
 	// write CSV chunks to the batch data
 	auto local_writer_state = global_state.GetLocalState(context, NextPowerOfTwo(collection->SizeInBytes()));
 	auto batch = make_uniq<WriteCSVBatchData>(std::move(local_writer_state));
+	auto row_count = collection->Count();
 	for (auto &chunk : collection->Chunks()) {
 		WriteCSVChunkInternal(global_state.writer, *batch->writer_local_state, cast_chunk, chunk, executor);
 	}
+	global_state.AddRows(row_count);
 	return std::move(batch);
 }
 
@@ -458,6 +564,7 @@ void CSVCopyFunction::RegisterFunction(BuiltinFunctions &set) {
 	info.copy_options = CSVListCopyOptions;
 	info.copy_to_initialize_local = WriteCSVInitializeLocal;
 	info.copy_to_initialize_global = WriteCSVInitializeGlobal;
+	info.copy_to_get_written_statistics = WriteCSVGetWrittenStatistics;
 	info.copy_to_sink = WriteCSVSink;
 	info.copy_to_combine = WriteCSVCombine;
 	info.copy_to_finalize = WriteCSVFinalize;
@@ -466,6 +573,8 @@ void CSVCopyFunction::RegisterFunction(BuiltinFunctions &set) {
 	info.flush_batch = WriteCSVFlushBatch;
 	info.rotate_files = WriteCSVRotateFiles;
 	info.rotate_next_file = WriteCSVRotateNextFile;
+	info.serialize = WriteCSVSerialize;
+	info.deserialize = WriteCSVDeserialize;
 
 	info.copy_from_bind = MultiFileFunction<CSVMultiFileInfo>::MultiFileBindCopy;
 	info.copy_from_function = ReadCSVTableFunction::GetFunction();

--- a/external/duckdb/src/function/table/read_csv.cpp
+++ b/external/duckdb/src/function/table/read_csv.cpp
@@ -31,6 +31,8 @@
 #include "duckdb/common/multi_file/multi_file_function.hpp"
 #include "duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp"
 
+#include <algorithm>
+
 namespace duckdb {
 
 SerializedCSVReaderOptions::SerializedCSVReaderOptions(CSVReaderOptions options_p, MultiFileOptions file_options_p)
@@ -48,6 +50,19 @@ unique_ptr<CSVFileHandle> ReadCSV::OpenCSV(const OpenFileInfo &file, const CSVRe
 }
 
 ReadCSVData::ReadCSVData() {
+}
+
+unique_ptr<FunctionData> ReadCSVData::Copy() const {
+	auto result = make_uniq<ReadCSVData>();
+	result->options = options;
+	result->filename_col_idx = filename_col_idx;
+	result->hive_partition_col_idx = hive_partition_col_idx;
+	result->manually_set = manually_set;
+	// The bind-time buffer manager owns mutable file position and cached buffers. A copied plan must open its own
+	// reader, especially when a distributed scan task narrows the same file to a byte range.
+	result->column_info = column_info;
+	result->csv_schema = csv_schema;
+	return std::move(result);
 }
 
 void ReadCSVData::FinalizeRead(ClientContext &context) {
@@ -101,43 +116,121 @@ void ReadCSVTableFunction::ReadCSVAddNamedParameters(TableFunction &table_functi
 
 static void CSVReaderSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
                                const TableFunction &function) {
-	throw NotImplementedException("CSVReaderSerialize not implemented");
-	// auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
-	// auto &csv_data = bind_data.bind_data->Cast<ReadCSVData>();
-	// serializer.WriteProperty(100, "extra_info", function.extra_info);
-	// // generate the serialized data
-	// SerializedReadCSVData serialized_data;
-	// serialized_data.return_types = serialized_data.csv_types = bind_data.types;
-	// serialized_data.return_names = serialized_data.csv_names = bind_data.names;
-	// serialized_data.files = bind_data.file_list->GetAllFiles();
-	// serialized_data.filename_col_idx = csv_data.filename_col_idx;
-	// serialized_data.options.options = csv_data.options;
-	// serialized_data.options.file_options = bind_data.file_options;
-	// serialized_data.reader_bind = bind_data.reader_bind;
-	// serializer.WriteProperty(101, "csv_data", serialized_data);
+	if (!bind_data_p) {
+		throw InternalException("Cannot serialize read_csv without bind data");
+	}
+	auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
+	auto &csv_data = bind_data.bind_data->Cast<ReadCSVData>();
+
+	SerializedReadCSVData serialized_data;
+	for (auto &file : bind_data.file_list->GetAllFiles()) {
+		serialized_data.files.emplace_back(file.path);
+	}
+	serialized_data.return_types = serialized_data.csv_types = bind_data.types;
+	serialized_data.return_names = serialized_data.csv_names = bind_data.names;
+	serialized_data.filename_col_idx = csv_data.filename_col_idx;
+	serialized_data.hive_partition_col_idx = csv_data.hive_partition_col_idx;
+	serialized_data.options = SerializedCSVReaderOptions(csv_data.options, bind_data.file_options);
+	serialized_data.reader_bind = bind_data.reader_bind;
+	serialized_data.table_columns = bind_data.table_columns;
+	serialized_data.manually_set = csv_data.manually_set;
+
+	if (!csv_data.csv_schema.Empty()) {
+		serialized_data.csv_schema_names = csv_data.csv_schema.GetNames();
+		serialized_data.csv_schema_types = csv_data.csv_schema.GetTypes();
+		serialized_data.csv_schema_path = csv_data.csv_schema.GetPath();
+		serialized_data.csv_schema_rows_read = csv_data.csv_schema.GetRowsRead();
+	}
+
+	if (bind_data.file_options.union_by_name) {
+		if (csv_data.column_info.empty()) {
+			throw InternalException("Cannot serialize CSV union-by-name scan without per-file reader information");
+		}
+		for (auto &file : serialized_data.files) {
+			auto entry = std::find_if(csv_data.column_info.begin(), csv_data.column_info.end(),
+			                          [&](const ColumnInfo &info) { return info.file_path == file; });
+			if (entry == csv_data.column_info.end()) {
+				throw InternalException("Missing serialized CSV union reader information for file \"%s\"", file);
+			}
+			if (entry->options.options.encoding.empty()) {
+				throw InternalException("CSV union reader information has no encoding for file \"%s\"", file);
+			}
+			serialized_data.column_info.push_back(*entry);
+		}
+	}
+	serializer.WriteProperty(100, "csv_data", serialized_data);
 }
 
 static unique_ptr<FunctionData> CSVReaderDeserialize(Deserializer &deserializer, TableFunction &function) {
-	throw NotImplementedException("CSVReaderDeserialize not implemented");
-	// auto &context = deserializer.Get<ClientContext &>();
-	// SerializedReadCSVData serialized_data;
-	// deserializer.ReadProperty(100, "extra_info", function.extra_info);
-	// deserializer.ReadProperty(101, "csv_data", serialized_data);
-	//
-	// vector<Value> file_path;
-	// for (auto &path : serialized_data.files) {
-	// 	file_path.emplace_back(path);
-	// }
-	// auto multi_file_reader = MultiFileReader::Create(function);
-	// auto file_list = multi_file_reader->CreateFileList(context, Value::LIST(LogicalType::VARCHAR, file_path),
-	//                                                    FileGlobOptions::ALLOW_EMPTY);
-	// auto csv_options = make_uniq<CSVFileReaderOptions>();
-	// csv_options->options = std::move(serialized_data.options.options);
-	//
-	// auto bind_data = MultiFileFunction<CSVMultiFileInfo>::MultiFileBindInternal(
-	//     context, std::move(multi_file_reader), std::move(file_list), serialized_data.return_types,
-	//     serialized_data.return_names, std::move(serialized_data.options.file_options), std::move(csv_options));
-	// return bind_data;
+	auto &context = deserializer.Get<ClientContext &>();
+	auto serialized_data = deserializer.ReadProperty<SerializedReadCSVData>(100, "csv_data");
+	if (serialized_data.files.empty()) {
+		throw IOException("%s needs at least one file to read", function.name);
+	}
+
+	vector<OpenFileInfo> open_files;
+	open_files.reserve(serialized_data.files.size());
+	for (auto &path : serialized_data.files) {
+		open_files.emplace_back(path);
+	}
+	auto file_list = make_shared_ptr<SimpleMultiFileList>(std::move(open_files));
+	auto multi_file_reader = MultiFileReader::Create(function);
+	auto interface = make_uniq<CSVMultiFileInfo>();
+	interface->InitializeInterface(context, *multi_file_reader, *file_list);
+
+	auto csv_options = make_uniq<CSVFileReaderOptions>(std::move(serialized_data.options.options));
+	auto result = make_uniq<MultiFileBindData>();
+	result->multi_file_reader = std::move(multi_file_reader);
+	result->file_list = std::move(file_list);
+	result->file_options = std::move(serialized_data.options.file_options);
+	result->interface = std::move(interface);
+	result->bind_data = result->interface->InitializeBindData(*result, std::move(csv_options));
+	result->types = std::move(serialized_data.return_types);
+	result->names = std::move(serialized_data.return_names);
+	result->reader_bind = std::move(serialized_data.reader_bind);
+	result->table_columns = std::move(serialized_data.table_columns);
+	if (result->file_options.union_by_name) {
+		if (serialized_data.column_info.size() != serialized_data.files.size()) {
+			throw SerializationException("CSV union-by-name scan has %llu files but %llu per-file reader entries",
+			                             serialized_data.files.size(), serialized_data.column_info.size());
+		}
+		for (idx_t file_idx = 0; file_idx < serialized_data.files.size(); ++file_idx) {
+			if (serialized_data.column_info[file_idx].file_path != serialized_data.files[file_idx]) {
+				throw SerializationException("CSV union-by-name reader entry %llu targets \"%s\", expected \"%s\"",
+				                             file_idx, serialized_data.column_info[file_idx].file_path,
+				                             serialized_data.files[file_idx]);
+			}
+		}
+	}
+
+	auto &csv_data = result->bind_data->Cast<ReadCSVData>();
+	csv_data.filename_col_idx = serialized_data.filename_col_idx;
+	csv_data.hive_partition_col_idx = serialized_data.hive_partition_col_idx;
+	csv_data.manually_set = std::move(serialized_data.manually_set);
+	if (!serialized_data.csv_schema_names.empty()) {
+		csv_data.csv_schema = CSVSchema(serialized_data.csv_schema_names, serialized_data.csv_schema_types,
+		                                serialized_data.csv_schema_path, serialized_data.csv_schema_rows_read);
+	}
+	for (auto &info : serialized_data.column_info) {
+		if (info.options.options.encoding.empty()) {
+			throw InternalException("Deserialized CSV union reader information has no encoding for file \"%s\"",
+			                        info.file_path);
+		}
+		auto union_data = make_shared_ptr<CSVUnionData>(OpenFileInfo(info.file_path));
+		union_data->names = info.names;
+		union_data->types = info.types;
+		union_data->options = info.options.options;
+		result->union_readers.push_back(std::move(union_data));
+	}
+	csv_data.column_info = std::move(serialized_data.column_info);
+
+	result->interface->FinalizeBindData(*result);
+	result->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(result->names, result->types);
+	virtual_column_map_t virtual_columns;
+	MultiFileReader::GetVirtualColumns(context, result->reader_bind, virtual_columns);
+	result->interface->GetVirtualColumns(context, *result, virtual_columns);
+	result->virtual_columns = std::move(virtual_columns);
+	return std::move(result);
 }
 
 TableFunction ReadCSVTableFunction::GetFunction() {

--- a/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_buffer_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_buffer_manager.hpp
@@ -49,6 +49,9 @@ public:
 	bool IsBlockUnloaded(idx_t block_idx);
 
 	idx_t GetBytesRead() const;
+	bool HasScanRange() const;
+	idx_t GetScanRangeStart() const;
+	idx_t GetScanRangeSize() const;
 
 	ClientContext &context;
 	idx_t skip_rows = 0;

--- a/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_file_handle.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_file_handle.hpp
@@ -33,8 +33,11 @@ public:
 	bool IsPipe() const;
 
 	void Reset();
+	void SetScanRange(idx_t start, idx_t end, idx_t overlap);
 
 	idx_t FileSize() const;
+	bool HasScanRange() const;
+	idx_t ScanRangeStart() const;
 
 	bool FinishedReading() const;
 
@@ -63,6 +66,10 @@ private:
 	idx_t uncompressed_bytes_read = 0;
 
 	idx_t file_size = 0;
+	bool has_scan_range = false;
+	idx_t scan_range_start = 0;
+	idx_t scan_range_end = 0;
+	idx_t scan_read_end = 0;
 
 	idx_t requested_bytes = 0;
 	//! If we finished reading the file

--- a/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_multi_file_info.hpp
@@ -64,6 +64,7 @@ struct CSVMultiFileInfo : MultiFileReaderInterface {
 	void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                   LocalTableFunctionState &local_state) override;
 	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
+	unique_ptr<MultiFileReaderInterface> Copy() override;
 	FileGlobInput GetGlobInput() override;
 };
 

--- a/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_scan_range.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/csv_scanner/csv_scan_range.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/open_file_info.hpp"
+
+namespace duckdb {
+
+struct CSVScanRange {
+	static constexpr const char *START_OPTION = "__vane_csv_scan_range_start";
+	static constexpr const char *END_OPTION = "__vane_csv_scan_range_end";
+
+	idx_t start;
+	idx_t end;
+
+	idx_t Size() const {
+		return end - start;
+	}
+
+	static bool TryGet(const OpenFileInfo &file, CSVScanRange &result) {
+		if (!file.extended_info) {
+			return false;
+		}
+		auto start_entry = file.extended_info->options.find(START_OPTION);
+		auto end_entry = file.extended_info->options.find(END_OPTION);
+		if (start_entry == file.extended_info->options.end() && end_entry == file.extended_info->options.end()) {
+			return false;
+		}
+		if (start_entry == file.extended_info->options.end() || end_entry == file.extended_info->options.end()) {
+			throw InvalidInputException("CSV scan task for \"%s\" has an incomplete byte range", file.path);
+		}
+		result.start = start_entry->second.GetValue<idx_t>();
+		result.end = end_entry->second.GetValue<idx_t>();
+		if (result.start >= result.end) {
+			throw InvalidInputException("CSV scan task for \"%s\" has invalid byte range [%llu, %llu)", file.path,
+			                            result.start, result.end);
+		}
+		return true;
+	}
+
+	static OpenFileInfo Set(const OpenFileInfo &file, idx_t start, idx_t end) {
+		OpenFileInfo result = file;
+		result.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		if (file.extended_info) {
+			result.extended_info->options = file.extended_info->options;
+		}
+		result.extended_info->options[START_OPTION] = Value::UBIGINT(start);
+		result.extended_info->options[END_OPTION] = Value::UBIGINT(end);
+		return result;
+	}
+
+	static OpenFileInfo Strip(const OpenFileInfo &file) {
+		if (!file.extended_info) {
+			return file;
+		}
+		OpenFileInfo result = file;
+		result.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		result.extended_info->options = file.extended_info->options;
+		result.extended_info->options.erase(START_OPTION);
+		result.extended_info->options.erase(END_OPTION);
+		if (result.extended_info->options.empty()) {
+			result.extended_info.reset();
+		}
+		return result;
+	}
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/function/table/read_csv.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/read_csv.hpp
@@ -51,20 +51,41 @@ struct WriteCSVData : public BaseCSVData {
 	idx_t flush_size = 4096ULL * 8ULL;
 	//! Expressions used to convert the input into strings
 	vector<unique_ptr<Expression>> cast_expressions;
+	//! Original input types, used to reconstruct the casts after plan deserialization
+	vector<LogicalType> sql_types;
+
+	unique_ptr<FunctionData> Copy() const override;
+};
+
+struct SerializedCSVReaderOptions {
+	SerializedCSVReaderOptions() = default;
+	SerializedCSVReaderOptions(CSVReaderOptions options, MultiFileOptions file_options);
+	SerializedCSVReaderOptions(CSVOption<char> single_byte_delimiter, const CSVOption<string> &multi_byte_delimiter);
+
+	CSVReaderOptions options;
+	MultiFileOptions file_options;
+
+	void Serialize(Serializer &serializer) const;
+	static SerializedCSVReaderOptions Deserialize(Deserializer &deserializer);
 };
 
 struct ColumnInfo {
 	ColumnInfo() {
 	}
-	ColumnInfo(vector<std::string> names_p, vector<LogicalType> types_p) {
+	ColumnInfo(vector<std::string> names_p, vector<LogicalType> types_p, string file_path_p,
+	           SerializedCSVReaderOptions options_p) {
 		names = std::move(names_p);
 		types = std::move(types_p);
+		file_path = std::move(file_path_p);
+		options = std::move(options_p);
 	}
 	void Serialize(Serializer &serializer) const;
 	static ColumnInfo Deserialize(Deserializer &deserializer);
 
 	vector<std::string> names;
 	vector<LogicalType> types;
+	string file_path;
+	SerializedCSVReaderOptions options;
 };
 
 struct ReadCSVData : public BaseCSVData {
@@ -80,18 +101,7 @@ struct ReadCSVData : public BaseCSVData {
 	CSVSchema csv_schema;
 
 	void FinalizeRead(ClientContext &context);
-};
-
-struct SerializedCSVReaderOptions {
-	SerializedCSVReaderOptions() = default;
-	SerializedCSVReaderOptions(CSVReaderOptions options, MultiFileOptions file_options);
-	SerializedCSVReaderOptions(CSVOption<char> single_byte_delimiter, const CSVOption<string> &multi_byte_delimiter);
-
-	CSVReaderOptions options;
-	MultiFileOptions file_options;
-
-	void Serialize(Serializer &serializer) const;
-	static SerializedCSVReaderOptions Deserialize(Deserializer &deserializer);
+	unique_ptr<FunctionData> Copy() const override;
 };
 
 struct SerializedReadCSVData {
@@ -100,10 +110,17 @@ struct SerializedReadCSVData {
 	vector<string> csv_names;
 	vector<LogicalType> return_types;
 	vector<string> return_names;
-	idx_t filename_col_idx;
+	idx_t filename_col_idx {};
+	idx_t hive_partition_col_idx {};
 	SerializedCSVReaderOptions options;
 	MultiFileReaderBindData reader_bind;
 	vector<ColumnInfo> column_info;
+	vector<string> table_columns;
+	vector<bool> manually_set;
+	vector<string> csv_schema_names;
+	vector<LogicalType> csv_schema_types;
+	string csv_schema_path;
+	idx_t csv_schema_rows_read {};
 
 	void Serialize(Serializer &serializer) const;
 	static SerializedReadCSVData Deserialize(Deserializer &deserializer);

--- a/external/duckdb/src/include/duckdb/storage/serialization/nodes.json
+++ b/external/duckdb/src/include/duckdb/storage/serialization/nodes.json
@@ -844,6 +844,56 @@
         "name": "buffer_size_option",
         "type": "CSVOption<idx_t>",
         "property": "options.buffer_size_option"
+      },
+      {"id": 144,
+        "name": "store_rejects",
+        "type": "CSVOption<bool>",
+        "property": "options.store_rejects"
+      },
+      {"id": 145,
+        "name": "thousands_separator",
+        "type": "char",
+        "property": "options.thousands_separator"
+      },
+      {"id": 146,
+        "name": "files_to_sniff",
+        "type": "int64_t",
+        "property": "options.files_to_sniff"
+      },
+      {"id": 147,
+        "name": "auto_type_candidates",
+        "type": "vector<LogicalType>",
+        "property": "options.auto_type_candidates"
+      },
+      {"id": 148,
+        "name": "user_defined_parameters",
+        "type": "map<string, string>",
+        "property": "options.user_defined_parameters"
+      },
+      {"id": 149,
+        "name": "prefix",
+        "type": "string",
+        "property": "options.prefix"
+      },
+      {"id": 150,
+        "name": "suffix",
+        "type": "string",
+        "property": "options.suffix"
+      },
+      {"id": 151,
+        "name": "write_newline",
+        "type": "string",
+        "property": "options.write_newline"
+      },
+      {"id": 152,
+        "name": "write_date_format",
+        "type": "map<LogicalTypeId, Value>",
+        "property": "options.write_date_format"
+      },
+      {"id": 153,
+        "name": "has_format",
+        "type": "map<LogicalTypeId, bool>",
+        "property": "options.has_format"
       }
     ],
     "constructor": ["delimiter", "multi_byte_delimiter"],
@@ -914,6 +964,41 @@
         "id": 108,
         "name": "column_info",
         "type": "vector<ColumnInfo>"
+      },
+      {
+        "id": 109,
+        "name": "hive_partition_col_idx",
+        "type": "idx_t"
+      },
+      {
+        "id": 110,
+        "name": "table_columns",
+        "type": "vector<string>"
+      },
+      {
+        "id": 111,
+        "name": "manually_set",
+        "type": "vector<bool>"
+      },
+      {
+        "id": 112,
+        "name": "csv_schema_names",
+        "type": "vector<string>"
+      },
+      {
+        "id": 113,
+        "name": "csv_schema_types",
+        "type": "vector<LogicalType>"
+      },
+      {
+        "id": 114,
+        "name": "csv_schema_path",
+        "type": "string"
+      },
+      {
+        "id": 115,
+        "name": "csv_schema_rows_read",
+        "type": "idx_t"
       }
     ],
     "pointer_type": "none"
@@ -930,6 +1015,16 @@
         "id": 101,
         "name": "types",
         "type": "vector<LogicalType>"
+      },
+      {
+        "id": 102,
+        "name": "file_path",
+        "type": "string"
+      },
+      {
+        "id": 103,
+        "name": "options",
+        "type": "SerializedCSVReaderOptions"
       }
     ],
     "pointer_type": "none"
@@ -1124,6 +1219,16 @@
         "id": 103,
         "name": "sample_options",
         "type": "unique_ptr<SampleOptions>"
+      },
+      {
+        "id": 104,
+        "name": "scan_node_id",
+        "type": "optional_idx"
+      },
+      {
+        "id": 105,
+        "name": "scan_group_id",
+        "type": "optional_idx"
       }
     ],
     "pointer_type": "none"

--- a/external/duckdb/src/storage/serialization/serialize_nodes.cpp
+++ b/external/duckdb/src/storage/serialization/serialize_nodes.cpp
@@ -238,12 +238,16 @@ ColumnIndex ColumnIndex::Deserialize(Deserializer &deserializer) {
 void ColumnInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<string>>(100, "names", names);
 	serializer.WritePropertyWithDefault<vector<LogicalType>>(101, "types", types);
+	serializer.WritePropertyWithDefault<string>(102, "file_path", file_path);
+	serializer.WriteProperty<SerializedCSVReaderOptions>(103, "options", options);
 }
 
 ColumnInfo ColumnInfo::Deserialize(Deserializer &deserializer) {
 	ColumnInfo result;
 	deserializer.ReadPropertyWithDefault<vector<string>>(100, "names", result.names);
 	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(101, "types", result.types);
+	deserializer.ReadPropertyWithDefault<string>(102, "file_path", result.file_path);
+	deserializer.ReadProperty<SerializedCSVReaderOptions>(103, "options", result.options);
 	return result;
 }
 
@@ -326,8 +330,8 @@ ExtraOperatorInfo ExtraOperatorInfo::Deserialize(Deserializer &deserializer) {
 	deserializer.ReadProperty<optional_idx>(101, "total_files", result.total_files);
 	deserializer.ReadProperty<optional_idx>(102, "filtered_files", result.filtered_files);
 	deserializer.ReadPropertyWithDefault<unique_ptr<SampleOptions>>(103, "sample_options", result.sample_options);
-	deserializer.ReadPropertyWithDefault<optional_idx>(104, "scan_node_id", result.scan_node_id);
-	deserializer.ReadPropertyWithDefault<optional_idx>(105, "scan_group_id", result.scan_group_id);
+	deserializer.ReadProperty<optional_idx>(104, "scan_node_id", result.scan_node_id);
+	deserializer.ReadProperty<optional_idx>(105, "scan_group_id", result.scan_group_id);
 	return result;
 }
 
@@ -553,6 +557,16 @@ void SerializedCSVReaderOptions::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<CSVOption<string>>(141, "multi_byte_delimiter", options.GetMultiByteDelimiter());
 	serializer.WritePropertyWithDefault<bool>(142, "multi_file_reader", options.multi_file_reader);
 	serializer.WriteProperty<CSVOption<idx_t>>(143, "buffer_size_option", options.buffer_size_option);
+	serializer.WriteProperty<CSVOption<bool>>(144, "store_rejects", options.store_rejects);
+	serializer.WriteProperty<char>(145, "thousands_separator", options.thousands_separator);
+	serializer.WritePropertyWithDefault<int64_t>(146, "files_to_sniff", options.files_to_sniff);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(147, "auto_type_candidates", options.auto_type_candidates);
+	serializer.WritePropertyWithDefault<map<string, string>>(148, "user_defined_parameters", options.user_defined_parameters);
+	serializer.WritePropertyWithDefault<string>(149, "prefix", options.prefix);
+	serializer.WritePropertyWithDefault<string>(150, "suffix", options.suffix);
+	serializer.WritePropertyWithDefault<string>(151, "write_newline", options.write_newline);
+	serializer.WritePropertyWithDefault<map<LogicalTypeId, Value>>(152, "write_date_format", options.write_date_format);
+	serializer.WritePropertyWithDefault<map<LogicalTypeId, bool>>(153, "has_format", options.has_format);
 }
 
 SerializedCSVReaderOptions SerializedCSVReaderOptions::Deserialize(Deserializer &deserializer) {
@@ -638,6 +652,16 @@ SerializedCSVReaderOptions SerializedCSVReaderOptions::Deserialize(Deserializer 
 	result.options.dialect_options.state_machine_options.strict_mode = options_dialect_options_state_machine_options_strict_mode;
 	deserializer.ReadPropertyWithDefault<bool>(142, "multi_file_reader", result.options.multi_file_reader);
 	deserializer.ReadProperty<CSVOption<idx_t>>(143, "buffer_size_option", result.options.buffer_size_option);
+	deserializer.ReadProperty<CSVOption<bool>>(144, "store_rejects", result.options.store_rejects);
+	deserializer.ReadProperty<char>(145, "thousands_separator", result.options.thousands_separator);
+	deserializer.ReadPropertyWithDefault<int64_t>(146, "files_to_sniff", result.options.files_to_sniff);
+	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(147, "auto_type_candidates", result.options.auto_type_candidates);
+	deserializer.ReadPropertyWithDefault<map<string, string>>(148, "user_defined_parameters", result.options.user_defined_parameters);
+	deserializer.ReadPropertyWithDefault<string>(149, "prefix", result.options.prefix);
+	deserializer.ReadPropertyWithDefault<string>(150, "suffix", result.options.suffix);
+	deserializer.ReadPropertyWithDefault<string>(151, "write_newline", result.options.write_newline);
+	deserializer.ReadPropertyWithDefault<map<LogicalTypeId, Value>>(152, "write_date_format", result.options.write_date_format);
+	deserializer.ReadPropertyWithDefault<map<LogicalTypeId, bool>>(153, "has_format", result.options.has_format);
 	return result;
 }
 
@@ -651,6 +675,13 @@ void SerializedReadCSVData::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<SerializedCSVReaderOptions>(106, "options", options);
 	serializer.WriteProperty<MultiFileReaderBindData>(107, "reader_bind", reader_bind);
 	serializer.WritePropertyWithDefault<vector<ColumnInfo>>(108, "column_info", column_info);
+	serializer.WritePropertyWithDefault<idx_t>(109, "hive_partition_col_idx", hive_partition_col_idx);
+	serializer.WritePropertyWithDefault<vector<string>>(110, "table_columns", table_columns);
+	serializer.WritePropertyWithDefault<vector<bool>>(111, "manually_set", manually_set);
+	serializer.WritePropertyWithDefault<vector<string>>(112, "csv_schema_names", csv_schema_names);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(113, "csv_schema_types", csv_schema_types);
+	serializer.WritePropertyWithDefault<string>(114, "csv_schema_path", csv_schema_path);
+	serializer.WritePropertyWithDefault<idx_t>(115, "csv_schema_rows_read", csv_schema_rows_read);
 }
 
 SerializedReadCSVData SerializedReadCSVData::Deserialize(Deserializer &deserializer) {
@@ -664,6 +695,13 @@ SerializedReadCSVData SerializedReadCSVData::Deserialize(Deserializer &deseriali
 	deserializer.ReadProperty<SerializedCSVReaderOptions>(106, "options", result.options);
 	deserializer.ReadProperty<MultiFileReaderBindData>(107, "reader_bind", result.reader_bind);
 	deserializer.ReadPropertyWithDefault<vector<ColumnInfo>>(108, "column_info", result.column_info);
+	deserializer.ReadPropertyWithDefault<idx_t>(109, "hive_partition_col_idx", result.hive_partition_col_idx);
+	deserializer.ReadPropertyWithDefault<vector<string>>(110, "table_columns", result.table_columns);
+	deserializer.ReadPropertyWithDefault<vector<bool>>(111, "manually_set", result.manually_set);
+	deserializer.ReadPropertyWithDefault<vector<string>>(112, "csv_schema_names", result.csv_schema_names);
+	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(113, "csv_schema_types", result.csv_schema_types);
+	deserializer.ReadPropertyWithDefault<string>(114, "csv_schema_path", result.csv_schema_path);
+	deserializer.ReadPropertyWithDefault<idx_t>(115, "csv_schema_rows_read", result.csv_schema_rows_read);
 	return result;
 }
 

--- a/external/duckdb/test/sql/copy/return_stats.test
+++ b/external/duckdb/test/sql/copy/return_stats.test
@@ -251,8 +251,8 @@ COPY multi_partitioned_test TO '__TEST_DIR__/multi_partitioned_test' (FORMAT PAR
 statement ok
 COPY (FROM test_all_types()) TO '__TEST_DIR__/test_all_types.parquet' (RETURN_STATS);
 
-# unsupported format (CSV)
-statement error
+# CSV returns row count and file size without column statistics
+query IIIIII
 COPY integers TO '__TEST_DIR__/test_copy_to_file.csv' (RETURN_STATS);
 ----
-not supported
+<REGEX>:.*test_copy_to_file.csv	200000	<REGEX>:\d+	NULL	{}	NULL

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -883,6 +883,9 @@ BuildDistributedPipelineNode(const std::shared_ptr<duckdb::distributed::Distribu
 		throw duckdb::InternalException("DistributedPhysicalPlan physical plan has no root");
 	}
 	PlanConfig cfg(plan->idx(), plan->query_id(), plan->execution_config());
+	if (client_context && client_context->db) {
+		cfg.db = client_context->db;
+	}
 	auto pipeline_res = physical_plan_to_pipeline_node(std::move(cfg), std::move(physical_plan), client_context);
 	if (!pipeline_res.is_ok()) {
 		throw duckdb::InternalException(string("Failed to build distributed pipeline node: ") +

--- a/tests/fast/test_ray_e2e_serialization.py
+++ b/tests/fast/test_ray_e2e_serialization.py
@@ -5,6 +5,8 @@
 Tests the core serialization functionality without requiring full execution pipeline.
 """
 
+import csv
+
 import pytest
 
 try:
@@ -105,3 +107,423 @@ def test_streaming_metadata_and_rows_full_execution(tmp_path):
         (8, 80),
         (10, 100),
     ]
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_csv_scan_executes_through_real_ray(tmp_path, monkeypatch):
+    """Execute a multi-file CSV scan with bound parser options on Ray workers."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_BYTES", "1")
+    (tmp_path / "part-0.csv").write_text(
+        "id|amount|label\n1|1,200.5|alpha\n2|2,300.5|beta\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "part-1.csv").write_text(
+        "id;amount;note\n3;3,400.5;gamma-note\n4;4,500.5;delta-note\n",
+        encoding="utf-8",
+    )
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, amount, label, note
+        FROM read_csv_auto(
+            '{tmp_path}/*.csv',
+            thousands=',',
+            union_by_name=true
+        )
+        """
+    )
+    physical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "csv-source-ray-plan",
+    ).to_physical_plan(connection)
+    assert [len(tasks) for tasks in physical_plan.scan_task_descriptor_map().values()] == [2]
+
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+    parts = list(runner.run_iter_tables(relation))
+    tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+    result = pa.concat_tables(tables)
+
+    assert sorted(
+        zip(
+            result.column(0).to_pylist(),
+            result.column(1).to_pylist(),
+            result.column(2).to_pylist(),
+            result.column(3).to_pylist(),
+        )
+    ) == [
+        (1, 1200.5, "alpha", None),
+        (2, 2300.5, "beta", None),
+        (3, 3400.5, None, "gamma-note"),
+        (4, 4500.5, None, "delta-note"),
+    ]
+    connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_csv_scan_restores_discovered_multi_file_schema_on_ray(tmp_path, monkeypatch):
+    """Restore the coordinator's merged CSV schema instead of independently inferring worker schemas."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_BYTES", "1")
+    (tmp_path / "part-0.csv").write_text("id,amount\n1,10\n2,20\n", encoding="utf-8")
+    (tmp_path / "part-1.csv").write_text("id,amount\n3,30.5\n4,40.5\n", encoding="utf-8")
+
+    connection = vane.connect()
+    relation = connection.sql(f"SELECT * FROM read_csv_auto('{tmp_path}/*.csv')")
+    physical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "csv-schema-ray-plan",
+    ).to_physical_plan(connection)
+    assert [len(tasks) for tasks in physical_plan.scan_task_descriptor_map().values()] == [2]
+
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+    parts = list(runner.run_iter_tables(relation))
+    tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+    result = pa.concat_tables(tables)
+
+    assert sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist())) == [
+        (1, 10.0),
+        (2, 20.0),
+        (3, 30.5),
+        (4, 40.5),
+    ]
+    connection.close()
+
+
+def test_csv_union_reader_restores_per_file_options_for_fte_subset(tmp_path, monkeypatch):
+    """Use the selected file's sniffed dialect when an FTE queue supplies only that split."""
+    pytest.importorskip("pyarrow")
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_BYTES", "1")
+
+    pipe_path = tmp_path / "part-0.csv"
+    semicolon_path = tmp_path / "part-1.csv"
+    pipe_path.write_text("id|label\n1|one\n2|two\n", encoding="utf-8")
+    semicolon_path.write_text("id;note\n3;three\n4;four\n", encoding="utf-8")
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, label, note
+        FROM read_csv_auto(
+            ['{pipe_path}', '{semicolon_path}'],
+            union_by_name=true
+        )
+        """
+    )
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "csv-union-fte-subset-plan",
+    ).to_physical_plan(connection)
+    scan_tasks = plan.scan_task_descriptor_map()
+    assert len(scan_tasks) == 1
+    node_id, descriptors = next(iter(scan_tasks.items()))
+    assert len(descriptors) == 2
+
+    worker_connection = vane.connect()
+    worker_plan = plan.clone(worker_connection)
+    split_queue = vane.ray_cxx.FteSplitQueue()
+    split_queue.add_scan_split(bytes(descriptors[1]))
+    split_queue.no_more_splits()
+    result = vane.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        worker_connection.cursor(),
+        worker_plan,
+        fte_scan_source_queues={str(node_id): split_queue},
+    )
+
+    assert result.completion_status == "ok"
+    assert len(result.partition_payloads) == 1
+    table = result.partition_payloads[0]
+    assert list(zip(table.column(0).to_pylist(), table.column(1).to_pylist(), table.column(2).to_pylist())) == [
+        (3, None, "three"),
+        (4, None, "four"),
+    ]
+    worker_connection.close()
+    connection.close()
+
+
+def test_static_csv_range_reopens_the_bind_time_union_reader(tmp_path, monkeypatch):
+    """Do not reuse sniffing buffers that have already advanced past the start of a static range task."""
+    pytest.importorskip("pyarrow")
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "4")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+
+    input_path = tmp_path / "static-range.csv"
+    input_path.write_text(
+        "id,label\n" + "".join(f"{row_id},value-{row_id}\n" for row_id in range(5000)),
+        encoding="utf-8",
+    )
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, label
+        FROM read_csv_auto(
+            '{input_path}',
+            union_by_name=true,
+            buffer_size=4096,
+            max_line_size=1024
+        )
+        """
+    )
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "static-csv-range-plan",
+    ).to_physical_plan(connection)
+    node_id, descriptors = next(iter(plan.scan_task_descriptor_map().items()))
+    assert len(descriptors) == 4
+
+    result = vane.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+        connection.cursor(),
+        plan,
+        scan_task={str(node_id): bytes(descriptors[0])},
+    )
+
+    assert result.completion_status == "ok"
+    ids = result.partition_payloads[0].column(0).to_pylist()
+    assert 0 < len(ids) < 5000
+    assert sorted(ids) == list(range(len(ids)))
+    connection.close()
+
+
+def test_static_csv_range_detects_newline_from_file_start(tmp_path, monkeypatch):
+    """Do not infer LF-only records from an embedded newline at a CRLF range boundary."""
+    pytest.importorskip("pyarrow")
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "2")
+
+    input_path = tmp_path / "range-newline-detection.csv"
+    file_bytes = bytearray(b"id,payload\r\n")
+    expected = []
+    row_id = 0
+    range_boundary = 2048
+    special_row_start = range_boundary - len(b'1,"line-a')
+    while special_row_start - len(file_bytes) > 450:
+        payload = "x" * 300
+        file_bytes.extend(f"{row_id},{payload}\r\n".encode())
+        expected.append((row_id, payload))
+        row_id += 1
+    remaining = special_row_start - len(file_bytes)
+    row_prefix = f"{row_id},".encode()
+    payload = "x" * (remaining - len(row_prefix) - len(b"\r\n"))
+    file_bytes.extend(row_prefix + payload.encode() + b"\r\n")
+    expected.append((row_id, payload))
+    row_id += 1
+
+    special_payload = "line-a\nline-b"
+    file_bytes.extend(f'{row_id},"{special_payload}"\r\n'.encode())
+    expected.append((row_id, special_payload))
+    row_id += 1
+    while len(file_bytes) < 3700:
+        payload = "y" * 100
+        file_bytes.extend(f"{row_id},{payload}\r\n".encode())
+        expected.append((row_id, payload))
+        row_id += 1
+    input_path.write_bytes(file_bytes)
+    assert file_bytes[range_boundary : range_boundary + 3] == b"\nli"
+    assert 7 * 512 <= len(file_bytes) < 8 * 512
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, payload
+        FROM read_csv(
+            '{input_path}',
+            delim=',',
+            quote='"',
+            escape='"',
+            header=true,
+            auto_detect=false,
+            columns={{'id': 'INTEGER', 'payload': 'VARCHAR'}},
+            buffer_size=1024,
+            max_line_size=512
+        )
+        """
+    )
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "static-csv-range-newline-plan",
+    ).to_physical_plan(connection)
+    node_id, descriptors = next(iter(plan.scan_task_descriptor_map().items()))
+    assert len(descriptors) == 2
+
+    actual = []
+    for descriptor in descriptors:
+        worker_connection = vane.connect()
+        worker_plan = plan.clone(worker_connection)
+        result = vane.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            worker_connection.cursor(),
+            worker_plan,
+            scan_task={str(node_id): bytes(descriptor)},
+        )
+        assert result.completion_status == "ok"
+        for table in result.partition_payloads:
+            actual.extend(zip(table.column(0).to_pylist(), table.column(1).to_pylist()))
+        worker_connection.close()
+
+    assert sorted(actual) == expected
+    connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_single_csv_file_is_byte_range_scanned_through_real_ray(tmp_path, monkeypatch):
+    """Split one seekable CSV across Ray tasks without losing or duplicating quoted rows."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "4")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+
+    input_path = tmp_path / "single-file.csv"
+    expected = []
+    with input_path.open("w", encoding="utf-8", newline="") as csv_file:
+        writer = csv.writer(csv_file, delimiter="|", lineterminator="\r\n")
+        writer.writerow(("id", "payload"))
+        for row_id in range(5000):
+            if row_id % 7 == 0:
+                payload = f'quoted | value "{row_id}"\n继续-{row_id}'
+            elif row_id % 11 == 0:
+                payload = f"你好🙂-{row_id}"
+            else:
+                payload = f"value-{row_id}"
+            writer.writerow((row_id, payload))
+            expected.append((row_id, payload))
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, payload
+        FROM read_csv_auto(
+            '{input_path}',
+            delim='|',
+            union_by_name=true,
+            buffer_size=65536,
+            max_line_size=16384
+        )
+        """
+    )
+    physical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "single-csv-byte-range-plan",
+    ).to_physical_plan(connection)
+    assert [len(tasks) for tasks in physical_plan.scan_task_descriptor_map().values()] == [4]
+
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+    parts = list(runner.run_iter_tables(relation))
+    tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+    result = pa.concat_tables(tables)
+
+    assert sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist())) == expected
+    connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_single_csv_byte_ranges_own_rows_that_start_on_partition_boundaries(tmp_path, monkeypatch):
+    """Assign a boundary-aligned row to exactly one adjacent Ray task."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "4")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+
+    input_path = tmp_path / "boundary-aligned.csv"
+    input_path.write_text(
+        "id,value\n" + "".join(f"{row_id:03d},xxxxxx\n" for row_id in range(26)),
+        encoding="utf-8",
+    )
+    assert input_path.stat().st_size == 295
+    assert input_path.read_bytes()[64:68] == b"005,"
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, value
+        FROM read_csv(
+            '{input_path}',
+            header=true,
+            auto_detect=false,
+            columns={{'id': 'INTEGER', 'value': 'VARCHAR'}},
+            buffer_size=256,
+            max_line_size=64
+        )
+        """
+    )
+    physical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "boundary-aligned-csv-plan",
+    ).to_physical_plan(connection)
+    assert [len(tasks) for tasks in physical_plan.scan_task_descriptor_map().values()] == [4]
+
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+    parts = list(runner.run_iter_tables(relation))
+    tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+    result = pa.concat_tables(tables)
+
+    assert sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist())) == [
+        (row_id, "xxxxxx") for row_id in range(26)
+    ]
+    connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_single_csv_byte_ranges_do_not_split_crlf_boundaries(tmp_path, monkeypatch):
+    """Keep a range starting on LF synchronized with the preceding CR."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "4")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+
+    input_path = tmp_path / "crlf-boundary.csv"
+    input_path.write_bytes(b"id,value\r\n" + b"".join(f"{row_id:03d},xxxxx\r\n".encode() for row_id in range(26)))
+    assert input_path.stat().st_size == 296
+    assert input_path.read_bytes()[63:66] == b"\r\n0"
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, value
+        FROM read_csv(
+            '{input_path}',
+            header=true,
+            auto_detect=false,
+            columns={{'id': 'INTEGER', 'value': 'VARCHAR'}},
+            buffer_size=256,
+            max_line_size=64
+        )
+        """
+    )
+    physical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "crlf-boundary-csv-plan",
+    ).to_physical_plan(connection)
+    assert [len(tasks) for tasks in physical_plan.scan_task_descriptor_map().values()] == [4]
+
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+    parts = list(runner.run_iter_tables(relation))
+    tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+    result = pa.concat_tables(tables)
+
+    assert sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist())) == [
+        (row_id, "xxxxx") for row_id in range(26)
+    ]
+    connection.close()

--- a/tests/fast/test_ray_relation_to_distributed_plan.py
+++ b/tests/fast/test_ray_relation_to_distributed_plan.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import gzip
 import os
 
 import pytest
@@ -193,6 +194,183 @@ def test_scan_task_min_partition_num_can_exceed_worker_slots(monkeypatch, tmp_pa
         assert descriptor_counts == [8], (
             f"expected min partition count above worker slots to produce 8 descriptors, got {descriptor_counts}"
         )
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_single_csv_file_creates_byte_range_scan_tasks(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+
+    source_path = tmp_path / "single.csv"
+    source_path.write_text("id,label\n" + "".join(f"{i},value-{i}\n" for i in range(1000)), encoding="utf-8")
+
+    con = vane.connect()
+    try:
+        relation = con.sql(
+            f"""
+            SELECT *
+            FROM read_csv(
+                '{source_path}',
+                header=true,
+                auto_detect=false,
+                columns={{'id': 'INTEGER', 'label': 'VARCHAR'}},
+                buffer_size=4096,
+                max_line_size=1024
+            )
+            """
+        )
+        logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "single-csv-range-task-plan",
+        )
+        distributed_plan = logical_plan.to_physical_plan(con)
+        scan_tasks = distributed_plan.scan_task_descriptor_map()
+        assert [len(tasks) for tasks in scan_tasks.values()] == [4]
+        descriptors = next(iter(scan_tasks.values()))
+        assert [vane.ray_cxx.scan_task_source_partition_id(bytes(descriptor)) for descriptor in descriptors] == [
+            0,
+            1,
+            2,
+            3,
+        ]
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_single_compressed_csv_rejects_byte_range_scan_tasks(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_SIZE_GROUPING", "0")
+
+    source_path = tmp_path / "single.csv.gz"
+    with gzip.open(source_path, "wt", encoding="utf-8") as csv_file:
+        csv_file.write("id,label\n1,one\n2,two\n")
+
+    con = vane.connect()
+    try:
+        relation = con.sql(f"SELECT * FROM read_csv_auto('{source_path}')")
+        logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "compressed-csv-range-task-plan",
+        )
+        distributed_plan = logical_plan.to_physical_plan(con)
+        with pytest.raises(vane.InvalidInputException, match="requires an uncompressed CSV file"):
+            distributed_plan.scan_task_descriptor_map()
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_single_csv_byte_range_scan_rejects_skip_rows(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "2")
+
+    source_path = tmp_path / "single-with-preamble.csv"
+    source_path.write_text("preamble\nid,label\n1,one\n2,two\n", encoding="utf-8")
+
+    con = vane.connect()
+    try:
+        relation = con.sql(
+            f"""
+            SELECT *
+            FROM read_csv(
+                '{source_path}',
+                skip=1,
+                header=true,
+                auto_detect=false,
+                columns={{'id': 'INTEGER', 'label': 'VARCHAR'}}
+            )
+            """
+        )
+        logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "csv-range-skip-rows-plan",
+        )
+        distributed_plan = logical_plan.to_physical_plan(con)
+        with pytest.raises(vane.InvalidInputException, match="does not support skip_rows"):
+            distributed_plan.scan_task_descriptor_map()
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+@pytest.mark.parametrize(
+    ("csv_option", "error_message"),
+    [
+        ("parallel=false", "requires parallel=true"),
+        ("encoding='utf-16'", "requires UTF-8 input"),
+    ],
+)
+def test_single_csv_byte_range_scan_rejects_unsupported_inputs(
+    monkeypatch,
+    tmp_path,
+    csv_option,
+    error_message,
+):
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "2")
+
+    source_path = tmp_path / "unsupported-range.csv"
+    source_path.write_text("id,label\n1,one\n2,two\n", encoding="utf-8")
+
+    con = vane.connect()
+    try:
+        relation = con.sql(
+            f"""
+            SELECT *
+            FROM read_csv(
+                '{source_path}',
+                header=true,
+                auto_detect=false,
+                columns={{'id': 'INTEGER', 'label': 'VARCHAR'}},
+                {csv_option}
+            )
+            """
+        )
+        logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "unsupported-csv-range-task-plan",
+        )
+        distributed_plan = logical_plan.to_physical_plan(con)
+        with pytest.raises(vane.InvalidInputException, match=error_message):
+            distributed_plan.scan_task_descriptor_map()
+    finally:
+        con.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_distributed_csv_scan_rejects_worker_local_reject_tables(tmp_path):
+    source_path = tmp_path / "malformed.csv"
+    source_path.write_text("id\n1\ninvalid\n", encoding="utf-8")
+
+    con = vane.connect()
+    try:
+        relation = con.sql(
+            f"""
+            SELECT *
+            FROM read_csv(
+                '{source_path}',
+                auto_detect=false,
+                columns={{'id': 'INTEGER'}},
+                store_rejects=true
+            )
+            """
+        )
+        logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "csv-store-rejects-plan",
+        )
+        distributed_plan = logical_plan.to_physical_plan(con)
+        with pytest.raises(vane.InvalidInputException, match="does not support store_rejects"):
+            distributed_plan.scan_task_descriptor_map()
     finally:
         con.close()
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -6337,6 +6337,53 @@ def test_run_plan_continues_with_final_tasks_after_order_by_barrier(tmp_path):
 
 
 @pytest.mark.usefixtures("ray_local")
+def test_run_single_csv_scan_uses_one_ray_partition_per_byte_range(tmp_path, monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+    ray = pytest.importorskip("ray")
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_PARTITION_NUM", "4")
+
+    source_path = tmp_path / "partitioned-single.csv"
+    source_path.write_text(
+        "id,label\n" + "".join(f"{row_id},value-{row_id}\n" for row_id in range(5000)),
+        encoding="utf-8",
+    )
+    con = vane.connect()
+    relation = con.sql(
+        f"""
+        SELECT id, label
+            FROM read_csv(
+                '{source_path}',
+                header=true,
+                auto_detect=false,
+                union_by_name=true,
+                columns={{'id': 'INTEGER', 'label': 'VARCHAR'}},
+            buffer_size=4096,
+            max_line_size=1024
+        )
+        """
+    )
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+    assert [len(descriptors) for descriptors in plan.scan_task_descriptor_map().values()] == [4]
+
+    runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
+    with _registered_low_level_plan(plan, con):
+        parts = list(iter(runner.run_plan(plan, con)))
+
+    assert len(parts) == 4
+    tables = ray.get([part.object_ref for part in parts])
+    result = pa.concat_tables(tables)
+    assert sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist())) == [
+        (row_id, f"value-{row_id}") for row_id in range(5000)
+    ]
+    con.close()
+
+
+@pytest.mark.usefixtures("ray_local")
 def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
     captured = []
     monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
@@ -6395,6 +6442,97 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
     assert committed_paths
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     assert sorted(row[0] for row in con.read_parquet(committed_paths).fetchall()) == [1, 2, 3]
+    assert not Path(str(dst) + ".duckdb_staging").exists()
+    con.close()
+
+
+@pytest.mark.usefixtures("ray_local")
+@pytest.mark.parametrize("compression,suffix", [(None, ".csv"), ("gzip", ".csv.gz")])
+def test_run_csv_copy_plan_writes_one_file_per_scan_task(tmp_path, monkeypatch, compression, suffix):
+    captured = []
+    monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "4")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+    monkeypatch.setenv("VANE_RAY_SCAN_TASK_MIN_BYTES", "1")
+
+    class _DummyRunner:
+        def run_write(self, relation):
+            captured.append(relation)
+            return {"ok": True}
+
+    import vane.runners as runners_mod
+
+    monkeypatch.setattr(runners_mod, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
+
+    con = vane.connect()
+    src = tmp_path / "csv_copy_input"
+    dst = tmp_path / f"csv_copy_output{suffix}"
+    con.execute(
+        f"""
+        COPY (
+            SELECT
+                i::INTEGER AS id,
+                CASE WHEN i % 7 = 1 THEN NULL ELSE 'value|' || i::VARCHAR END AS label,
+                DATE '2026-08-10' + i::INTEGER AS event_date,
+                (i % 4)::INTEGER AS file_id
+            FROM range(40) tbl(i)
+        ) TO '{src}' (FORMAT PARQUET, PARTITION_BY (file_id))
+        """
+    )
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    con.read_parquet(str(src / "**" / "*.parquet")).project("id, label, event_date").write_csv(
+        str(dst),
+        sep="|",
+        na_rep="NULL",
+        date_format="%Y%m%d",
+        compression=compression,
+    )
+
+    assert captured, "expected write relation to be captured"
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        captured[0],
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+    scan_task_descriptors = dict(plan.scan_task_descriptor_map())
+    assert [len(descriptors) for descriptors in scan_task_descriptors.values()] == [4]
+
+    runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
+    with _registered_low_level_plan(plan, con):
+        result = runner.run_copy_plan(plan, con)
+
+    assert result["rows_copied"] == 40
+    assert len(result["files"]) == 4
+    assert sum(entry["row_count"] for entry in result["files"]) == 40
+    assert all(entry["file_size_bytes"] > 0 for entry in result["files"])
+    assert result["copy_output_committed"] is True
+
+    committed = vane.ray_cxx.read_committed_copy_direct_write_result(
+        result["copy_output_base_path"],
+        result["copy_output_run_id"],
+    )
+    committed_paths = [entry["final_path"] for entry in committed["files"]]
+    assert len(committed_paths) == 4
+    file_list = ", ".join(f"'{path}'" for path in committed_paths)
+    assert con.execute(
+        f"""
+        SELECT id, label, event_date::VARCHAR
+        FROM read_csv(
+            [{file_list}],
+            delim='|',
+            nullstr='NULL',
+            dateformat='%Y%m%d'
+        )
+        ORDER BY id
+        """
+    ).fetchall() == [
+        (
+            row_id,
+            None if row_id % 7 == 1 else f"value|{row_id}",
+            f"2026-08-{10 + row_id:02d}" if row_id < 22 else f"2026-09-{row_id - 21:02d}",
+        )
+        for row_id in range(40)
+    ]
     assert not Path(str(dst) + ".duckdb_staging").exists()
     con.close()
 


### PR DESCRIPTION
## Summary

- Enable Ray CSV sources to distribute both multiple files and one seekable, uncompressed UTF-8 file as aligned byte-range scan tasks, with exact row ownership across quoted multiline fields, CR/LF/CRLF boundaries, BOMs, and UTF-8 code points.
- Serialize and rebuild CSV read/write bind state, union-by-name metadata, scan identities, casts, and COPY writer statistics so Ray workers execute CSV scans and writes without coordinator-only state.
- Preserve stable source-task identities for fault-tolerant execution and emit one distributed CSV output file per scan task.
- Reject unsupported distributed CSV configurations explicitly (`compression`, non-UTF-8 encodings, `parallel = false`, `skip_rows`, and `store_rejects`); this change intentionally adds no compatibility path or local fallback.

## Related issue

N/A

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change extends the existing Ray runner implementation without adding a new public API. Its strict unsupported-option behavior is covered by tests and documented above.

## Validation

- Incremental native install in Release mode with `VANE_NATIVE_BUILD_JOBS=8` and `SKBUILD_BUILD_DIR=$PWD/build/python-release`.
- `scripts/format workspace --from-ref upstream/main --check`
- `git diff --check upstream/main`
- Regenerated `serialize_nodes.cpp` into a temporary directory and verified an exact diff against the checked-in generated source.
- `scripts/run_installed_pytest.sh tests/fast/test_ray_relation_to_distributed_plan.py -q`: 12 passed.
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e_serialization.py -q`: 10 passed.
- `scripts/run_installed_pytest.sh tests/fast/test_ray_result_contract.py -q`: 224 passed.
- `scripts/run_native_tests.sh "test/sql/copy/return_stats.test" -s`: 332 assertions in 1 test case passed.
- `scripts/run_release_tests.sh`: passed; Ray shard 14 passed, 525 deselected.
- Randomized byte-range stress coverage: 12 seeds × 8 tasks over LF/CRLF/CR files, quoted delimiters/quotes, embedded newlines, Unicode, and missing final newlines.
- `scripts/run_fast_tests.sh`: non-Ray shard passed (5,972 passed, 622 skipped, 132 deselected, 7 xfailed, 1 xpassed); all new CSV Ray tests passed. The shared-Ray shard retained 15 unrelated generic Ray failures, and representative failures reproduced unchanged in a pristine `upstream/main` worktree on the same host.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

No new dependencies, copied code, model assets, or datasets are introduced.
