### PR TITLE
[fix](ray) Balance sequential tasks across idle workers

### DIFF
--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -5788,6 +5788,27 @@ def test_fte_owner_selection_uses_reserved_memory_pressure(monkeypatch):
     assert high_memory.fte_pressure_stats()["total_memory_bytes"] == 0
 
 
+def test_fte_owner_selection_balances_sequential_tasks_across_idle_workers():
+    first = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        manager_instance_id="manager-a",
+    )
+    second = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-b:0",
+        manager_instance_id="manager-a",
+    )
+
+    assert first._select_fte_worker() is first
+    first.record_fte_task_terminal_without_drain("query-fair.0.0.0")
+    assert first._select_fte_worker() is second
+    second.record_fte_task_terminal_without_drain("query-fair.0.1.0")
+    assert first._select_fte_worker() is first
+
+
 def test_fte_create_promotes_reservation_to_running_atomically(monkeypatch):
     actor = _FakeActor()
     handle = RayWorkerActorHandle(actor, memory_capacity_bytes=15, worker_id="worker-0")

--- a/vane/runners/ray/fte_fragment_scheduler.py
+++ b/vane/runners/ray/fte_fragment_scheduler.py
@@ -1540,7 +1540,7 @@ def _fte_worker_selection_key(
     memory_requirement_bytes: Any = None,
     execution_class: FteTaskExecutionClass | str | None = None,
     node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
-) -> tuple[int, int, int, int, int, int, str]:
+) -> tuple[int, int, int, int, int, int, int, str]:
     stats = _required_fte_pressure_stats(handle)
     running = int(stats.get("running_attempt_count", 0)) + int(stats.get("reserved_partition_count", 0))
     current_memory_bytes = _fte_pressure_capacity_memory_bytes(
@@ -1553,6 +1553,14 @@ def _fte_worker_selection_key(
     over_budget = 1 if memory_after_bytes > budget_bytes else 0
     split_bytes = int(stats.get("assigned_split_bytes", 0))
     split_count = int(stats.get("assigned_split_count", 0))
+    # QRM can intentionally admit source partitions one at a time. Without a
+    # completed-task tie breaker, every idle worker has identical live
+    # pressure between those partitions and the stable worker-id tie breaker
+    # sends the entire scan to one actor. Terminal task identities are already
+    # compacted per query and removed during query teardown, so they provide a
+    # bounded, retry-aware fairness signal without weakening locality or live
+    # resource-pressure priorities.
+    completed = int(stats.get("terminal_attempt_count", 0))
     return (
         over_budget,
         _node_requirements_preference_penalty(handle, node_requirements),
@@ -1560,6 +1568,7 @@ def _fte_worker_selection_key(
         memory_after_bytes,
         split_bytes,
         split_count,
+        completed,
         str(handle.worker_id),
     )
 


### PR DESCRIPTION
## Summary

Ray FTE worker selection currently falls back to the stable worker ID whenever workers have equal live pressure. When QRM admits source partitions sequentially, the selected worker can return to idle before the next partition is admitted, so every partition repeatedly lands on the same actor.

This change adds each worker's bounded `terminal_attempt_count` as the final fairness signal before the worker-ID tie breaker. Locality, live task pressure, memory pressure, and assigned split pressure keep their existing priority; workers that have completed fewer attempts win only when those signals tie. A focused regression test covers sequential admission across two idle workers.

## Related issue

close: #569

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

No public API or user-facing configuration changes.

## Validation

- `scripts/format root --from-ref upstream/feature/distributed-extension-io-core --check` — passed with the project virtual environment active.
- `python -m pytest tests/fast/test_ray_fragment_submission.py -q` — 291 passed on Linux x86_64 with Python 3.12.3 using the fast-test artifact and fake Ray actors.
- `git diff --check upstream/feature/distributed-extension-io-core...HEAD` — passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
