### PR TITLE
[fix](ray) Fence plan teardown on startup

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -498,7 +498,8 @@ public:
 	/// Unified run_plan: auto-detects sink nodes and handles both streaming and finalize paths.
 	/// - Non-sink plans → returns PlanResultStream (streaming pull)
 	/// - Sink plans (CopyFinish) → collects all outputs, calls finalize(), returns DistributedCopyResult
-	DuckDBResult<PlanResult> run_plan(std::shared_ptr<DistributedPhysicalPlan> plan, TaskInputs initial_inputs = {}) {
+	DuckDBResult<PlanResult> run_plan(std::shared_ptr<DistributedPhysicalPlan> plan, TaskInputs initial_inputs = {},
+	                                  std::function<void()> on_execution_started = {}) {
 		if (!client_context_) {
 			return DuckDBResult<PlanResult>::err(DuckDBError("run_plan requires a ClientContext"));
 		}
@@ -656,6 +657,9 @@ public:
 				output_lifetime_guard.reset();
 			}
 		});
+		if (on_execution_started) {
+			on_execution_started();
+		}
 
 		// ── Step 4: Dispatch based on sink presence ──
 		if (!sink_node) {

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -2646,6 +2646,8 @@ struct PyPhysicalPlanWrapperRunner {
 	py::object run_copy_plan(const PyPhysicalPlanWrapper &plan,
 	                         duckdb::shared_ptr<duckdb::ClientContext> client_context = nullptr,
 	                         duckdb::distributed::python::ray::SafePyObject py_conn_keepalive =
+	                             duckdb::distributed::python::ray::SafePyObject(),
+	                         duckdb::distributed::python::ray::SafePyObject on_execution_started =
 	                             duckdb::distributed::python::ray::SafePyObject()) {
 		using namespace duckdb::distributed;
 		(void)py_conn_keepalive;
@@ -2719,10 +2721,18 @@ struct PyPhysicalPlanWrapperRunner {
 				auto run_plan_started = std::chrono::steady_clock::now();
 				py::gil_scoped_release release;
 				DuckDBResult<duckdb::distributed::PlanRunner::PlanResult> plan_res;
+				auto publish_execution_started = [&]() {
+					if (!on_execution_started.has_value()) {
+						return;
+					}
+					py::gil_scoped_acquire acquire;
+					on_execution_started.get()();
+				};
 				if (!client_context) {
-					plan_res = runner->run_plan(plan.plan_);
+					plan_res = runner->run_plan(plan.plan_, {}, publish_execution_started);
 				} else {
-					client_context->RunFunctionInTransaction([&]() { plan_res = runner->run_plan(plan.plan_); });
+					client_context->RunFunctionInTransaction(
+					    [&]() { plan_res = runner->run_plan(plan.plan_, {}, publish_execution_started); });
 				}
 				if (!plan_res.is_ok()) {
 					res = DuckDBResult<DistributedCopyResult>::err(plan_res.error());

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -1051,7 +1051,8 @@ void register_ray_bindings(py::module_ &mod) {
 	        py::arg("plan"), py::arg("conn") = py::none())
 	    .def(
 	        "run_copy_plan",
-	        [](PyPhysicalPlanWrapperRunner &self, py::object plan_obj, py::object conn_obj) -> py::object {
+	        [](PyPhysicalPlanWrapperRunner &self, py::object plan_obj, py::object conn_obj,
+	           py::object on_execution_started_obj) -> py::object {
 		        if (!py::isinstance<PyPhysicalPlanWrapper>(plan_obj)) {
 			        throw py::type_error("plan must be DistributedPhysicalPlan (PyPhysicalPlanWrapper)");
 		        }
@@ -1101,9 +1102,15 @@ void register_ray_bindings(py::module_ &mod) {
 
 		        duckdb::distributed::python::ray::SafePyObject keepalive;
 		        auto client_context = get_client_context(conn_obj, keepalive);
-		        return self.run_copy_plan(*plan_ptr, client_context, std::move(keepalive));
+		        duckdb::distributed::python::ray::SafePyObject on_execution_started;
+		        if (!on_execution_started_obj.is_none()) {
+			        on_execution_started =
+			            duckdb::distributed::python::ray::SafePyObject(std::move(on_execution_started_obj));
+		        }
+		        return self.run_copy_plan(*plan_ptr, client_context, std::move(keepalive),
+		                                  std::move(on_execution_started));
 	        },
-	        py::arg("plan"), py::arg("conn") = py::none())
+	        py::arg("plan"), py::arg("conn") = py::none(), py::arg("on_execution_started") = py::none())
 	    .def(
 	        "finalize_copy",
 	        [](PyPhysicalPlanWrapperRunner &self, py::list file_infos, py::str copy_spec_key, py::str staging_root,

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -234,6 +234,7 @@ def _runner(events, coordinator):
     runner._detached_client_results = BoundedReplayMap(capacity=65_536)
     runner._session_lock = threading.RLock()
     runner._closed_session_owners = BoundedReplayMap(capacity=65_536)
+    runner._plan_lifecycles = {}
     runner._plan_session_ids = {}
     runner._plan_connections = {}
     runner._plan_teardown_condition = threading.Condition(runner._session_lock)
@@ -260,6 +261,7 @@ def _runner(events, coordinator):
     runner._active_vllm_actors_by_plan = {}
     runner.curr_plans = {}
     runner.curr_streams = {}
+    runner._async_result_streams = {}
     runner._plan_query_ids = {}
     runner._query_terminal_errors = {}
     runner._query_resource_admission_loop = None
@@ -438,12 +440,12 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
         max_workers=1,
         thread_name_prefix="vane-test-saturated",
     )
+    runner._driver_native_executor = executor
 
     runner._precreate_udf_actors = lambda *_args, **_kwargs: startup_entered.set() or []
 
     async def _exercise() -> None:
         loop = asyncio.get_running_loop()
-        loop.set_default_executor(executor)
         registration_complete = asyncio.Event()
         blocker_future = None
         register_query_resources = runner_cls._register_query_resources
@@ -466,7 +468,7 @@ def test_run_plan_cancellation_releases_registration_before_startup_worker_claim
                 expected_plan_id=expected_plan_id,
             )
             blocker_future = loop.run_in_executor(
-                None,
+                executor,
                 _occupy_default_executor,
             )
             while not blocker_started.is_set():
@@ -562,7 +564,7 @@ def test_run_plan_cancellation_after_startup_claim_tears_down_once():
 
     with pytest.raises(KeyError, match="query resource graph is not registered"):
         get_query_resource_manager(query_id)
-    assert fragment_drops == [query_id]
+    assert fragment_drops == []
     assert coordinator.released == [(query_id, 7)]
     assert query_id not in runner.curr_plans
     assert query_id not in runner.curr_streams
@@ -617,10 +619,13 @@ def test_copy_registration_keeps_streaming_udf_admission_bounded_when_ray_nodes_
     runner._precreate_udf_actors = lambda *_args, **_kwargs: []
     runner._precreate_vllm_actors = lambda *_args, **_kwargs: []
     runner._get_plan_runner = lambda: SimpleNamespace(
-        run_copy_plan=lambda _plan, _conn: {
-            "rows_copied": 1,
-            "copy_output_committed": True,
-        },
+        run_copy_plan=lambda _plan, _conn, on_execution_started: (
+            on_execution_started()
+            or {
+                "rows_copied": 1,
+                "copy_output_committed": True,
+            }
+        ),
     )
     runner._build_local_progress_snapshot = lambda query_id, _started_at: {
         "query_id": query_id,

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -282,8 +282,13 @@ def _make_local_query_driver_actor():
     runner = cls.__new__(cls)
     runner.curr_streams = {}
     runner.curr_plans = {}
+    runner._async_result_streams = {}
     runner._plan_query_ids = {}
     runner._query_terminal_errors = {}
+    runner._leased_result_partition_refs = {}
+    runner._result_partition_ref_counters = {}
+    runner._query_resource_graphs = {}
+    runner._query_allocations = {}
     runner._duckdb_conn = _FakeConnection()
     runner.plan_runner = None
     runner._active_udf_actors = []
@@ -318,6 +323,7 @@ def _make_local_query_driver_actor():
     runner._client_lease_maintenance_failures = 0
     runner._session_lock = threading.RLock()
     runner._closed_session_owners = driver.BoundedReplayMap(capacity=65_536)
+    runner._plan_lifecycles = {}
     runner._plan_session_ids = {}
     runner._plan_connections = {}
     runner._plan_teardown_condition = threading.Condition(runner._session_lock)
@@ -678,17 +684,87 @@ def _bind_test_query_resource_owner(
         ),
     )
     manager.update_unit_state(unit.resource_unit_id, runnable=True)
-    runner._plan_query_ids[str(plan_id)] = query_id
-    runner._plan_session_ids[str(plan_id)] = _TEST_SESSION_ID
-    runner._sessions[_TEST_SESSION_ID].plan_ids.add(str(plan_id))
+    _bind_test_plan_session(runner, plan_id, query_id=query_id)
     return manager
 
 
-def _bind_test_plan_session(runner, plan_id: str, *, query_id: str | None = None) -> None:
+def _bind_test_plan_session(
+    runner,
+    plan_id: str,
+    *,
+    query_id: str | None = None,
+    query_connection=None,
+) -> driver._PlanLifecycle:
     plan_key = str(plan_id)
+    query_key = str(plan_key if query_id is None else query_id)
+    lifecycle = driver._PlanLifecycle(
+        plan_id=plan_key,
+        session_id=_TEST_SESSION_ID,
+    )
+    if query_key:
+        lifecycle.set_query_id(query_key)
+    if query_connection is not None:
+        lifecycle.set_query_connection(query_connection)
+    assert lifecycle.begin_startup()
+    if query_key:
+        assert lifecycle.begin_fragment_execution()
+        assert lifecycle.finish_setup(succeeded=True) is False
+    else:
+        assert lifecycle.finish_setup(succeeded=False) is True
+    runner._plan_lifecycles[plan_key] = lifecycle
     runner._plan_session_ids[plan_key] = _TEST_SESSION_ID
-    runner._plan_query_ids[plan_key] = str(plan_key if query_id is None else query_id)
+    runner._plan_query_ids[plan_key] = query_key
+    if query_connection is not None:
+        runner._plan_connections[plan_key] = query_connection
     runner._sessions[_TEST_SESSION_ID].plan_ids.add(plan_key)
+    return lifecycle
+
+
+def _test_plan_teardown_state(runner, plan_id: str):
+    lifecycle = runner._plan_lifecycles[str(plan_id)]
+    query_id, query_connection, drop_fragments = lifecycle.wait_for_setup()
+    return lifecycle, query_id, query_connection, drop_fragments
+
+
+def _release_test_plan_session_state(cls, runner, plan_id: str) -> None:
+    lifecycle, _query_id, query_connection, _drop_fragments = _test_plan_teardown_state(runner, plan_id)
+    lifecycle.request_close()
+    cls._release_plan_session_state(runner, lifecycle, _query_id, query_connection)
+
+
+def _run_test_plan_preparation(
+    cls,
+    runner,
+    session,
+    logical_plan,
+    plan_id: str,
+    *,
+    copy_plan: bool,
+):
+    lifecycle = cls._register_plan_lifecycle(runner, _TEST_SESSION_ID, session, plan_id)
+    try:
+        if copy_plan:
+            return cls._prepare_copy_plan_sync(
+                runner,
+                _TEST_SESSION_ID,
+                session,
+                logical_plan,
+                plan_id,
+                lifecycle,
+            )
+        return cls._prepare_plan_sync(
+            runner,
+            _TEST_SESSION_ID,
+            session,
+            logical_plan,
+            plan_id,
+            lifecycle,
+        )
+    except BaseException:
+        lifecycle.request_close()
+        lifecycle.finish_setup(succeeded=False)
+        cls._teardown_plan_resources(runner, plan_id)
+        raise
 
 
 def _fake_task_context_info(task_id):
@@ -758,6 +834,10 @@ def test_owned_thread_side_effect_finishes_before_cancellation_is_exposed():
         task.cancel()
         await asyncio.sleep(0)
         assert task.done() is False
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+        assert task.cancelling() == 2
 
         release.set()
         with pytest.raises(asyncio.CancelledError):
@@ -784,18 +864,22 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
         _graph,
         _query_connection,
         _session_config,
+        _lifecycle,
     ):
         assert plan is logical_plan.physical_plan
         assert plan_id == "cancelled-plan"
+        assert _lifecycle.begin_fragment_execution()
         started.set()
         assert release.wait(timeout=1.0)
         events.append("started")
+        return True
 
-    def _cleanup(_self, plan_id, query_id, *, drop_fragments):
+    def _cleanup(_self, plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, plan_id)
         assert query_id == "cancelled-plan"
         assert drop_fragments is True
         events.append(("cleanup", plan_id))
-        cls._release_plan_session_state(runner, plan_id)
+        _release_test_plan_session_state(cls, runner, plan_id)
 
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub("cancelled-plan"))
     monkeypatch.setattr(cls, "_run_plan_sync", _start)
@@ -812,6 +896,10 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
         task.cancel()
         await asyncio.sleep(0)
         assert task.done() is False
+        task.cancel()
+        await asyncio.sleep(0)
+        assert task.done() is False
+        assert task.cancelling() == 2
 
         release.set()
         with pytest.raises(asyncio.CancelledError):
@@ -822,6 +910,81 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
     assert events == ["started", ("cleanup", "cancelled-plan")]
     assert "cancelled-plan" not in runner._plan_session_ids
     assert "cancelled-plan" not in runner._sessions[_TEST_SESSION_ID].plan_ids
+
+
+def test_close_plan_waits_for_startup_before_closing_owned_resources(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "close-during-stream-startup"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    startup_started = threading.Event()
+    startup_release = threading.Event()
+
+    class _Pool:
+        def __init__(self):
+            self.shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    pool = _Pool()
+
+    def _precreate_vllm_actors(
+        _self,
+        _plan,
+        *,
+        query_connection,
+        session_config,
+    ):
+        assert session_config == _TEST_SESSION_CONFIG
+        startup_started.set()
+        assert startup_release.wait(timeout=2.0)
+        assert query_connection.closed is False
+        runner._active_vllm_actors.append(pool)
+        runner._active_vllm_actors_by_plan[plan_id] = [pool]
+        return [pool]
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", _precreate_vllm_actors)
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_release_query_resources", lambda *_args, **_kwargs: None)
+
+    async def _close_during_startup():
+        run_task = asyncio.create_task(_run_actor_stream_plan(runner, logical_plan))
+        assert await asyncio.to_thread(startup_started.wait, 1.0)
+        query_connection = runner._test_session_connection.cursors[-1]
+        close_task = asyncio.create_task(
+            cls.close_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            )
+        )
+        for _ in range(100):
+            lifecycle = runner._plan_lifecycles[plan_id]
+            if lifecycle.close_requested():
+                break
+            await asyncio.sleep(0.001)
+        assert lifecycle.close_requested() is True
+        assert close_task.done() is False
+        assert query_connection.closed is False
+
+        startup_release.set()
+        with pytest.raises(RuntimeError, match="closed before fragment startup"):
+            await run_task
+        await asyncio.wait_for(close_task, timeout=1.0)
+        return query_connection
+
+    query_connection = asyncio.run(_close_during_startup())
+
+    assert query_connection.closed is True
+    assert pool.shutdown_calls == 1
+    assert runner._active_vllm_actors == []
+    assert runner._active_vllm_actors_by_plan == {}
+    assert plan_id not in runner._plan_lifecycles
+    assert plan_id not in runner._plan_session_ids
+    assert plan_id not in runner._plan_connections
+    assert plan_id not in runner._plan_query_ids
 
 
 def test_session_close_does_not_block_actor_loop_during_stream_startup(monkeypatch):
@@ -853,7 +1016,7 @@ def test_session_close_does_not_block_actor_loop_during_stream_startup(monkeypat
     def _cleanup(_self, plan_id):
         runner.curr_plans.pop(plan_id, None)
         runner.curr_streams.pop(plan_id, None)
-        cls._release_plan_session_state(runner, plan_id)
+        _release_test_plan_session_state(cls, runner, plan_id)
 
     monkeypatch.setattr(cls, "_cleanup_finished_plan", _cleanup)
 
@@ -890,10 +1053,11 @@ def test_query_driver_run_copy_plan_passes_distributed_physical_plan_wrapper(mon
     captured = {"lifecycle": []}
 
     class _PlanRunner:
-        def run_copy_plan(self, plan, conn):
+        def run_copy_plan(self, plan, conn, on_execution_started):
             captured["plan"] = plan
             captured["conn"] = conn
             captured["copy_thread"] = threading.current_thread().name
+            on_execution_started()
             return _committed_copy_result(ok=True)
 
     def _precreate_udf_actors(
@@ -968,7 +1132,8 @@ def test_query_driver_copy_progresses_while_default_executor_is_saturated(monkey
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(_plan, _conn):
+        def run_copy_plan(_plan, _conn, on_execution_started):
+            on_execution_started()
             copy_started.set()
             assert actor_loop is not None
             producer = asyncio.run_coroutine_threadsafe(
@@ -981,10 +1146,11 @@ def test_query_driver_copy_progresses_while_default_executor_is_saturated(monkey
             producer.result(timeout=1.0)
             return _committed_copy_result()
 
-    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         assert actual_plan_id == plan_id
+        _, _query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert drop_fragments is True
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1028,6 +1194,89 @@ def test_query_driver_copy_progresses_while_default_executor_is_saturated(monkey
     assert outcome.cleanup_state == "complete"
 
 
+def test_close_plan_cancels_queued_copy_before_connection_teardown(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    runner._driver_executors_shutdown = False
+    runner._driver_copy_executor = driver.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="test-queued-copy",
+    )
+    plan_id = "copy-queued-before-native-start"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    blocker_started = threading.Event()
+    blocker_release = threading.Event()
+    native_calls = 0
+
+    def _occupy_copy_executor():
+        blocker_started.set()
+        assert blocker_release.wait(timeout=10.0)
+
+    blocker = runner._driver_copy_executor.submit(_occupy_copy_executor)
+    assert blocker_started.wait(timeout=1.0)
+
+    class _PlanRunner:
+        @staticmethod
+        def run_copy_plan(_plan, _conn, on_execution_started):
+            nonlocal native_calls
+            native_calls += 1
+            on_execution_started()
+            return _committed_copy_result()
+
+    def _teardown_once(
+        _self,
+        lifecycle,
+        query_id,
+        query_connection,
+        *,
+        drop_fragments,
+    ):
+        assert query_id == plan_id
+        assert drop_fragments is False
+        cls._release_plan_session_state(runner, lifecycle, query_id, query_connection)
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_get_plan_runner", lambda _self: _PlanRunner())
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_teardown_plan_resources_once", _teardown_once)
+
+    async def _close_while_copy_is_queued():
+        copy_task = asyncio.create_task(_run_actor_copy_plan(runner, logical_plan))
+        for _ in range(1000):
+            lifecycle = runner._plan_lifecycles.get(plan_id)
+            if lifecycle is not None and lifecycle._startup_future is not None:
+                break
+            await asyncio.sleep(0.001)
+        else:
+            raise AssertionError("COPY startup was not queued")
+        query_connection = runner._plan_connections[plan_id]
+        await asyncio.wait_for(
+            cls.close_plan(
+                runner,
+                _TEST_RUNTIME_OWNER_ID,
+                _TEST_SESSION_ID,
+                plan_id,
+            ),
+            timeout=1.0,
+        )
+        with pytest.raises(RuntimeError, match="closed before fragment startup"):
+            await asyncio.wait_for(copy_task, timeout=1.0)
+        return query_connection
+
+    try:
+        query_connection = asyncio.run(_close_while_copy_is_queued())
+        assert blocker_release.is_set() is False
+        assert native_calls == 0
+        assert query_connection.closed is True
+        assert plan_id not in runner._plan_lifecycles
+        assert plan_id not in runner._plan_session_ids
+        assert plan_id not in runner._sessions[_TEST_SESSION_ID].plan_ids
+    finally:
+        blocker_release.set()
+        blocker.result(timeout=1.0)
+        cls._shutdown_driver_executors(runner)
+
+
 def test_query_driver_committed_copy_preserves_late_actor_initialization_warning(monkeypatch):
     cls, runner = _make_local_query_driver_actor()
     physical_plan = _FakePhysicalPlanWithoutPlanAttr("copy-plan-terminal")
@@ -1035,7 +1284,8 @@ def test_query_driver_committed_copy_preserves_late_actor_initialization_warning
     teardown_calls = []
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
+        def run_copy_plan(self, _plan, _conn, on_execution_started):
+            on_execution_started()
             runner._query_terminal_errors["copy-query-terminal"] = "Ray actor UDF pool initialization failed"
             return _committed_copy_result(ok=True)
 
@@ -1048,9 +1298,11 @@ def test_query_driver_committed_copy_preserves_late_actor_initialization_warning
         _query_registration_stub("copy-query-terminal"),
     )
 
-    def _teardown(_self, plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, plan_id)
         teardown_calls.append((plan_id, query_id, drop_fragments))
         runner._query_terminal_errors.pop(query_id, None)
+        _release_test_plan_session_state(cls, runner, plan_id)
 
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
 
@@ -1070,7 +1322,8 @@ def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatc
     teardown_calls = []
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
+        def run_copy_plan(self, _plan, _conn, on_execution_started):
+            on_execution_started()
             return _committed_copy_result()
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
@@ -1086,10 +1339,16 @@ def test_query_driver_copy_progress_failure_returns_committed_warning(monkeypatc
         "_build_local_progress_snapshot",
         lambda *_args: (_ for _ in ()).throw(RuntimeError("invalid progress topology")),
     )
+
+    def _teardown(_self, plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, plan_id)
+        teardown_calls.append((plan_id, query_id, drop_fragments))
+        _release_test_plan_session_state(cls, runner, plan_id)
+
     monkeypatch.setattr(
         cls,
         "_teardown_plan_resources",
-        lambda _self, plan_id, query_id, *, drop_fragments: teardown_calls.append((plan_id, query_id, drop_fragments)),
+        _teardown,
     )
 
     outcome = asyncio.run(_run_actor_copy_plan(runner, logical_plan))
@@ -1120,19 +1379,21 @@ def test_query_driver_concurrent_copy_retries_share_one_write(monkeypatch):
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(_plan, _conn):
+        def run_copy_plan(_plan, _conn, on_execution_started):
             nonlocal plan_calls
             plan_calls += 1
+            on_execution_started()
             plan_started.set()
             assert plan_release.wait(timeout=2.0)
             return _committed_copy_result(rows_copied=17)
 
-    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         nonlocal teardown_calls
         teardown_calls += 1
         assert actual_plan_id == plan_id
+        _, _query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert drop_fragments is True
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1167,14 +1428,16 @@ def test_query_driver_copy_result_logging_failure_replays_committed_success(monk
     teardown_calls = []
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
+        def run_copy_plan(self, _plan, _conn, on_execution_started):
             nonlocal plan_calls
             plan_calls += 1
+            on_execution_started()
             return _committed_copy_result(rows_copied=5)
 
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         teardown_calls.append((actual_plan_id, query_id, drop_fragments))
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1207,18 +1470,20 @@ def test_query_driver_committed_copy_teardown_is_retryable_without_reexecution(m
     teardown_calls = 0
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
+        def run_copy_plan(self, _plan, _conn, on_execution_started):
             nonlocal plan_calls
             plan_calls += 1
+            on_execution_started()
             return _committed_copy_result(rows_copied=7)
 
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         nonlocal teardown_calls
         teardown_calls += 1
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert (actual_plan_id, query_id, drop_fragments) == (plan_id, plan_id, True)
         if teardown_calls == 1:
             raise RuntimeError("planned post-commit teardown failure")
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1262,15 +1527,17 @@ def test_query_driver_copy_failure_is_replayed_without_reexecution(monkeypatch):
     plan_calls = 0
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
+        def run_copy_plan(self, _plan, _conn, on_execution_started):
             nonlocal plan_calls
             plan_calls += 1
+            on_execution_started()
             raise ValueError("planned failure before commit")
 
-    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         assert actual_plan_id == plan_id
+        _, _query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert drop_fragments is True
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1317,15 +1584,17 @@ def test_query_driver_unknown_native_copy_outcome_is_structured_and_never_reexec
     }
 
     class _PlanRunner:
-        def run_copy_plan(self, _plan, _conn):
+        def run_copy_plan(self, _plan, _conn, on_execution_started):
             nonlocal plan_calls
             plan_calls += 1
+            on_execution_started()
             return unknown_result
 
-    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         assert actual_plan_id == plan_id
+        _, _query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert drop_fragments is True
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1375,9 +1644,10 @@ def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(plan, _conn):
+        def run_copy_plan(plan, _conn, on_execution_started):
             plan_id = str(plan.idx())
             plan_calls[plan_id] += 1
+            on_execution_started()
             return _committed_copy_result(rows_copied=plan_calls[plan_id])
 
     async def _register(
@@ -1392,10 +1662,11 @@ def test_query_driver_evicted_copy_outcome_refuses_reexecution(monkeypatch):
         assert expected_plan_id == plan_id
         return SimpleNamespace(query_id=plan_id, units=()), object()
 
-    def _teardown(_self, plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, plan_id)
         assert query_id == plan_id
         assert drop_fragments is True
-        cls._release_plan_session_state(runner, plan_id)
+        _release_test_plan_session_state(cls, runner, plan_id)
 
     runner._copy_operation_terminal = driver.BoundedReplayMap(capacity=1)
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
@@ -1546,7 +1817,8 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(_plan, _conn):
+        def run_copy_plan(_plan, _conn, on_execution_started):
+            on_execution_started()
             return _committed_copy_result(ok=True)
 
     def _build_snapshot(_self, query_id, _started_at):
@@ -1556,10 +1828,11 @@ def test_query_driver_copy_progress_cancellation_waits_before_teardown(monkeypat
         snapshot_finished.set()
         return {"query_id": query_id}
 
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         assert snapshot_finished.is_set()
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         teardown_calls.append((actual_plan_id, query_id, drop_fragments))
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1602,18 +1875,20 @@ def test_query_driver_copy_operation_cancellation_waits_for_native_commit(monkey
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(_plan, _conn):
+        def run_copy_plan(_plan, _conn, on_execution_started):
             nonlocal plan_calls
             plan_calls += 1
+            on_execution_started()
             native_started.set()
             assert native_release.wait(timeout=2.0)
             native_finished.set()
             return _committed_copy_result(rows_copied=11)
 
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert (actual_plan_id, query_id, drop_fragments) == (plan_id, plan_id, True)
         teardown_started.set()
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(cls, "_precreate_vllm_actors", lambda *_args, **_kwargs: [])
@@ -1658,14 +1933,16 @@ def test_query_driver_copy_teardown_cancellation_reports_cleanup_complete(monkey
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(_plan, _conn):
+        def run_copy_plan(_plan, _conn, on_execution_started):
+            on_execution_started()
             return _committed_copy_result(rows_copied=13)
 
-    def _teardown(_self, actual_plan_id, query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
+        _, query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert (actual_plan_id, query_id, drop_fragments) == (plan_id, plan_id, True)
         teardown_started.set()
         assert teardown_release.wait(timeout=2.0)
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
         teardown_finished.set()
 
     monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
@@ -1703,7 +1980,8 @@ def test_query_driver_copy_starts_without_eager_actor_or_topology_barriers(monke
 
     class _PlanRunner:
         @staticmethod
-        def run_copy_plan(_plan, _conn):
+        def run_copy_plan(_plan, _conn, on_execution_started):
+            on_execution_started()
             events.append("plan")
             return _committed_copy_result(rows_copied=1)
 
@@ -2811,8 +3089,6 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
         cls._teardown_plan_resources(
             runner,
             plan_id,
-            "teardown-query",
-            drop_fragments=True,
         )
 
     assert "output release failed" in str(exc_info.value)
@@ -2835,8 +3111,6 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
     cls._teardown_plan_resources(
         runner,
         plan_id,
-        "teardown-query",
-        drop_fragments=True,
     )
 
     assert calls == [
@@ -2853,6 +3127,61 @@ def test_teardown_plan_resources_attempts_every_owned_release(monkeypatch):
     assert plan_id not in runner._plan_session_ids
     assert runner._leased_result_partition_refs == {}
     assert runner._result_partition_ref_counters == {}
+
+
+def test_query_connection_close_failure_retains_plan_ownership_for_teardown_retry(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "query-connection-close-retry"
+    query_id = "query-connection-close-retry-query"
+
+    class _RetryingQueryConnection:
+        def __init__(self):
+            self.close_calls = 0
+            self.closed = False
+
+        def close(self):
+            self.close_calls += 1
+            if self.close_calls == 1:
+                raise RuntimeError("planned query connection close failure")
+            self.closed = True
+
+    query_connection = _RetryingQueryConnection()
+    lifecycle = _bind_test_plan_session(
+        runner,
+        plan_id,
+        query_id=query_id,
+        query_connection=query_connection,
+    )
+    runner._query_terminal_errors[query_id] = "planned terminal marker"
+    fragment_drops = []
+    monkeypatch.setattr(
+        cls,
+        "_drop_query_fragments_sync",
+        lambda _self, actual_query_id: fragment_drops.append(actual_query_id),
+    )
+
+    with pytest.raises(RuntimeError, match="planned query connection close failure"):
+        cls._teardown_plan_resources(runner, plan_id)
+
+    assert query_connection.close_calls == 1
+    assert runner._plan_lifecycles[plan_id] is lifecycle
+    assert runner._plan_session_ids[plan_id] == _TEST_SESSION_ID
+    assert runner._plan_query_ids[plan_id] == query_id
+    assert runner._plan_connections[plan_id] is query_connection
+    assert plan_id in runner._sessions[_TEST_SESSION_ID].plan_ids
+    assert runner._query_terminal_errors[query_id] == "planned terminal marker"
+
+    cls._teardown_plan_resources(runner, plan_id)
+
+    assert query_connection.close_calls == 2
+    assert query_connection.closed is True
+    assert fragment_drops == [query_id, query_id]
+    assert plan_id not in runner._plan_lifecycles
+    assert plan_id not in runner._plan_session_ids
+    assert plan_id not in runner._plan_query_ids
+    assert plan_id not in runner._plan_connections
+    assert plan_id not in runner._sessions[_TEST_SESSION_ID].plan_ids
+    assert query_id not in runner._query_terminal_errors
 
 
 @pytest.mark.parametrize(
@@ -2924,8 +3253,6 @@ def test_failed_execution_owner_cleanup_blocks_query_resource_release(monkeypatc
             cls._teardown_plan_resources(
                 runner,
                 plan_id,
-                query_id,
-                drop_fragments=True,
             )
 
         assert fragment_calls == [(query_id, False)]
@@ -2958,8 +3285,6 @@ def test_teardown_fence_failure_retains_retryable_query_ownership(monkeypatch):
             cls._teardown_plan_resources(
                 runner,
                 plan_id,
-                query_id,
-                drop_fragments=True,
             )
 
         assert runner._plan_query_ids[plan_id] == query_id
@@ -3085,7 +3410,6 @@ def test_close_session_does_not_deadlock_with_plan_teardown(monkeypatch):
 def test_session_close_waits_until_query_connection_is_closed():
     cls, runner = _make_local_query_driver_actor()
     plan_id = "close-during-query-connection-release"
-    _bind_test_plan_session(runner, plan_id, query_id="")
     query_close_started = threading.Event()
     query_close_release = threading.Event()
     errors = []
@@ -3095,7 +3419,13 @@ def test_session_close_waits_until_query_connection_is_closed():
             query_close_started.set()
             assert query_close_release.wait(timeout=1.0)
 
-    runner._plan_connections[plan_id] = _BlockingQueryConnection()
+    query_connection = _BlockingQueryConnection()
+    _bind_test_plan_session(
+        runner,
+        plan_id,
+        query_id="",
+        query_connection=query_connection,
+    )
 
     def _teardown():
         try:
@@ -3355,6 +3685,80 @@ def test_expired_client_reclamation_cancels_owned_active_operation():
 
     assert _TEST_RUNTIME_OWNER_ID not in runner._client_ids
     assert "surviving-owner" in runner._client_ids
+    assert _TEST_SESSION_ID not in runner._sessions
+
+
+def test_expired_client_reclamation_joins_plan_startup_before_session_close(monkeypatch):
+    cls, runner = _make_local_query_driver_actor()
+    runner._client_ids.add("surviving-owner")
+    cls._ensure_client_lease_state(runner)
+    plan_id = "expired-owner-blocked-startup"
+    logical_plan = _FakeLogicalPlan(_FakePhysicalPlanWithoutPlanAttr(plan_id))
+    startup_started = threading.Event()
+    startup_release = threading.Event()
+
+    class _Pool:
+        def __init__(self):
+            self.shutdown_calls = 0
+
+        def shutdown(self):
+            self.shutdown_calls += 1
+
+    pool = _Pool()
+
+    def _precreate_vllm_actors(
+        _self,
+        _plan,
+        *,
+        query_connection,
+        session_config,
+    ):
+        assert session_config == _TEST_SESSION_CONFIG
+        startup_started.set()
+        assert startup_release.wait(timeout=2.0)
+        assert query_connection.closed is False
+        runner._active_vllm_actors.append(pool)
+        runner._active_vllm_actors_by_plan[plan_id] = [pool]
+        return [pool]
+
+    monkeypatch.setattr(cls, "_precreate_udf_actors", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(cls, "_precreate_vllm_actors", _precreate_vllm_actors)
+    monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
+    monkeypatch.setattr(cls, "_release_query_resources", lambda *_args, **_kwargs: None)
+
+    async def _expire_during_startup():
+        run_task = asyncio.create_task(_run_actor_stream_plan(runner, logical_plan))
+        assert await asyncio.to_thread(startup_started.wait, 1.0)
+        query_connection = runner._test_session_connection.cursors[-1]
+        runner._client_leases[_TEST_RUNTIME_OWNER_ID].expires_at = 1.0
+        cls._schedule_expired_client_reclamations(runner)
+        cleanup_task = runner._expired_client_cleanup_tasks[_TEST_RUNTIME_OWNER_ID]
+        for _ in range(100):
+            if run_task.cancelling():
+                break
+            await asyncio.sleep(0.001)
+        assert run_task.cancelling() == 1
+        assert run_task.done() is False
+        assert cleanup_task.done() is False
+        assert query_connection.closed is False
+
+        startup_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await run_task
+        assert await asyncio.wait_for(cleanup_task, timeout=1.0) is False
+        return query_connection, run_task
+
+    query_connection, run_task = asyncio.run(_expire_during_startup())
+
+    assert run_task.cancelling() == 1
+    assert query_connection.closed is True
+    assert pool.shutdown_calls == 1
+    assert runner._active_vllm_actors == []
+    assert runner._active_vllm_actors_by_plan == {}
+    assert plan_id not in runner._plan_lifecycles
+    assert plan_id not in runner._plan_session_ids
+    assert plan_id not in runner._plan_connections
+    assert plan_id not in runner._plan_query_ids
     assert _TEST_SESSION_ID not in runner._sessions
 
 
@@ -3752,26 +4156,59 @@ def test_driver_rejects_active_plan_identity_collision(copy_plan):
 
     existing_cursor_count = len(session.connection.cursors)
     with pytest.raises(RuntimeError, match="query plan identity is already active"):
-        if copy_plan:
-            cls._prepare_copy_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _LogicalPlan(),
-                plan_id,
-            )
-        else:
-            cls._prepare_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _LogicalPlan(),
-                plan_id,
-            )
+        _run_test_plan_preparation(
+            cls,
+            runner,
+            session,
+            _LogicalPlan(),
+            plan_id,
+            copy_plan=copy_plan,
+        )
 
-    assert len(session.connection.cursors) == existing_cursor_count + 1
-    assert session.connection.cursors[-1].closed is True
+    assert len(session.connection.cursors) == existing_cursor_count
     assert plan_id not in session.plan_ids
+
+
+@pytest.mark.parametrize("copy_plan", [False, True])
+@pytest.mark.parametrize("orphaned_owner", ["teardown", "vllm_pool", "resource_graph"])
+def test_driver_rejects_plan_identity_with_orphaned_resource_owner(copy_plan, orphaned_owner):
+    cls, runner = _make_local_query_driver_actor()
+    session = runner._sessions[_TEST_SESSION_ID]
+    plan_id = "orphaned-plan-owner"
+    if orphaned_owner == "teardown":
+        runner._plan_teardowns_in_progress.add(plan_id)
+    elif orphaned_owner == "vllm_pool":
+        runner._active_vllm_actors_by_plan[plan_id] = [object()]
+    else:
+        runner._query_resource_graphs[plan_id] = object()
+
+    class _LogicalPlan:
+        @staticmethod
+        def idx():
+            return plan_id
+
+    with pytest.raises(RuntimeError, match="query plan identity is already active"):
+        _run_test_plan_preparation(
+            cls,
+            runner,
+            session,
+            _LogicalPlan(),
+            plan_id,
+            copy_plan=copy_plan,
+        )
+
+    assert plan_id not in runner._plan_lifecycles
+    assert plan_id not in runner._plan_session_ids
+    assert plan_id not in session.plan_ids
+
+
+def test_teardown_fails_closed_for_orphaned_actor_pool():
+    cls, runner = _make_local_query_driver_actor()
+    plan_id = "orphaned-actor-pool"
+    runner._active_vllm_actors_by_plan[plan_id] = [object()]
+
+    with pytest.raises(RuntimeError, match="active query plan is missing its lifecycle"):
+        cls._teardown_plan_resources(runner, plan_id)
 
 
 @pytest.mark.parametrize("copy_plan", [False, True])
@@ -3800,22 +4237,14 @@ def test_driver_applies_session_s3_config_to_query_cursor(copy_plan):
             raise RuntimeError("planned stop after query cursor configuration")
 
     with pytest.raises(RuntimeError, match="planned stop after query cursor configuration"):
-        if copy_plan:
-            cls._prepare_copy_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _LogicalPlan(),
-                "s3-config-plan",
-            )
-        else:
-            cls._prepare_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _LogicalPlan(),
-                "s3-config-plan",
-            )
+        _run_test_plan_preparation(
+            cls,
+            runner,
+            session,
+            _LogicalPlan(),
+            "s3-config-plan",
+            copy_plan=copy_plan,
+        )
 
     query_connection = session.connection.cursors[-1]
     assert "SET s3_access_key_id='session-key'" in query_connection.statements
@@ -3860,22 +4289,14 @@ def test_driver_explicit_s3_settings_bypass_and_clear_session_credentials(monkey
             raise RuntimeError("planned stop after explicit S3 baseline reset")
 
     with pytest.raises(RuntimeError, match="planned stop after explicit S3 baseline reset"):
-        if copy_plan:
-            cls._prepare_copy_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _LogicalPlan(),
-                "explicit-s3-config-plan",
-            )
-        else:
-            cls._prepare_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _LogicalPlan(),
-                "explicit-s3-config-plan",
-            )
+        _run_test_plan_preparation(
+            cls,
+            runner,
+            session,
+            _LogicalPlan(),
+            "explicit-s3-config-plan",
+            copy_plan=copy_plan,
+        )
 
     query_connection = session.connection.cursors[-1]
     assert "SET s3_access_key_id=''" in query_connection.statements
@@ -3954,10 +4375,11 @@ def test_copy_resource_registration_does_not_block_actor_loop(monkeypatch):
         assert registration_release.wait(timeout=1.0)
         raise RuntimeError("planned stop after COPY resource registration")
 
-    def _teardown(_self, actual_plan_id, _query_id, *, drop_fragments):
+    def _teardown(_self, actual_plan_id):
         assert actual_plan_id == plan_id
+        _, _query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         assert drop_fragments is False
-        cls._release_plan_session_state(runner, actual_plan_id)
+        _release_test_plan_session_state(cls, runner, actual_plan_id)
 
     monkeypatch.setattr(cls, "_prepare_query_resource_registration", _delayed_registration)
     monkeypatch.setattr(cls, "_teardown_plan_resources", _teardown)
@@ -4007,22 +4429,14 @@ def test_driver_rejects_logical_to_physical_plan_identity_change(copy_plan):
 
     existing_cursor_count = len(session.connection.cursors)
     with pytest.raises(RuntimeError, match="logical/physical query plan identity changed"):
-        if copy_plan:
-            cls._prepare_copy_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _ChangedIdentityLogicalPlan(),
-                "logical-plan",
-            )
-        else:
-            cls._prepare_plan_sync(
-                runner,
-                _TEST_SESSION_ID,
-                session,
-                _ChangedIdentityLogicalPlan(),
-                "logical-plan",
-            )
+        _run_test_plan_preparation(
+            cls,
+            runner,
+            session,
+            _ChangedIdentityLogicalPlan(),
+            "logical-plan",
+            copy_plan=copy_plan,
+        )
 
     assert len(session.connection.cursors) == existing_cursor_count + 1
     assert session.connection.cursors[-1].closed is True
@@ -5865,7 +6279,8 @@ def test_get_next_partition_surfaces_late_actor_initialization_failure_before_de
     runner._query_terminal_errors[query_id] = "Ray actor UDF pool initialization failed"
     teardown_calls = []
 
-    def _teardown(actual_plan_id, actual_query_id, *, drop_fragments):
+    def _teardown(actual_plan_id):
+        _, actual_query_id, _query_connection, drop_fragments = _test_plan_teardown_state(runner, actual_plan_id)
         teardown_calls.append((actual_plan_id, actual_query_id, drop_fragments))
         runner._query_terminal_errors.pop(actual_query_id, None)
 
@@ -6587,9 +7002,11 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
     assert scan_task_descriptors
 
     runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
+    execution_started = threading.Event()
     with _registered_low_level_plan(plan, con):
-        result = runner.run_copy_plan(plan, con)
+        result = runner.run_copy_plan(plan, con, execution_started.set)
 
+    assert execution_started.is_set()
     assert result["rows_copied"] == 3
     assert result["copy_output_base_path"] == str(dst)
     assert result["copy_output_run_id"]

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -831,13 +831,12 @@ def test_owned_thread_side_effect_finishes_before_cancellation_is_exposed():
             await asyncio.sleep(0.001)
         assert started.is_set()
 
-        task.cancel()
+        assert task.cancel() is True
         await asyncio.sleep(0)
         assert task.done() is False
-        task.cancel()
+        assert task.cancel() is True
         await asyncio.sleep(0)
         assert task.done() is False
-        assert task.cancelling() == 2
 
         release.set()
         with pytest.raises(asyncio.CancelledError):
@@ -893,13 +892,12 @@ def test_query_driver_run_plan_cancellation_waits_for_startup_and_tears_down(mon
             await asyncio.sleep(0.001)
         assert started.is_set()
 
-        task.cancel()
+        assert task.cancel() is True
         await asyncio.sleep(0)
         assert task.done() is False
-        task.cancel()
+        assert task.cancel() is True
         await asyncio.sleep(0)
         assert task.done() is False
-        assert task.cancelling() == 2
 
         release.set()
         with pytest.raises(asyncio.CancelledError):
@@ -3726,18 +3724,27 @@ def test_expired_client_reclamation_joins_plan_startup_before_session_close(monk
     monkeypatch.setattr(cls, "_register_query_resources", _query_registration_stub(plan_id))
     monkeypatch.setattr(cls, "_release_query_resources", lambda *_args, **_kwargs: None)
 
+    class _CancelCountingTask(asyncio.Task):
+        def __init__(self, coroutine):
+            super().__init__(coroutine)
+            self.cancel_calls = 0
+
+        def cancel(self, *args, **kwargs):
+            self.cancel_calls += 1
+            return super().cancel(*args, **kwargs)
+
     async def _expire_during_startup():
-        run_task = asyncio.create_task(_run_actor_stream_plan(runner, logical_plan))
+        run_task = _CancelCountingTask(_run_actor_stream_plan(runner, logical_plan))
         assert await asyncio.to_thread(startup_started.wait, 1.0)
         query_connection = runner._test_session_connection.cursors[-1]
         runner._client_leases[_TEST_RUNTIME_OWNER_ID].expires_at = 1.0
         cls._schedule_expired_client_reclamations(runner)
         cleanup_task = runner._expired_client_cleanup_tasks[_TEST_RUNTIME_OWNER_ID]
         for _ in range(100):
-            if run_task.cancelling():
+            if run_task.cancel_calls:
                 break
             await asyncio.sleep(0.001)
-        assert run_task.cancelling() == 1
+        assert run_task.cancel_calls == 1
         assert run_task.done() is False
         assert cleanup_task.done() is False
         assert query_connection.closed is False
@@ -3750,7 +3757,7 @@ def test_expired_client_reclamation_joins_plan_startup_before_session_close(monk
 
     query_connection, run_task = asyncio.run(_expire_during_startup())
 
-    assert run_task.cancelling() == 1
+    assert run_task.cancel_calls == 1
     assert query_connection.closed is True
     assert pool.shutdown_calls == 1
     assert runner._active_vllm_actors == []

--- a/vane/_native/ray_cxx.pyi
+++ b/vane/_native/ray_cxx.pyi
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, SupportsFloat, SupportsIndex, SupportsInt, overload
 
 from typing_extensions import Never
@@ -40,7 +40,12 @@ class DistributedPhysicalPlanRunner:
     @overload
     def __init__(self, backend: object) -> None: ...
     def run_plan(self, plan: DistributedPhysicalPlan, conn: object | None = ...) -> ResultPartitionStream: ...
-    def run_copy_plan(self, plan: DistributedPhysicalPlan, conn: object | None = ...) -> dict[str, Any]: ...
+    def run_copy_plan(
+        self,
+        plan: DistributedPhysicalPlan,
+        conn: object | None = ...,
+        on_execution_started: Callable[[], None] | None = ...,
+    ) -> dict[str, Any]: ...
     def finalize_copy(
         self,
         file_infos: list[Any],

--- a/vane/runners/ray/driver.py
+++ b/vane/runners/ray/driver.py
@@ -65,6 +65,7 @@ _LEASE_REQUEST_REPLAY_CAPACITY = 65_536
 _SESSION_CLOSE_REPLAY_CAPACITY = 65_536
 _CLIENT_DETACH_REPLAY_CAPACITY = 65_536
 _COPY_OPERATION_REPLAY_CAPACITY = 1_024
+_COPY_PLAN_NOT_STARTED = object()
 _DEFAULT_COPY_RECONCILIATION_TIMEOUT_S = 30.0
 _RUNTIME_ATTACH_TIMEOUT_S = 300.0
 _RUNTIME_ATTACH_RETRY_INTERVAL_S = 0.05
@@ -391,26 +392,206 @@ class _PreparedQueryResourceRegistration:
     capacity_snapshot_started_at: float
 
 
-class _PlanStartupOwnership:
-    """Hand registered resources to exactly one startup or cancellation path."""
+@dataclass
+class _PlanLifecycle:
+    """Own one plan from preparation until deterministic teardown."""
 
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._owner = "caller"
+    plan_id: str
+    session_id: str
+    _condition: threading.Condition = field(default_factory=threading.Condition)
+    _state: Literal["preparing", "starting", "running", "closing", "closed"] = "preparing"
+    _startup_owner: Literal["caller", "worker", "cancelled"] = "caller"
+    _close_requested: bool = False
+    _setup_finished: bool = False
+    _fragments_started: bool = False
+    _query_id: str = ""
+    _query_connection: Any | None = None
+    _startup_future: ConcurrentFuture[Any] | None = field(default=None, repr=False)
+    _startup_decision: ConcurrentFuture[bool] = field(default_factory=ConcurrentFuture, repr=False)
 
-    def claim_for_worker(self) -> bool:
-        with self._lock:
-            if self._owner != "caller":
+    def _complete_startup_decision_locked(
+        self,
+        *,
+        started: bool | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        if self._startup_decision.done():
+            return
+        if error is not None:
+            self._startup_decision.set_exception(error)
+            return
+        if started is None:
+            raise RuntimeError("startup decision requires a result or error")
+        self._startup_decision.set_result(started)
+
+    def set_query_connection(self, connection: Any) -> None:
+        with self._condition:
+            if self._query_connection is not None:
+                raise RuntimeError(f"query plan {self.plan_id} already owns a query connection")
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup is already terminal")
+            if self._state != "preparing":
+                raise RuntimeError(
+                    f"query plan {self.plan_id} cannot attach a query connection from state {self._state!r}"
+                )
+            self._query_connection = connection
+
+    def set_query_id(self, query_id: str) -> None:
+        query_key = str(query_id).strip()
+        if not query_key:
+            raise ValueError("query_id must not be empty")
+        with self._condition:
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup is already terminal")
+            if self._state != "preparing":
+                raise RuntimeError(f"query plan {self.plan_id} cannot set its query id from state {self._state!r}")
+            self._query_id = query_key
+
+    def begin_startup(self) -> bool:
+        with self._condition:
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup is already terminal")
+            if self._close_requested:
                 return False
-            self._owner = "worker"
+            if self._state != "preparing":
+                raise RuntimeError(f"query plan {self.plan_id} cannot start from state {self._state!r}")
+            self._state = "starting"
             return True
 
-    def cancel_before_worker_claim(self) -> bool:
-        with self._lock:
-            if self._owner != "caller":
+    def bind_startup_future(self, future: ConcurrentFuture[Any]) -> None:
+        """Attach the executor job while preserving close/start ownership."""
+
+        cancel_future = False
+        with self._condition:
+            if self._startup_future is not None:
+                raise RuntimeError(f"query plan {self.plan_id} startup future was bound more than once")
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup is already terminal")
+            self._startup_future = future
+            if self._startup_owner == "cancelled" or (self._startup_owner == "caller" and self._close_requested):
+                self._startup_owner = "cancelled"
+                self._complete_startup_decision_locked(started=False)
+                cancel_future = True
+        if cancel_future:
+            future.cancel()
+
+    def startup_decision_future(self) -> ConcurrentFuture[bool]:
+        return self._startup_decision
+
+    def claim_startup_for_worker(self) -> bool:
+        with self._condition:
+            if self._startup_owner != "caller":
                 return False
-            self._owner = "cancelled"
+            if self._close_requested or self._state != "starting":
+                self._startup_owner = "cancelled"
+                self._complete_startup_decision_locked(started=False)
+                return False
+            self._startup_owner = "worker"
             return True
+
+    def request_close(self) -> None:
+        """Fence new execution publication for this plan."""
+
+        startup_future: ConcurrentFuture[Any] | None = None
+        with self._condition:
+            self._close_requested = True
+            if self._state != "closed":
+                self._state = "closing"
+            if self._startup_owner == "caller":
+                self._startup_owner = "cancelled"
+                startup_future = self._startup_future
+                self._complete_startup_decision_locked(started=False)
+            self._condition.notify_all()
+        if startup_future is not None:
+            startup_future.cancel()
+
+    def close_requested(self) -> bool:
+        with self._condition:
+            return self._close_requested
+
+    def begin_fragment_execution(self) -> bool:
+        with self._condition:
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup is already terminal")
+            if self._close_requested:
+                return False
+            if self._state != "starting":
+                raise RuntimeError(
+                    f"query plan {self.plan_id} cannot begin fragment execution from state {self._state!r}"
+                )
+            if self._fragments_started:
+                raise RuntimeError(f"query plan {self.plan_id} fragment execution started more than once")
+            self._fragments_started = True
+            return True
+
+    def publish_copy_execution_started(self) -> None:
+        """Open COPY's native-start fence after its execution task is registered."""
+
+        with self._condition:
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup is already terminal")
+            if self._startup_owner != "worker":
+                raise RuntimeError(f"query plan {self.plan_id} COPY startup is not owned by its worker")
+            if self._state not in {"starting", "closing"}:
+                raise RuntimeError(
+                    f"query plan {self.plan_id} cannot publish COPY execution from state {self._state!r}"
+                )
+            if self._fragments_started:
+                raise RuntimeError(f"query plan {self.plan_id} fragment execution started more than once")
+            self._fragments_started = True
+            self._complete_startup_decision_locked(started=True)
+            self._condition.notify_all()
+
+    def publish_startup_result(self, *, started: bool) -> None:
+        """Publish a worker's terminal streaming-start decision."""
+
+        with self._condition:
+            if started and not self._fragments_started:
+                raise RuntimeError(
+                    f"query plan {self.plan_id} cannot publish successful startup before fragment execution"
+                )
+            self._complete_startup_decision_locked(started=started)
+            self._condition.notify_all()
+
+    def fail_startup(self, error: BaseException) -> None:
+        """Wake a startup waiter when the worker fails before publication."""
+
+        with self._condition:
+            self._complete_startup_decision_locked(error=error)
+            self._condition.notify_all()
+
+    def finish_setup(self, *, succeeded: bool) -> bool:
+        """Publish the setup barrier and return whether close already won."""
+        with self._condition:
+            if self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} setup completed more than once")
+            if succeeded and not self._fragments_started:
+                raise RuntimeError(f"query plan {self.plan_id} cannot publish running state before fragment execution")
+            self._complete_startup_decision_locked(started=succeeded)
+            self._setup_finished = True
+            self._startup_future = None
+            if succeeded and not self._close_requested:
+                self._state = "running"
+            else:
+                self._close_requested = True
+                self._state = "closing"
+            self._condition.notify_all()
+            return self._close_requested
+
+    def wait_for_setup(self) -> tuple[str, Any | None, bool]:
+        with self._condition:
+            while not self._setup_finished:
+                self._condition.wait()
+            return self._query_id, self._query_connection, self._fragments_started
+
+    def mark_closed(self) -> None:
+        with self._condition:
+            if not self._setup_finished:
+                raise RuntimeError(f"query plan {self.plan_id} closed before setup reached a terminal state")
+            if not self._close_requested:
+                raise RuntimeError(f"query plan {self.plan_id} closed without a close request")
+            self._state = "closed"
+            self._condition.notify_all()
 
 
 @dataclass
@@ -482,10 +663,22 @@ def _submit_to_executor(
     *args: Any,
     **kwargs: Any,
 ) -> asyncio.Future[Any]:
+    _, future = _submit_to_executor_with_source(executor, callback, *args, **kwargs)
+    return future
+
+
+def _submit_to_executor_with_source(
+    executor: Executor,
+    callback: Callable[..., Any],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> tuple[ConcurrentFuture[Any], asyncio.Future[Any]]:
     loop = asyncio.get_running_loop()
     context = contextvars.copy_context()
     call = functools.partial(callback, *args, **kwargs)
-    return loop.run_in_executor(executor, context.run, call)
+    source = executor.submit(context.run, call)
+    return source, asyncio.wrap_future(source, loop=loop)
 
 
 async def _run_in_executor(
@@ -508,13 +701,22 @@ async def _run_in_executor_with_owned_side_effects(
     """Finish an executor-owned mutation before exposing caller cancellation."""
 
     executor_future = _submit_to_executor(executor, callback, *args, **kwargs)
+    return await _await_future_with_owned_side_effects(executor_future)
+
+
+async def _await_future_with_owned_side_effects(future: asyncio.Future[Any]) -> Any:
+    """Observe one owned mutation to completion across repeated cancellation."""
+
     cancellation: asyncio.CancelledError | None = None
-    while not executor_future.done():
+    while not future.done():
         try:
-            await asyncio.shield(executor_future)
+            await asyncio.shield(future)
         except asyncio.CancelledError as error:
-            cancellation = error
-    result = executor_future.result()
+            if cancellation is None:
+                cancellation = error
+        except BaseException:
+            break
+    result = future.result()
     if cancellation is not None:
         raise cancellation
     return result
@@ -1364,6 +1566,7 @@ class RayQueryDriverActor:
         self._sessions: dict[str, _DriverSession] = {}
         self._closed_session_owners = BoundedReplayMap[str, str](capacity=_SESSION_CLOSE_REPLAY_CAPACITY)
         self._session_lock = threading.RLock()
+        self._plan_lifecycles: dict[str, _PlanLifecycle] = {}
         self._plan_session_ids: dict[str, str] = {}
         self._plan_connections: dict[str, Any] = {}
         self._plan_teardown_condition = threading.Condition(self._session_lock)
@@ -1959,10 +2162,10 @@ class RayQueryDriverActor:
     def _require_plan_session(self, owner_id: str, session_id: str, plan_id: str) -> _DriverSession:
         session = self._require_session(owner_id, session_id)
         plan_key = str(plan_id)
-        with self._session_lock:
-            plan_session_id = self._plan_session_ids.get(plan_key)
         with session.condition:
-            owns_plan = plan_key in session.plan_ids
+            with self._session_lock:
+                plan_session_id = self._plan_session_ids.get(plan_key)
+                owns_plan = plan_key in session.plan_ids
         if plan_session_id != str(session_id) or not owns_plan:
             raise PermissionError("query plan does not belong to the requested Vane session")
         return session
@@ -2141,13 +2344,6 @@ class RayQueryDriverActor:
 
     def _schedule_expired_client_reclamations(self) -> None:
         for owner_key in self._mark_expired_client_leases():
-            with self._session_lock:
-                sessions = tuple(session for session in self._sessions.values() if session.owner_id == owner_key)
-            for session in sessions:
-                with session.condition:
-                    active_operation_tasks = tuple(session.active_operation_tasks)
-                for active_operation in active_operation_tasks:
-                    active_operation.cancel()
             task = asyncio.create_task(
                 self._detach_client_owner(owner_key, expired=True),
                 name=f"vane-expired-client-cleanup:{owner_key}",
@@ -2240,13 +2436,18 @@ class RayQueryDriverActor:
                 session_ids = [
                     session_id for session_id, session in self._sessions.items() if session.owner_id == owner_key
                 ]
+                sessions = tuple(self._sessions[session_id] for session_id in session_ids)
+            if expired_cleanup:
+                active_operation_tasks: set[asyncio.Task[Any]] = set()
+                for session in sessions:
+                    with session.condition:
+                        session.closing = True
+                        active_operation_tasks.update(session.active_operation_tasks)
+                for active_operation in active_operation_tasks:
+                    active_operation.cancel()
             try:
                 for session_id in session_ids:
-                    await self._close_session_for_owner(
-                        owner_key,
-                        session_id,
-                        cancel_active=expired_cleanup,
-                    )
+                    await self._close_session_for_owner(owner_key, session_id)
                 with self._session_lock:
                     last_owner = len(self._client_ids) == 1
                     if last_owner:
@@ -2304,8 +2505,6 @@ class RayQueryDriverActor:
         self,
         owner_key: str,
         session_id: str,
-        *,
-        cancel_active: bool = False,
     ) -> None:
         session_key = str(session_id).strip()
         if not session_key:
@@ -2326,10 +2525,6 @@ class RayQueryDriverActor:
             if session.closed:
                 return
             session.closing = True
-            active_operation_tasks = tuple(session.active_operation_tasks)
-        if cancel_active:
-            for task in active_operation_tasks:
-                task.cancel()
 
         def _close() -> None:
             with session.condition:
@@ -5809,8 +6004,98 @@ class RayQueryDriverActor:
                 f"failed to shut down {len(errors)} query-owned vLLM actor pool(s): " + "; ".join(errors)
             )
 
-    def _release_plan_session_state(self, plan_id: str) -> None:
-        plan_key = str(plan_id)
+    def _register_plan_lifecycle(
+        self,
+        session_id: str,
+        session: _DriverSession,
+        plan_id: str,
+    ) -> _PlanLifecycle:
+        plan_key = str(plan_id).strip()
+        session_key = str(session_id).strip()
+        if not plan_key:
+            raise ValueError("query plan identity must not be empty")
+        lifecycle = _PlanLifecycle(plan_id=plan_key, session_id=session_key)
+        with session.condition:
+            if session.closing or session.closed:
+                raise RuntimeError(f"Vane session closed during query startup: {session_key}")
+            with self._session_lock:
+                if self._sessions.get(session_key) is not session:
+                    raise RuntimeError(f"Vane session closed during query startup: {session_key}")
+                if (
+                    plan_key in self._plan_lifecycles
+                    or plan_key in self._plan_session_ids
+                    or plan_key in self._plan_connections
+                    or plan_key in self._plan_query_ids
+                    or plan_key in self._plan_teardowns_in_progress
+                    or plan_key in session.plan_ids
+                    or plan_key in self.curr_plans
+                    or plan_key in self.curr_streams
+                    or plan_key in self._async_result_streams
+                    or plan_key in self._leased_result_partition_refs
+                    or plan_key in self._result_partition_ref_counters
+                    or plan_key in self._active_udf_actors_by_plan
+                    or plan_key in self._active_udf_actor_by_unit
+                    or plan_key in self._active_vllm_actors_by_plan
+                    or plan_key in self._query_udf_actor_nodes
+                    or plan_key in self._query_udf_session_configs
+                    or plan_key in self._query_resource_graphs
+                    or plan_key in self._query_allocations
+                    or plan_key in self._query_terminal_errors
+                    or any(query_id == plan_key for query_id, _ in self._query_udf_actor_activation_tasks)
+                ):
+                    raise RuntimeError(f"query plan identity is already active: {plan_key}")
+                self._plan_lifecycles[plan_key] = lifecycle
+                self._plan_session_ids[plan_key] = session_key
+                session.plan_ids.add(plan_key)
+        return lifecycle
+
+    def _attach_plan_connection(
+        self,
+        lifecycle: _PlanLifecycle,
+        query_connection: Any,
+    ) -> None:
+        plan_key = lifecycle.plan_id
+        with self._session_lock:
+            if self._plan_lifecycles.get(plan_key) is not lifecycle:
+                raise RuntimeError(f"query plan lifecycle changed during preparation: {plan_key}")
+            if plan_key in self._plan_connections:
+                raise RuntimeError(f"query plan {plan_key} already owns a query connection")
+            lifecycle.set_query_connection(query_connection)
+            self._plan_connections[plan_key] = query_connection
+
+    def _set_plan_query_id(self, lifecycle: _PlanLifecycle, query_id: str) -> None:
+        plan_key = lifecycle.plan_id
+        with self._session_lock:
+            if self._plan_lifecycles.get(plan_key) is not lifecycle:
+                raise RuntimeError(f"query plan lifecycle changed during registration: {plan_key}")
+            lifecycle.set_query_id(query_id)
+            self._plan_query_ids[plan_key] = str(query_id).strip()
+
+    def _release_plan_session_state(
+        self,
+        lifecycle: _PlanLifecycle,
+        query_id: str,
+        query_connection: Any | None,
+    ) -> None:
+        plan_key = lifecycle.plan_id
+        query_key = str(query_id or "").strip()
+        with self._session_lock:
+            current_lifecycle = self._plan_lifecycles.get(plan_key)
+            session_id = self._plan_session_ids.get(plan_key)
+            indexed_query_id = self._plan_query_ids.get(plan_key, "")
+            indexed_connection = self._plan_connections.get(plan_key)
+            if current_lifecycle is not lifecycle:
+                raise RuntimeError(f"query plan lifecycle changed during teardown: {plan_key}")
+            if session_id != lifecycle.session_id:
+                raise RuntimeError(f"query plan session ownership changed during teardown: {plan_key}")
+            if indexed_query_id != query_key:
+                raise RuntimeError(f"query plan resource identity changed during teardown: {plan_key}")
+            if indexed_connection is not query_connection:
+                raise RuntimeError(f"query plan connection ownership changed during teardown: {plan_key}")
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise RuntimeError(f"query plan session disappeared during teardown: {plan_key}")
+
         activation_tasks = [
             task
             for (query_id, _resource_unit_id), task in tuple(self._query_udf_actor_activation_tasks.items())
@@ -5828,46 +6113,92 @@ class RayQueryDriverActor:
                 continue
             if loop is not None and loop.is_running() and not loop.is_closed():
                 loop.call_soon_threadsafe(task.cancel)
-        with self._session_lock:
-            session_id = self._plan_session_ids.get(plan_key)
-            query_connection = self._plan_connections.get(plan_key)
-            session = self._sessions.get(session_id) if session_id is not None else None
         if query_connection is not None:
             query_connection.close()
-        with self._session_lock:
-            if self._plan_session_ids.get(plan_key) == session_id:
-                self._plan_session_ids.pop(plan_key, None)
-            if self._plan_connections.get(plan_key) is query_connection:
+        lifecycle.mark_closed()
+        # Registration publishes these indices while holding the same locks in
+        # this order. Remove them as one ownership commit so close_plan cannot
+        # observe a half-released plan.
+        with session.condition:
+            with self._session_lock:
+                if self._plan_lifecycles.get(plan_key) is not lifecycle:
+                    raise RuntimeError(f"query plan lifecycle changed while releasing teardown state: {plan_key}")
+                if self._plan_session_ids.get(plan_key) != lifecycle.session_id:
+                    raise RuntimeError(f"query plan session changed while releasing teardown state: {plan_key}")
+                if self._plan_query_ids.get(plan_key, "") != query_key:
+                    raise RuntimeError(f"query plan resource changed while releasing teardown state: {plan_key}")
+                if self._plan_connections.get(plan_key) is not query_connection:
+                    raise RuntimeError(f"query plan connection changed while releasing teardown state: {plan_key}")
+                if self._sessions.get(lifecycle.session_id) is not session:
+                    raise RuntimeError(f"query plan session disappeared while releasing teardown state: {plan_key}")
+                self._plan_lifecycles.pop(plan_key)
+                self._plan_session_ids.pop(plan_key)
+                self._plan_query_ids.pop(plan_key, None)
                 self._plan_connections.pop(plan_key, None)
-            lifecycle_locks = getattr(self, "_query_udf_actor_lifecycle_locks", None)
-            if lifecycle_locks is not None:
-                lifecycle_locks.pop(plan_key, None)
-        if session is not None:
-            with session.condition:
+                terminal_errors = getattr(self, "_query_terminal_errors", None)
+                if terminal_errors is not None:
+                    terminal_errors.pop(query_key, None)
                 session.plan_ids.discard(plan_key)
 
     def _teardown_plan_resources(
         self,
         plan_id: str,
-        query_id: str,
-        *,
-        drop_fragments: bool,
     ) -> None:
         plan_key = str(plan_id)
         with self._plan_teardown_condition:
             while plan_key in self._plan_teardowns_in_progress:
                 self._plan_teardown_condition.wait()
-            if plan_key not in self._plan_session_ids:
+            lifecycle = self._plan_lifecycles.get(plan_key)
+            if lifecycle is None:
+                if (
+                    plan_key in self._plan_session_ids
+                    or plan_key in self._plan_connections
+                    or plan_key in self._plan_query_ids
+                    or plan_key in self.curr_plans
+                    or plan_key in self.curr_streams
+                    or plan_key in self._async_result_streams
+                    or plan_key in self._leased_result_partition_refs
+                    or plan_key in self._result_partition_ref_counters
+                    or plan_key in self._active_udf_actors_by_plan
+                    or plan_key in self._active_udf_actor_by_unit
+                    or plan_key in self._active_vllm_actors_by_plan
+                    or plan_key in self._query_udf_actor_nodes
+                    or plan_key in self._query_udf_session_configs
+                    or plan_key in self._query_resource_graphs
+                    or plan_key in self._query_allocations
+                    or plan_key in self._query_terminal_errors
+                    or any(query_id == plan_key for query_id, _ in self._query_udf_actor_activation_tasks)
+                ):
+                    raise RuntimeError(f"active query plan is missing its lifecycle: {plan_key}")
                 return
+            if self._plan_session_ids.get(plan_key) != lifecycle.session_id:
+                raise RuntimeError(f"query plan lifecycle/session index mismatch: {plan_key}")
+            lifecycle.request_close()
             self._plan_teardowns_in_progress.add(plan_key)
-        lifecycle_lock = _query_udf_actor_lifecycle_lock(self, plan_key)
         try:
+            query_id, query_connection, drop_fragments = lifecycle.wait_for_setup()
+            with self._session_lock:
+                if self._plan_lifecycles.get(plan_key) is not lifecycle:
+                    raise RuntimeError(f"query plan lifecycle changed before teardown: {plan_key}")
+                indexed_query_id = self._plan_query_ids.get(plan_key, "")
+                if indexed_query_id != query_id:
+                    raise RuntimeError(f"query plan resource identity changed before teardown: {plan_key}")
+                if self._plan_connections.get(plan_key) is not query_connection:
+                    raise RuntimeError(f"query plan connection identity changed before teardown: {plan_key}")
+            lifecycle_lock = _query_udf_actor_lifecycle_lock(self, plan_key)
             with lifecycle_lock:
                 self._teardown_plan_resources_once(
-                    plan_key,
+                    lifecycle,
                     query_id,
+                    query_connection,
                     drop_fragments=drop_fragments,
                 )
+            with self._session_lock:
+                if self._plan_lifecycles.get(plan_key) is lifecycle:
+                    raise RuntimeError(f"query plan teardown returned without releasing its lifecycle: {plan_key}")
+                lifecycle_locks = getattr(self, "_query_udf_actor_lifecycle_locks", None)
+                if lifecycle_locks is not None and lifecycle_locks.get(plan_key) is lifecycle_lock:
+                    lifecycle_locks.pop(plan_key, None)
         finally:
             with self._plan_teardown_condition:
                 self._plan_teardowns_in_progress.discard(plan_key)
@@ -5875,11 +6206,13 @@ class RayQueryDriverActor:
 
     def _teardown_plan_resources_once(
         self,
-        plan_id: str,
+        lifecycle: _PlanLifecycle,
         query_id: str,
+        query_connection: Any | None,
         *,
         drop_fragments: bool,
     ) -> None:
+        plan_id = lifecycle.plan_id
         errors: list[BaseException] = []
         execution_owner_errors: list[BaseException] = []
         self.curr_plans.pop(plan_id, None)
@@ -5948,19 +6281,10 @@ class RayQueryDriverActor:
             raise RuntimeError(
                 f"query plan {plan_id} teardown failed: " + "; ".join(f"{type(exc).__name__}: {exc}" for exc in errors)
             ) from errors[0]
-        self._plan_query_ids.pop(plan_id, None)
-        terminal_errors = getattr(self, "_query_terminal_errors", None)
-        if terminal_errors is not None:
-            terminal_errors.pop(str(query_id or ""), None)
-        self._release_plan_session_state(plan_id)
+        self._release_plan_session_state(lifecycle, query_id, query_connection)
 
     def _cleanup_finished_plan(self, plan_id: str) -> None:
-        query_id = self._plan_query_ids.get(plan_id, "")
-        self._teardown_plan_resources(
-            plan_id,
-            query_id,
-            drop_fragments=bool(query_id),
-        )
+        self._teardown_plan_resources(plan_id)
 
     def _finish_terminal_query(self, plan_id: str, query_id: str) -> None:
         reason = str(getattr(self, "_query_terminal_errors", {}).get(str(query_id), ""))
@@ -5968,11 +6292,7 @@ class RayQueryDriverActor:
             return
         primary_error = RuntimeError(reason)
         try:
-            self._teardown_plan_resources(
-                plan_id,
-                query_id,
-                drop_fragments=True,
-            )
+            self._teardown_plan_resources(plan_id)
         except BaseException as teardown_error:
             aggregate_error = QueryExecutionCleanupError.from_errors(
                 f"terminal query {query_id} failed and deterministic teardown also failed",
@@ -6079,7 +6399,6 @@ class RayQueryDriverActor:
         with self._session_lock:
             session = self._sessions.get(session_key)
             closed_owner = self._closed_session_owners.get(session_key)
-            plan_session_id = self._plan_session_ids.get(plan_key)
         if session is None:
             if closed_owner is None:
                 raise RuntimeError(f"Vane session is not open: {session_key}")
@@ -6089,7 +6408,9 @@ class RayQueryDriverActor:
         if session.owner_id != owner_key:
             raise PermissionError("Vane session operation requires its owning runtime client")
         with session.condition:
-            owns_plan = plan_key in session.plan_ids
+            with self._session_lock:
+                plan_session_id = self._plan_session_ids.get(plan_key)
+                owns_plan = plan_key in session.plan_ids
         if plan_session_id is None and not owns_plan:
             return
         if plan_session_id is not None and plan_session_id != session_key:
@@ -6115,6 +6436,10 @@ class RayQueryDriverActor:
         plan_id = str(plan.idx())
         self._begin_session_operation(session, session_id)
         try:
+            lifecycle = self._register_plan_lifecycle(session_id, session, plan_id)
+            startup: asyncio.Future[Any] | None = None
+            startup_decision: asyncio.Future[bool] | None = None
+            setup_finished = False
             try:
                 plan, plan_id, query_connection = await _run_in_executor_with_owned_side_effects(
                     self._get_driver_native_executor(),
@@ -6123,115 +6448,89 @@ class RayQueryDriverActor:
                     session,
                     plan,
                     plan_id,
+                    lifecycle,
                 )
-            except asyncio.CancelledError as cancellation_error:
-                try:
-                    await _run_in_executor_with_owned_side_effects(
-                        self._get_driver_lifecycle_executor(),
-                        self._teardown_plan_resources,
-                        plan_id,
-                        "",
-                        drop_fragments=False,
-                    )
-                except asyncio.CancelledError:
-                    pass
-                except BaseException as teardown_error:
-                    aggregate_error = QueryExecutionCleanupError.from_errors(
-                        f"query plan {plan_id} was cancelled during preparation and teardown failed",
-                        cancellation_error,
-                        [teardown_error],
-                    )
-                    raise aggregate_error from cancellation_error
-                raise cancellation_error
-
-            self._plan_query_ids[plan_id] = plan_id
-            try:
+                self._set_plan_query_id(lifecycle, plan_id)
                 graph, _ = await self._register_query_resources(
                     plan,
                     query_connection=query_connection,
                     expected_plan_id=plan_id,
                 )
-            except BaseException as registration_error:
-                try:
-                    await _run_in_executor_with_owned_side_effects(
-                        self._get_driver_lifecycle_executor(),
-                        self._teardown_plan_resources,
-                        plan_id,
-                        plan_id,
-                        drop_fragments=False,
-                    )
-                except asyncio.CancelledError:
-                    pass
-                except BaseException as teardown_error:
-                    aggregate_error = QueryExecutionCleanupError.from_errors(
-                        f"query plan {plan_id} registration failed and teardown also failed",
-                        registration_error,
-                        [teardown_error],
-                    )
-                    raise aggregate_error from registration_error
-                raise
-            self._plan_query_ids[plan_id] = str(graph.query_id)
+                self._set_plan_query_id(lifecycle, str(graph.query_id))
+                if not lifecycle.begin_startup():
+                    raise RuntimeError(f"query plan closed during startup: {plan_id}")
 
-            startup_ownership = _PlanStartupOwnership()
-            startup = asyncio.create_task(
-                _run_in_executor(
+                startup_decision = asyncio.wrap_future(lifecycle.startup_decision_future())
+                startup_source, startup = _submit_to_executor_with_source(
                     self._get_driver_native_executor(),
-                    self._run_plan_sync_with_ownership,
+                    self._run_plan_sync_with_lifecycle,
                     plan,
                     plan_id,
                     graph,
                     query_connection,
                     session.config,
-                    startup_ownership,
-                ),
-                name=f"vane-plan-startup:{plan_id}",
-            )
-            try:
-                await asyncio.shield(startup)
-            except asyncio.CancelledError as cancellation_error:
-                if startup_ownership.cancel_before_worker_claim():
-                    startup.cancel()
-                    await asyncio.gather(startup, return_exceptions=True)
+                    lifecycle,
+                )
+                lifecycle.bind_startup_future(startup_source)
+                started = await asyncio.shield(startup_decision)
+                try:
+                    await _await_future_with_owned_side_effects(startup)
+                except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    cancelling = None if current_task is None else getattr(current_task, "cancelling", None)
+                    if started or (callable(cancelling) and cancelling()):
+                        raise
+                if not started:
+                    raise RuntimeError(f"query plan closed before fragment startup: {plan_id}")
+                close_requested = lifecycle.finish_setup(succeeded=True)
+                setup_finished = True
+                if close_requested:
+                    raise RuntimeError(f"query plan closed during startup: {plan_id}")
+            except BaseException as execution_error:
+                lifecycle.request_close()
+                primary_error = execution_error
+                if startup_decision is not None:
                     try:
-                        await _run_in_executor_with_owned_side_effects(
-                            self._get_driver_lifecycle_executor(),
-                            self._teardown_plan_resources,
-                            plan_id,
-                            str(graph.query_id),
-                            drop_fragments=False,
-                        )
+                        await _await_future_with_owned_side_effects(startup_decision)
                     except asyncio.CancelledError:
                         pass
-                    except BaseException as teardown_error:
-                        aggregate_error = QueryExecutionCleanupError.from_errors(
-                            f"query plan {plan_id} was cancelled before startup and teardown failed",
-                            cancellation_error,
-                            [teardown_error],
-                        )
-                        raise aggregate_error from cancellation_error
-                else:
-                    try:
-                        await asyncio.shield(startup)
                     except BaseException as startup_error:
-                        raise startup_error from cancellation_error
+                        if isinstance(primary_error, asyncio.CancelledError):
+                            primary_error = startup_error
+                if startup is not None:
                     try:
-                        await _run_in_executor_with_owned_side_effects(
-                            self._get_driver_lifecycle_executor(),
-                            self._teardown_plan_resources,
-                            plan_id,
-                            str(graph.query_id),
-                            drop_fragments=True,
-                        )
+                        await _await_future_with_owned_side_effects(startup)
                     except asyncio.CancelledError:
                         pass
-                    except BaseException as teardown_error:
-                        aggregate_error = QueryExecutionCleanupError.from_errors(
-                            f"query plan {plan_id} was cancelled during startup and teardown failed",
-                            cancellation_error,
-                            [teardown_error],
-                        )
-                        raise aggregate_error from cancellation_error
-                raise
+                    except BaseException as startup_error:
+                        if isinstance(primary_error, asyncio.CancelledError):
+                            primary_error = startup_error
+                if not setup_finished:
+                    lifecycle.finish_setup(succeeded=False)
+                    setup_finished = True
+                teardown_error: BaseException | None = None
+                try:
+                    await _run_in_executor_with_owned_side_effects(
+                        self._get_driver_lifecycle_executor(),
+                        self._teardown_plan_resources,
+                        plan_id,
+                    )
+                except asyncio.CancelledError:
+                    # The lifecycle-owned teardown completed before exposing
+                    # any additional cancellation to this already-failing call.
+                    pass
+                except BaseException as error:
+                    teardown_error = error
+                if teardown_error is not None:
+                    aggregate_error = QueryExecutionCleanupError.from_errors(
+                        f"query plan {plan_id} failed to start and teardown also failed",
+                        primary_error,
+                        [teardown_error],
+                    )
+                    raise aggregate_error from primary_error
+                if primary_error is execution_error:
+                    raise
+                raise primary_error from execution_error
         finally:
             self._end_session_operation(session)
 
@@ -6241,6 +6540,7 @@ class RayQueryDriverActor:
         session: _DriverSession,
         plan: vane.ray_cxx.PyLogicalPlan,
         plan_id: str,
+        lifecycle: _PlanLifecycle,
     ) -> tuple[Any, str, Any]:
         """Prepare a physical plan on an owned worker thread."""
         if os.environ.get("VANE_WORKER") == "1":
@@ -6251,48 +6551,45 @@ class RayQueryDriverActor:
         with session.operation_lock:
             logical_plan = plan
             query_connection = session.connection.cursor()
-            with self._session_lock:
-                if self._sessions.get(str(session_id)) is not session:
-                    query_connection.close()
-                    raise RuntimeError(f"Vane session closed during query startup: {session_id}")
-                if plan_id in self._plan_session_ids:
-                    query_connection.close()
-                    raise RuntimeError(f"query plan identity is already active: {plan_id}")
-                session.plan_ids.add(plan_id)
-                self._plan_session_ids[plan_id] = str(session_id)
-                self._plan_connections[plan_id] = query_connection
-
             try:
-                from vane.runners.ray.worker import (
-                    _configure_duckdb_s3,
-                    _refresh_effective_duckdb_s3_config,
-                )
-
-                use_session_credentials = not bool(logical_plan.has_explicit_s3_credentials())
-                refreshed_s3_config = _refresh_effective_duckdb_s3_config(
-                    session.config,
-                    session.s3_config,
-                    use_session_credentials=use_session_credentials,
-                )
-                session.s3_config = _configure_duckdb_s3(
-                    query_connection,
-                    refreshed_s3_config,
-                    use_session_credentials=use_session_credentials,
-                )
-                physical_plan = logical_plan.to_physical_plan(
-                    query_connection,
-                    session.s3_config,
-                )
-                physical_plan_id = str(physical_plan.idx())
-                if physical_plan_id != plan_id:
-                    raise RuntimeError(
-                        f"logical/physical query plan identity changed: logical={plan_id!r} "
-                        f"physical={physical_plan_id!r}"
-                    )
-                self._validate_plan_session(session_id, physical_plan, session)
+                with self._session_lock:
+                    if self._sessions.get(str(session_id)) is not session:
+                        raise RuntimeError(f"Vane session closed during query startup: {session_id}")
+                    if self._plan_lifecycles.get(plan_id) is not lifecycle:
+                        raise RuntimeError(f"query plan lifecycle changed during preparation: {plan_id}")
+                self._attach_plan_connection(lifecycle, query_connection)
             except BaseException:
-                self._release_plan_session_state(plan_id)
-                raise
+                try:
+                    query_connection.close()
+                finally:
+                    raise
+
+            from vane.runners.ray.worker import (
+                _configure_duckdb_s3,
+                _refresh_effective_duckdb_s3_config,
+            )
+
+            use_session_credentials = not bool(logical_plan.has_explicit_s3_credentials())
+            refreshed_s3_config = _refresh_effective_duckdb_s3_config(
+                session.config,
+                session.s3_config,
+                use_session_credentials=use_session_credentials,
+            )
+            session.s3_config = _configure_duckdb_s3(
+                query_connection,
+                refreshed_s3_config,
+                use_session_credentials=use_session_credentials,
+            )
+            physical_plan = logical_plan.to_physical_plan(
+                query_connection,
+                session.s3_config,
+            )
+            physical_plan_id = str(physical_plan.idx())
+            if physical_plan_id != plan_id:
+                raise RuntimeError(
+                    f"logical/physical query plan identity changed: logical={plan_id!r} physical={physical_plan_id!r}"
+                )
+            self._validate_plan_session(session_id, physical_plan, session)
         return physical_plan, plan_id, query_connection
 
     def _run_plan_sync(
@@ -6302,63 +6599,86 @@ class RayQueryDriverActor:
         graph: Any,
         query_connection: Any,
         session_config: dict[str, str],
-    ) -> None:
+        lifecycle: _PlanLifecycle,
+    ) -> bool:
         """Start an already registered streaming plan on a worker thread."""
-        plan_runner_started = False
-        try:
-            self._precreate_udf_actors(
-                plan,
-                graph,
-                query_connection=query_connection,
-                session_config=session_config,
-            )
-            self._precreate_vllm_actors(
-                plan,
-                query_connection=query_connection,
-                session_config=session_config,
-            )
+        self._precreate_udf_actors(
+            plan,
+            graph,
+            query_connection=query_connection,
+            session_config=session_config,
+        )
+        if lifecycle.close_requested():
+            return False
+        self._precreate_vllm_actors(
+            plan,
+            query_connection=query_connection,
+            session_config=session_config,
+        )
+        if lifecycle.close_requested():
+            return False
 
-            self.curr_plans[plan_id] = plan
-            self._plan_query_ids[plan_id] = str(graph.query_id)
-            plan_runner = self._get_plan_runner()
-            plan_runner_started = True
-            self.curr_streams[plan_id] = plan_runner.run_plan(plan, query_connection)
-        except BaseException as start_error:
-            query_id = self._plan_query_ids.get(plan_id, "")
-            try:
-                self._teardown_plan_resources(
-                    plan_id,
-                    query_id,
-                    drop_fragments=plan_runner_started,
-                )
-            except BaseException as teardown_error:
-                aggregate_error = QueryExecutionCleanupError.from_errors(
-                    f"query plan {plan_id} failed to start and teardown also failed",
-                    start_error,
-                    [teardown_error],
-                )
-                raise aggregate_error from start_error
-            raise
+        self.curr_plans[plan_id] = plan
+        plan_runner = self._get_plan_runner()
+        if not lifecycle.begin_fragment_execution():
+            return False
+        self.curr_streams[plan_id] = plan_runner.run_plan(plan, query_connection)
+        return True
 
-    def _run_plan_sync_with_ownership(
+    def _run_plan_sync_with_lifecycle(
         self,
         plan: Any,
         plan_id: str,
         graph: Any,
         query_connection: Any,
         session_config: dict[str, str],
-        startup_ownership: _PlanStartupOwnership,
-    ) -> None:
+        lifecycle: _PlanLifecycle,
+    ) -> bool:
         """Start only after atomically claiming the registered resources."""
-        if not startup_ownership.claim_for_worker():
-            return
-        self._run_plan_sync(
-            plan,
-            plan_id,
-            graph,
-            query_connection,
-            session_config,
-        )
+        if not lifecycle.claim_startup_for_worker():
+            return False
+        try:
+            started = self._run_plan_sync(
+                plan,
+                plan_id,
+                graph,
+                query_connection,
+                session_config,
+                lifecycle,
+            )
+        except BaseException as error:
+            lifecycle.fail_startup(error)
+            raise
+        lifecycle.publish_startup_result(started=started)
+        return started
+
+    @staticmethod
+    def _run_copy_plan_sync_with_lifecycle(
+        plan_runner: Any,
+        plan: Any,
+        query_connection: Any,
+        lifecycle: _PlanLifecycle,
+    ) -> Any:
+        """Run COPY only after claiming startup and publishing its native fence."""
+
+        if not lifecycle.claim_startup_for_worker():
+            return _COPY_PLAN_NOT_STARTED
+        try:
+            result = plan_runner.run_copy_plan(
+                plan,
+                query_connection,
+                lifecycle.publish_copy_execution_started,
+            )
+        except BaseException as error:
+            lifecycle.fail_startup(error)
+            raise
+        if not lifecycle.startup_decision_future().done():
+            startup_contract_error = RuntimeError(
+                f"native COPY plan {lifecycle.plan_id} returned without publishing its execution-start fence"
+            )
+            lifecycle.fail_startup(startup_contract_error)
+            raise startup_contract_error
+        return result
 
     def _ensure_copy_operation_state(self) -> None:
         if not isinstance(getattr(self, "_copy_operations_inflight", None), dict):
@@ -6439,7 +6759,7 @@ class RayQueryDriverActor:
         )
 
     @staticmethod
-    async def _await_copy_operation(task: asyncio.Task[CopyPlanOutcome]) -> CopyPlanOutcome:
+    async def _await_copy_operation(task: asyncio.Future[CopyPlanOutcome]) -> CopyPlanOutcome:
         cancellation: asyncio.CancelledError | None = None
         while not task.done():
             try:
@@ -6792,8 +7112,10 @@ class RayQueryDriverActor:
         logical_plan = plan
         plan_id = str(logical_plan.idx())
         graph = None
-        plan_runner_started = False
-        plan_execution: asyncio.Task[Any] | None = None
+        plan_execution: asyncio.Future[Any] | None = None
+        startup_decision: asyncio.Future[bool] | None = None
+        lifecycle = self._register_plan_lifecycle(session_id, session, plan_id)
+        setup_finished = False
         try:
             plan, query_connection = await _run_in_executor_with_owned_side_effects(
                 self._get_driver_native_executor(),
@@ -6802,14 +7124,17 @@ class RayQueryDriverActor:
                 session,
                 logical_plan,
                 plan_id,
+                lifecycle,
             )
-            self._plan_query_ids[plan_id] = plan_id
+            self._set_plan_query_id(lifecycle, plan_id)
             graph, _ = await self._register_query_resources(
                 plan,
                 query_connection=query_connection,
                 expected_plan_id=plan_id,
             )
-            self._plan_query_ids[plan_id] = str(graph.query_id)
+            self._set_plan_query_id(lifecycle, str(graph.query_id))
+            if not lifecycle.begin_startup():
+                raise RuntimeError(f"COPY query plan closed during startup: {plan_id}")
             await _run_in_executor_with_owned_side_effects(
                 self._get_driver_native_executor(),
                 self._precreate_udf_actors,
@@ -6818,6 +7143,8 @@ class RayQueryDriverActor:
                 query_connection=query_connection,
                 session_config=session.config,
             )
+            if lifecycle.close_requested():
+                raise RuntimeError(f"COPY query plan closed during actor startup: {plan_id}")
             await _run_in_executor_with_owned_side_effects(
                 self._get_driver_native_executor(),
                 self._precreate_vllm_actors,
@@ -6825,17 +7152,26 @@ class RayQueryDriverActor:
                 query_connection=query_connection,
                 session_config=session.config,
             )
+            if lifecycle.close_requested():
+                raise RuntimeError(f"COPY query plan closed during actor startup: {plan_id}")
             plan_runner = self._get_plan_runner()
-            plan_runner_started = True
-            plan_execution = asyncio.create_task(
-                _run_in_executor(
-                    self._get_driver_copy_executor(),
-                    plan_runner.run_copy_plan,
-                    plan,
-                    query_connection,
-                ),
-                name=f"vane-copy-plan:{plan_id}",
+            startup_decision = asyncio.wrap_future(lifecycle.startup_decision_future())
+            startup_source, plan_execution = _submit_to_executor_with_source(
+                self._get_driver_copy_executor(),
+                self._run_copy_plan_sync_with_lifecycle,
+                plan_runner,
+                plan,
+                query_connection,
+                lifecycle,
             )
+            lifecycle.bind_startup_future(startup_source)
+            started = await asyncio.shield(startup_decision)
+            if not started:
+                raise RuntimeError(f"COPY query plan closed before fragment startup: {plan_id}")
+            close_requested = lifecycle.finish_setup(succeeded=True)
+            setup_finished = True
+            if close_requested:
+                raise RuntimeError(f"COPY query plan closed during startup: {plan_id}")
             # Cancellation must reach the exception path promptly so teardown
             # can interrupt a still-running native write, but it must not
             # cancel the asyncio wrapper around that thread. The exception path
@@ -6849,6 +7185,19 @@ class RayQueryDriverActor:
             if result.get("copy_output_committed") is not True:
                 raise RuntimeError(f"native COPY plan {plan_id} returned without a committed output marker")
         except BaseException as execution_error:
+            lifecycle.request_close()
+            primary_error = execution_error
+            if startup_decision is not None and not setup_finished:
+                try:
+                    await _await_future_with_owned_side_effects(startup_decision)
+                except asyncio.CancelledError:
+                    pass
+                except BaseException as startup_error:
+                    if isinstance(primary_error, asyncio.CancelledError):
+                        primary_error = startup_error
+            if not setup_finished:
+                lifecycle.finish_setup(succeeded=False)
+                setup_finished = True
             query_id = self._plan_query_ids.get(plan_id, "")
             teardown_error: BaseException | None = None
             try:
@@ -6856,8 +7205,6 @@ class RayQueryDriverActor:
                     self._get_driver_lifecycle_executor(),
                     self._teardown_plan_resources,
                     plan_id,
-                    query_id,
-                    drop_fragments=plan_runner_started,
                 )
             except asyncio.CancelledError:
                 # The owned teardown finished before cancellation was exposed.
@@ -6868,7 +7215,7 @@ class RayQueryDriverActor:
             # terminal result so a concurrent failure cannot escape as an
             # unobserved asyncio task exception.
             committed_result: Mapping[str, Any] | None = None
-            unknown_outcome_error = execution_error if isinstance(execution_error, CopyOutcomeUnknownError) else None
+            unknown_outcome_error = primary_error if isinstance(primary_error, CopyOutcomeUnknownError) else None
             if plan_execution is not None:
                 try:
                     await self._await_copy_operation(plan_execution)
@@ -6892,7 +7239,7 @@ class RayQueryDriverActor:
                 cleanup_warnings = self._copy_native_cleanup_warnings(committed_result) + (
                     self._copy_cleanup_warning(
                         "COPY post-commit execution finalization",
-                        execution_error,
+                        primary_error,
                     ),
                 )
                 cleanup_state: Literal["complete", "pending"] = "complete"
@@ -6921,28 +7268,32 @@ class RayQueryDriverActor:
                     cleanup_warnings=cleanup_warnings,
                 )
             if unknown_outcome_error is not None:
-                if unknown_outcome_error is not execution_error:
+                if unknown_outcome_error is not primary_error:
                     unknown_outcome_error.add_cleanup_warnings(
                         self._copy_cleanup_warning(
                             "COPY outcome-unknown execution finalization",
-                            execution_error,
+                            primary_error,
                         )
                     )
                 if teardown_error is not None:
                     unknown_outcome_error.add_cleanup_warnings(
                         self._copy_cleanup_warning("COPY outcome-unknown teardown", teardown_error)
                     )
-                if unknown_outcome_error is execution_error:
-                    raise
-                raise unknown_outcome_error from execution_error
+                if unknown_outcome_error is primary_error:
+                    if primary_error is execution_error:
+                        raise
+                    raise primary_error from execution_error
+                raise unknown_outcome_error from primary_error
             if teardown_error is not None:
                 aggregate_error = QueryExecutionCleanupError.from_errors(
                     f"COPY query plan {plan_id} failed and teardown also failed",
-                    execution_error,
+                    primary_error,
                     [teardown_error],
                 )
-                raise aggregate_error from execution_error
-            raise
+                raise aggregate_error from primary_error
+            if primary_error is execution_error:
+                raise
+            raise primary_error from execution_error
         query_id = str(graph.query_id)
         cleanup_warnings = self._copy_native_cleanup_warnings(result)
         try:
@@ -6978,8 +7329,6 @@ class RayQueryDriverActor:
                 self._get_driver_lifecycle_executor(),
                 self._teardown_plan_resources,
                 plan_id,
-                query_id,
-                drop_fragments=True,
             )
         except asyncio.CancelledError:
             # The owned teardown completed before cancellation was exposed.
@@ -7006,51 +7355,49 @@ class RayQueryDriverActor:
         session: _DriverSession,
         logical_plan: Any,
         plan_id: str,
+        lifecycle: _PlanLifecycle,
     ) -> tuple[Any, Any]:
         """Build a COPY plan on an owned thread without blocking actor control RPCs."""
         with session.operation_lock:
             query_connection = session.connection.cursor()
-            with self._session_lock:
-                if self._sessions.get(str(session_id)) is not session:
-                    query_connection.close()
-                    raise RuntimeError(f"Vane session closed during COPY startup: {session_id}")
-                if plan_id in self._plan_session_ids:
-                    query_connection.close()
-                    raise RuntimeError(f"query plan identity is already active: {plan_id}")
-                session.plan_ids.add(plan_id)
-                self._plan_session_ids[plan_id] = str(session_id)
-                self._plan_connections[plan_id] = query_connection
             try:
-                from vane.runners.ray.worker import (
-                    _configure_duckdb_s3,
-                    _refresh_effective_duckdb_s3_config,
-                )
-
-                use_session_credentials = not bool(logical_plan.has_explicit_s3_credentials())
-                refreshed_s3_config = _refresh_effective_duckdb_s3_config(
-                    session.config,
-                    session.s3_config,
-                    use_session_credentials=use_session_credentials,
-                )
-                session.s3_config = _configure_duckdb_s3(
-                    query_connection,
-                    refreshed_s3_config,
-                    use_session_credentials=use_session_credentials,
-                )
-                plan = logical_plan.to_physical_plan(
-                    query_connection,
-                    session.s3_config,
-                )
-                physical_plan_id = str(plan.idx())
-                if physical_plan_id != plan_id:
-                    raise RuntimeError(
-                        f"logical/physical query plan identity changed: logical={plan_id!r} "
-                        f"physical={physical_plan_id!r}"
-                    )
-                self._validate_plan_session(session_id, plan, session)
+                with self._session_lock:
+                    if self._sessions.get(str(session_id)) is not session:
+                        raise RuntimeError(f"Vane session closed during COPY startup: {session_id}")
+                    if self._plan_lifecycles.get(plan_id) is not lifecycle:
+                        raise RuntimeError(f"COPY query plan lifecycle changed during preparation: {plan_id}")
+                self._attach_plan_connection(lifecycle, query_connection)
             except BaseException:
-                self._release_plan_session_state(plan_id)
-                raise
+                try:
+                    query_connection.close()
+                finally:
+                    raise
+            from vane.runners.ray.worker import (
+                _configure_duckdb_s3,
+                _refresh_effective_duckdb_s3_config,
+            )
+
+            use_session_credentials = not bool(logical_plan.has_explicit_s3_credentials())
+            refreshed_s3_config = _refresh_effective_duckdb_s3_config(
+                session.config,
+                session.s3_config,
+                use_session_credentials=use_session_credentials,
+            )
+            session.s3_config = _configure_duckdb_s3(
+                query_connection,
+                refreshed_s3_config,
+                use_session_credentials=use_session_credentials,
+            )
+            plan = logical_plan.to_physical_plan(
+                query_connection,
+                session.s3_config,
+            )
+            physical_plan_id = str(plan.idx())
+            if physical_plan_id != plan_id:
+                raise RuntimeError(
+                    f"logical/physical query plan identity changed: logical={plan_id!r} physical={physical_plan_id!r}"
+                )
+            self._validate_plan_session(session_id, plan, session)
         return plan, query_connection
 
     async def get_next_partition(


### PR DESCRIPTION
## Summary

- Introduce one authoritative plan lifecycle from pre-execution preparation through deterministic teardown, with atomic session/resource ownership publication and fail-closed consistency checks.
- Make startup and teardown cancellation-safe across repeated cancellation: queued work is cancelled before it can touch the query connection, while claimed work is joined or fenced before resources are closed.
- Move expired-owner cancellation to a single owner and make session shutdown wait for plan operations to finish their lifecycle teardown.
- Publish a native COPY execution-start fence immediately after `PlanTaskExecutor::ScheduleTask`, allowing teardown to interrupt registered work without racing an unowned startup thread.
- Keep failed connection/resource cleanup retryable and add deterministic regression coverage for streaming, COPY, lease-expiry, queued-executor, and teardown-failure interleavings.

## Related issue

Related: #214

This fixes the remaining plan-start path with the same startup/teardown ownership pattern.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change establishes an internal Ray driver/native lifecycle contract and does not add a user-facing API workflow.

## Validation

- Incremental non-editable native build: `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `scripts/run_installed_pytest.sh tests/fast/test_ray_result_contract.py tests/fast/test_driver_query_resource_graph_registration.py` (251 passed)
- Repeated cancellation/race selection with `pytest-repeat` (3 tests x 20: 60 passed)
- `scripts/run_release_tests.sh` (base: 530 passed; real Ray: 11 passed)
- `scripts/run_fast_tests.sh` (non-Ray: 6200 passed; shared Ray: 106 passed; test-owned Ray: 7 passed; optional dependency/hardware skips only)
- `scripts/format workspace --changed --check`
- `pre-commit run --files ...` for all seven changed files (ruff, clang-format, mypy, repository checks passed)
- `python -m py_compile vane/runners/ray/driver.py tests/fast/test_ray_result_contract.py tests/fast/test_driver_query_resource_graph_registration.py`
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
