### PR TITLE
[fix](ray) Clean up startup cancellation test executors

### DIFF
--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -436,11 +436,11 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
     blocker_started = threading.Event()
     blocker_release = threading.Event()
     startup_entered = threading.Event()
-    executor = ThreadPoolExecutor(
+    native_executor = ThreadPoolExecutor(
         max_workers=1,
-        thread_name_prefix="vane-test-saturated",
+        thread_name_prefix="vane-test-native-saturated",
     )
-    runner._driver_native_executor = executor
+    runner._driver_native_executor = native_executor
 
     runner._precreate_udf_actors = lambda *_args, **_kwargs: startup_entered.set() or []
 
@@ -450,7 +450,7 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         blocker_future = None
         register_query_resources = runner_cls._register_query_resources
 
-        def _occupy_default_executor() -> None:
+        def _occupy_native_executor() -> None:
             blocker_started.set()
             assert blocker_release.wait(timeout=2.0)
 
@@ -468,8 +468,8 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
                 expected_plan_id=expected_plan_id,
             )
             blocker_future = loop.run_in_executor(
-                executor,
-                _occupy_default_executor,
+                native_executor,
+                _occupy_native_executor,
             )
             while not blocker_started.is_set():
                 await asyncio.sleep(0)
@@ -506,7 +506,7 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         asyncio.run(_exercise())
     finally:
         blocker_release.set()
-        executor.shutdown(wait=True)
+        runner_cls._shutdown_driver_executors(runner)
 
     with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager(query_id)


### PR DESCRIPTION
## Summary

- Name the saturated executor and blocker for the dedicated driver native executor they actually exercise.
- Use `_shutdown_driver_executors()` so the cancellation regression deterministically joins both the injected native executor and the lazily created lifecycle executor.
- Remove the test's dependency on cyclic garbage collection for executor thread cleanup.

## Context

PR #571 already moved this regression to `_driver_native_executor` and superseded the original scheduling correction from this PR. This follow-up retains only the residual executor cleanup and naming improvements.

Production code and public behavior are unchanged.

## Related issue

Follow-up to #571.

## Documentation impact

- [x] No user-facing documentation update is required.

This is a test-only correction.

## Validation

- `scripts/format root --from-ref upstream/main --check`
- `pre-commit run --files tests/fast/test_driver_query_resource_graph_registration.py`
- targeted cancellation regression: passed
- targeted cancellation regression in 20 independent pytest processes: 20/20 passed
- same-process post-test thread audit before `gc.collect()`: no `vane-driver-*` or test native executor threads remained
- affected test file: 17 passed
- `scripts/run_release_tests.sh`: 527 passed, 4 skipped; 11 real-Ray tests passed
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] No dependencies, copied code, model assets, or datasets are added.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications have been considered.
- [x] No native or production source changed; relevant test and formatting checks passed.
