### PR TITLE
[fix](ray) Support read_blob in distributed plans

### DIFF
--- a/external/duckdb/src/common/multi_file/multi_file_reader.cpp
+++ b/external/duckdb/src/common/multi_file/multi_file_reader.cpp
@@ -60,6 +60,7 @@ MultiFileBindData::~MultiFileBindData() {
 
 unique_ptr<FunctionData> MultiFileBindData::Copy() const {
 	auto result = make_uniq<MultiFileBindData>();
+	result->column_ids = column_ids;
 	if (bind_data) {
 		if (typeid(*bind_data) == typeid(TableFunctionData)) {
 			result->bind_data = make_uniq<TableFunctionData>();

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -6,6 +6,7 @@
 
 #include "duckdb/execution/distributed/pipeline_node/translator.hpp"
 #include "duckdb/execution/physical_operator_visitor.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception.hpp"
 
 #include "duckdb/execution/distributed/pipeline_node/translator_scan.hpp"
@@ -69,6 +70,10 @@ PhysicalPlanToPipelineNodeTranslator::physical_plan_to_pipeline_node(PlanConfig 
 	}
 	try {
 		translator.VisitOperator(plan->Root());
+	} catch (const NotImplementedException &ex) {
+		ErrorData error(ex);
+		return DuckDBResult<std::shared_ptr<DistributedPipelineNode>>::err(
+		    DuckDBError::value_error(std::string("failed to translate physical plan: ") + error.RawMessage()));
 	} catch (const std::exception &ex) {
 		return DuckDBResult<std::shared_ptr<DistributedPipelineNode>>::err(
 		    DuckDBError::invalid_state_error(std::string("failed to translate physical plan: ") + ex.what()));

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -416,9 +416,9 @@ physical_plan_scan_task_map_wrapper(DuckPhysicalPlanRef plan, DuckDBExecutionCon
 				scan.extra_info.scan_node_id = optional_idx(next_id++);
 			}
 
-			auto tasks = MakeTableScanTasks(scan, *exec_cfg, db);
-			if (!tasks.empty()) {
-				out.emplace(scan.extra_info.scan_node_id.GetIndex(), std::move(tasks));
+			auto task_set = MakeTableScanTasks(scan, *exec_cfg, db);
+			if (!task_set.tasks.empty()) {
+				out.emplace(scan.extra_info.scan_node_id.GetIndex(), std::move(task_set.tasks));
 			}
 		}
 		for (auto &child : op.children) {

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/execution/distributed/pipeline_node/translator_scan.hpp"
 
 #include "duckdb/common/allocator.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
@@ -226,7 +227,16 @@ DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
 	Allocator &alloc = Allocator::DefaultAllocator();
 	auto plan = std::make_shared<PhysicalPlan>(alloc);
 
-	auto bind_data = scan.bind_data ? scan.bind_data->Copy() : nullptr;
+	unique_ptr<FunctionData> bind_data;
+	if (scan.bind_data) {
+		try {
+			bind_data = scan.bind_data->Copy();
+		} catch (const NotImplementedException &ex) {
+			ErrorData error(ex);
+			throw NotImplementedException("Distributed execution does not support table function \"%s\": %s",
+			                              scan.function.name, error.RawMessage());
+		}
+	}
 	auto table_filters = scan.table_filters ? scan.table_filters->Copy() : nullptr;
 	auto extra_info = CopyExtraOperatorInfo(scan.extra_info);
 
@@ -243,7 +253,9 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 	std::vector<ScanTaskDescriptor> tasks;
 
 	if (!scan.bind_data) {
-		throw BinderException("MakeTableScanTasks: bind_data is nullptr for function '%s'", scan.function.name);
+		throw NotImplementedException("Distributed execution does not support table function \"%s\": bind data is "
+		                              "missing",
+		                              scan.function.name);
 	}
 
 	vector<OpenFileInfo> files;
@@ -253,9 +265,9 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 	} else {
 		auto *ext_provider = dynamic_cast<ExtensionFileListProvider *>(scan.bind_data.get());
 		if (!ext_provider) {
-			throw BinderException("MakeTableScanTasks: bind_data for '%s' is not MultiFileBindData or "
-			                      "ExtensionFileListProvider (type: %s)",
-			                      scan.function.name, typeid(*scan.bind_data).name());
+			throw NotImplementedException("Distributed execution does not support table function \"%s\": its bind data "
+			                              "does not provide a distributable file list",
+			                              scan.function.name);
 		}
 		for (auto &path : ext_provider->GetFileList()) {
 			files.emplace_back(path);

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
@@ -248,8 +248,8 @@ DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
 	return plan;
 }
 
-std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan, const DuckDBExecutionConfig &exec_cfg,
-                                                   const shared_ptr<DatabaseInstance> &db) {
+TableScanTaskSet MakeTableScanTasks(const PhysicalTableScan &scan, const DuckDBExecutionConfig &exec_cfg,
+                                    const shared_ptr<DatabaseInstance> &db) {
 	std::vector<ScanTaskDescriptor> tasks;
 
 	if (!scan.bind_data) {
@@ -274,7 +274,7 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 		}
 	}
 	if (files.empty()) {
-		return tasks;
+		return {std::move(tasks), true};
 	}
 	const idx_t estimated_scan_rows =
 	    scan.estimated_cardinality == DConstants::INVALID_INDEX ? 0 : scan.estimated_cardinality;
@@ -335,7 +335,7 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 		task.estimated_bytes = static_cast<idx_t>(total_file_bytes);
 		task.source_task_partition_id = 0;
 		tasks.push_back(std::move(task));
-		return tasks;
+		return {std::move(tasks), false};
 	}
 
 	size_t target_task_count = ResolveScanTaskTargetCount(files.size(), exec_cfg);
@@ -409,7 +409,7 @@ std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan
 		tasks.push_back(std::move(task));
 	}
 
-	return tasks;
+	return {std::move(tasks), false};
 }
 
 SchemaRef MakeTableScanSchema(const PhysicalTableScan &scan, const vector<LogicalType> &output_types) {

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_source.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_source.cpp
@@ -72,9 +72,9 @@ SchemaRef MakeSchemaFromTypes(const duckdb::vector<LogicalType> &types) {
 std::shared_ptr<DistributedPipelineNode>
 MakeScanSourceNode(PipelineNodeContext context, DuckPhysicalPlanRef scan_plan,
                    std::vector<duckdb::distributed::ScanTaskDescriptor> scan_tasks, SchemaRef schema,
-                   DuckDBExecutionConfigRef exec_cfg, bool is_external_scan) {
+                   DuckDBExecutionConfigRef exec_cfg, bool require_scan_tasks) {
 	auto scan_node = std::make_shared<ScanSourceNode>(std::move(context), std::move(scan_plan), std::move(scan_tasks),
-	                                                  std::move(schema), std::move(exec_cfg), is_external_scan);
+	                                                  std::move(schema), std::move(exec_cfg), require_scan_tasks);
 	return std::make_shared<DistributedPipelineNode>(scan_node);
 }
 
@@ -142,6 +142,7 @@ PhysicalPlanToPipelineNodeTranslator::TranslateTableScanSource(PhysicalTableScan
 	auto scan_node_id = get_next_pipeline_node_id();
 	DuckPhysicalPlanRef scan_plan;
 	std::vector<duckdb::distributed::ScanTaskDescriptor> scan_tasks;
+	bool require_scan_tasks;
 
 	if (op.extra_info.scan_node_id.IsValid()) {
 		scan_node_id = static_cast<int>(op.extra_info.scan_node_id.GetIndex());
@@ -156,7 +157,9 @@ PhysicalPlanToPipelineNodeTranslator::TranslateTableScanSource(PhysicalTableScan
 	}
 
 	scan_plan = MakeTableScanPlan(op);
-	scan_tasks = MakeTableScanTasks(op, *exec_cfg, plan_config_.db);
+	auto scan_task_set = MakeTableScanTasks(op, *exec_cfg, plan_config_.db);
+	require_scan_tasks = !scan_task_set.known_empty;
+	scan_tasks = std::move(scan_task_set.tasks);
 	if (!scan_plan || !scan_plan->HasRoot()) {
 		throw std::runtime_error(
 		    "[translate.cpp] TABLE_SCAN: MakeTableScanPlan returned null/empty plan for function " + op.function.name);
@@ -173,7 +176,7 @@ PhysicalPlanToPipelineNodeTranslator::TranslateTableScanSource(PhysicalTableScan
 	auto schema = MakeTableScanSchema(op, op.GetTypes());
 	return MakeScanSourceNode(
 	    MakePipelineNodeContext(plan_config_.query_idx, plan_config_.query_id, scan_node_id, "ScanSource"),
-	    std::move(scan_plan), std::move(scan_tasks), schema, exec_cfg, true);
+	    std::move(scan_plan), std::move(scan_tasks), schema, exec_cfg, require_scan_tasks);
 }
 
 } // namespace distributed

--- a/external/duckdb/src/function/function.cpp
+++ b/external/duckdb/src/function/function.cpp
@@ -37,7 +37,7 @@ TableFunctionData::~TableFunctionData() {
 }
 
 unique_ptr<FunctionData> TableFunctionData::Copy() const {
-	throw InternalException("Copy not supported for TableFunctionData");
+	throw NotImplementedException("Copy not supported for TableFunctionData");
 }
 
 bool TableFunctionData::Equals(const FunctionData &other) const {

--- a/external/duckdb/src/function/table/read_file.cpp
+++ b/external/duckdb/src/function/table/read_file.cpp
@@ -1,6 +1,9 @@
 #include "duckdb/function/table/read_file.hpp"
 #include "duckdb/function/table/direct_file_reader.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "duckdb/common/multi_file/multi_file_list.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -9,6 +12,15 @@
 #include "duckdb/storage/caching_file_system.hpp"
 
 namespace duckdb {
+
+unique_ptr<FunctionData> ReadFileBindData::Copy() const {
+	auto result = make_uniq<ReadFileBindData>();
+	result->column_ids = column_ids;
+	if (options) {
+		result->options = make_uniq<BaseFileReaderOptions>(*options);
+	}
+	return std::move(result);
+}
 
 namespace {
 
@@ -44,6 +56,7 @@ struct DirectMultiFileInfo : MultiFileReaderInterface {
 	                                        BaseFileReaderOptions &options,
 	                                        const MultiFileOptions &file_options) override;
 	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
+	unique_ptr<MultiFileReaderInterface> Copy() override;
 	FileGlobInput GetGlobInput() override;
 };
 
@@ -160,6 +173,11 @@ unique_ptr<NodeStatistics> DirectMultiFileInfo<OP>::GetCardinality(const MultiFi
 }
 
 template <class OP>
+unique_ptr<MultiFileReaderInterface> DirectMultiFileInfo<OP>::Copy() {
+	return make_uniq<DirectMultiFileInfo>();
+}
+
+template <class OP>
 FileGlobInput DirectMultiFileInfo<OP>::GetGlobInput() {
 	return FileGlobOptions::ALLOW_EMPTY;
 }
@@ -184,9 +202,95 @@ struct ReadTextOperation {
 	}
 };
 
+static void ReadFileSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                              const TableFunction &function) {
+	if (!bind_data_p) {
+		throw SerializationException("Cannot serialize %s without bind data", function.name);
+	}
+	auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
+	if (!bind_data.file_list) {
+		throw SerializationException("Cannot serialize %s without a file list", function.name);
+	}
+
+	auto files = bind_data.file_list->GetAllFiles();
+	serializer.WriteList(100, "files", files.size(), [&](Serializer::List &list, idx_t index) {
+		list.WriteObject([&](Serializer &object) {
+			object.WriteProperty(100, "path", files[index].path);
+			unordered_map<string, Value> options;
+			if (files[index].extended_info) {
+				options = files[index].extended_info->options;
+			}
+			object.WriteProperty(101, "options", options);
+		});
+	});
+	serializer.WriteProperty(101, "types", bind_data.types);
+	serializer.WriteProperty(102, "names", bind_data.names);
+	serializer.WriteProperty(103, "file_options", bind_data.file_options);
+	serializer.WriteProperty(104, "reader_bind", bind_data.reader_bind);
+	serializer.WriteProperty(105, "table_columns", bind_data.table_columns);
+	serializer.WriteProperty(106, "column_ids", bind_data.column_ids);
+}
+
+template <class OP>
+static unique_ptr<FunctionData> ReadFileDeserialize(Deserializer &deserializer, TableFunction &function) {
+	auto &context = deserializer.Get<ClientContext &>();
+	vector<OpenFileInfo> files;
+	deserializer.ReadList(100, "files", [&](Deserializer::List &list, idx_t) {
+		list.ReadObject([&](Deserializer &object) {
+			OpenFileInfo file;
+			file.path = object.ReadProperty<string>(100, "path");
+			auto options = object.ReadProperty<unordered_map<string, Value>>(101, "options");
+			if (!options.empty()) {
+				auto extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+				extended_info->options = std::move(options);
+				file.extended_info = std::move(extended_info);
+			}
+			files.push_back(std::move(file));
+		});
+	});
+	auto types = deserializer.ReadProperty<vector<LogicalType>>(101, "types");
+	auto names = deserializer.ReadProperty<vector<string>>(102, "names");
+	auto file_options = deserializer.ReadProperty<MultiFileOptions>(103, "file_options");
+	auto reader_bind = deserializer.ReadProperty<MultiFileReaderBindData>(104, "reader_bind");
+	auto table_columns = deserializer.ReadProperty<vector<string>>(105, "table_columns");
+	auto column_ids = deserializer.ReadProperty<vector<idx_t>>(106, "column_ids");
+
+	if (types.size() != names.size()) {
+		throw SerializationException("Cannot deserialize %s with mismatched names and types", function.name);
+	}
+
+	auto multi_file_reader = MultiFileReader::Create(function);
+	auto file_list = make_shared_ptr<SimpleMultiFileList>(std::move(files));
+	auto interface = DirectMultiFileInfo<OP>::CreateInterface(context);
+	interface->InitializeInterface(context, *multi_file_reader, *file_list);
+	auto options = interface->InitializeOptions(context, nullptr);
+
+	auto result = make_uniq<MultiFileBindData>();
+	result->file_list = std::move(file_list);
+	result->multi_file_reader = std::move(multi_file_reader);
+	result->interface = std::move(interface);
+	result->file_options = std::move(file_options);
+	result->reader_bind = std::move(reader_bind);
+	result->types = std::move(types);
+	result->names = std::move(names);
+	result->table_columns = std::move(table_columns);
+	result->column_ids = std::move(column_ids);
+	result->bind_data = result->interface->InitializeBindData(*result, std::move(options));
+	result->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(result->names, result->types);
+
+	virtual_column_map_t virtual_columns;
+	MultiFileReader::GetVirtualColumns(context, result->reader_bind, virtual_columns);
+	result->interface->GetVirtualColumns(context, *result, virtual_columns);
+	result->virtual_columns = std::move(virtual_columns);
+	result->interface->FinalizeBindData(*result);
+	return std::move(result);
+}
+
 template <class OP>
 static TableFunction GetFunction() {
 	MultiFileFunction<DirectMultiFileInfo<OP>> table_function(OP::NAME);
+	table_function.serialize = ReadFileSerialize;
+	table_function.deserialize = ReadFileDeserialize<OP>;
 	// Erase extra multi file reader options
 	table_function.named_parameters.erase("filename");
 	table_function.named_parameters.erase("hive_partitioning");

--- a/external/duckdb/src/include/duckdb/execution/distributed/common_types.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/common_types.hpp
@@ -198,10 +198,11 @@ public:
 	enum class Type { InternalError, ExternalError, IoError, ValueError, InvalidStateError };
 
 	/// Default constructor for pair compatibility
-	DuckDBError() : std::runtime_error("uninitialized") {
+	DuckDBError() : std::runtime_error("uninitialized"), type_(Type::InternalError) {
 	}
 
-	explicit DuckDBError(Type type, const std::string &message) : std::runtime_error(format_message(type, message)) {
+	explicit DuckDBError(Type type, const std::string &message)
+	    : std::runtime_error(format_message(type, message)), type_(type) {
 	}
 
 	explicit DuckDBError(const std::string &message) : DuckDBError(Type::InternalError, message) {
@@ -227,6 +228,10 @@ public:
 		return DuckDBError(Type::InvalidStateError, msg);
 	}
 
+	Type type() const noexcept {
+		return type_;
+	}
+
 private:
 	static std::string format_message(Type type, const std::string &msg) {
 		const char *prefix = "DuckDBError";
@@ -249,6 +254,8 @@ private:
 		}
 		return std::string(prefix) + " " + msg;
 	}
+
+	Type type_;
 };
 
 //------------------------------------------------------------------------------

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator_scan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator_scan.hpp
@@ -19,8 +19,13 @@ namespace distributed {
 
 DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan);
 
-std::vector<ScanTaskDescriptor> MakeTableScanTasks(const PhysicalTableScan &scan, const DuckDBExecutionConfig &exec_cfg,
-                                                   const shared_ptr<DatabaseInstance> &db);
+struct TableScanTaskSet {
+	std::vector<ScanTaskDescriptor> tasks;
+	bool known_empty;
+};
+
+TableScanTaskSet MakeTableScanTasks(const PhysicalTableScan &scan, const DuckDBExecutionConfig &exec_cfg,
+                                    const shared_ptr<DatabaseInstance> &db);
 
 SchemaRef MakeTableScanSchema(const PhysicalTableScan &scan, const vector<LogicalType> &output_types);
 

--- a/external/duckdb/src/include/duckdb/function/table/read_file.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/read_file.hpp
@@ -17,6 +17,8 @@ namespace duckdb {
 struct ReadFileBindData : public TableFunctionData {
 	unique_ptr<BaseFileReaderOptions> options;
 
+	unique_ptr<FunctionData> Copy() const override;
+
 	static constexpr const idx_t FILE_NAME_COLUMN = 0;
 	static constexpr const idx_t FILE_CONTENT_COLUMN = 1;
 	static constexpr const idx_t FILE_SIZE_COLUMN = 2;

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -452,6 +452,29 @@ TEST_CASE("PhysicalPlanTranslator: plan without root returns error", "[distribut
 	REQUIRE(msg.find("physical plan has no root") != std::string::npos);
 }
 
+TEST_CASE("PhysicalPlanTranslator: unsupported table function bind data is a value error", "[distributed]") {
+	Allocator allocator;
+	auto plan_ptr = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> types = {LogicalType::INTEGER};
+	TableFunction function;
+	function.name = "unsupported_table_scan";
+	auto bind_data = make_uniq<TableFunctionData>();
+	vector<ColumnIndex> column_ids = {ColumnIndex(0)};
+	vector<string> names = {"value"};
+
+	auto &scan = plan_ptr->Make<PhysicalTableScan>(types, function, std::move(bind_data), types, std::move(column_ids),
+	                                               vector<idx_t> {}, std::move(names), nullptr, 0, ExtraOperatorInfo {},
+	                                               vector<Value> {}, virtual_column_map_t {});
+	plan_ptr->SetRoot(scan);
+
+	auto res = duckdb::distributed::physical_plan_to_pipeline_node(duckdb::distributed::PlanConfig {}, plan_ptr);
+	REQUIRE(res.is_err());
+	REQUIRE(res.error().type() == DuckDBError::Type::ValueError);
+	auto msg = std::string(res.error().what());
+	REQUIRE(msg.find("unsupported_table_scan") != std::string::npos);
+	REQUIRE(msg.find("Copy not supported for TableFunctionData") != std::string::npos);
+}
+
 TEST_CASE("PhysicalPlanTranslator: auto broadcast only considers semantically safe sides", "[distributed][join]") {
 	ScopedTranslatorEnvironment strategy("VANE_DISTRIBUTED_JOIN_STRATEGY", nullptr);
 	ScopedTranslatorEnvironment threshold("VANE_DISTRIBUTED_AUTO_BROADCAST_THRESHOLD_BYTES", "64");

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -885,6 +885,10 @@ BuildDistributedPipelineNode(const std::shared_ptr<duckdb::distributed::Distribu
 	PlanConfig cfg(plan->idx(), plan->query_id(), plan->execution_config());
 	auto pipeline_res = physical_plan_to_pipeline_node(std::move(cfg), std::move(physical_plan), client_context);
 	if (!pipeline_res.is_ok()) {
+		if (pipeline_res.error().type() == DuckDBError::Type::ValueError) {
+			throw duckdb::InvalidInputException("Ray runner cannot execute this query: %s",
+			                                    pipeline_res.error().what());
+		}
 		throw duckdb::InternalException(string("Failed to build distributed pipeline node: ") +
 		                                pipeline_res.error().what());
 	}

--- a/tests/fast/test_ray_read_file.py
+++ b/tests/fast/test_ray_read_file.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+try:
+    import ray
+except Exception:
+    ray = None
+
+import vane
+from vane import runners
+
+
+def _sql_string(value):
+    return value.replace("'", "''")
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+@pytest.mark.parametrize(
+    ("function_name", "suffix", "payloads"),
+    [
+        ("read_blob", ".blob", [b"\x00\xffbinary-a", b"binary-b\x00"]),
+        ("read_text", ".txt", ["plain text", "unicode \u6587\u672c"]),
+    ],
+    ids=["blob", "text"],
+)
+def test_read_file_functions_run_through_ray(tmp_path, function_name, suffix, payloads):
+    pa = pytest.importorskip("pyarrow")
+
+    expected = []
+    for index, payload in enumerate(payloads):
+        path = tmp_path / f"input-{index}{suffix}"
+        if isinstance(payload, bytes):
+            path.write_bytes(payload)
+            size = len(payload)
+        else:
+            path.write_text(payload, encoding="utf-8")
+            size = len(payload.encode("utf-8"))
+        expected.append((str(path), payload, size))
+
+    pattern = _sql_string(str(tmp_path / f"*{suffix}"))
+    connection = vane.connect()
+    try:
+        relation = connection.sql(f"SELECT filename, content, size FROM {function_name}('{pattern}')")
+        runners.set_runner_ray(noop_if_initialized=True)
+        runner = runners.get_or_create_runner()
+
+        partitions = list(runner.run_iter_tables(relation))
+        tables = [partition.to_arrow() if hasattr(partition, "to_arrow") else partition for partition in partitions]
+        result = pa.concat_tables(tables)
+        actual = list(
+            zip(
+                result.column(0).to_pylist(),
+                result.column(1).to_pylist(),
+                result.column(2).to_pylist(),
+                strict=True,
+            )
+        )
+
+        assert sorted(actual) == sorted(expected)
+    finally:
+        connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_unsupported_table_function_reports_user_error():
+    connection = vane.connect()
+    try:
+        relation = connection.sql("SELECT name FROM duckdb_settings()")
+        runners.set_runner_ray(noop_if_initialized=True)
+        runner = runners.get_or_create_runner()
+
+        with pytest.raises(
+            vane.InvalidInputException,
+            match=r'Ray runner.*table function "duckdb_settings".*bind data is missing',
+        ):
+            list(runner.run_iter_tables(relation))
+    finally:
+        connection.close()

--- a/tests/fast/test_ray_read_file.py
+++ b/tests/fast/test_ray_read_file.py
@@ -66,6 +66,26 @@ def test_read_file_functions_run_through_ray(tmp_path, function_name, suffix, pa
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")
 @pytest.mark.usefixtures("ray_local")
+@pytest.mark.parametrize("function_name", ["read_blob", "read_text"], ids=["blob", "text"])
+def test_read_file_functions_allow_empty_glob_through_ray(tmp_path, function_name):
+    pattern = _sql_string(str(tmp_path / "missing-*"))
+    connection = vane.connect()
+    try:
+        assert connection.sql(f"SELECT filename FROM {function_name}('{pattern}')").fetchall() == []
+
+        relation = connection.sql(f"SELECT filename FROM {function_name}('{pattern}')")
+        runners.set_runner_ray(noop_if_initialized=True)
+        runner = runners.get_or_create_runner()
+
+        partitions = list(runner.run_iter_tables(relation))
+        tables = [partition.to_arrow() if hasattr(partition, "to_arrow") else partition for partition in partitions]
+        assert sum(table.num_rows for table in tables) == 0
+    finally:
+        connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
 def test_unsupported_table_function_reports_user_error():
     connection = vane.connect()
     try:


### PR DESCRIPTION
## Summary

- Make the `read_blob` and `read_text` multi-file bind state and reader interface copyable so distributed scan plans can be split safely.
- Serialize the materialized file list, per-file options, schema, reader options, table columns, and projection state, then reconstruct worker bind data without opening files during deserialization.
- Distinguish a successfully materialized empty file list from a missing scan-task partition set, so allowed empty globs return zero rows while missing tasks continue to fail closed.
- Preserve distributed error categories and report unsupported table-function bind data as a user-facing `InvalidInputException` instead of an internal error.
- Add real-Ray regressions for non-empty and empty BLOB/text scans, plus a native regression for the unsupported-`TableFunctionData::Copy()` path.

The root cause was that Ray's physical-plan translator clones table-scan bind data, while the direct file reader inherited the unsupported base `Copy()` implementation and had no plan serialization callbacks. The default Ray runner can now materialize `read_blob`/`read_text`, including their `ALLOW_EMPTY` glob contract; local execution remains unchanged. Unsupported distributed table functions now fail through the user-error channel. No compatibility or fallback path is added.

## Related issue

close: #549

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This restores the documented/default runner behavior and does not add a new public API.

## Validation

- `uv pip install . --no-build-isolation` with the required Release incremental build directory: passed before and after the final native commit (non-editable install).
- `scripts/format workspace --changed` and `scripts/format workspace --changed --check`: passed.
- `git diff --check`: passed.
- `scripts/run_installed_pytest.sh tests/fast/test_ray_read_file.py`: 5 passed.
- The two new empty-glob real-Ray cases failed with `ScanSourceNode missing scan task partition set` before the fix and passed afterward.
- `scripts/run_installed_pytest.sh tests/fast/test_package_metadata.py::test_duckdb_version_and_source_id_match_recorded_engine_identities`: passed after the final commit rebuild.
- Issue reproduction with the default runner and `read_blob('examples/example.png')`: `RayRunner` materialized and displayed the prompt/image row.
- Local FTE `read_blob` -> Parquet -> read-back byte comparison: passed (9,776 bytes).
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e_serialization.py`: 2 passed.
- `scripts/run_native_tests.sh "PhysicalPlanTranslator: unsupported table function bind data is a value error"`: 1 test case passed (4 assertions).
- `scripts/run_native_tests.sh "[distributed]"`: 188 test cases passed (7,992 assertions).
- `scripts/run_release_tests.sh` with an isolated short `RAY_TMPDIR`: 517 passed / 4 optional-dependency skips, followed by 11 real-Ray tests passed.
- `scripts/run_native_tests.sh "test/sql/table_function/read_text_and_blob.test"`: skipped by the DuckDB test requirement because the native gate does not link `httpfs`; local behavior was covered by the explicit local-FTE round trip above.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

No dependencies, copied assets, datasets, UDFs, remote code, or new network access are introduced. The serialized state is limited to the existing scan metadata needed by workers, validates the schema shape, and reconstructs bind state without opening files.