### PR TITLE
[fix](ray) Balance sequential FTE partitions per query

### DIFF
--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -3511,6 +3511,8 @@ def test_fte_drop_query_clears_fte_registry_and_worker_pressure(monkeypatch):
     }
     assert sum(worker["running_attempt_count"] for worker in before["workers"].values()) == 2
     assert sum(worker["terminal_attempt_count"] for worker in before["workers"].values()) == 1
+    assert sum(worker.fte_query_partition_assignment_count("query-drop") for worker in (handle0, handle1)) == 1
+    assert sum(worker.fte_query_partition_assignment_count("query-keep") for worker in (handle0, handle1)) == 1
 
     assert handle0.fte_drop_query("query-drop") == {
         "tasks_removed": 1,
@@ -3530,6 +3532,8 @@ def test_fte_drop_query_clears_fte_registry_and_worker_pressure(monkeypatch):
     }
     assert sum(worker["running_attempt_count"] for worker in after["workers"].values()) == 1
     assert sum(worker["terminal_attempt_count"] for worker in after["workers"].values()) == 0
+    assert all(worker.fte_query_partition_assignment_count("query-drop") == 0 for worker in (handle0, handle1))
+    assert sum(worker.fte_query_partition_assignment_count("query-keep") for worker in (handle0, handle1)) == 1
     assert all(
         "query-drop" not in attempt
         for worker in (handle0, handle1)
@@ -5846,8 +5850,8 @@ def test_fte_registry_stats_reports_query_fragment_partition_metrics(monkeypatch
 def test_fte_owner_selection_uses_reserved_memory_pressure(monkeypatch):
     actor0 = _FakeActor()
     actor1 = _FakeActor()
-    high_memory = RayWorkerActorHandle(actor0, memory_capacity_bytes=20, worker_id="worker-0")
-    low_memory = RayWorkerActorHandle(actor1, memory_capacity_bytes=20, worker_id="worker-1")
+    high_memory = RayWorkerActorHandle(actor0, memory_capacity_bytes=30, worker_id="worker-0")
+    low_memory = RayWorkerActorHandle(actor1, memory_capacity_bytes=30, worker_id="worker-1")
 
     high_memory.reserve_fte_partition(
         "query-pressure",
@@ -5861,15 +5865,125 @@ def test_fte_owner_selection_uses_reserved_memory_pressure(monkeypatch):
         1,
         memory_requirement_bytes=5,
     )
+    for partition_id in (2, 3):
+        low_memory.reserve_fte_partition(
+            "query-pressure",
+            "fragment",
+            partition_id,
+        )
+        low_memory.release_fte_partition_reservation(
+            "query-pressure",
+            "fragment",
+            partition_id,
+        )
 
-    selected = high_memory._select_fte_worker(memory_requirement_bytes=10)
+    selected = high_memory._select_fte_worker(query_id="query-pressure", memory_requirement_bytes=10)
 
     assert selected is low_memory
+    assert high_memory.fte_query_partition_assignment_count("query-pressure") == 1
+    assert low_memory.fte_query_partition_assignment_count("query-pressure") == 3
     assert high_memory.fte_pressure_stats()["reserved_memory_bytes"] == 15
     assert high_memory.fte_pressure_stats()["total_memory_bytes"] == 15
     high_memory.release_fte_partition_reservation("query-pressure", "fragment", 0)
     assert high_memory.fte_pressure_stats()["reserved_memory_bytes"] == 0
     assert high_memory.fte_pressure_stats()["total_memory_bytes"] == 0
+
+
+def test_fte_sequential_partition_admission_balances_query_assignments():
+    first_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-0",
+    )
+    second_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-1",
+    )
+    query_id = "query-sequential-fairness"
+    fragment_id = _install_manual_test_fragment(query_id, "7", partition_count=3)
+    selected_workers = []
+
+    for partition_id in range(3):
+        reservation = first_worker._fte_worker_placement_manager.acquire(
+            query_id=query_id,
+            fragment_id=fragment_id,
+            partition_id=partition_id,
+            memory_requirement_bytes=10,
+        )
+        selected_workers.append(reservation.worker)
+        first_worker._fte_worker_placement_manager.release(
+            query_id=query_id,
+            fragment_id=fragment_id,
+            partition_id=partition_id,
+        )
+
+    assert selected_workers == [first_worker, second_worker, first_worker]
+    assert first_worker.fte_query_partition_assignment_count(query_id) == 2
+    assert second_worker.fte_query_partition_assignment_count(query_id) == 1
+    assert first_worker.fte_pressure_stats()["reserved_partition_count"] == 0
+    assert second_worker.fte_pressure_stats()["reserved_partition_count"] == 0
+
+
+def test_fte_partition_assignment_fairness_is_query_scoped():
+    first_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-0",
+    )
+    second_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-1",
+    )
+    for partition_id in range(3):
+        first_worker.reserve_fte_partition(
+            "query-old",
+            "fragment",
+            partition_id,
+        )
+        first_worker.release_fte_partition_reservation(
+            "query-old",
+            "fragment",
+            partition_id,
+        )
+
+    assert first_worker._select_fte_worker(query_id="query-new") is first_worker
+    assert first_worker._select_fte_worker(query_id="query-old") is second_worker
+
+
+def test_fte_partition_assignment_fairness_spans_fragments_in_one_query():
+    first_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-0",
+    )
+    second_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-1",
+    )
+    first_worker.reserve_fte_partition("query-multi-fragment", "fragment-a", 0)
+    first_worker.release_fte_partition_reservation("query-multi-fragment", "fragment-a", 0)
+
+    selected = first_worker._select_fte_worker(query_id="query-multi-fragment")
+
+    assert selected is second_worker
+    assert first_worker.fte_query_partition_assignment_count("query-multi-fragment") == 1
+
+
+def test_fte_partition_assignment_history_is_retry_idempotent():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="worker-0",
+    )
+
+    for _ in range(3):
+        handle.reserve_fte_partition("query-retry", "fragment", 0)
+        handle.release_fte_partition_reservation("query-retry", "fragment", 0)
+
+    assert handle.fte_query_partition_assignment_count("query-retry") == 1
 
 
 def test_fte_create_promotes_reservation_to_running_atomically(monkeypatch):
@@ -6067,12 +6181,25 @@ def test_fte_owner_selection_prefers_node_requirement_host(monkeypatch):
         worker_id="manager-a:node-b:0",
         host="zzz",
     )
+    for partition_id in range(3):
+        matching.reserve_fte_partition(
+            "query-node-requirement",
+            "fragment",
+            partition_id,
+        )
+        matching.release_fte_partition_reservation(
+            "query-node-requirement",
+            "fragment",
+            partition_id,
+        )
 
     selected = non_matching._select_fte_worker(
+        query_id="query-node-requirement",
         node_requirements=NodeRequirements(host="zzz"),
     )
 
     assert selected is matching
+    assert matching.fte_query_partition_assignment_count("query-node-requirement") == 3
 
 
 def test_fte_worker_registry_rejects_duplicate_worker_identity():
@@ -6109,7 +6236,26 @@ def test_fte_worker_selection_stays_with_manager_scope():
         manager_instance_id="manager-b",
     )
 
-    assert current._select_fte_worker() is current
+    assert current._select_fte_worker(query_id="query-manager-scope") is current
+
+
+def test_fte_worker_selection_requires_query_identity():
+    current = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        manager_instance_id="manager-a",
+    )
+
+    with pytest.raises(ValueError, match="worker selection requires query_id"):
+        current._select_fte_worker(query_id="")
+    with pytest.raises(ValueError, match="replacement worker selection requires query_id"):
+        fte_fragment_scheduler_mod._select_replacement_fte_worker(
+            "manager-a:failed:0",
+            query_id="",
+            exclude_worker_incarnation_ids={"manager-a:failed:0": "failed-incarnation"},
+            manager_instance_id="manager-a",
+        )
 
 
 def test_fte_registry_stats_exposes_worker_topology():
@@ -6195,11 +6341,45 @@ def test_fte_worker_failure_replacement_stays_with_manager_scope():
 
     replacement = fte_fragment_scheduler_mod._select_replacement_fte_worker(
         "manager-a:failed:0",
+        query_id="query-replacement-manager-scope",
         exclude_worker_incarnation_ids={"manager-a:failed:0": "failed-incarnation"},
         manager_instance_id="manager-a",
     )
 
     assert replacement is same_manager
+
+
+def test_fte_worker_failure_replacement_uses_query_scoped_fairness():
+    first_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:0",
+        manager_instance_id="manager-a",
+    )
+    second_worker = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-b:0",
+        manager_instance_id="manager-a",
+    )
+    first_worker.reserve_fte_partition("query-old", "fragment", 0)
+    first_worker.release_fte_partition_reservation("query-old", "fragment", 0)
+
+    new_query_replacement = fte_fragment_scheduler_mod._select_replacement_fte_worker(
+        "manager-a:failed:0",
+        query_id="query-new",
+        exclude_worker_incarnation_ids={"manager-a:failed:0": "failed-incarnation"},
+        manager_instance_id="manager-a",
+    )
+    old_query_replacement = fte_fragment_scheduler_mod._select_replacement_fte_worker(
+        "manager-a:failed:0",
+        query_id="query-old",
+        exclude_worker_incarnation_ids={"manager-a:failed:0": "failed-incarnation"},
+        manager_instance_id="manager-a",
+    )
+
+    assert new_query_replacement is first_worker
+    assert old_query_replacement is second_worker
 
 
 def test_fte_worker_quarantine_rejects_cross_manager_identity():
@@ -6739,9 +6919,11 @@ def test_fte_non_remote_node_requirement_requires_matching_host(monkeypatch):
     matching = RayWorkerActorHandle(actor1, memory_capacity_bytes=1 << 60, worker_id="bbb#0")
 
     selected = non_matching._select_fte_worker(
+        query_id="query-non-remote-node",
         node_requirements=NodeRequirements(host="bbb", remotely_accessible=False),
     )
     missing = non_matching._select_fte_worker(
+        query_id="query-non-remote-node",
         node_requirements=NodeRequirements(host="missing", remotely_accessible=False),
     )
 
@@ -6763,11 +6945,13 @@ def test_fte_remote_node_requirement_waits_before_fallback(monkeypatch):
     )
 
     not_expired = fallback._select_fte_worker(
+        query_id="query-locality",
         memory_requirement_bytes=10,
         node_requirements=NodeRequirements(host="bbb"),
         node_requirements_wait_started_at=worker_handle_mod.time.time(),
     )
     expired = fallback._select_fte_worker(
+        query_id="query-locality",
         memory_requirement_bytes=10,
         node_requirements=NodeRequirements(host="bbb"),
         node_requirements_wait_started_at=worker_handle_mod.time.time() - 61,
@@ -6791,6 +6975,7 @@ def test_fte_non_remote_node_requirement_never_fallback_after_wait(monkeypatch):
     )
 
     selected = fallback._select_fte_worker(
+        query_id="query-locality-hard",
         memory_requirement_bytes=10,
         node_requirements=NodeRequirements(host="bbb", remotely_accessible=False),
         node_requirements_wait_started_at=worker_handle_mod.time.time() - 60,
@@ -11467,6 +11652,12 @@ def test_worker_pressure_drop_uses_exact_query_identity():
     pressure.split_counts_by_attempt.update({parent_attempt: 1, child_attempt: 2})
     pressure.pending_split_counts_by_attempt.update({parent_attempt: 3, child_attempt: 4})
     pressure.reserved_partitions.update({parent_reservation, child_reservation})
+    pressure.assigned_partitions_by_query.update(
+        {
+            parent_reservation[0]: {(parent_reservation[1], parent_reservation[2])},
+            child_reservation[0]: {(child_reservation[1], child_reservation[2])},
+        }
+    )
     pressure.memory_bytes_by_reservation.update({parent_reservation: 10, child_reservation: 20})
 
     pressure.drop_query("q")
@@ -11476,6 +11667,9 @@ def test_worker_pressure_drop_uses_exact_query_identity():
     assert pressure.split_counts_by_attempt == {child_attempt: 2}
     assert pressure.pending_split_counts_by_attempt == {child_attempt: 4}
     assert pressure.reserved_partitions == {child_reservation}
+    assert pressure.assigned_partitions_by_query == {
+        child_reservation[0]: {(child_reservation[1], child_reservation[2])}
+    }
     assert pressure.memory_bytes_by_reservation == {child_reservation: 20}
 
 

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -2936,7 +2936,20 @@ def test_fte_worker_selection_requires_pressure_stats_protocol():
         worker_id = "worker-a"
 
     with pytest.raises(AttributeError, match="fte_pressure_stats"):
-        fte_fragment_scheduler._fte_worker_selection_key(_Worker())
+        fte_fragment_scheduler._fte_worker_selection_key(_Worker(), query_id="q")
+
+
+def test_fte_worker_selection_requires_query_assignment_protocol():
+    class _Worker:
+        worker_id = "worker-a"
+        memory_capacity_bytes = 1 << 60
+
+        @staticmethod
+        def fte_pressure_stats():
+            return {}
+
+    with pytest.raises(AttributeError, match="fte_query_partition_assignment_count"):
+        fte_fragment_scheduler._fte_worker_selection_key(_Worker(), query_id="q")
 
 
 def test_fte_fragment_execution_assignment_creates_task_and_sends_later_updates():

--- a/vane/runners/ray/fragment_registry.py
+++ b/vane/runners/ray/fragment_registry.py
@@ -124,6 +124,12 @@ class _FteWorkerPressure:
         # for every retry for the lifetime of the query.
         self.terminal_attempt_id_by_task: dict[str, int] = {}
         self.reserved_partitions: set[tuple[str, str, int]] = set()
+        # Retain one entry for every logical partition assigned to this worker
+        # during an active query.  Reservations may be released between
+        # sequential tasks, so live pressure alone cannot provide a stable
+        # fairness tie-breaker.  Query-indexed sets make selection and teardown
+        # cheap while keeping repeated reservations and retries idempotent.
+        self.assigned_partitions_by_query: dict[str, set[tuple[str, int]]] = {}
         self.split_counts_by_attempt: dict[str, int] = {}
         self.split_bytes_by_attempt: dict[str, int] = {}
         self.pending_split_counts_by_attempt: dict[str, int] = {}
@@ -144,6 +150,12 @@ class _FteWorkerPressure:
             int(attempt_id.attempt_id),
             self.terminal_attempt_id_by_task.get(task_key, -1),
         )
+
+    def query_partition_assignment_count(self, query_id: str) -> int:
+        query_key = str(query_id or "").strip()
+        if not query_key:
+            raise ValueError("query partition assignment count requires query_id")
+        return len(self.assigned_partitions_by_query.get(query_key, ()))
 
     def score(self) -> int:
         return (
@@ -244,6 +256,7 @@ class _FteWorkerPressure:
             self.reserved_partitions = {
                 reservation for reservation in self.reserved_partitions if reservation[0] != query_id
             }
+            self.assigned_partitions_by_query.pop(query_id, None)
             self.split_counts_by_attempt = {
                 attempt: count for attempt, count in self.split_counts_by_attempt.items() if not owned_attempt(attempt)
             }

--- a/vane/runners/ray/fragment_worker_placement.py
+++ b/vane/runners/ray/fragment_worker_placement.py
@@ -50,6 +50,7 @@ class FteWorkerPlacementMixin:
     def _select_fte_worker(
         self,
         *,
+        query_id: str,
         exclude: set[str] | None = None,
         allowed_node_ids: set[str] | None = None,
         memory_requirement_bytes: Any = None,
@@ -60,6 +61,7 @@ class FteWorkerPlacementMixin:
         return select_fte_worker(
             self,
             self.worker_id,
+            query_id=query_id,
             exclude=exclude,
             allowed_node_ids=allowed_node_ids,
             memory_requirement_bytes=memory_requirement_bytes,

--- a/vane/runners/ray/fragment_worker_pressure_accounting.py
+++ b/vane/runners/ray/fragment_worker_pressure_accounting.py
@@ -88,12 +88,17 @@ class FteWorkerPressureAccountingMixin:
         task_class = FteTaskExecutionClass.coerce(execution_class)
         with _FTE_REGISTRY_LOCK:
             self._fte_pressure.reserved_partitions.add(key)
+            self._fte_pressure.assigned_partitions_by_query.setdefault(key[0], set()).add((key[1], key[2]))
             self._fte_pressure.execution_class_by_reservation[key] = task_class.value
             if memory_bytes > 0:
                 self._fte_pressure.memory_bytes_by_reservation[key] = memory_bytes
             else:
                 self._fte_pressure.memory_bytes_by_reservation.pop(key, None)
             self._fte_pressure.last_seen_at = time.time()
+
+    def fte_query_partition_assignment_count(self, query_id: str) -> int:
+        with _FTE_REGISTRY_LOCK:
+            return self._fte_pressure.query_partition_assignment_count(query_id)
 
     def release_fte_partition_reservation(self, query_id: str, fragment_id: str, partition_id: int) -> None:
         key = partition_reservation_key(query_id, fragment_id, partition_id)

--- a/vane/runners/ray/fragment_worker_selection.py
+++ b/vane/runners/ray/fragment_worker_selection.py
@@ -52,6 +52,7 @@ def select_fte_worker(
     current_worker: Any,
     current_worker_id: str | None,
     *,
+    query_id: str,
     exclude: set[str] | None = None,
     allowed_node_ids: set[str] | None = None,
     memory_requirement_bytes: Any = None,
@@ -59,6 +60,9 @@ def select_fte_worker(
     node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
     node_requirements_wait_started_at: float | None = None,
 ) -> Any | None:
+    query_id = str(query_id or "").strip()
+    if not query_id:
+        raise ValueError("FTE worker selection requires query_id")
     workers = available_fte_workers(current_worker, current_worker_id, exclude=exclude)
     if allowed_node_ids is not None:
         workers = [worker for worker in workers if str(worker.node_id) in allowed_node_ids]
@@ -87,6 +91,7 @@ def select_fte_worker(
         workers,
         key=lambda handle: _fte_worker_selection_key(
             handle,
+            query_id=query_id,
             memory_requirement_bytes=memory_requirement_bytes,
             execution_class=execution_class,
             node_requirements=node_requirements,

--- a/vane/runners/ray/fte_fragment_scheduler.py
+++ b/vane/runners/ray/fte_fragment_scheduler.py
@@ -1537,10 +1537,11 @@ def _fte_worker_has_memory_capacity(
 def _fte_worker_selection_key(
     handle: RayWorkerActorHandle,
     *,
+    query_id: str,
     memory_requirement_bytes: Any = None,
     execution_class: FteTaskExecutionClass | str | None = None,
     node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
-) -> tuple[int, int, int, int, int, int, str]:
+) -> tuple[int, int, int, int, int, int, int, str]:
     stats = _required_fte_pressure_stats(handle)
     running = int(stats.get("running_attempt_count", 0)) + int(stats.get("reserved_partition_count", 0))
     current_memory_bytes = _fte_pressure_capacity_memory_bytes(
@@ -1553,6 +1554,7 @@ def _fte_worker_selection_key(
     over_budget = 1 if memory_after_bytes > budget_bytes else 0
     split_bytes = int(stats.get("assigned_split_bytes", 0))
     split_count = int(stats.get("assigned_split_count", 0))
+    query_partition_assignment_count = handle.fte_query_partition_assignment_count(query_id)
     return (
         over_budget,
         _node_requirements_preference_penalty(handle, node_requirements),
@@ -1560,6 +1562,7 @@ def _fte_worker_selection_key(
         memory_after_bytes,
         split_bytes,
         split_count,
+        query_partition_assignment_count,
         str(handle.worker_id),
     )
 
@@ -1579,6 +1582,7 @@ def _worker_matches_failure_incarnation(
 def _select_replacement_fte_worker(
     exclude_worker_id: str | set[str],
     *,
+    query_id: str,
     exclude_worker_incarnation_ids: Mapping[str, str],
     manager_instance_id: str,
     memory_requirement_bytes: Any = None,
@@ -1586,6 +1590,9 @@ def _select_replacement_fte_worker(
     node_requirements: NodeRequirements | Mapping[str, Any] | None = None,
     node_requirements_wait_started_at: float | None = None,
 ) -> RayWorkerActorHandle | None:
+    query_id = str(query_id or "").strip()
+    if not query_id:
+        raise ValueError("FTE replacement worker selection requires query_id")
     exclude_worker_ids = (
         {str(exclude_worker_id)}
         if isinstance(exclude_worker_id, str)
@@ -1627,6 +1634,7 @@ def _select_replacement_fte_worker(
         candidates,
         key=lambda handle: _fte_worker_selection_key(
             handle,
+            query_id=query_id,
             memory_requirement_bytes=memory_requirement_bytes,
             execution_class=execution_class,
             node_requirements=node_requirements,
@@ -2065,6 +2073,7 @@ class FteWorkerPlacementManager:
             if owner is None:
                 try:
                     owner = self.coordinator._select_fte_worker(
+                        query_id=query_id,
                         exclude=set(),
                         memory_requirement_bytes=memory_requirement_bytes,
                         execution_class=execution_class,
@@ -2616,6 +2625,7 @@ def _mark_fte_worker_failed(
         wait_started_at = time.time()
         replacement = _select_replacement_fte_worker(
             failed_worker_ids,
+            query_id=owner_key[0],
             exclude_worker_incarnation_ids=failed_worker_incarnation_ids,
             manager_instance_id=normalized_manager_instance_id,
             memory_requirement_bytes=memory_requirement_bytes,


### PR DESCRIPTION
## Summary

- retain each worker's logical FTE partition assignments per execution query until query teardown, so sequential idle work balances deterministically instead of repeatedly selecting the lowest worker id
- use the query-local, retry-idempotent assignment count only after node preference and live running, memory, and split pressure in both normal placement and worker-failure replacement; require query identity without a compatibility fallback
- cover A/B/A admission, cross-query isolation, multi-fragment scope, retry idempotence, teardown, resource priority, replacement selection, and the required worker protocol

This supersedes the global terminal-attempt tie-breaker proposed in #570. Global terminal history can bias a fresh query based on unrelated completed work; the query-scoped assignment ledger cannot.

## Related issue

close: #569

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed`
- `pre-commit run --files tests/fast/test_ray_fragment_submission.py tests/fast/test_ray_fte.py vane/runners/ray/fragment_registry.py vane/runners/ray/fragment_worker_placement.py vane/runners/ray/fragment_worker_pressure_accounting.py vane/runners/ray/fragment_worker_selection.py vane/runners/ray/fte_fragment_scheduler.py`
- `scripts/run_installed_pytest.sh -q tests/fast/test_ray_fte.py tests/fast/test_ray_fragment_submission.py` — 500 passed
- `scripts/run_release_tests.sh` — 519 base tests and 11 real-Ray tests passed
- installed-package 100-partition audit across three workers — 34/33/33 assignments; duplicate reservation remained idempotent; cross-query isolation and teardown passed
- `scripts/run_fast_tests.sh` — clean non-Ray shard (6,196 passed) and shared-Ray shard (106 passed, 6 skipped); `scripts/run_fast_tests.sh owner-ray` rerun passed 7 and skipped the unavailable-vLLM case
- two initial full-suite attempts each encountered a different pre-existing timing flake: the native vLLM assertion reproduced on unchanged `upstream/main` once in 100 repetitions, and the no-replacement fault-injection assertion reproduced there once in 20 repetitions; both isolated reruns passed on this branch

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
