### PR TITLE
[chore](deps) Run routine Dependabot updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "04:00"
       timezone: Asia/Shanghai
     open-pull-requests-limit: 5
@@ -14,19 +13,29 @@ updates:
   - package-ecosystem: pip
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "04:30"
       timezone: Asia/Shanghai
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[chore](deps) "
 
+  # Apply the shared title prefix to benchmark security updates without
+  # enabling routine updates for the pinned benchmark environment.
+  - package-ecosystem: pip
+    directory: /benchmarking/parquet
+    schedule:
+      interval: monthly
+      time: "04:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "[chore](deps) "
+
   - package-ecosystem: pre-commit
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: "05:00"
       timezone: Asia/Shanghai
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Weekly Dependabot jobs generated repeated routine update PRs. Separately, parquet benchmark security PRs such as #529 and #530 did not inherit the required `[chore](deps)` title prefix and failed title validation.

This change:

- runs routine GitHub Actions, root pip, and pre-commit updates monthly;
- configures `/benchmarking/parquet` for security updates only;
- applies the required title prefix to future benchmark security PRs.

## Related issue

N/A

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format workspace --from-ref upstream/main --check`
- `pre-commit run --show-diff-on-failure --files .github/dependabot.yml`
- `git show --check --stat HEAD`
- Runtime tests were not run because this changes only Dependabot configuration.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
