### PR TITLE
[fix](ai) Reject incomplete and blocked Prompt results

### DIFF
--- a/tests/ai/test_ai_functions.py
+++ b/tests/ai/test_ai_functions.py
@@ -2030,7 +2030,7 @@ def test_openai_responses_request_mapping_preserves_part_order():
         "max_output_tokens": 17,
         "top_p": 0.8,
     }
-    response = SimpleNamespace(output_text="answer", usage=None)
+    response = SimpleNamespace(output_text="answer", status="completed", output=[], usage=None)
     prompter._client = MagicMock()
     prompter._client.responses.create = AsyncMock(return_value=response)
 
@@ -2073,7 +2073,7 @@ def test_openai_chat_request_maps_max_output_tokens_and_stop_sequences():
     prompter._official_openai_endpoint = True
     prompter._options = {"max_output_tokens": 11, "stop_sequences": ["STOP"]}
     response = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="chat answer"))],
+        choices=[SimpleNamespace(finish_reason="stop", message=SimpleNamespace(content="chat answer", refusal=None))],
         usage=None,
     )
     prompter._client = MagicMock()
@@ -2189,7 +2189,7 @@ def test_google_request_mapping_preserves_text_image_order():
         "max_output_tokens": 19,
         "stop_sequences": ["END"],
     }
-    response = SimpleNamespace(text="answer", usage_metadata=None)
+    response = SimpleNamespace(text="answer", candidates=[SimpleNamespace(finish_reason="STOP")], usage_metadata=None)
     prompter._client = MagicMock()
     prompter._client.aio.models.generate_content = AsyncMock(return_value=response)
 
@@ -2362,6 +2362,42 @@ def test_anthropic_terminal_result_obeys_prompt_error_policy(on_error):
     else:
         assert _drive(wrapper, table).column("response").to_pylist() == [None]
     assert prompter._client.messages.create.await_count == 1
+
+
+@pytest.mark.parametrize("on_error", ["raise", "ignore"])
+def test_openai_incomplete_result_obeys_prompt_error_policy(on_error):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from vane.ai.functions import _PromptBatch
+    from vane.ai.provider import _ProviderResultError
+    from vane.ai.providers.openai import OpenAIPrompter
+
+    prompter = OpenAIPrompter.__new__(OpenAIPrompter)
+    prompter._provider_name = "openai"
+    prompter._model = "gpt-test"
+    prompter._system_message = None
+    prompter._use_chat_completions = False
+    prompter._return_format = None
+    prompter._return_raw_response = False
+    prompter._options = {}
+    prompter._client = MagicMock()
+    prompter._client.responses.create = AsyncMock(
+        return_value=SimpleNamespace(status="incomplete", output_text="partial")
+    )
+
+    class Descriptor:
+        def instantiate(self):
+            return prompter
+
+    wrapper = _PromptBatch(Descriptor(), ["message"], "response", max_retries=3, on_error=on_error)
+    table = pa.table({"message": ["hello"]})
+    if on_error == "raise":
+        with pytest.raises(_ProviderResultError, match="expected 'completed'"):
+            _drive(wrapper, table)
+    else:
+        assert _drive(wrapper, table).column("response").to_pylist() == [None]
+    assert prompter._client.responses.create.await_count == 1
 
 
 def test_prompt_batch_retry_and_row_isolation(monkeypatch):

--- a/tests/ai/test_prompt_provider_contracts.py
+++ b/tests/ai/test_prompt_provider_contracts.py
@@ -49,7 +49,7 @@ def _openai_prompter(*, chat: bool, raw: bool, strict: bool = True):
 def test_openai_responses_structured_and_raw_request_contracts():
     structured = _openai_prompter(chat=False, raw=False)
     structured._client.responses.create = AsyncMock(
-        return_value=SimpleNamespace(output_text='{"answer":"ok"}', usage=None)
+        return_value=SimpleNamespace(output_text='{"answer":"ok"}', status="completed", output=[], usage=None)
     )
 
     assert asyncio.run(structured.prompt(("question",))) == '{"answer":"ok"}'
@@ -73,7 +73,9 @@ def test_openai_chat_completions_uses_json_schema_response_format():
     prompter = _openai_prompter(chat=True, raw=False)
     prompter._client.chat.completions.create = AsyncMock(
         return_value=SimpleNamespace(
-            choices=[SimpleNamespace(message=SimpleNamespace(content='{"answer":"ok"}'))],
+            choices=[
+                SimpleNamespace(finish_reason="stop", message=SimpleNamespace(content='{"answer":"ok"}', refusal=None))
+            ],
             usage=None,
         )
     )
@@ -86,19 +88,113 @@ def test_openai_chat_completions_uses_json_schema_response_format():
     }
 
 
+@pytest.mark.parametrize("finish_reason", ["length", "content_filter", None])
+def test_openai_chat_rejects_unsuccessful_terminal_results(finish_reason):
+    from vane.ai.provider import _ProviderResultError
+
+    prompter = _openai_prompter(chat=True, raw=False)
+    prompter._client.chat.completions.create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    finish_reason=finish_reason,
+                    message=SimpleNamespace(content="partial", refusal=None),
+                )
+            ]
+        )
+    )
+
+    with pytest.raises(_ProviderResultError, match="expected finish_reason 'stop'"):
+        asyncio.run(prompter.prompt(("question",)))
+
+
+def test_openai_chat_rejects_empty_choices_refusal_and_unknown_reason_without_leaking_state():
+    from vane.ai.provider import _ProviderResultError
+
+    prompter = _openai_prompter(chat=True, raw=False)
+    cases = (
+        (SimpleNamespace(choices=[]), ()),
+        (
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(finish_reason="stop", message=SimpleNamespace(content=None, refusal="blocked"))
+                ]
+            ),
+            ("blocked",),
+        ),
+        (
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="secret-" + "x" * 1_048_576,
+                        message=SimpleNamespace(content="partial", refusal=None),
+                    )
+                ]
+            ),
+            ("secret-",),
+        ),
+    )
+    for response, forbidden in cases:
+        prompter._client.chat.completions.create = AsyncMock(return_value=response)
+        with pytest.raises(_ProviderResultError) as error:
+            asyncio.run(prompter.prompt(("question",)))
+        assert len(str(error.value)) < 500
+        for value in forbidden:
+            assert value not in str(error.value)
+
+
+def test_openai_responses_rejects_incomplete_and_refusal_results():
+    from vane.ai.provider import _ProviderResultError
+
+    prompter = _openai_prompter(chat=False, raw=False)
+    prompter._client.responses.create = AsyncMock(
+        return_value=SimpleNamespace(status="incomplete", output_text="partial")
+    )
+    with pytest.raises(_ProviderResultError, match="expected 'completed'"):
+        asyncio.run(prompter.prompt(("question",)))
+
+    for status in (None, "future-" + "x" * 1_048_576):
+        prompter._client.responses.create = AsyncMock(
+            return_value=SimpleNamespace(status=status, output_text="partial")
+        )
+        with pytest.raises(_ProviderResultError) as error:
+            asyncio.run(prompter.prompt(("question",)))
+        assert len(str(error.value)) < 500
+        assert "future-" not in str(error.value)
+
+    prompter._client.responses.create = AsyncMock(
+        return_value=SimpleNamespace(
+            status="completed",
+            output_text="",
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="refusal", refusal="blocked")],
+                )
+            ],
+        )
+    )
+    with pytest.raises(_ProviderResultError, match="refused"):
+        asyncio.run(prompter.prompt(("question",)))
+
+
 @pytest.mark.parametrize("chat", [False, True])
 def test_openai_compatible_endpoint_omits_strict_schema_flag(chat):
     prompter = _openai_prompter(chat=chat, raw=False, strict=False)
     if chat:
         prompter._client.chat.completions.create = AsyncMock(
             return_value=SimpleNamespace(
-                choices=[SimpleNamespace(message=SimpleNamespace(content='{"answer":"ok"}'))],
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop", message=SimpleNamespace(content='{"answer":"ok"}', refusal=None)
+                    )
+                ],
                 usage=None,
             )
         )
     else:
         prompter._client.responses.create = AsyncMock(
-            return_value=SimpleNamespace(output_text='{"answer":"ok"}', usage=None)
+            return_value=SimpleNamespace(output_text='{"answer":"ok"}', status="completed", output=[], usage=None)
         )
 
     asyncio.run(prompter.prompt(("question",)))
@@ -180,7 +276,9 @@ def test_google_structured_config_and_raw_body_contracts():
     prompter._options = {}
     prompter._client = MagicMock()
     prompter._client.aio.models.generate_content = AsyncMock(
-        return_value=SimpleNamespace(text='{"answer":"ok"}', usage_metadata=None)
+        return_value=SimpleNamespace(
+            text='{"answer":"ok"}', candidates=[SimpleNamespace(finish_reason="STOP")], usage_metadata=None
+        )
     )
 
     assert asyncio.run(prompter.prompt(("question",))) == '{"answer":"ok"}'
@@ -199,3 +297,55 @@ def test_google_structured_config_and_raw_body_contracts():
         )
     )
     assert json.loads(asyncio.run(prompter.prompt(("question",)))) == {"candidates": []}
+
+
+@pytest.mark.skipif(
+    __import__("importlib").util.find_spec("google.genai") is None,
+    reason="google-genai not installed",
+)
+@pytest.mark.parametrize("finish_reason", ["MAX_TOKENS", "SAFETY", None])
+def test_google_rejects_unsuccessful_terminal_results(finish_reason):
+    from vane.ai.provider import _ProviderResultError
+    from vane.ai.providers.google import GooglePrompter
+
+    prompter = GooglePrompter.__new__(GooglePrompter)
+    prompter._provider_name = "google"
+    prompter._model = "gemini-test"
+    prompter._system_message = None
+    prompter._return_format = None
+    prompter._return_raw_response = False
+    prompter._options = {}
+    prompter._client = MagicMock()
+    prompter._client.aio.models.generate_content = AsyncMock(
+        return_value=SimpleNamespace(
+            candidates=[SimpleNamespace(finish_reason=finish_reason)],
+            text="partial",
+        )
+    )
+
+    with pytest.raises(_ProviderResultError, match="expected 'STOP'"):
+        asyncio.run(prompter.prompt(("question",)))
+
+
+def test_google_rejects_prompt_block_and_unknown_reason_without_leaking_state():
+    from vane.ai.provider import _ProviderResultError
+    from vane.ai.providers.google import GooglePrompter
+
+    prompter = GooglePrompter.__new__(GooglePrompter)
+    prompter._provider_name = "google"
+    prompter._model = "gemini-test"
+    prompter._system_message = None
+    prompter._return_format = None
+    prompter._return_raw_response = False
+    prompter._options = {}
+    prompter._client = MagicMock()
+    for response in (
+        SimpleNamespace(candidates=[], prompt_feedback=SimpleNamespace(block_reason="secret-" + "x" * 1_048_576)),
+        SimpleNamespace(candidates=[SimpleNamespace(finish_reason="future-" + "x" * 1_048_576)], text="partial"),
+    ):
+        prompter._client.aio.models.generate_content = AsyncMock(return_value=response)
+        with pytest.raises(_ProviderResultError) as error:
+            asyncio.run(prompter.prompt(("question",)))
+        assert len(str(error.value)) < 500
+        assert "secret-" not in str(error.value)
+        assert "future-" not in str(error.value)

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -39,6 +39,16 @@ from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultE
 from vane.ai.providers._mime import ImageMimePolicy
 from vane.ai.typing import UDFOptions
 
+
+def _terminal_state_label(value: Any, known: frozenset[str]) -> str:
+    if value is None:
+        return "missing"
+    normalized = getattr(value, "value", value)
+    if isinstance(normalized, str) and normalized in known:
+        return repr(normalized)
+    return "unsupported"
+
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -690,5 +700,26 @@ class GooglePrompter:
                 exclude={"automatic_function_calling_history", "parsed", "sdk_http_response"},
             )
 
+        candidates = getattr(response, "candidates", None) or []
+        if not candidates:
+            feedback = getattr(response, "prompt_feedback", None)
+            reason = getattr(feedback, "block_reason", None) if feedback is not None else None
+            raise _ProviderResultError(
+                f"Google response from model {self._model!r} returned no candidate"
+                + (
+                    f" (prompt block reason {_terminal_state_label(reason, frozenset({'SAFETY', 'OTHER', 'BLOCKED_REASON_UNSPECIFIED'}))})"
+                    if reason is not None
+                    else ""
+                )
+            )
+        candidate = candidates[0]
+        finish_reason = getattr(candidate, "finish_reason", None)
+        reason_value = getattr(finish_reason, "value", finish_reason)
+        if reason_value != "STOP":
+            raise _ProviderResultError(
+                f"Google response from model {self._model!r} returned finish_reason "
+                f"{_terminal_state_label(reason_value, frozenset({'STOP', 'MAX_TOKENS', 'SAFETY', 'RECITATION', 'OTHER'}))} "
+                "for Prompt output; expected 'STOP'"
+            )
         text = response.text
         return text if text else None

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -39,6 +39,16 @@ from vane.ai.provider import Provider, ProviderCapabilityError, _ProviderResultE
 from vane.ai.providers._mime import ImageMimePolicy
 from vane.ai.typing import UDFOptions
 
+
+def _terminal_state_label(value: Any, known: frozenset[str]) -> str:
+    if value is None:
+        return "missing"
+    normalized = getattr(value, "value", value)
+    if isinstance(normalized, str) and normalized in known:
+        return repr(normalized)
+    return "unsupported"
+
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -935,7 +945,25 @@ class OpenAIPrompter:
             raise capability_error from None
         if getattr(self, "_return_raw_response", False):
             return serialize_raw_response(response)
-        return cast(str | None, response.choices[0].message.content)
+        choices = getattr(response, "choices", None) or []
+        if len(choices) != 1:
+            raise _ProviderResultError(
+                f"OpenAI response from model {self._model!r} returned {len(choices)} choices; expected exactly one"
+            )
+        choice = choices[0]
+        finish_reason = getattr(choice, "finish_reason", None)
+        message = getattr(choice, "message", None)
+        refusal = getattr(message, "refusal", None)
+        if finish_reason != "stop" or message is None or refusal is not None:
+            received = f"finish_reason {_terminal_state_label(finish_reason, frozenset({'stop', 'length', 'content_filter', 'tool_calls', 'function_call'}))}"
+            if message is None:
+                received += " with no message"
+            if refusal is not None:
+                received += " with a refusal"
+            raise _ProviderResultError(
+                f"OpenAI response from model {self._model!r} returned {received} for Prompt output; expected finish_reason 'stop'"
+            )
+        return cast(str | None, message.content)
 
     async def _prompt_responses(self, messages: list[dict[str, Any]]) -> str | None:
         """Prompt using the Responses API."""
@@ -961,7 +989,21 @@ class OpenAIPrompter:
             raise capability_error from None
         if getattr(self, "_return_raw_response", False):
             return serialize_raw_response(response)
-        return cast(str | None, response.output_text)
+        status = getattr(response, "status", None)
+        if status != "completed":
+            raise _ProviderResultError(
+                f"OpenAI response from model {self._model!r} returned status "
+                f"{_terminal_state_label(status, frozenset({'completed', 'failed', 'incomplete', 'cancelled', 'in_progress', 'queued'}))} "
+                "for Prompt output; expected 'completed'"
+            )
+        output = getattr(response, "output", None) or []
+        if any(
+            getattr(block, "type", None) == "message"
+            and any(getattr(content, "type", None) == "refusal" for content in (getattr(block, "content", None) or []))
+            for block in output
+        ):
+            raise _ProviderResultError(f"OpenAI response from model {self._model!r} refused the Prompt request")
+        return cast(str | None, getattr(response, "output_text", None))
 
     async def prompt(self, messages: tuple[Any, ...]) -> str | None:
         chat_messages: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary

The OpenAI and Google Prompt paths extracted text before validating terminal
response metadata. Truncated, filtered, blocked, or refused responses could
therefore be accepted as successful text or NULL.

Validate terminal status before non-raw extraction, route unsuccessful results
through the existing Prompt error policy, preserve raw-response passthrough,
and keep reported terminal states bounded. Add regression coverage for
incomplete, refused, missing, and unknown terminal states.

## Related issue

close: #567

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This tightens existing Prompt result validation without changing public APIs.

## Validation

- `scripts/format root --changed --check`
- Pre-commit on all four changed files, including Ruff and mypy
- Affected Prompt tests: 204 passed
- Full AI tests: 628 passed, 6 deselected
- `scripts/run_release_tests.sh`: 515 passed, 4 skipped, 15 deselected;
  real-Ray: 11 passed, 523 deselected

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
