### PR TITLE
[fix](release) Upload only regular files so nested supplemental assets attach

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -504,9 +504,53 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           draft="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)"
           test "$draft" = "true"
-          gh release upload "$GITHUB_REF_NAME" release-files/* --clobber
+
+          # release-supplemental is packed from two source directories, so the
+          # artifact keeps its packages/ and release-assets/ prefixes. The
+          # non-recursive release-files/* used to hand gh those directories,
+          # which it rejects only after uploading the assets ahead of them.
+          mapfile -t assets < <(find release-files -type f -print | sort)
+          if [[ ${#assets[@]} -eq 0 ]]; then
+            echo "::error::no regular files found under release-files/"
+            exit 1
+          fi
+
+          # Release assets are a flat namespace keyed by basename; the tree
+          # being flattened is not. Same-named files in different directories
+          # would overwrite each other under --clobber and publish a release
+          # quietly missing an asset.
+          if duplicates="$(printf '%s\n' "${assets[@]}" | xargs -n1 basename | sort | uniq -d)" \
+             && [[ -n "$duplicates" ]]; then
+            echo "::error::asset basenames collide, refusing to upload:"
+            printf '::error::  %s\n' $duplicates
+            exit 1
+          fi
+
+          echo "attaching ${#assets[@]} asset(s):"
+          printf '  %s\n' "${assets[@]}"
+          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
+
+      - name: Verify every asset reached the draft release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          find release-files -type f -printf '%f\n' | sort > local-assets.txt
+          gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name' | sort > remote-assets.txt
+
+          if missing="$(comm -23 local-assets.txt remote-assets.txt)" && [[ -n "$missing" ]]; then
+            echo "::error::assets missing from the draft release after upload:"
+            printf '::error::  %s\n' $missing
+            exit 1
+          fi
+
+          echo "verified $(wc -l < local-assets.txt) asset(s) on the draft release"
 
       - name: Publish the complete draft release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -513,25 +513,19 @@ jobs:
           # artifact keeps its packages/ and release-assets/ prefixes. The
           # non-recursive release-files/* used to hand gh those directories,
           # which it rejects only after uploading the assets ahead of them.
-          mapfile -t assets < <(find release-files -type f -print | sort)
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            echo "::error::no regular files found under release-files/"
-            exit 1
-          fi
+          #
+          # Collection, the basename-collision guard and the expected-inventory
+          # assertion all live in the script so they can be tested; it exits
+          # non-zero on any of them, which set -e turns into a failed step
+          # before a single asset is uploaded.
+          python scripts/check_release_assets.py collect release-files --output upload-list
 
-          # Release assets are a flat namespace keyed by basename; the tree
-          # being flattened is not. Same-named files in different directories
-          # would overwrite each other under --clobber and publish a release
-          # quietly missing an asset.
-          if duplicates="$(printf '%s\n' "${assets[@]}" | xargs -n1 basename | sort | uniq -d)" \
-             && [[ -n "$duplicates" ]]; then
-            echo "::error::asset basenames collide, refusing to upload:"
-            printf '::error::  %s\n' $duplicates
-            exit 1
-          fi
+          # NUL-delimited, so a name containing whitespace survives the round
+          # trip. mapfile's own status is the one checked here -- the script
+          # already failed the step above if collection went wrong.
+          mapfile -d '' -t assets < upload-list
 
-          echo "attaching ${#assets[@]} asset(s):"
-          printf '  %s\n' "${assets[@]}"
+          echo "attaching ${#assets[@]} asset(s)"
           gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
 
       - name: Verify every asset reached the draft release
@@ -541,16 +535,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          find release-files -type f -printf '%f\n' | sort > local-assets.txt
-          gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name' | sort > remote-assets.txt
-
-          if missing="$(comm -23 local-assets.txt remote-assets.txt)" && [[ -n "$missing" ]]; then
-            echo "::error::assets missing from the draft release after upload:"
-            printf '::error::  %s\n' $missing
-            exit 1
-          fi
-
-          echo "verified $(wc -l < local-assets.txt) asset(s) on the draft release"
+          # Comparing names alone passes for a truncated upload and for stale
+          # assets left on the release by an earlier run, so both sides are
+          # reduced to (name, size, sha256) and required to match exactly.
+          # Assigning in its own statement, not inside an `if`, keeps this
+          # under set -e: a failure here must fail the step, not read as false.
+          gh release view "$GITHUB_REF_NAME" --json assets > remote-assets.json
+          python scripts/check_release_assets.py verify release-files --remote remote-assets.json
 
       - name: Publish the complete draft release
         env:

--- a/scripts/check_release_assets.py
+++ b/scripts/check_release_assets.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collect and verify the GitHub Release asset set.
+
+The release job downloads two artifacts into one directory and attaches every
+regular file under it to the draft release. Two things have to hold before the
+draft is published, and neither is expressible as a one-line shell test:
+
+* The local tree must carry the complete expected inventory -- one sdist, five
+  wheels, a Sigstore bundle for each of those six distributions, ``SHA256SUMS``,
+  the CycloneDX SBOM and the provenance bundle. Fifteen assets, no more.
+* Every one of them must be on the release *with the bytes it has locally*.
+  Name equality is not enough: an upload truncated by a dropped connection, or
+  a stale asset left over from a re-run of an earlier build, both produce a
+  release whose asset *names* look right.
+
+Release assets are a flat namespace keyed by basename, so the nested tree is
+flattened on upload; a basename collision would silently overwrite under
+``--clobber`` and publish a release quietly missing an asset. That is checked
+here too, before anything is uploaded.
+
+Usage::
+
+    check_release_assets.py collect release-files --output assets.txt
+    check_release_assets.py verify release-files --remote remote.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+# One sdist plus five wheels, each with its own Sigstore bundle, plus the three
+# supplemental assets below.
+EXPECTED_SDISTS = 1
+EXPECTED_WHEELS = 5
+EXPECTED_DISTRIBUTIONS = EXPECTED_SDISTS + EXPECTED_WHEELS
+SHA256SUMS = "SHA256SUMS"
+SBOM = "vane-ai-sbom.cdx.json"
+PROVENANCE = "vane-ai-build-provenance.sigstore.json"
+SUPPLEMENTAL = (SHA256SUMS, SBOM, PROVENANCE)
+EXPECTED_ASSET_COUNT = EXPECTED_DISTRIBUTIONS * 2 + len(SUPPLEMENTAL)
+
+SIGSTORE_SUFFIX = ".sigstore.json"
+READ_CHUNK = 1024 * 1024
+
+
+class AssetError(Exception):
+    """A release asset problem worth failing the workflow for."""
+
+
+@dataclass(frozen=True)
+class Asset:
+    """One asset reduced to the three fields both sides can agree on."""
+
+    name: str
+    size: int
+    digest: str  # lowercase hex sha256, no algorithm prefix
+
+    def describe(self) -> str:
+        return f"{self.name} ({self.size} bytes, sha256:{self.digest})"
+
+
+def sha256_of(path: Path) -> str:
+    """Hash a file without reading it entirely into memory."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(READ_CHUNK):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def collect_files(root: Path) -> list[Path]:
+    """Return every regular file under ``root``, sorted, following no symlinks.
+
+    ``Path.rglob`` yields directories too, and the bug this script exists to
+    prevent was precisely a directory being handed to ``gh release upload``.
+    Symlinks are excluded rather than resolved: an asset that is a link out of
+    the tree is not something the release should publish silently.
+    """
+
+    if not root.is_dir():
+        raise AssetError(f"{root} is not a directory")
+    files = [path for path in root.rglob("*") if path.is_file() and not path.is_symlink()]
+    return sorted(files)
+
+
+def local_manifest(paths: Sequence[Path]) -> dict[str, Asset]:
+    """Reduce local files to a basename-keyed manifest, rejecting collisions."""
+
+    if not paths:
+        raise AssetError("no regular files found to upload")
+
+    seen: dict[str, list[Path]] = {}
+    for path in paths:
+        seen.setdefault(path.name, []).append(path)
+
+    collisions = {name: found for name, found in seen.items() if len(found) > 1}
+    if collisions:
+        lines = ["asset basenames collide, refusing to upload:"]
+        for name in sorted(collisions):
+            joined = ", ".join(str(path) for path in sorted(collisions[name]))
+            lines.append(f"  {name}: {joined}")
+        raise AssetError("\n".join(lines))
+
+    return {path.name: Asset(name=path.name, size=path.stat().st_size, digest=sha256_of(path)) for path in paths}
+
+
+def remote_manifest(payload: str) -> dict[str, Asset]:
+    """Parse ``gh release view --json assets`` output into the same shape.
+
+    ``gh`` reports the digest as ``sha256:<hex>``; older releases and assets
+    still processing report an empty string. An asset we cannot compare is
+    reported rather than skipped -- silently passing it is the fail-open this
+    check exists to close.
+    """
+
+    try:
+        document = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise AssetError(f"could not parse the release JSON: {exc}") from exc
+
+    assets = document.get("assets") if isinstance(document, dict) else document
+    if not isinstance(assets, list):
+        raise AssetError("release JSON has no 'assets' array")
+
+    manifest: dict[str, Asset] = {}
+    for entry in assets:
+        name = entry.get("name")
+        if not name:
+            raise AssetError(f"release asset without a name: {entry!r}")
+        digest = str(entry.get("digest") or "")
+        if not digest.startswith("sha256:"):
+            raise AssetError(f"release asset {name} reports digest {digest!r}, expected 'sha256:<hex>'")
+        manifest[name] = Asset(
+            name=name,
+            size=int(entry.get("size", -1)),
+            digest=digest[len("sha256:") :].lower(),
+        )
+    return manifest
+
+
+def check_inventory(names: Iterable[str]) -> None:
+    """Assert the expected 15-asset inventory, naming what is off.
+
+    Checked by shape rather than by pinned filename so a version bump does not
+    have to touch this script, but strictly enough that a missing wheel or an
+    unsigned distribution fails.
+    """
+
+    names = set(names)
+    problems: list[str] = []
+
+    sdists = {name for name in names if name.endswith(".tar.gz")}
+    wheels = {name for name in names if name.endswith(".whl")}
+    distributions = sdists | wheels
+
+    if len(sdists) != EXPECTED_SDISTS:
+        problems.append(f"expected {EXPECTED_SDISTS} sdist, found {len(sdists)}: {sorted(sdists)}")
+    if len(wheels) != EXPECTED_WHEELS:
+        problems.append(f"expected {EXPECTED_WHEELS} wheels, found {len(wheels)}: {sorted(wheels)}")
+
+    # Every distribution must carry its own bundle: sigstore-python names the
+    # bundle after its input, so this pairs them exactly rather than counting.
+    for distribution in sorted(distributions):
+        bundle = f"{distribution}{SIGSTORE_SUFFIX}"
+        if bundle not in names:
+            problems.append(f"missing Sigstore bundle for {distribution}: expected {bundle}")
+
+    for required in SUPPLEMENTAL:
+        if required not in names:
+            problems.append(f"missing supplemental asset: {required}")
+
+    expected = (
+        distributions | {f"{distribution}{SIGSTORE_SUFFIX}" for distribution in distributions} | set(SUPPLEMENTAL)
+    )
+    unexpected = names - expected
+    if unexpected:
+        problems.append(f"unexpected assets: {sorted(unexpected)}")
+
+    if len(names) != EXPECTED_ASSET_COUNT:
+        problems.append(f"expected {EXPECTED_ASSET_COUNT} unique assets, found {len(names)}")
+
+    if problems:
+        raise AssetError("release asset inventory is wrong:\n" + "\n".join(f"  {p}" for p in problems))
+
+
+def compare_manifests(local: dict[str, Asset], remote: dict[str, Asset]) -> None:
+    """Require the two manifests to be equal, reporting every difference.
+
+    A subset check would pass with stale extra assets left on the release by an
+    earlier run, and a name-only check would pass with a truncated upload.
+    """
+
+    problems: list[str] = []
+
+    for name in sorted(set(local) - set(remote)):
+        problems.append(f"missing from the release: {local[name].describe()}")
+    for name in sorted(set(remote) - set(local)):
+        problems.append(f"unexpected asset on the release: {remote[name].describe()}")
+
+    for name in sorted(set(local) & set(remote)):
+        want, got = local[name], remote[name]
+        if want.size != got.size:
+            problems.append(f"size mismatch for {name}: local {want.size}, release {got.size}")
+        if want.digest != got.digest:
+            problems.append(f"digest mismatch for {name}: local sha256:{want.digest}, release sha256:{got.digest}")
+
+    if problems:
+        raise AssetError(
+            "the release asset set does not match what was built:\n" + "\n".join(f"  {p}" for p in problems)
+        )
+
+
+def _emit_error(message: str) -> None:
+    for line in message.splitlines():
+        print(f"::error::{line}", file=sys.stderr)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    collect = subcommands.add_parser("collect", help="list the files to upload")
+    collect.add_argument("root", type=Path)
+    collect.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="write the NUL-delimited file list here for the caller to read",
+    )
+
+    verify = subcommands.add_parser("verify", help="compare local files against the release")
+    verify.add_argument("root", type=Path)
+    verify.add_argument(
+        "--remote",
+        type=Path,
+        required=True,
+        help="'gh release view --json assets' output ('-' for stdin)",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        files = collect_files(args.root)
+        manifest = local_manifest(files)
+        check_inventory(manifest)
+
+        if args.command == "collect":
+            # NUL-delimited: an asset name may contain anything but a slash,
+            # and a newline-delimited list would split it in half.
+            args.output.write_bytes(b"".join(f"{path}\0".encode() for path in files))
+            print(f"collected {len(files)} asset(s):")
+            for path in files:
+                print(f"  {path}")
+            return 0
+
+        payload = sys.stdin.read() if str(args.remote) == "-" else args.remote.read_text(encoding="utf-8")
+        compare_manifests(manifest, remote_manifest(payload))
+        print(f"verified {len(manifest)} asset(s) on the release by name, size and sha256")
+        return 0
+    except AssetError as exc:
+        _emit_error(str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fast/test_release_asset_manifest.py
+++ b/tests/fast/test_release_asset_manifest.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cover the release asset collection and verification contract.
+
+The bug in #550 was that ``release-files/*`` handed ``gh release upload`` a
+directory, which it rejects only after uploading the assets ahead of it. The
+checks here pin the shape of the fixed tree walk and, more importantly, the
+verification that follows it -- the part that has to fail closed, since every
+one of these cases previously produced a green step.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import check_release_assets
+from scripts.check_release_assets import AssetError
+
+SDIST = "vane_ai-0.1.0.tar.gz"
+WHEELS = (
+    "vane_ai-0.1.0-cp310-cp310-manylinux_2_28_x86_64.whl",
+    "vane_ai-0.1.0-cp311-cp311-manylinux_2_28_x86_64.whl",
+    "vane_ai-0.1.0-cp312-cp312-manylinux_2_28_x86_64.whl",
+    "vane_ai-0.1.0-cp313-cp313-manylinux_2_28_x86_64.whl",
+    "vane_ai-0.1.0-cp314-cp314-manylinux_2_28_x86_64.whl",
+)
+DISTRIBUTIONS = (SDIST, *WHEELS)
+SUPPLEMENTAL = (
+    check_release_assets.SHA256SUMS,
+    check_release_assets.SBOM,
+    check_release_assets.PROVENANCE,
+)
+
+
+def _write(path: Path, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+
+
+def _release_tree(root: Path) -> Path:
+    """Build the real post-download layout: two artifacts, nested directories.
+
+    ``release-distributions`` unpacks flat into ``release-files/``, while
+    ``release-supplemental`` keeps the ``packages/`` and ``release-assets/``
+    prefixes it was packed with -- the nesting that broke the original glob.
+    """
+
+    files = root / "release-files"
+    for distribution in DISTRIBUTIONS:
+        _write(files / distribution, f"payload of {distribution}".encode())
+        _write(
+            files / "packages" / f"{distribution}.sigstore.json",
+            f"bundle for {distribution}".encode(),
+        )
+    for name in SUPPLEMENTAL:
+        _write(files / "release-assets" / name, f"contents of {name}".encode())
+    return files
+
+
+def _remote_json(manifest: dict[str, check_release_assets.Asset]) -> str:
+    return json.dumps(
+        {"assets": [{"name": a.name, "size": a.size, "digest": f"sha256:{a.digest}"} for a in manifest.values()]}
+    )
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    return _release_tree(tmp_path)
+
+
+def test_collect_walks_into_nested_artifact_directories(tree: Path) -> None:
+    """The regression itself: nested files are collected, directories are not."""
+
+    collected = check_release_assets.collect_files(tree)
+
+    assert len(collected) == check_release_assets.EXPECTED_ASSET_COUNT
+    assert all(path.is_file() for path in collected)
+    names = {path.name for path in collected}
+    assert names == set(DISTRIBUTIONS) | {f"{d}.sigstore.json" for d in DISTRIBUTIONS} | set(SUPPLEMENTAL)
+    # The two directories the old glob tried to upload.
+    assert not any(path.name in {"packages", "release-assets"} for path in collected)
+
+
+def test_collect_rejects_a_directory_that_is_not_one(tmp_path: Path) -> None:
+    with pytest.raises(AssetError, match="is not a directory"):
+        check_release_assets.collect_files(tmp_path / "absent")
+
+
+def test_an_empty_tree_is_refused(tmp_path: Path) -> None:
+    """An empty download would otherwise publish a release with no assets."""
+
+    empty = tmp_path / "release-files"
+    empty.mkdir()
+
+    with pytest.raises(AssetError, match="no regular files"):
+        check_release_assets.local_manifest(check_release_assets.collect_files(empty))
+
+
+def test_colliding_basenames_are_refused_before_upload(tree: Path) -> None:
+    """Assets are a flat namespace; --clobber would drop one of these silently."""
+
+    _write(tree / "release-assets" / SDIST, b"a different file with the same name")
+
+    with pytest.raises(AssetError, match="collide") as caught:
+        check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+
+    message = str(caught.value)
+    assert SDIST in message
+    # Both paths are named, so the operator can tell which one to fix.
+    assert message.count(SDIST) >= 2
+
+
+def test_the_expected_inventory_passes(tree: Path) -> None:
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+
+    check_release_assets.check_inventory(manifest)
+    assert len(manifest) == 15
+
+
+def test_a_missing_wheel_fails_the_inventory(tree: Path) -> None:
+    (tree / WHEELS[0]).unlink()
+    (tree / "packages" / f"{WHEELS[0]}.sigstore.json").unlink()
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    with pytest.raises(AssetError, match="expected 5 wheels, found 4"):
+        check_release_assets.check_inventory(manifest)
+
+
+def test_an_unsigned_distribution_fails_the_inventory(tree: Path) -> None:
+    """A distribution without its Sigstore bundle must not reach the release."""
+
+    (tree / "packages" / f"{SDIST}.sigstore.json").unlink()
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    with pytest.raises(AssetError, match=f"missing Sigstore bundle for {SDIST}"):
+        check_release_assets.check_inventory(manifest)
+
+
+@pytest.mark.parametrize("missing", SUPPLEMENTAL)
+def test_a_missing_supplemental_asset_fails_the_inventory(tree: Path, missing: str) -> None:
+    (tree / "release-assets" / missing).unlink()
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    with pytest.raises(AssetError, match=f"missing supplemental asset: {missing}"):
+        check_release_assets.check_inventory(manifest)
+
+
+def test_an_unexpected_extra_asset_fails_the_inventory(tree: Path) -> None:
+    _write(tree / "release-assets" / "internal-debug.log", b"not for publication")
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    with pytest.raises(AssetError, match="unexpected assets"):
+        check_release_assets.check_inventory(manifest)
+
+
+def test_a_matching_release_verifies(tree: Path) -> None:
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+
+    check_release_assets.compare_manifests(manifest, remote)
+
+
+def test_an_asset_missing_from_the_release_is_reported(tree: Path) -> None:
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+    del remote[SDIST]
+
+    with pytest.raises(AssetError, match=f"missing from the release: {SDIST}"):
+        check_release_assets.compare_manifests(manifest, remote)
+
+
+def test_a_stale_extra_asset_on_the_release_is_reported(tree: Path) -> None:
+    """comm -23 passed this: extra remote names are a superset, not a mismatch."""
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+    remote["vane_ai-0.0.9.tar.gz"] = check_release_assets.Asset(name="vane_ai-0.0.9.tar.gz", size=10, digest="0" * 64)
+
+    with pytest.raises(AssetError, match="unexpected asset on the release"):
+        check_release_assets.compare_manifests(manifest, remote)
+
+
+def test_a_truncated_upload_is_caught_by_size(tree: Path) -> None:
+    """Same name, fewer bytes -- the dropped-connection case."""
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+    intact = remote[SDIST]
+    remote[SDIST] = check_release_assets.Asset(name=SDIST, size=intact.size - 1, digest=intact.digest)
+
+    with pytest.raises(AssetError, match=f"size mismatch for {SDIST}"):
+        check_release_assets.compare_manifests(manifest, remote)
+
+
+def test_a_substituted_asset_is_caught_by_digest(tree: Path) -> None:
+    """Right name, right length, different bytes."""
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+    intact = remote[SDIST]
+    remote[SDIST] = check_release_assets.Asset(
+        name=SDIST,
+        size=intact.size,
+        digest=hashlib.sha256(b"substituted").hexdigest(),
+    )
+
+    with pytest.raises(AssetError, match=f"digest mismatch for {SDIST}"):
+        check_release_assets.compare_manifests(manifest, remote)
+
+
+def test_every_difference_is_reported_at_once(tree: Path) -> None:
+    """One run should list everything wrong, not fail on the first problem."""
+
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+    del remote[WHEELS[0]]
+    remote["leftover.whl"] = check_release_assets.Asset("leftover.whl", 1, "f" * 64)
+    intact = remote[SDIST]
+    remote[SDIST] = check_release_assets.Asset(SDIST, intact.size + 5, intact.digest)
+
+    with pytest.raises(AssetError) as caught:
+        check_release_assets.compare_manifests(manifest, remote)
+
+    message = str(caught.value)
+    assert WHEELS[0] in message
+    assert "leftover.whl" in message
+    assert f"size mismatch for {SDIST}" in message
+
+
+def test_an_asset_without_a_digest_is_refused_not_skipped() -> None:
+    """gh reports '' for an asset still processing; comparing nothing must not pass."""
+
+    payload = json.dumps({"assets": [{"name": SDIST, "size": 10, "digest": ""}]})
+
+    with pytest.raises(AssetError, match="expected 'sha256:<hex>'"):
+        check_release_assets.remote_manifest(payload)
+
+
+def test_malformed_release_json_is_reported() -> None:
+    with pytest.raises(AssetError, match="could not parse"):
+        check_release_assets.remote_manifest("{not json")
+
+
+def test_release_json_without_an_assets_array_is_reported() -> None:
+    with pytest.raises(AssetError, match="no 'assets' array"):
+        check_release_assets.remote_manifest(json.dumps({"tagName": "v0.1.0"}))
+
+
+def test_collect_writes_a_nul_delimited_list(tree: Path, tmp_path: Path) -> None:
+    """The workflow reads this with `mapfile -d ''`, so the delimiter matters."""
+
+    output = tmp_path / "upload-list"
+
+    assert check_release_assets.main(["collect", str(tree), "--output", str(output)]) == 0
+
+    raw = output.read_bytes()
+    assert raw.endswith(b"\0")
+    entries = [chunk for chunk in raw.split(b"\0") if chunk]
+    assert len(entries) == check_release_assets.EXPECTED_ASSET_COUNT
+    assert not any(b"\n" in entry for entry in entries)
+
+
+def test_collect_fails_without_writing_a_list_when_the_inventory_is_wrong(tree: Path, tmp_path: Path) -> None:
+    """A partial upload list is worse than none: the step must stop first."""
+
+    (tree / WHEELS[0]).unlink()
+    output = tmp_path / "upload-list"
+
+    assert check_release_assets.main(["collect", str(tree), "--output", str(output)]) == 1
+    assert not output.exists()
+
+
+def test_verify_exits_non_zero_on_a_mismatch(tree: Path, tmp_path: Path) -> None:
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    remote = check_release_assets.remote_manifest(_remote_json(manifest))
+    del remote[SDIST]
+    payload = tmp_path / "remote.json"
+    payload.write_text(_remote_json(remote), encoding="utf-8")
+
+    assert check_release_assets.main(["verify", str(tree), "--remote", str(payload)]) == 1
+
+
+def test_verify_exits_zero_on_a_complete_release(tree: Path, tmp_path: Path) -> None:
+    manifest = check_release_assets.local_manifest(check_release_assets.collect_files(tree))
+    payload = tmp_path / "remote.json"
+    payload.write_text(_remote_json(manifest), encoding="utf-8")
+
+    assert check_release_assets.main(["verify", str(tree), "--remote", str(payload)]) == 0


### PR DESCRIPTION
Closes #550.

## Root cause

`release-supplemental` is packed from **two** source directories:

```yaml
path: |
  release-assets/*
  packages/*.sigstore.json
```

With two roots there is no common prefix to strip, so the artifact keeps its `packages/` and `release-assets/` prefixes. `release-distributions`, by contrast, is packed from `packages/*.tar.gz` + `packages/*.whl` — one common prefix, so it flattens.

Both download into `release-files/`, which is why the tree is mixed: loose wheels at the top, plus two directories. `release-files/*` then handed `gh release upload` those directories, and it refuses them — but only after uploading the assets that sorted ahead alphabetically, which is why three wheels landed before the failure.

## Fix

Enumerate regular files recursively (`find release-files -type f`) and pass those explicitly. Plus three guards the previous one-liner had no room for:

1. **Empty `release-files/` fails loudly** instead of "succeeding" with nothing attached.
2. **Colliding basenames are refused.** Release assets are a flat namespace keyed by basename; the tree being flattened is not. Two same-named files in different directories (say a `SHA256SUMS` in both `release-assets/` and `packages/`) would overwrite each other under `--clobber` and publish a release quietly missing one. This isn't in the current layout, but flattening a tree into a flat namespace is exactly where it would appear later.
3. **Post-upload verification** as its own step, before `Publish the complete draft release`. Steps fail fast, so the publish can no longer promote an incomplete draft.

The verification is a **set comparison, not a hardcoded count** — the issue mentions six distributions and nine supplemental assets, but pinning `15` would need editing every time the build matrix changes. Comparing local filenames against `gh release view --json assets` catches a missing asset regardless of how many there should be.

## Verification

I can't run the release workflow, so I reproduced the artifact layout locally and exercised the logic directly.

**The bug, reproduced** — same shape as the issue:

```
=== OLD behaviour: release-files/* ===
  DIRECTORY -> gh fails: release-files/packages
  DIRECTORY -> gh fails: release-files/release-assets
  file: release-files/vane-0.1.0-cp312-cp312-linux.whl
  ...
=== NEW behaviour: find -type f ===
  count: 7   (all regular files, no directories)
```

**All three guards fire, and the happy path doesn't false-positive:**

```
=== duplicate-basename guard ===  CAUGHT collision: SHA256SUMS
=== empty-dir guard ===           CAUGHT empty
=== missing-asset verify ===      CAUGHT missing: b
=== verify passes when complete === OK, no missing
```

`release.yml` parses as YAML, and the step order is `Attach` → `Verify` → `Publish`.

`find -printf` is GNU find, which `ubuntu-24.04` has.

## Note on the alternative fix

This could instead be fixed at the *upload* end, by flattening `release-supplemental` when the artifact is built (two `upload-artifact` steps, or staging both sets into one directory first). I went with the download end because it is the smaller change and keeps the artifact contents traceable to their source directories. Happy to switch if you'd rather the artifact were flat.
