### PR TITLE
[fix](ai) Reject model in vLLM engine args

### DIFF
--- a/tests/fast/test_vllm_sampling_param_fold.py
+++ b/tests/fast/test_vllm_sampling_param_fold.py
@@ -162,6 +162,21 @@ def test_public_vllm_rejects_guided_decoding_alias_mapping():
         _plan_from_prompt_options({"generate_args": {"sampling_params": {"guided_decoding": {"regex": ".*"}}}})
 
 
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(_plan_from_prompt_options, id="prompt-entry-point-default-model"),
+        pytest.param(
+            lambda options: VLLMProvider().get_prompter(model="selected-model", options=options),
+            id="provider-factory-explicit-model",
+        ),
+    ],
+)
+def test_public_vllm_rejects_model_in_engine_args_during_planning(factory):
+    with pytest.raises(ValueError, match=r"engine_args\.model.*top-level 'model' argument"):
+        factory({"engine_args": {"model": "engine-model"}})
+
+
 @pytest.mark.parametrize("sampling_params", [{"temperature": -0.1}, '{"temperature":-0.1}'])
 @pytest.mark.parametrize(
     "factory",
@@ -291,6 +306,16 @@ class TestNoOpCases:
 
 class TestSQLPathFolds:
     """SQL struct_pack options flow through get_prompter into the same fold."""
+
+    def test_sql_rejects_model_in_engine_args_during_planning(self):
+        from vane.ai._sql import build_ai_prompt_sql_spec
+
+        with pytest.raises(ValueError, match=r"engine_args\.model.*top-level 'model' argument"):
+            build_ai_prompt_sql_spec(
+                provider="vllm",
+                model="selected-model",
+                options={"engine_args": {"model": "engine-model"}},
+            )
 
     def test_sql_top_level_options_fold(self):
         from vane.ai._sql import _normalize_sql_options

--- a/vane/ai/providers/vllm.py
+++ b/vane/ai/providers/vllm.py
@@ -156,6 +156,8 @@ def _validate_vllm_prompt_options(options: Mapping[str, Any]) -> dict[str, Any]:
         _require_prompt_number({nested_name: sampling_params["temperature"]}, nested_name, minimum=0, nullable=True)
 
     engine_args = copied.get("engine_args", {})
+    if "model" in engine_args:
+        raise ValueError("Prompt option 'engine_args.model' is not supported; use the top-level 'model' argument")
     if "trust_remote_code" in engine_args and not isinstance(engine_args["trust_remote_code"], bool):
         raise ValueError("Prompt option 'engine_args.trust_remote_code' must be a bool")
     if engine_args.get("trust_remote_code") is True:


### PR DESCRIPTION
## Summary

vLLM Prompt planning passes the public `model` separately from `engine_args`. Allowing `engine_args.model` therefore supplies `model` twice to `AsyncEngineArgs`, raising `TypeError` before engine initialization.

Reject direct `engine_args.model` during planning and direct users to the top-level `model` argument. Preserve valid nested fields such as `engine_args.speculative_config.model`, with Python and SQL regression coverage.

## Related issue

close: #443

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed --check`
- Pre-commit on both changed files, including Ruff and mypy
- `scripts/run_installed_pytest.sh tests/fast/test_vllm_sampling_param_fold.py`: 53 passed
- `scripts/run_release_tests.sh`: 526 passed, 4 skipped; real-Ray: 11 passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
