### PR TITLE
[fix](ai) Preserve structured Prompt control characters

### DIFF
--- a/src/vane_py/ai_sql_functions.cpp
+++ b/src/vane_py/ai_sql_functions.cpp
@@ -237,6 +237,18 @@ static unique_ptr<Expression> BindScalarFunction(ClientContext &context, const s
 	return result;
 }
 
+static unique_ptr<Expression> CastPromptOutput(ClientContext &context, unique_ptr<Expression> result,
+                                               const LogicalType &target_type) {
+	if (result->return_type == target_type) {
+		return result;
+	}
+	if (target_type.id() == LogicalTypeId::STRUCT) {
+		// Structured Prompt UDFs return validated JSON text, not DuckDB's STRUCT literal syntax.
+		result = BoundCastExpression::AddCastToType(context, std::move(result), LogicalType::JSON());
+	}
+	return BoundCastExpression::AddCastToType(context, std::move(result), target_type);
+}
+
 static unique_ptr<Expression> BuildNativeVLLMPromptArgument(ClientContext &context, unique_ptr<Expression> prompt,
                                                             const Value &system_message) {
 	if (system_message.IsNull() || StringValue::Get(system_message).empty()) {
@@ -272,10 +284,7 @@ static unique_ptr<Expression> LowerNativeVLLMPrompt(FunctionBindExpressionInput 
 		validation_children.push_back(make_uniq<BoundConstantExpression>(data.validation_payload));
 		result = BindScalarFunction(input.context, UDFFunction::Name, std::move(validation_children));
 	}
-	if (result->return_type != data.return_type) {
-		result = BoundCastExpression::AddCastToType(input.context, std::move(result), data.return_type);
-	}
-	return result;
+	return CastPromptOutput(input.context, std::move(result), data.return_type);
 }
 
 static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction &bound_function,
@@ -393,10 +402,7 @@ static unique_ptr<Expression> LowerAISQLPromptExpressionUDF(FunctionBindExpressi
 		throw BinderException("ai_prompt payload is missing ai_return_type");
 	}
 	auto target_type = TransformStringToLogicalType(public_type.second, input.context);
-	if (result->return_type != target_type) {
-		result = BoundCastExpression::AddCastToType(input.context, std::move(result), target_type);
-	}
-	return result;
+	return CastPromptOutput(input.context, std::move(result), target_type);
 }
 
 static unique_ptr<Expression> LowerAISQLEmbedExpressionUDF(FunctionBindExpressionInput &input) {

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import math
 from collections import deque
 from dataclasses import dataclass
@@ -65,11 +66,17 @@ class MockTextEmbedderDescriptor(TextEmbedderDescriptor):
 
 
 class MockPrompter:
+    def __init__(self, return_format: dict[str, Any] | None = None) -> None:
+        self._return_format = return_format
+
     def prompt_batch(self, text: list[str]) -> list[str]:
         return [f"topic:{item}" for item in text]
 
     async def prompt(self, messages: tuple[object, ...]) -> str:
-        return f"topic:{messages[0]}"
+        result = f"topic:{messages[0]}"
+        if self._return_format is not None:
+            return json.dumps({"answer": result})
+        return result
 
 
 @dataclass
@@ -77,6 +84,7 @@ class MockPrompterDescriptor(PrompterDescriptor):
     actor_number: int | None = None
     max_concurrency_per_actor: int | None = None
     num_gpus: float | None = 0
+    return_format: dict[str, Any] | None = None
 
     def get_provider(self) -> str:
         return "mock"
@@ -103,7 +111,7 @@ class MockPrompterDescriptor(PrompterDescriptor):
         )
 
     def instantiate(self) -> MockPrompter:
-        return MockPrompter()
+        return MockPrompter(self.return_format)
 
 
 class MockProvider(Provider):
@@ -129,7 +137,7 @@ class MockProvider(Provider):
         *,
         options: dict[str, object] | None = None,
     ) -> PrompterDescriptor:
-        return MockPrompterDescriptor()
+        return MockPrompterDescriptor(return_format=return_format)
 
 
 def test_prompt_and_embed_ignore_descriptor_execution_defaults():
@@ -994,6 +1002,37 @@ def test_ai_prompt_expression_basic():
     assert rel.select(expr).fetchall() == [("topic:search",), ("topic:ranking",)]
 
 
+def test_ai_prompt_structured_output_preserves_json_control_characters():
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+        "additionalProperties": False,
+    }
+    relation = vane.connect().sql("SELECT concat('line1', chr(10), 'line2', chr(9), chr(1))::VARCHAR AS message")
+    message = vane.col("message")
+    expected = [({"answer": "topic:line1\nline2\t\x01"},)]
+
+    expression_result = relation.select(
+        vane.ai.prompt(message, provider=MockProvider(), return_format=schema).alias("response")
+    )
+    relation_result = vane.ai.prompt(
+        relation,
+        message,
+        provider=MockProvider(),
+        return_format=schema,
+    ).project("response")
+    method_result = relation.prompt(
+        message,
+        provider=MockProvider(),
+        return_format=schema,
+    ).project("response")
+
+    assert expression_result.fetchall() == expected
+    assert relation_result.fetchall() == expected
+    assert method_result.fetchall() == expected
+
+
 def test_ai_prompt_runtime_signature_matches_public_contract():
     signature = inspect.signature(vane.ai.prompt, eval_str=True)
     parameters = signature.parameters
@@ -1573,33 +1612,47 @@ def test_vllm_prompt_injects_structured_schema_without_mutating_callers():
     }
 
 
-def test_ai_prompt_vllm_validates_structured_output_and_nulls_invalid_rows(monkeypatch):
+@pytest.mark.parametrize("entry_point", ["expression", "relation"])
+def test_ai_prompt_vllm_validates_structured_output_and_nulls_invalid_rows(monkeypatch, entry_point):
     import vane.execution.vllm as vllm_executor
 
+    control_text = "line1\nline2\t\x01"
     schema = {
         "type": "object",
         "properties": {"answer": {"type": "string"}},
         "required": ["answer"],
         "additionalProperties": False,
     }
-    executor = _RecordingNativeVLLMExecutor({"valid": '{"answer":"ok"}', "invalid": '{"answer":1}'})
+    executor = _RecordingNativeVLLMExecutor({"valid": json.dumps({"answer": control_text}), "invalid": '{"answer":1}'})
     monkeypatch.setattr(vllm_executor, "build_executor", lambda _model, _options: executor)
     relation = vane.connect().sql(
         "select * from (values (1, 'valid'::VARCHAR), (2, 'invalid'::VARCHAR), "
         "(3, NULL::VARCHAR)) source(id, prompt) order by id"
     )
 
-    result = vane.ai.prompt(
-        relation,
-        vane.col("prompt"),
-        provider="vllm",
-        return_format=schema,
-        on_error="ignore",
-    )
+    if entry_point == "expression":
+        result = relation.select(
+            vane.col("id"),
+            vane.col("prompt"),
+            vane.ai.prompt(
+                vane.col("prompt"),
+                provider="vllm",
+                return_format=schema,
+                on_error="ignore",
+            ).alias("response"),
+        )
+    else:
+        result = vane.ai.prompt(
+            relation,
+            vane.col("prompt"),
+            provider="vllm",
+            return_format=schema,
+            on_error="ignore",
+        )
 
     assert str(result.types[-1]) == "STRUCT(answer VARCHAR)"
     assert sorted(result.fetchall()) == [
-        (1, "valid", {"answer": "ok"}),
+        (1, "valid", {"answer": control_text}),
         (2, "invalid", None),
         (3, None, None),
     ]

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -276,6 +276,35 @@ def test_ai_prompt_sql_structured_output_has_native_struct_type():
     ]
 
 
+def test_ai_prompt_sql_structured_output_preserves_json_control_characters():
+    schema = json.dumps(
+        {
+            "type": "object",
+            "properties": {
+                "answer": {"type": "string"},
+                "score": {"type": "integer"},
+            },
+            "required": ["answer", "score"],
+            "additionalProperties": False,
+        }
+    )
+    response = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            concat('line1', chr(10), 'line2', chr(9), chr(1)),
+            return_format := json '{schema}',
+            provider := 'mock_ai_sql',
+            model := 'structured'
+        ) AS response
+    """)
+        .fetchone()[0]
+    )
+
+    answer = "structured:line1\nline2\t\x01"
+    assert response == {"answer": answer, "score": len(answer)}
+
+
 def test_ai_prompt_sql_structured_output_composes_with_positional_image():
     schema = json.dumps(
         {
@@ -512,7 +541,7 @@ def test_ai_prompt_sql_structured_type_survives_plan_round_trip():
     )
     relation = vane.connect().sql(f"""
         SELECT ai_prompt(
-            'alpha',
+            concat('line1', chr(10), 'line2', chr(9), chr(1)),
             return_format := json '{schema}',
             provider := 'mock_ai_sql',
             model := 'structured',
@@ -524,8 +553,9 @@ def test_ai_prompt_sql_structured_type_survives_plan_round_trip():
     node = physical.collect_udf_nodes()[0]
     table = _execute_ai_physical_plan(target, physical)
 
+    answer = "structured:line1\nline2\t\x01"
     assert table.schema.field(0).type == pa.struct([pa.field("answer", pa.string()), pa.field("score", pa.int64())])
-    assert table.column(0).to_pylist() == [{"answer": "structured:alpha", "score": 16}]
+    assert table.column(0).to_pylist() == [{"answer": answer, "score": len(answer)}]
     assert node["payload"]["ai_return_type"] == 'STRUCT("answer" VARCHAR, "score" BIGINT)'
 
 
@@ -748,7 +778,8 @@ def test_ai_prompt_sql_vllm_rejects_raw_response_during_planning():
 def test_ai_prompt_sql_vllm_validates_structured_output(monkeypatch):
     import vane.execution.vllm as vllm_executor
 
-    executor = RecordingNativeVLLMExecutor({"alpha": '{"answer":"ok"}', "beta": '{"answer":1}'})
+    control_text = "line1\nline2\t\x01"
+    executor = RecordingNativeVLLMExecutor({"alpha": json.dumps({"answer": control_text}), "beta": '{"answer":1}'})
     builds = []
 
     def build_executor(model, options):
@@ -776,7 +807,7 @@ def test_ai_prompt_sql_vllm_validates_structured_output(monkeypatch):
     """)
 
     assert str(relation.types[-1]) == "STRUCT(answer VARCHAR)"
-    assert sorted(relation.fetchall()) == [(1, {"answer": "ok"}), (2, None), (3, None)]
+    assert sorted(relation.fetchall()) == [(1, {"answer": control_text}), (2, None), (3, None)]
     assert builds[0][1]["generate_args"]["sampling_params"]["structured_outputs"] == {"json": json.loads(schema)}
 
 

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -1632,6 +1632,14 @@ def _build_native_vllm_expression(messages: list[Any], descriptor: NativeVLLMPro
     )
 
 
+def _cast_structured_prompt_output(
+    expression: Expression,
+    structured_output: StructuredOutputSpec,
+) -> Expression:
+    """Decode validated JSON text into the public structured type."""
+    return expression.cast("JSON").cast(structured_output.duckdb_type)
+
+
 def _prompt_relation(
     rel: Any,
     messages: Any,
@@ -1675,15 +1683,18 @@ def _prompt_relation(
                 output_column,
                 udf_options.on_error,
             )
-            expression = _build_map_batches_expression(
-                validator.__call__,
-                name="validate_vllm_structured_output",
-                inputs={input_column: expression},
-                schema={output_column: "VARCHAR"},
-                batch_size=None,
-                row_preserving=True,
-                gpus=0,
-            ).cast(structured_output.duckdb_type)
+            expression = _cast_structured_prompt_output(
+                _build_map_batches_expression(
+                    validator.__call__,
+                    name="validate_vllm_structured_output",
+                    inputs={input_column: expression},
+                    schema={output_column: "VARCHAR"},
+                    batch_size=None,
+                    row_preserving=True,
+                    gpus=0,
+                ),
+                structured_output,
+            )
         expression = expression.alias(output_column)
         star = _star_excluding_existing_output_column(rel, output_column)
         return rel.select(star, expression)
@@ -1707,9 +1718,6 @@ def _prompt_relation(
         max_retries=udf_options.max_retries,
         on_error=udf_options.on_error,
     )
-    output_type = (
-        structured_output.duckdb_type if structured_output is not None and not return_raw_response else "VARCHAR"
-    )
     expression = _build_ai_batch_expression(
         wrapper,
         inputs=dict(zip(input_names, message_expressions, strict=True)),
@@ -1718,7 +1726,11 @@ def _prompt_relation(
         udf_opts=udf_options,
         name="ai_prompt",
         execution_backend=execution_backend,
-    ).cast(output_type)
+    )
+    if structured_output is not None and not return_raw_response:
+        expression = _cast_structured_prompt_output(expression, structured_output)
+    else:
+        expression = expression.cast("VARCHAR")
     star = _star_excluding_existing_output_column(rel, output_column)
     return rel.select(star, expression.alias(output_column))
 
@@ -1758,15 +1770,18 @@ def _prompt_expression(
             "response",
             udf_options.on_error,
         )
-        return _build_map_batches_expression(
-            validator.__call__,
-            name="validate_vllm_structured_output",
-            inputs={input_column: expression},
-            schema={"response": "VARCHAR"},
-            batch_size=None,
-            row_preserving=True,
-            gpus=0,
-        ).cast(structured_output.duckdb_type)
+        return _cast_structured_prompt_output(
+            _build_map_batches_expression(
+                validator.__call__,
+                name="validate_vllm_structured_output",
+                inputs={input_column: expression},
+                schema={"response": "VARCHAR"},
+                batch_size=None,
+                row_preserving=True,
+                gpus=0,
+            ),
+            structured_output,
+        )
     if isinstance(descriptor, NativePrompterPlan):
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
 
@@ -1786,17 +1801,17 @@ def _prompt_expression(
         max_retries=udf_options.max_retries,
         on_error=udf_options.on_error,
     )
-    output_type = (
-        structured_output.duckdb_type if structured_output is not None and not return_raw_response else "VARCHAR"
-    )
-    return _build_ai_batch_expression(
+    expression = _build_ai_batch_expression(
         wrapper,
         inputs=dict(zip(input_names, validated_messages, strict=True)),
         output_column="response",
         output_type="VARCHAR",
         udf_opts=udf_options,
         name="ai_prompt",
-    ).cast(output_type)
+    )
+    if structured_output is not None and not return_raw_response:
+        return _cast_structured_prompt_output(expression, structured_output)
+    return expression.cast("VARCHAR")
 
 
 def _is_relation_like(value: Any) -> TypeGuard[Relation]:


### PR DESCRIPTION
## Summary

Structured Prompt validation produces canonical JSON text, but the existing Python and SQL paths cast that `VARCHAR` directly to the schema-derived `STRUCT`. DuckDB's generic nested-literal parser treats backslashes as escape prefixes, silently corrupting JSON escapes such as `\n`, `\t`, and `\u0001`.

Decode validated output through DuckDB's JSON type before converting it to `STRUCT`. Apply the fix consistently to Python Expression/Relation, SQL, native vLLM, and serialized-plan paths, with regression coverage for escaped control characters. Public APIs and output types are unchanged.

## Related issue

close: #565

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This restores the existing structured-output contract.

## Validation

- Incremental Release native build and non-editable install
- Affected AI test files: 238 passed
- `scripts/run_release_tests.sh`: 515 passed, 4 skipped; 11 real-Ray tests passed
- `scripts/format workspace --from-ref upstream/main --check`
- Changed-range pre-commit checks, including Ruff, clang-format, mypy, conflict, credential, and large-file checks

The broader `tests/ai` run had 13 unrelated OpenAI embedding failures because the local environment lacks the optional `openai` and `tiktoken` dependencies; all structured Prompt tests passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
