### PR TITLE
[fix](distributed) Quiesce COPY workers before failure cleanup

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -680,27 +680,78 @@ public:
 			RemoveDistributedCopyDirectoryTree(fs, staging_root);
 			RemoveDistributedCopyDirectoryIfEmpty(fs, sink_node->staging_root_base());
 		};
+		auto quiesce_copy_workers = [&]() -> DuckDBResult<void> {
+			if (!worker_manager_) {
+				return DuckDBResult<void>::err(
+				    DuckDBError::invalid_state_error("distributed COPY has no worker manager to quiesce"));
+			}
+			if (plan->query_id().empty()) {
+				return DuckDBResult<void>::err(
+				    DuckDBError::invalid_state_error("distributed COPY cannot quiesce workers without a query id"));
+			}
+			try {
+				return worker_manager_->quiesce_fte_query(plan->query_id());
+			} catch (const std::exception &ex) {
+				return DuckDBResult<void>::err(DuckDBError::external_error(
+				    "worker manager threw while quiescing FTE query: " + std::string(ex.what())));
+			} catch (...) {
+				return DuckDBResult<void>::err(
+				    DuckDBError::external_error("worker manager threw an unknown exception while quiescing FTE query"));
+			}
+		};
+		auto fail_after_copy_quiescence = [&](const DuckDBError &primary_error) -> DuckDBResult<PlanResult> {
+			auto quiesce_res = quiesce_copy_workers();
+			if (quiesce_res.is_err()) {
+				return DuckDBResult<PlanResult>::err(DuckDBError::io_error(
+				    StringUtil::Format("%s; worker quiescence failed: %s; operation-owned output is retained",
+				                       primary_error.what(), quiesce_res.error().what())));
+			}
+			cleanup_sink_output();
+			return DuckDBResult<PlanResult>::err(primary_error);
+		};
 		std::vector<ResultPartitionRef> partitions;
+		std::shared_ptr<DuckDBError> deferred_collection_error;
+		auto capture_execution_error = [&]() {
+			auto execution_error = execute_status->GetError();
+			if (execution_error && !deferred_collection_error) {
+				deferred_collection_error = std::move(execution_error);
+			}
+		};
 		auto staging_write_started = std::chrono::steady_clock::now();
-		while (true) {
-			auto item = receiver.recv();
-			if (auto execute_error = execute_status->GetError()) {
-				cleanup_sink_output();
-				return DuckDBResult<PlanResult>::err(*execute_error);
+		try {
+			while (true) {
+				auto item = receiver.recv();
+				capture_execution_error();
+				if (!item.first) {
+					break;
+				}
+				// Once an execution error is known, consume any queued results until
+				// the plan-control channel reaches its terminal state before entering
+				// the worker barrier.
+				if (deferred_collection_error) {
+					continue;
+				}
+				if (!item.second.has_node_id(sink_node_id)) {
+					continue;
+				}
+				for (auto &part : item.second.fragments()) {
+					partitions.push_back(part);
+				}
 			}
-			if (!item.first) {
-				break;
+		} catch (const std::exception &ex) {
+			if (!deferred_collection_error) {
+				deferred_collection_error = std::make_shared<DuckDBError>(DuckDBError::external_error(ex.what()));
 			}
-			if (!item.second.has_node_id(sink_node_id))
-				continue;
-			for (auto &part : item.second.fragments()) {
-				partitions.push_back(part);
+		} catch (...) {
+			if (!deferred_collection_error) {
+				deferred_collection_error = std::make_shared<DuckDBError>(
+				    DuckDBError::external_error("distributed COPY result collection threw an unknown exception"));
 			}
 		}
 
-		if (auto execute_error = execute_status->GetError()) {
-			cleanup_sink_output();
-			return DuckDBResult<PlanResult>::err(*execute_error);
+		capture_execution_error();
+		if (deferred_collection_error) {
+			return fail_after_copy_quiescence(*deferred_collection_error);
 		}
 
 		auto staging_write_ms = DistributedCopyElapsedMillis(staging_write_started);

--- a/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/scheduling/worker.hpp
@@ -164,6 +164,14 @@ public:
 		return res;
 	}
 
+	/// Fence and drain all worker execution for a query before deleting any
+	/// operation-owned output. Implementations must return success only when no
+	/// worker can publish or recreate artifacts for query_id after this call.
+	virtual DuckDBResult<void> quiesce_fte_query(const std::string &query_id) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::invalid_state_error("worker manager does not support FTE query quiescence"));
+	}
+
 	virtual DuckDBResult<std::vector<MaterializedOutput>>
 	wait_fte_query(const std::string &query_id, double timeout_s,
 	               const std::unordered_set<TaskContext, TaskContextHash> &task_contexts,

--- a/external/duckdb/test/execution/distributed/test_planrunner_local.cpp
+++ b/external/duckdb/test/execution/distributed/test_planrunner_local.cpp
@@ -12,12 +12,76 @@
 #include "test_common.hpp"
 
 #include "duckdb.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/execution/distributed/plan/runner.hpp"
 #include "duckdb/execution/distributed/plan/distributed_physical_plan.hpp"
+#include "test_helpers.hpp"
+
+#include <atomic>
 
 using namespace duckdb;
 using namespace duckdb::distributed;
 using namespace duckdb::distributed::testing;
+
+class FailingCopyWorkerManager final : public WorkerManager {
+public:
+	FailingCopyWorkerManager(int quiescence_failure_mode, FileSystem &fs, string operation_output_root)
+	    : quiescence_failure_mode(quiescence_failure_mode), fs(fs),
+	      operation_output_root(std::move(operation_output_root)) {
+	}
+
+	DuckDBResult<std::vector<WorkerSnapshot>> worker_snapshots() const override {
+		std::vector<WorkerSnapshot> snapshots;
+		snapshots.emplace_back(make_worker_id("failing-copy-w1"), 1, 0);
+		return DuckDBResult<std::vector<WorkerSnapshot>>::ok(std::move(snapshots));
+	}
+
+	DuckDBResult<void> try_autoscale(const std::vector<TaskResourceRequest> &) override {
+		return DuckDBResult<void>::ok();
+	}
+
+	DuckDBResult<void> shutdown() override {
+		return DuckDBResult<void>::ok();
+	}
+
+	DuckDBResult<void> submit_fte_task_events(std::vector<WorkerTask>) override {
+		return DuckDBResult<void>::ok();
+	}
+
+	DuckDBResult<void> task_input_stream_exhausted_for_query(const string &,
+	                                                         const std::unordered_set<SourceNodeId> &) override {
+		return DuckDBResult<void>::ok();
+	}
+
+	DuckDBResult<void> materialization_barrier_completed(const string &, NodeID) override {
+		return DuckDBResult<void>::ok();
+	}
+
+	DuckDBResult<std::vector<MaterializedOutput>> wait_fte_query(const string &, double) override {
+		return DuckDBResult<std::vector<MaterializedOutput>>::err(
+		    DuckDBError::external_error("planned worker execution failure"));
+	}
+
+	DuckDBResult<void> quiesce_fte_query(const string &) override {
+		quiesce_calls++;
+		output_existed_during_quiescence = fs.DirectoryExists(operation_output_root);
+		if (quiescence_failure_mode == 2) {
+			throw std::runtime_error("planned worker quiescence exception");
+		}
+		if (quiescence_failure_mode == 1) {
+			return DuckDBResult<void>::err(DuckDBError::external_error("planned worker quiescence failure"));
+		}
+		return DuckDBResult<void>::ok();
+	}
+
+	std::atomic<idx_t> quiesce_calls {0};
+	std::atomic<bool> output_existed_during_quiescence {false};
+	const int quiescence_failure_mode;
+
+private:
+	FileSystem &fs;
+	const string operation_output_root;
+};
 
 TEST_CASE("PlanRunner instantiation", "[distributed][plan][local]") {
 	// 1. Create mock workers and manager (pure C++, no Ray)
@@ -33,4 +97,55 @@ TEST_CASE("PlanRunner instantiation", "[distributed][plan][local]") {
 	auto runner = std::make_shared<PlanRunner>(worker_mgr, con.context);
 
 	REQUIRE(runner != nullptr);
+}
+
+TEST_CASE("PlanRunner quiesces failed COPY workers before deleting output", "[distributed][plan][copy]") {
+	const int quiescence_failure_mode = GENERATE(0, 1, 2);
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto &fs = FileSystem::GetFileSystem(*con.context);
+	const auto suffix = quiescence_failure_mode == 0   ? "planrunner_copy_quiescence_ok.parquet"
+	                    : quiescence_failure_mode == 1 ? "planrunner_copy_quiescence_error.parquet"
+	                                                   : "planrunner_copy_quiescence_exception.parquet";
+	const auto output_path = TestCreatePath(suffix);
+	const auto commit_root = output_path + ".duckdb_commit";
+	const auto staging_root = output_path + ".duckdb_staging";
+	const auto operation_output_root = DistributedCopyLocalStagingEnabled() ? staging_root : commit_root;
+	RemoveDistributedCopyDirectoryTree(fs, commit_root);
+	RemoveDistributedCopyDirectoryTree(fs, staging_root);
+
+	auto sql = "COPY (SELECT 42 AS value) TO '" + StringUtil::Replace(output_path, "'", "''") +
+	           "' (FORMAT PARQUET, RETURN_STATS true, USE_TMP_FILE false)";
+	auto logical_plan = con.ExtractPlan(sql);
+	REQUIRE(logical_plan != nullptr);
+	PhysicalPlanGenerator generator(*con.context);
+	auto generated_plan = generator.Plan(std::move(logical_plan));
+	REQUIRE(generated_plan != nullptr);
+	auto physical_plan = DuckPhysicalPlanRef(generated_plan.release());
+
+	auto worker_manager =
+	    std::make_shared<FailingCopyWorkerManager>(quiescence_failure_mode, fs, operation_output_root);
+	auto runner = std::make_shared<PlanRunner>(worker_manager, con.context);
+	auto execution_config = std::make_shared<DuckDBExecutionConfig>(DuckDBExecutionConfig::from_env());
+	auto distributed_plan = std::make_shared<DistributedPhysicalPlan>(23, "planrunner-copy-worker-failure",
+	                                                                  physical_plan, std::move(execution_config));
+
+	auto result = runner->run_plan(std::move(distributed_plan));
+
+	REQUIRE(result.is_err());
+	REQUIRE(StringUtil::Contains(result.error().what(), "planned worker execution failure"));
+	REQUIRE(worker_manager->quiesce_calls == 1);
+	REQUIRE(worker_manager->output_existed_during_quiescence);
+	if (quiescence_failure_mode == 0) {
+		REQUIRE_FALSE(fs.DirectoryExists(operation_output_root));
+		return;
+	}
+
+	REQUIRE(StringUtil::Contains(result.error().what(), quiescence_failure_mode == 1
+	                                                        ? "planned worker quiescence failure"
+	                                                        : "planned worker quiescence exception"));
+	REQUIRE(StringUtil::Contains(result.error().what(), "output is retained"));
+	REQUIRE(fs.DirectoryExists(operation_output_root));
+	RemoveDistributedCopyDirectoryTree(fs, commit_root);
+	RemoveDistributedCopyDirectoryTree(fs, staging_root);
 }

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -1455,6 +1455,23 @@ public:
 		return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::ok(std::move(outputs));
 	}
 
+	DuckDBResult<void> quiesce_fte_query(const string &query_id) override {
+		if (query_id.empty()) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::value_error("Python backend FTE query quiescence requires non-empty query_id"));
+		}
+		try {
+			drop_query_fragments(query_id);
+			return DuckDBResult<void>::ok();
+		} catch (const std::exception &ex) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::external_error(string("failed to quiesce Python backend FTE query: ") + ex.what()));
+		} catch (...) {
+			return DuckDBResult<void>::err(
+			    DuckDBError::external_error("failed to quiesce Python backend FTE query: unknown error"));
+		}
+	}
+
 	void drop_query_fragments(const string &query_id) {
 		if (query_id.empty()) {
 			return;

--- a/src/vane_py/ray/worker_manager.cpp
+++ b/src/vane_py/ray/worker_manager.cpp
@@ -957,6 +957,21 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 	}
 }
 
+DuckDBResult<void> RayWorkerManager::quiesce_fte_query(const string &query_id) {
+	if (query_id.empty()) {
+		return DuckDBResult<void>::err(DuckDBError::value_error("FTE query quiescence requires non-empty query_id"));
+	}
+	try {
+		drop_query_fragments(query_id);
+		return DuckDBResult<void>::ok();
+	} catch (const std::exception &ex) {
+		return DuckDBResult<void>::err(
+		    DuckDBError::external_error(string("failed to quiesce FTE query: ") + ex.what()));
+	} catch (...) {
+		return DuckDBResult<void>::err(DuckDBError::external_error("failed to quiesce FTE query: unknown error"));
+	}
+}
+
 DuckDBResult<void> RayWorkerManager::task_input_stream_exhausted_for_query(
     const string &query_id, const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids) {
 	if (query_id.empty()) {

--- a/src/vane_py/ray/worker_manager.hpp
+++ b/src/vane_py/ray/worker_manager.hpp
@@ -48,6 +48,7 @@ public:
 	    const string &query_id, double timeout_s,
 	    const std::unordered_set<duckdb::distributed::TaskContext, duckdb::distributed::TaskContextHash> &task_contexts,
 	    duckdb::distributed::MaterializedOutputCallback on_output) override;
+	DuckDBResult<void> quiesce_fte_query(const string &query_id) override;
 	DuckDBResult<void> task_input_stream_exhausted_for_query(
 	    const string &query_id, const std::unordered_set<duckdb::distributed::SourceNodeId> &source_node_ids) override;
 	DuckDBResult<void> materialization_barrier_completed(const string &query_id,


### PR DESCRIPTION
## Summary

- add an explicit `WorkerManager::quiesce_fte_query` contract backed by the existing two-phase Ray and Python query teardown
- quiesce workers before `PlanRunner` removes operation-owned COPY output after execution or result-collection failures
- fail closed and retain output when the barrier returns an error or throws
- cover successful quiescence, returned errors, and exceptions in a focused native regression test

## Why

A distributed COPY can fail after some worker tasks have already been submitted. `PlanRunner` previously deleted the direct-write run or staging directory before the outer query teardown, allowing a late worker to publish or recreate files after cleanup.

Fixes #577

## Testing

- `scripts/format workspace --changed --check`
- CMake Release build of `_native` and `unittest`
- `build/pr-577-validation/duckdb/test/unittest "PlanRunner quiesces failed COPY workers before deleting output" -s` (25 assertions passed)