### PR TITLE
[feat](distributed) Serialize DML targets and repartition plans safely

### DIFF
--- a/external/duckdb/src/catalog/catalog_entry/duck_schema_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/duck_schema_entry.cpp
@@ -149,6 +149,9 @@ optional_ptr<CatalogEntry> DuckSchemaEntry::AddEntryInternal(CatalogTransaction 
 }
 
 optional_ptr<CatalogEntry> DuckSchemaEntry::CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) {
+	if (!info.preserve_logical_write_target_identity) {
+		info.Base().logical_write_target_identity = CreateTableInfo::GenerateLogicalWriteTargetIdentity();
+	}
 	auto table = make_uniq<DuckTableEntry>(catalog, *this, info);
 
 	// add a foreign key constraint in main key table if there is a foreign key constraint

--- a/external/duckdb/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -713,7 +713,13 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
 	// Removing a column remaps physical column indexes. Assign a new logical-write
 	// identity so a serialized plan can never become valid again after a later
-	// schema change restores the same logical definition.
+	// schema change restores the same logical definition. The physical ALTER
+	// selects this value before catalog mutation so the same value is recorded in
+	// the WAL and reused during recovery.
+	if (info.new_logical_write_target_identity.empty()) {
+		throw SerializationException("DROP COLUMN does not provide a new logical write target identity");
+	}
+	create_info->logical_write_target_identity = info.new_logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;

--- a/external/duckdb/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -24,7 +24,6 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/common/type_visitor.hpp"
-#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -82,9 +81,6 @@ DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, Bou
                                shared_ptr<DataTable> inherited_storage)
     : TableCatalogEntry(catalog, schema, info.Base()), storage(std::move(inherited_storage)),
       column_dependency_manager(std::move(info.column_dependency_manager)) {
-	if (logical_write_target_identity.empty()) {
-		logical_write_target_identity = "duckdb-table:v1:" + UUID::ToString(UUID::GenerateRandomUUID());
-	}
 	if (storage) {
 		if (!info.indexes.empty()) {
 			storage->SetIndexStorageInfo(std::move(info.indexes));
@@ -715,7 +711,9 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 	}
 
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
-	create_info->logical_write_target_identity = logical_write_target_identity;
+	// Removing a column remaps physical column indexes. Assign a new logical-write
+	// identity so a serialized plan can never become valid again after a later
+	// schema change restores the same logical definition.
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;

--- a/external/duckdb/src/catalog/catalog_entry/duck_table_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/duck_table_entry.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/storage/table_storage_info.hpp"
 #include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -81,6 +82,9 @@ DuckTableEntry::DuckTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, Bou
                                shared_ptr<DataTable> inherited_storage)
     : TableCatalogEntry(catalog, schema, info.Base()), storage(std::move(inherited_storage)),
       column_dependency_manager(std::move(info.column_dependency_manager)) {
+	if (logical_write_target_identity.empty()) {
+		logical_write_target_identity = "duckdb-table:v1:" + UUID::ToString(UUID::GenerateRandomUUID());
+	}
 	if (storage) {
 		if (!info.indexes.empty()) {
 			storage->SetIndexStorageInfo(std::move(info.indexes));
@@ -326,6 +330,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RenameColumn(ClientContext &context, Re
 		throw CatalogException("Cannot rename rowid column");
 	}
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
+	create_info->logical_write_target_identity = logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;
@@ -400,6 +405,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddColumn(ClientContext &context, AddCo
 	}
 
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
+	create_info->logical_write_target_identity = logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;
@@ -709,6 +715,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::RemoveColumn(ClientContext &context, Re
 	}
 
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
+	create_info->logical_write_target_identity = logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;
@@ -1037,6 +1044,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::ChangeColumnType(ClientContext &context
 
 	auto change_idx = GetColumnIndex(info.column_name);
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
+	create_info->logical_write_target_identity = logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;
@@ -1154,6 +1162,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::SetColumnComment(ClientContext &context
 unique_ptr<CatalogEntry> DuckTableEntry::AddForeignKeyConstraint(AlterForeignKeyInfo &info) {
 	D_ASSERT(info.type == AlterForeignKeyType::AFT_ADD);
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
+	create_info->logical_write_target_identity = logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;
@@ -1179,6 +1188,7 @@ unique_ptr<CatalogEntry> DuckTableEntry::AddForeignKeyConstraint(AlterForeignKey
 unique_ptr<CatalogEntry> DuckTableEntry::DropForeignKeyConstraint(ClientContext &context, AlterForeignKeyInfo &info) {
 	D_ASSERT(info.type == AlterForeignKeyType::AFT_DELETE);
 	auto create_info = make_uniq<CreateTableInfo>(schema, name);
+	create_info->logical_write_target_identity = logical_write_target_identity;
 	create_info->temporary = temporary;
 	create_info->comment = comment;
 	create_info->tags = tags;

--- a/external/duckdb/src/catalog/catalog_entry/index_catalog_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/index_catalog_entry.cpp
@@ -29,6 +29,7 @@ unique_ptr<CreateInfo> IndexCatalogEntry::GetInfo() const {
 	result->index_type = index_type;
 	result->constraint_type = index_constraint_type;
 	result->column_ids = column_ids;
+	result->options = options;
 	result->dependencies = dependencies;
 
 	for (auto &expr : expressions) {

--- a/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -130,46 +130,52 @@ string TableCatalogEntry::GetLogicalWriteTargetDefinition(ClientContext &context
 			signature << ":" << column;
 		}
 		index_signatures.push_back(signature.str());
-	}
 
-	// TableStorageInfo captures the columns and constraint flags that affect DML
-	// planning, but intentionally omits standalone index expressions and types.
-	// Include their catalog definitions so replacing an index with another index
-	// over the same columns cannot make a stale write plan appear valid.
-	schema.Scan(context, CatalogType::INDEX_ENTRY, [&](CatalogEntry &entry) {
-		auto &index = entry.Cast<IndexCatalogEntry>();
-		if (!StringUtil::CIEquals(index.GetTableName(), name)) {
-			return;
+		// TableStorageInfo captures the columns and constraint flags that affect
+		// DML planning, but intentionally omits standalone index expressions and
+		// types. Resolve the catalog entry by this target index's name instead of
+		// scanning every index in the schema.
+		if (index.name.empty()) {
+			continue;
+		}
+		auto entry = schema.GetEntry(schema.GetCatalogTransaction(context), CatalogType::INDEX_ENTRY, index.name);
+		if (!entry) {
+			continue;
+		}
+		auto &catalog_index = entry->Cast<IndexCatalogEntry>();
+		if (!StringUtil::CIEquals(catalog_index.GetTableName(), name)) {
+			continue;
 		}
 
-		duckdb::stringstream signature;
-		signature << "catalog-index:v1";
-		AppendWriteDefinitionField(signature, index.index_type);
-		signature << ":" << static_cast<uint32_t>(index.index_constraint_type) << ":" << index.column_ids.size();
-		for (auto column : index.column_ids) {
-			signature << ":" << column;
+		duckdb::stringstream catalog_signature;
+		catalog_signature << "catalog-index:v1";
+		AppendWriteDefinitionField(catalog_signature, catalog_index.index_type);
+		catalog_signature << ":" << static_cast<uint32_t>(catalog_index.index_constraint_type) << ":"
+		                  << catalog_index.column_ids.size();
+		for (auto column : catalog_index.column_ids) {
+			catalog_signature << ":" << column;
 		}
-		signature << ":" << index.parsed_expressions.size();
-		for (auto &expression : index.parsed_expressions) {
+		catalog_signature << ":" << catalog_index.parsed_expressions.size();
+		for (auto &expression : catalog_index.parsed_expressions) {
 			if (!expression) {
-				throw SerializationException("Index \"%s\" contains a null parsed expression", index.name);
+				throw SerializationException("Index \"%s\" contains a null parsed expression", catalog_index.name);
 			}
-			AppendWriteDefinitionField(signature, expression->ToString());
+			AppendWriteDefinitionField(catalog_signature, expression->ToString());
 		}
 
 		vector<pair<string, string>> options;
-		options.reserve(index.options.size());
-		for (auto &option : index.options) {
+		options.reserve(catalog_index.options.size());
+		for (auto &option : catalog_index.options) {
 			options.emplace_back(option.first, option.second.ToString());
 		}
 		std::sort(options.begin(), options.end());
-		signature << ":" << options.size();
+		catalog_signature << ":" << options.size();
 		for (auto &option : options) {
-			AppendWriteDefinitionField(signature, option.first);
-			AppendWriteDefinitionField(signature, option.second);
+			AppendWriteDefinitionField(catalog_signature, option.first);
+			AppendWriteDefinitionField(catalog_signature, option.second);
 		}
-		index_signatures.push_back(signature.str());
-	});
+		index_signatures.push_back(catalog_signature.str());
+	}
 	std::sort(index_signatures.begin(), index_signatures.end());
 
 	auto table_definition = GetInfo()->ToString();

--- a/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -110,6 +110,33 @@ string TableCatalogEntry::GetLogicalWriteTargetIdentity() const {
 	return logical_write_target_identity;
 }
 
+string TableCatalogEntry::GetLogicalWriteTargetDefinition(ClientContext &context) {
+	vector<string> index_signatures;
+	auto storage_info = GetStorageInfo(context);
+	index_signatures.reserve(storage_info.index_info.size());
+	for (auto &index : storage_info.index_info) {
+		vector<column_t> columns(index.column_set.begin(), index.column_set.end());
+		std::sort(columns.begin(), columns.end());
+
+		duckdb::stringstream signature;
+		signature << index.is_unique << index.is_primary << index.is_foreign << ":" << columns.size();
+		for (auto column : columns) {
+			signature << ":" << column;
+		}
+		index_signatures.push_back(signature.str());
+	}
+	std::sort(index_signatures.begin(), index_signatures.end());
+
+	auto table_definition = GetInfo()->ToString();
+	duckdb::stringstream result;
+	result << "duckdb-write-definition:v1:" << table_definition.size() << ":" << table_definition << ":"
+	       << index_signatures.size();
+	for (auto &signature : index_signatures) {
+		result << ":" << signature.size() << ":" << signature;
+	}
+	return result.str();
+}
+
 string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints) {
 	duckdb::stringstream ss;
 

--- a/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/common/algorithm.hpp"
 #include "duckdb/common/exception.hpp"
@@ -110,6 +111,10 @@ string TableCatalogEntry::GetLogicalWriteTargetIdentity() const {
 	return logical_write_target_identity;
 }
 
+static void AppendWriteDefinitionField(duckdb::stringstream &result, const string &field) {
+	result << ":" << field.size() << ":" << field;
+}
+
 string TableCatalogEntry::GetLogicalWriteTargetDefinition(ClientContext &context) {
 	vector<string> index_signatures;
 	auto storage_info = GetStorageInfo(context);
@@ -119,17 +124,57 @@ string TableCatalogEntry::GetLogicalWriteTargetDefinition(ClientContext &context
 		std::sort(columns.begin(), columns.end());
 
 		duckdb::stringstream signature;
-		signature << index.is_unique << index.is_primary << index.is_foreign << ":" << columns.size();
+		signature << "storage-index:v1:" << index.is_unique << index.is_primary << index.is_foreign << ":"
+		          << columns.size();
 		for (auto column : columns) {
 			signature << ":" << column;
 		}
 		index_signatures.push_back(signature.str());
 	}
+
+	// TableStorageInfo captures the columns and constraint flags that affect DML
+	// planning, but intentionally omits standalone index expressions and types.
+	// Include their catalog definitions so replacing an index with another index
+	// over the same columns cannot make a stale write plan appear valid.
+	schema.Scan(context, CatalogType::INDEX_ENTRY, [&](CatalogEntry &entry) {
+		auto &index = entry.Cast<IndexCatalogEntry>();
+		if (!StringUtil::CIEquals(index.GetTableName(), name)) {
+			return;
+		}
+
+		duckdb::stringstream signature;
+		signature << "catalog-index:v1";
+		AppendWriteDefinitionField(signature, index.index_type);
+		signature << ":" << static_cast<uint32_t>(index.index_constraint_type) << ":" << index.column_ids.size();
+		for (auto column : index.column_ids) {
+			signature << ":" << column;
+		}
+		signature << ":" << index.parsed_expressions.size();
+		for (auto &expression : index.parsed_expressions) {
+			if (!expression) {
+				throw SerializationException("Index \"%s\" contains a null parsed expression", index.name);
+			}
+			AppendWriteDefinitionField(signature, expression->ToString());
+		}
+
+		vector<pair<string, string>> options;
+		options.reserve(index.options.size());
+		for (auto &option : index.options) {
+			options.emplace_back(option.first, option.second.ToString());
+		}
+		std::sort(options.begin(), options.end());
+		signature << ":" << options.size();
+		for (auto &option : options) {
+			AppendWriteDefinitionField(signature, option.first);
+			AppendWriteDefinitionField(signature, option.second);
+		}
+		index_signatures.push_back(signature.str());
+	});
 	std::sort(index_signatures.begin(), index_signatures.end());
 
 	auto table_definition = GetInfo()->ToString();
 	duckdb::stringstream result;
-	result << "duckdb-write-definition:v1:" << table_definition.size() << ":" << table_definition << ":"
+	result << "duckdb-write-definition:v2:" << table_definition.size() << ":" << table_definition << ":"
 	       << index_signatures.size();
 	for (auto &signature : index_signatures) {
 		result << ":" << signature.size() << ":" << signature;

--- a/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/external/duckdb/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -25,7 +25,8 @@ constexpr const char *TableCatalogEntry::Name;
 
 TableCatalogEntry::TableCatalogEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info)
     : StandardEntry(CatalogType::TABLE_ENTRY, schema, catalog, info.table), columns(std::move(info.columns)),
-      constraints(std::move(info.constraints)) {
+      constraints(std::move(info.constraints)),
+      logical_write_target_identity(std::move(info.logical_write_target_identity)) {
 	this->temporary = info.temporary;
 	this->dependencies = info.dependencies;
 	this->comment = info.comment;
@@ -92,6 +93,7 @@ unique_ptr<CreateInfo> TableCatalogEntry::GetInfo() const {
 	result->catalog = catalog.GetName();
 	result->schema = schema.name;
 	result->table = name;
+	result->logical_write_target_identity = logical_write_target_identity;
 	result->columns = columns.Copy();
 	result->constraints.reserve(constraints.size());
 	result->dependencies = dependencies;
@@ -102,6 +104,10 @@ unique_ptr<CreateInfo> TableCatalogEntry::GetInfo() const {
 	result->comment = comment;
 	result->tags = tags;
 	return std::move(result);
+}
+
+string TableCatalogEntry::GetLogicalWriteTargetIdentity() const {
+	return logical_write_target_identity;
 }
 
 string TableCatalogEntry::ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints) {

--- a/external/duckdb/src/execution/operator/schema/physical_alter.cpp
+++ b/external/duckdb/src/execution/operator/schema/physical_alter.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parser/parsed_data/alter_database_info.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
 
 namespace duckdb {
 
@@ -17,6 +18,13 @@ SourceResultType PhysicalAlter::GetDataInternal(ExecutionContext &context, DataC
 		db_manager.Alter(context.client, db_info);
 	} else {
 		auto &catalog = Catalog::GetCatalog(context.client, info->catalog);
+		if (catalog.IsDuckCatalog() && info->type == AlterType::ALTER_TABLE) {
+			auto &table_info = info->Cast<AlterTableInfo>();
+			if (table_info.alter_table_type == AlterTableType::REMOVE_COLUMN) {
+				table_info.Cast<RemoveColumnInfo>().new_logical_write_target_identity =
+				    CreateTableInfo::GenerateLogicalWriteTargetIdentity();
+			}
+		}
 		catalog.Alter(context.client, *info);
 	}
 	return SourceResultType::FINISHED;

--- a/external/duckdb/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/external/duckdb/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -106,6 +106,11 @@ public:
 		return false;
 	}
 
+	//! Returns a stable identifier for this table incarnation. The identifier must
+	//! survive catalog persistence and must change when a table is dropped and
+	//! recreated. An empty value means serialized logical writes are unsupported.
+	DUCKDB_API virtual string GetLogicalWriteTargetIdentity() const;
+
 	DUCKDB_API static string ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints);
 
 	//! Returns the expression string list of the column names e.g. (col1, col2, col3)
@@ -135,5 +140,7 @@ protected:
 	ColumnList columns;
 	//! A list of constraints that are part of this table
 	vector<unique_ptr<Constraint>> constraints;
+	//! Identity persisted through CreateTableInfo for catalogs using the base implementation
+	string logical_write_target_identity;
 };
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
+++ b/external/duckdb/src/include/duckdb/catalog/catalog_entry/table_catalog_entry.hpp
@@ -110,6 +110,10 @@ public:
 	//! survive catalog persistence and must change when a table is dropped and
 	//! recreated. An empty value means serialized logical writes are unsupported.
 	DUCKDB_API virtual string GetLogicalWriteTargetIdentity() const;
+	//! Returns a canonical definition of the state that a bound logical write
+	//! depends on. A changed definition invalidates serialized logical writes even
+	//! when they still refer to the same table incarnation.
+	DUCKDB_API virtual string GetLogicalWriteTargetDefinition(ClientContext &context);
 
 	DUCKDB_API static string ColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints);
 

--- a/external/duckdb/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
+++ b/external/duckdb/src/include/duckdb/parser/parsed_data/alter_table_info.hpp
@@ -239,6 +239,8 @@ struct RemoveColumnInfo : public AlterTableInfo {
 	bool if_column_exists;
 	//! Whether or not the column should be removed if a dependency conflict arises (used by GENERATED columns)
 	bool cascade;
+	//! Fresh table-incarnation identity selected for this physical remapping
+	string new_logical_write_target_identity;
 
 public:
 	unique_ptr<AlterInfo> Copy() const override;

--- a/external/duckdb/src/include/duckdb/parser/parsed_data/create_table_info.hpp
+++ b/external/duckdb/src/include/duckdb/parser/parsed_data/create_table_info.hpp
@@ -23,6 +23,8 @@ struct CreateTableInfo : public CreateInfo {
 
 	//! Table name to insert to
 	string table;
+	//! Stable identity of this table incarnation, used by serialized logical writes
+	string logical_write_target_identity;
 	//! List of columns of the table
 	ColumnList columns;
 	//! List of constraints on the table

--- a/external/duckdb/src/include/duckdb/parser/parsed_data/create_table_info.hpp
+++ b/external/duckdb/src/include/duckdb/parser/parsed_data/create_table_info.hpp
@@ -39,6 +39,8 @@ struct CreateTableInfo : public CreateInfo {
 	case_insensitive_map_t<unique_ptr<ParsedExpression>> options;
 
 public:
+	DUCKDB_API static string GenerateLogicalWriteTargetIdentity();
+
 	DUCKDB_API unique_ptr<CreateInfo> Copy() const override;
 
 	DUCKDB_API void Serialize(Serializer &serializer) const override;

--- a/external/duckdb/src/include/duckdb/planner/logical_write_target.hpp
+++ b/external/duckdb/src/include/duckdb/planner/logical_write_target.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/common/string.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class Deserializer;
+class Serializer;
+class TableCatalogEntry;
+
+//! A write target captured when a logical DML operator is bound.
+//!
+//! The catalog path resolves the target on the receiving process. The identity
+//! distinguishes a particular table incarnation from a different table later
+//! created at the same path.
+class LogicalWriteTarget {
+public:
+	explicit LogicalWriteTarget(const TableCatalogEntry &table);
+
+	TableCatalogEntry &Resolve(ClientContext &context) const;
+
+	void Serialize(Serializer &serializer) const;
+	static LogicalWriteTarget Deserialize(Deserializer &deserializer);
+
+	const string &CatalogName() const {
+		return catalog_name;
+	}
+	const string &SchemaName() const {
+		return schema_name;
+	}
+	const string &TableName() const {
+		return table_name;
+	}
+	const string &Identity() const {
+		return identity;
+	}
+
+private:
+	LogicalWriteTarget(string catalog_name, string schema_name, string table_name, string identity);
+	void Validate() const;
+
+private:
+	string catalog_name;
+	string schema_name;
+	string table_name;
+	string identity;
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/planner/logical_write_target.hpp
+++ b/external/duckdb/src/include/duckdb/planner/logical_write_target.hpp
@@ -16,10 +16,11 @@ class TableCatalogEntry;
 //!
 //! The catalog path resolves the target on the receiving process. The identity
 //! distinguishes a particular table incarnation from a different table later
-//! created at the same path.
+//! created at the same path, while the definition prevents a plan bound against
+//! an earlier physical column mapping or write-relevant schema from being reused.
 class LogicalWriteTarget {
 public:
-	explicit LogicalWriteTarget(const TableCatalogEntry &table);
+	LogicalWriteTarget(ClientContext &context, TableCatalogEntry &table);
 
 	TableCatalogEntry &Resolve(ClientContext &context) const;
 
@@ -38,9 +39,12 @@ public:
 	const string &Identity() const {
 		return identity;
 	}
+	const string &Definition() const {
+		return definition;
+	}
 
 private:
-	LogicalWriteTarget(string catalog_name, string schema_name, string table_name, string identity);
+	LogicalWriteTarget(string catalog_name, string schema_name, string table_name, string identity, string definition);
 	void Validate() const;
 
 private:
@@ -48,6 +52,7 @@ private:
 	string schema_name;
 	string table_name;
 	string identity;
+	string definition;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_delete.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_delete.hpp
@@ -20,9 +20,9 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_DELETE;
 
 public:
-	explicit LogicalDelete(TableCatalogEntry &table, idx_t table_index);
+	LogicalDelete(ClientContext &context, TableCatalogEntry &table, idx_t table_index);
 
-	//! Bound path and table-incarnation identity of the write target
+	//! Bound path, table incarnation, and write-relevant definition of the target
 	LogicalWriteTarget write_target;
 	TableCatalogEntry &table;
 	idx_t table_index;

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_delete.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_delete.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/logical_write_target.hpp"
 #include "duckdb/planner/bound_constraint.hpp"
 
 namespace duckdb {
@@ -21,6 +22,8 @@ public:
 public:
 	explicit LogicalDelete(TableCatalogEntry &table, idx_t table_index);
 
+	//! Bound path and table-incarnation identity of the write target
+	LogicalWriteTarget write_target;
 	TableCatalogEntry &table;
 	idx_t table_index;
 	bool return_chunk;
@@ -39,6 +42,6 @@ protected:
 	void ResolveTypes() override;
 
 private:
-	LogicalDelete(ClientContext &context, const unique_ptr<CreateInfo> &table_info);
+	LogicalDelete(ClientContext &context, const LogicalWriteTarget &write_target);
 };
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/logical_write_target.hpp"
 #include "duckdb/common/index_vector.hpp"
 #include "duckdb/parser/statement/insert_statement.hpp"
 
@@ -57,6 +58,8 @@ public:
 	physical_index_vector_t<idx_t> column_index_map;
 	//! The expected types for the INSERT statement (obtained from the column types)
 	vector<LogicalType> expected_types;
+	//! Bound path and table-incarnation identity of the write target
+	LogicalWriteTarget write_target;
 	//! The base table to insert into
 	TableCatalogEntry &table;
 	idx_t table_index;
@@ -82,6 +85,6 @@ protected:
 	string GetName() const override;
 
 private:
-	LogicalInsert(ClientContext &context, const unique_ptr<CreateInfo> table_info);
+	LogicalInsert(ClientContext &context, const LogicalWriteTarget &write_target);
 };
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_insert.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_insert.hpp
@@ -51,14 +51,14 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_INSERT;
 
 public:
-	LogicalInsert(TableCatalogEntry &table, idx_t table_index);
+	LogicalInsert(ClientContext &context, TableCatalogEntry &table, idx_t table_index);
 
 	vector<vector<unique_ptr<Expression>>> insert_values;
 	//! The insertion map ([table_index -> index in result, or DConstants::INVALID_INDEX if not specified])
 	physical_index_vector_t<idx_t> column_index_map;
 	//! The expected types for the INSERT statement (obtained from the column types)
 	vector<LogicalType> expected_types;
-	//! Bound path and table-incarnation identity of the write target
+	//! Bound path, table incarnation, and write-relevant definition of the target
 	LogicalWriteTarget write_target;
 	//! The base table to insert into
 	TableCatalogEntry &table;

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -42,9 +42,9 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_MERGE_INTO;
 
 public:
-	explicit LogicalMergeInto(TableCatalogEntry &table);
+	LogicalMergeInto(ClientContext &context, TableCatalogEntry &table);
 
-	//! Bound path and table-incarnation identity of the write target
+	//! Bound path, table incarnation, and write-relevant definition of the target
 	LogicalWriteTarget write_target;
 	//! The base table to merge into
 	TableCatalogEntry &table;

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_merge_into.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_merge_into.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/logical_write_target.hpp"
 #include "duckdb/common/enums/merge_action_type.hpp"
 #include "duckdb/common/index_vector.hpp"
 
@@ -43,6 +44,8 @@ public:
 public:
 	explicit LogicalMergeInto(TableCatalogEntry &table);
 
+	//! Bound path and table-incarnation identity of the write target
+	LogicalWriteTarget write_target;
 	//! The base table to merge into
 	TableCatalogEntry &table;
 	//! projection index
@@ -69,7 +72,7 @@ protected:
 	void ResolveTypes() override;
 
 private:
-	LogicalMergeInto(ClientContext &context, const unique_ptr<CreateInfo> &table_info);
+	LogicalMergeInto(ClientContext &context, const LogicalWriteTarget &write_target);
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_update.hpp
@@ -23,9 +23,9 @@ public:
 	static constexpr const LogicalOperatorType TYPE = LogicalOperatorType::LOGICAL_UPDATE;
 
 public:
-	explicit LogicalUpdate(TableCatalogEntry &table);
+	LogicalUpdate(ClientContext &context, TableCatalogEntry &table);
 
-	//! Bound path and table-incarnation identity of the write target
+	//! Bound path, table incarnation, and write-relevant definition of the target
 	LogicalWriteTarget write_target;
 	//! The base table to update
 	TableCatalogEntry &table;

--- a/external/duckdb/src/include/duckdb/planner/operator/logical_update.hpp
+++ b/external/duckdb/src/include/duckdb/planner/operator/logical_update.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/planner/logical_operator.hpp"
+#include "duckdb/planner/logical_write_target.hpp"
 #include "duckdb/planner/bound_constraint.hpp"
 #include "duckdb/common/index_map.hpp"
 
@@ -24,6 +25,8 @@ public:
 public:
 	explicit LogicalUpdate(TableCatalogEntry &table);
 
+	//! Bound path and table-incarnation identity of the write target
+	LogicalWriteTarget write_target;
 	//! The base table to update
 	TableCatalogEntry &table;
 	//! projection index
@@ -50,6 +53,6 @@ protected:
 	void ResolveTypes() override;
 
 private:
-	LogicalUpdate(ClientContext &context, const unique_ptr<CreateInfo> &table_info);
+	LogicalUpdate(ClientContext &context, const LogicalWriteTarget &write_target);
 };
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/planner/parsed_data/bound_create_table_info.hpp
+++ b/external/duckdb/src/include/duckdb/planner/parsed_data/bound_create_table_info.hpp
@@ -44,6 +44,8 @@ struct BoundCreateTableInfo {
 	unique_ptr<LogicalOperator> query;
 	//! Indexes created by this table
 	vector<IndexStorageInfo> indexes;
+	//! Preserve the persisted table-incarnation identity when restoring catalog state
+	bool preserve_logical_write_target_identity = false;
 
 	CreateTableInfo &Base() {
 		D_ASSERT(base);

--- a/external/duckdb/src/include/duckdb/storage/index_storage_info.hpp
+++ b/external/duckdb/src/include/duckdb/storage/index_storage_info.hpp
@@ -82,6 +82,7 @@ struct IndexStorageInfo {
 
 //! Additional index information for tables
 struct IndexInfo {
+	string name;
 	bool is_unique;
 	bool is_primary;
 	bool is_foreign;

--- a/external/duckdb/src/include/duckdb/storage/serialization/create_info.json
+++ b/external/duckdb/src/include/duckdb/storage/serialization/create_info.json
@@ -170,6 +170,11 @@
         "id": 206,
         "name": "options",
         "type": "case_insensitive_map_t<ParsedExpression*>"
+      },
+      {
+        "id": 207,
+        "name": "logical_write_target_identity",
+        "type": "string"
       }
     ]
   },

--- a/external/duckdb/src/include/duckdb/storage/serialization/logical_operator.json
+++ b/external/duckdb/src/include/duckdb/storage/serialization/logical_operator.json
@@ -43,6 +43,91 @@
     ]
   },
   {
+    "class": "LogicalVLLMProject",
+    "base": "LogicalOperator",
+    "enum": "LOGICAL_VLLM_PROJECT",
+    "members": [
+      {
+        "id": 200,
+        "name": "table_index",
+        "type": "idx_t"
+      },
+      {
+        "id": 201,
+        "name": "vllm_expr",
+        "type": "Expression*"
+      },
+      {
+        "id": 202,
+        "name": "output_column_name",
+        "type": "string"
+      }
+    ],
+    "constructor": [
+      "table_index",
+      "vllm_expr",
+      "output_column_name"
+    ]
+  },
+  {
+    "class": "LogicalUDFProject",
+    "base": "LogicalOperator",
+    "enum": "LOGICAL_UDF_PROJECT",
+    "members": [
+      {
+        "id": 200,
+        "name": "table_index",
+        "type": "idx_t"
+      },
+      {
+        "id": 201,
+        "name": "udf_expr",
+        "type": "Expression*"
+      },
+      {
+        "id": 202,
+        "name": "output_column_name",
+        "type": "string"
+      },
+      {
+        "id": 203,
+        "name": "is_flat_map",
+        "type": "bool"
+      },
+      {
+        "id": 204,
+        "name": "flat_map_output_types",
+        "type": "vector<LogicalType>"
+      },
+      {
+        "id": 205,
+        "name": "flat_map_output_names",
+        "type": "vector<string>"
+      },
+      {
+        "id": 206,
+        "name": "is_scalar_map",
+        "type": "bool"
+      },
+      {
+        "id": 207,
+        "name": "is_row_preserving_batch",
+        "type": "bool"
+      }
+    ],
+    "constructor": [
+      "table_index",
+      "udf_expr",
+      "output_column_name"
+    ]
+  },
+  {
+    "class": "LogicalLocalExchange",
+    "base": "LogicalOperator",
+    "enum": "LOGICAL_LOCAL_EXCHANGE",
+    "custom_implementation": true
+  },
+  {
     "class": "LogicalFilter",
     "base": "LogicalOperator",
     "enum": "LOGICAL_FILTER",
@@ -58,6 +143,12 @@
         "type": "vector<idx_t>"
       }
     ]
+  },
+  {
+    "class": "LogicalRepartition",
+    "base": "LogicalOperator",
+    "enum": "LOGICAL_REPARTITION",
+    "custom_implementation": true
   },
   {
     "class": "LogicalAggregate",
@@ -630,15 +721,13 @@
     "base": "LogicalOperator",
     "enum": "LOGICAL_INSERT",
     "includes": [
-      "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp",
-      "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+      "duckdb/planner/logical_write_target.hpp"
     ],
     "members": [
       {
         "id": 200,
-        "name": "table_info",
-        "type": "CreateInfo*",
-        "serialize_property": "table.GetInfo()"
+        "name": "write_target",
+        "type": "LogicalWriteTarget"
       },
       {
         "id": 201,
@@ -746,7 +835,7 @@
     ],
     "constructor": [
       "$ClientContext",
-      "table_info"
+      "write_target&"
     ]
   },
   {
@@ -756,9 +845,8 @@
     "members": [
       {
         "id": 200,
-        "name": "table_info",
-        "type": "CreateInfo*",
-        "serialize_property": "table.GetInfo()"
+        "name": "write_target",
+        "type": "LogicalWriteTarget"
       },
       {
         "id": 201,
@@ -778,7 +866,7 @@
     ],
     "constructor": [
       "$ClientContext",
-      "table_info&"
+      "write_target&"
     ]
   },
   {
@@ -788,9 +876,8 @@
     "members": [
       {
         "id": 200,
-        "name": "table_info",
-        "type": "CreateInfo*",
-        "serialize_property": "table.GetInfo()"
+        "name": "write_target",
+        "type": "LogicalWriteTarget"
       },
       {
         "id": 201,
@@ -825,7 +912,7 @@
     ],
     "constructor": [
       "$ClientContext",
-      "table_info&"
+      "write_target&"
     ]
   },
   {
@@ -835,9 +922,8 @@
     "members": [
       {
         "id": 200,
-        "name": "table_info",
-        "type": "CreateInfo*",
-        "serialize_property": "table.GetInfo()"
+        "name": "write_target",
+        "type": "LogicalWriteTarget"
       },
       {
         "id": 201,
@@ -870,7 +956,7 @@
         "type": "bool"
       }
     ],
-    "constructor": ["$ClientContext", "table_info&"]
+    "constructor": ["$ClientContext", "write_target&"]
   },
   {
     "class": "BoundMergeIntoAction",

--- a/external/duckdb/src/include/duckdb/storage/serialization/parse_info.json
+++ b/external/duckdb/src/include/duckdb/storage/serialization/parse_info.json
@@ -176,6 +176,11 @@
         "id": 402,
         "name": "cascade",
         "type": "bool"
+      },
+      {
+        "id": 403,
+        "name": "new_logical_write_target_identity",
+        "type": "string"
       }
     ]
   },

--- a/external/duckdb/src/parser/parsed_data/alter_table_info.cpp
+++ b/external/duckdb/src/parser/parsed_data/alter_table_info.cpp
@@ -289,7 +289,9 @@ RemoveColumnInfo::~RemoveColumnInfo() {
 }
 
 unique_ptr<AlterInfo> RemoveColumnInfo::Copy() const {
-	return make_uniq_base<AlterInfo, RemoveColumnInfo>(GetAlterEntryData(), removed_column, if_column_exists, cascade);
+	auto result = make_uniq<RemoveColumnInfo>(GetAlterEntryData(), removed_column, if_column_exists, cascade);
+	result->new_logical_write_target_identity = new_logical_write_target_identity;
+	return std::move(result);
 }
 
 string RemoveColumnInfo::ToString() const {

--- a/external/duckdb/src/parser/parsed_data/create_table_info.cpp
+++ b/external/duckdb/src/parser/parsed_data/create_table_info.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -14,6 +15,10 @@ CreateTableInfo::CreateTableInfo(string catalog_p, string schema_p, string name_
 
 CreateTableInfo::CreateTableInfo(SchemaCatalogEntry &schema, string name_p)
     : CreateTableInfo(schema.catalog.GetName(), schema.name, std::move(name_p)) {
+}
+
+string CreateTableInfo::GenerateLogicalWriteTargetIdentity() {
+	return "duckdb-table:v1:" + UUID::ToString(UUID::GenerateRandomUUID());
 }
 
 unique_ptr<CreateInfo> CreateTableInfo::Copy() const {

--- a/external/duckdb/src/parser/parsed_data/create_table_info.cpp
+++ b/external/duckdb/src/parser/parsed_data/create_table_info.cpp
@@ -19,6 +19,7 @@ CreateTableInfo::CreateTableInfo(SchemaCatalogEntry &schema, string name_p)
 unique_ptr<CreateInfo> CreateTableInfo::Copy() const {
 	auto result = make_uniq<CreateTableInfo>(catalog, schema, table);
 	CopyProperties(*result);
+	result->logical_write_target_identity = logical_write_target_identity;
 	result->columns = columns.Copy();
 	for (auto &constraint : constraints) {
 		result->constraints.push_back(constraint->Copy());

--- a/external/duckdb/src/planner/CMakeLists.txt
+++ b/external/duckdb/src/planner/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library_unity(
   expression_binder.cpp
   joinside.cpp
   logical_operator.cpp
+  logical_write_target.cpp
   binder.cpp
   bind_context.cpp
   planner.cpp

--- a/external/duckdb/src/planner/binder/statement/bind_copy_database.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_copy_database.cpp
@@ -28,6 +28,12 @@ unique_ptr<LogicalOperator> Binder::BindCopyDatabaseSchema(Catalog &from_databas
 	for (auto &entry : catalog_entries) {
 		auto create_info = entry.get().GetInfo();
 		create_info->catalog = target_database_name;
+		if (create_info->type == CatalogType::TABLE_ENTRY) {
+			// COPY DATABASE creates a distinct table incarnation. The target
+			// catalog must assign its own logical-write identity rather than
+			// inheriting the source table's identity.
+			create_info->Cast<CreateTableInfo>().logical_write_target_identity.clear();
+		}
 		auto on_conflict = create_info->type == CatalogType::SCHEMA_ENTRY ? OnCreateConflict::IGNORE_ON_CONFLICT
 		                                                                  : OnCreateConflict::ERROR_ON_CONFLICT;
 		// Update all the dependencies of the entry to point to the newly created entries on the target database

--- a/external/duckdb/src/planner/binder/statement/bind_create_table.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_create_table.cpp
@@ -24,7 +24,6 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/common/type_visitor.hpp"
-#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -349,6 +348,7 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
 unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableCheckpoint(unique_ptr<CreateInfo> info,
                                                                    SchemaCatalogEntry &schema) {
 	auto result = make_uniq<BoundCreateTableInfo>(schema, std::move(info));
+	result->preserve_logical_write_target_identity = true;
 	CreateColumnDependencyManager(*result);
 	return result;
 }
@@ -591,9 +591,6 @@ unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateIn
                                                              vector<unique_ptr<Expression>> &bound_defaults) {
 	auto &base = info->Cast<CreateTableInfo>();
 	auto &catalog = schema.ParentCatalog();
-	if (catalog.IsDuckCatalog() && base.logical_write_target_identity.empty()) {
-		base.logical_write_target_identity = "duckdb-table:v1:" + UUID::ToString(UUID::GenerateRandomUUID());
-	}
 	auto result = make_uniq<BoundCreateTableInfo>(schema, std::move(info));
 	auto &dependencies = result->dependencies;
 	optional_ptr<StorageManager> storage_manager;

--- a/external/duckdb/src/planner/binder/statement/bind_create_table.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_create_table.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/storage_manager.hpp"
 #include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/types/uuid.hpp"
 
 namespace duckdb {
 
@@ -589,9 +590,12 @@ static void BindCreateTableConstraints(CreateTableInfo &create_info, CatalogEntr
 unique_ptr<BoundCreateTableInfo> Binder::BindCreateTableInfo(unique_ptr<CreateInfo> info, SchemaCatalogEntry &schema,
                                                              vector<unique_ptr<Expression>> &bound_defaults) {
 	auto &base = info->Cast<CreateTableInfo>();
+	auto &catalog = schema.ParentCatalog();
+	if (catalog.IsDuckCatalog() && base.logical_write_target_identity.empty()) {
+		base.logical_write_target_identity = "duckdb-table:v1:" + UUID::ToString(UUID::GenerateRandomUUID());
+	}
 	auto result = make_uniq<BoundCreateTableInfo>(schema, std::move(info));
 	auto &dependencies = result->dependencies;
-	auto &catalog = schema.ParentCatalog();
 	optional_ptr<StorageManager> storage_manager;
 	if (catalog.IsDuckCatalog() && !catalog.InMemory()) {
 		storage_manager = StorageManager::Get(catalog);

--- a/external/duckdb/src/planner/binder/statement/bind_delete.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_delete.cpp
@@ -61,7 +61,7 @@ BoundStatement Binder::Bind(DeleteStatement &stmt) {
 		root = std::move(filter);
 	}
 	// create the delete node
-	auto del = make_uniq<LogicalDelete>(table, GenerateTableIndex());
+	auto del = make_uniq<LogicalDelete>(context, table, GenerateTableIndex());
 	del->bound_constraints = BindConstraints(table);
 	del->AddChild(std::move(root));
 

--- a/external/duckdb/src/planner/binder/statement/bind_insert.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_insert.cpp
@@ -526,7 +526,7 @@ BoundStatement Binder::Bind(InsertStatement &stmt) {
 		properties.RegisterDBModify(table.catalog, context, modification_type);
 	}
 
-	auto insert = make_uniq<LogicalInsert>(table, GenerateTableIndex());
+	auto insert = make_uniq<LogicalInsert>(context, table, GenerateTableIndex());
 
 	auto values_list = stmt.GetValuesList();
 

--- a/external/duckdb/src/planner/binder/statement/bind_merge_into.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_merge_into.cpp
@@ -82,7 +82,7 @@ unique_ptr<BoundMergeIntoAction> Binder::BindMergeAction(LogicalMergeInto &merge
 		// FIXME: this is pretty hacky
 		// construct a dummy projection and update
 		LogicalProjection proj(proj_index, std::move(expressions));
-		LogicalUpdate update(table);
+		LogicalUpdate update(context, table);
 		update.return_chunk = merge_into.return_chunk;
 		update.columns = std::move(result->columns);
 		update.expressions = std::move(result->expressions);
@@ -303,7 +303,7 @@ BoundStatement Binder::Bind(MergeIntoStatement &stmt) {
 	auto &source = join_ref.get().children[inverted ? 1 : 0];
 	auto &get = ExtractLogicalGet(*join_ref.get().children[inverted ? 0 : 1]);
 
-	auto merge_into = make_uniq<LogicalMergeInto>(table);
+	auto merge_into = make_uniq<LogicalMergeInto>(context, table);
 	merge_into->table_index = GenerateTableIndex();
 	if (!stmt.returning_list.empty()) {
 		merge_into->return_chunk = true;

--- a/external/duckdb/src/planner/binder/statement/bind_update.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_update.cpp
@@ -148,7 +148,7 @@ BoundStatement Binder::Bind(UpdateStatement &stmt) {
 		auto &properties = GetStatementProperties();
 		properties.RegisterDBModify(table.catalog, context, DatabaseModificationType::UPDATE_DATA);
 	}
-	auto update = make_uniq<LogicalUpdate>(table);
+	auto update = make_uniq<LogicalUpdate>(context, table);
 
 	// set return_chunk boolean early because it needs uses update_is_del_and_insert logic
 	if (!stmt.returning_list.empty()) {

--- a/external/duckdb/src/planner/logical_write_target.cpp
+++ b/external/duckdb/src/planner/logical_write_target.cpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/planner/logical_write_target.hpp"
+
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+
+LogicalWriteTarget::LogicalWriteTarget(const TableCatalogEntry &table)
+    : LogicalWriteTarget(table.catalog.GetName(), table.schema.name, table.name,
+                         table.GetLogicalWriteTargetIdentity()) {
+}
+
+LogicalWriteTarget::LogicalWriteTarget(string catalog_name_p, string schema_name_p, string table_name_p,
+                                       string identity_p)
+    : catalog_name(std::move(catalog_name_p)), schema_name(std::move(schema_name_p)),
+      table_name(std::move(table_name_p)), identity(std::move(identity_p)) {
+}
+
+void LogicalWriteTarget::Validate() const {
+	if (catalog_name.empty() || schema_name.empty() || table_name.empty()) {
+		throw SerializationException("Cannot serialize a logical write target with an incomplete catalog path");
+	}
+	if (identity.empty()) {
+		throw SerializationException("Table \"%s.%s.%s\" does not provide a logical write target identity",
+		                             catalog_name, schema_name, table_name);
+	}
+}
+
+TableCatalogEntry &LogicalWriteTarget::Resolve(ClientContext &context) const {
+	Validate();
+	auto &table = Catalog::GetEntry<TableCatalogEntry>(context, catalog_name, schema_name, table_name);
+	auto current_identity = table.GetLogicalWriteTargetIdentity();
+	if (current_identity.empty()) {
+		throw CatalogException("Table \"%s.%s.%s\" does not provide a logical write target identity", catalog_name,
+		                       schema_name, table_name);
+	}
+	if (current_identity != identity) {
+		throw CatalogException("Logical write target \"%s.%s.%s\" was replaced after the plan was bound", catalog_name,
+		                       schema_name, table_name);
+	}
+	return table;
+}
+
+void LogicalWriteTarget::Serialize(Serializer &serializer) const {
+	Validate();
+	serializer.WriteProperty<string>(100, "catalog_name", catalog_name);
+	serializer.WriteProperty<string>(101, "schema_name", schema_name);
+	serializer.WriteProperty<string>(102, "table_name", table_name);
+	serializer.WriteProperty<string>(103, "identity", identity);
+}
+
+LogicalWriteTarget LogicalWriteTarget::Deserialize(Deserializer &deserializer) {
+	auto catalog_name = deserializer.ReadProperty<string>(100, "catalog_name");
+	auto schema_name = deserializer.ReadProperty<string>(101, "schema_name");
+	auto table_name = deserializer.ReadProperty<string>(102, "table_name");
+	auto identity = deserializer.ReadProperty<string>(103, "identity");
+	LogicalWriteTarget result(std::move(catalog_name), std::move(schema_name), std::move(table_name),
+	                          std::move(identity));
+	result.Validate();
+	return result;
+}
+
+} // namespace duckdb

--- a/external/duckdb/src/planner/logical_write_target.cpp
+++ b/external/duckdb/src/planner/logical_write_target.cpp
@@ -12,15 +12,18 @@
 
 namespace duckdb {
 
-LogicalWriteTarget::LogicalWriteTarget(const TableCatalogEntry &table)
-    : LogicalWriteTarget(table.catalog.GetName(), table.schema.name, table.name,
-                         table.GetLogicalWriteTargetIdentity()) {
+LogicalWriteTarget::LogicalWriteTarget(ClientContext &context, TableCatalogEntry &table)
+    : catalog_name(table.catalog.GetName()), schema_name(table.schema.name), table_name(table.name),
+      identity(table.GetLogicalWriteTargetIdentity()) {
+	if (!identity.empty()) {
+		definition = table.GetLogicalWriteTargetDefinition(context);
+	}
 }
 
 LogicalWriteTarget::LogicalWriteTarget(string catalog_name_p, string schema_name_p, string table_name_p,
-                                       string identity_p)
+                                       string identity_p, string definition_p)
     : catalog_name(std::move(catalog_name_p)), schema_name(std::move(schema_name_p)),
-      table_name(std::move(table_name_p)), identity(std::move(identity_p)) {
+      table_name(std::move(table_name_p)), identity(std::move(identity_p)), definition(std::move(definition_p)) {
 }
 
 void LogicalWriteTarget::Validate() const {
@@ -29,6 +32,10 @@ void LogicalWriteTarget::Validate() const {
 	}
 	if (identity.empty()) {
 		throw SerializationException("Table \"%s.%s.%s\" does not provide a logical write target identity",
+		                             catalog_name, schema_name, table_name);
+	}
+	if (definition.empty()) {
+		throw SerializationException("Table \"%s.%s.%s\" does not provide a logical write target definition",
 		                             catalog_name, schema_name, table_name);
 	}
 }
@@ -45,6 +52,15 @@ TableCatalogEntry &LogicalWriteTarget::Resolve(ClientContext &context) const {
 		throw CatalogException("Logical write target \"%s.%s.%s\" was replaced after the plan was bound", catalog_name,
 		                       schema_name, table_name);
 	}
+	auto current_definition = table.GetLogicalWriteTargetDefinition(context);
+	if (current_definition.empty()) {
+		throw CatalogException("Table \"%s.%s.%s\" does not provide a logical write target definition", catalog_name,
+		                       schema_name, table_name);
+	}
+	if (current_definition != definition) {
+		throw CatalogException("Logical write target \"%s.%s.%s\" definition changed after the plan was bound",
+		                       catalog_name, schema_name, table_name);
+	}
 	return table;
 }
 
@@ -54,6 +70,7 @@ void LogicalWriteTarget::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<string>(101, "schema_name", schema_name);
 	serializer.WriteProperty<string>(102, "table_name", table_name);
 	serializer.WriteProperty<string>(103, "identity", identity);
+	serializer.WriteProperty<string>(104, "definition", definition);
 }
 
 LogicalWriteTarget LogicalWriteTarget::Deserialize(Deserializer &deserializer) {
@@ -61,8 +78,9 @@ LogicalWriteTarget LogicalWriteTarget::Deserialize(Deserializer &deserializer) {
 	auto schema_name = deserializer.ReadProperty<string>(101, "schema_name");
 	auto table_name = deserializer.ReadProperty<string>(102, "table_name");
 	auto identity = deserializer.ReadProperty<string>(103, "identity");
+	auto definition = deserializer.ReadProperty<string>(104, "definition");
 	LogicalWriteTarget result(std::move(catalog_name), std::move(schema_name), std::move(table_name),
-	                          std::move(identity));
+	                          std::move(identity), std::move(definition));
 	result.Validate();
 	return result;
 }

--- a/external/duckdb/src/planner/operator/logical_delete.cpp
+++ b/external/duckdb/src/planner/operator/logical_delete.cpp
@@ -6,9 +6,9 @@
 
 namespace duckdb {
 
-LogicalDelete::LogicalDelete(TableCatalogEntry &table, idx_t table_index)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE), write_target(table), table(table), table_index(table_index),
-      return_chunk(false) {
+LogicalDelete::LogicalDelete(ClientContext &context, TableCatalogEntry &table, idx_t table_index)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE), write_target(context, table), table(table),
+      table_index(table_index), return_chunk(false) {
 }
 
 LogicalDelete::LogicalDelete(ClientContext &context, const LogicalWriteTarget &write_target_p)

--- a/external/duckdb/src/planner/operator/logical_delete.cpp
+++ b/external/duckdb/src/planner/operator/logical_delete.cpp
@@ -2,20 +2,18 @@
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
 LogicalDelete::LogicalDelete(TableCatalogEntry &table, idx_t table_index)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE), table(table), table_index(table_index),
+    : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE), write_target(table), table(table), table_index(table_index),
       return_chunk(false) {
 }
 
-LogicalDelete::LogicalDelete(ClientContext &context, const unique_ptr<CreateInfo> &table_info)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
-                                                 table_info->Cast<CreateTableInfo>().table)) {
+LogicalDelete::LogicalDelete(ClientContext &context, const LogicalWriteTarget &write_target_p)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_DELETE), write_target(write_target_p),
+      table(write_target_p.Resolve(context)) {
 	auto binder = Binder::CreateBinder(context);
 	bound_constraints = binder->BindConstraints(table);
 }

--- a/external/duckdb/src/planner/operator/logical_insert.cpp
+++ b/external/duckdb/src/planner/operator/logical_insert.cpp
@@ -9,9 +9,9 @@ namespace duckdb {
 BoundOnConflictInfo::BoundOnConflictInfo() : action_type(OnConflictAction::THROW), update_is_del_and_insert(false) {
 }
 
-LogicalInsert::LogicalInsert(TableCatalogEntry &table, idx_t table_index)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT), write_target(table), table(table), table_index(table_index),
-      return_chunk(false) {
+LogicalInsert::LogicalInsert(ClientContext &context, TableCatalogEntry &table, idx_t table_index)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT), write_target(context, table), table(table),
+      table_index(table_index), return_chunk(false) {
 }
 
 LogicalInsert::LogicalInsert(ClientContext &context, const LogicalWriteTarget &write_target_p)

--- a/external/duckdb/src/planner/operator/logical_insert.cpp
+++ b/external/duckdb/src/planner/operator/logical_insert.cpp
@@ -2,7 +2,6 @@
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
@@ -11,14 +10,13 @@ BoundOnConflictInfo::BoundOnConflictInfo() : action_type(OnConflictAction::THROW
 }
 
 LogicalInsert::LogicalInsert(TableCatalogEntry &table, idx_t table_index)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT), table(table), table_index(table_index),
+    : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT), write_target(table), table(table), table_index(table_index),
       return_chunk(false) {
 }
 
-LogicalInsert::LogicalInsert(ClientContext &context, const unique_ptr<CreateInfo> table_info)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
-                                                 table_info->Cast<CreateTableInfo>().table)) {
+LogicalInsert::LogicalInsert(ClientContext &context, const LogicalWriteTarget &write_target_p)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_INSERT), write_target(write_target_p),
+      table(write_target_p.Resolve(context)) {
 	auto binder = Binder::CreateBinder(context);
 	bound_constraints = binder->BindConstraints(table);
 }

--- a/external/duckdb/src/planner/operator/logical_merge_into.cpp
+++ b/external/duckdb/src/planner/operator/logical_merge_into.cpp
@@ -5,8 +5,8 @@
 
 namespace duckdb {
 
-LogicalMergeInto::LogicalMergeInto(TableCatalogEntry &table)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_MERGE_INTO), write_target(table), table(table) {
+LogicalMergeInto::LogicalMergeInto(ClientContext &context, TableCatalogEntry &table)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_MERGE_INTO), write_target(context, table), table(table) {
 }
 
 LogicalMergeInto::LogicalMergeInto(ClientContext &context, const LogicalWriteTarget &write_target_p)

--- a/external/duckdb/src/planner/operator/logical_merge_into.cpp
+++ b/external/duckdb/src/planner/operator/logical_merge_into.cpp
@@ -1,19 +1,17 @@
 #include "duckdb/planner/operator/logical_merge_into.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
 LogicalMergeInto::LogicalMergeInto(TableCatalogEntry &table)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_MERGE_INTO), table(table) {
+    : LogicalOperator(LogicalOperatorType::LOGICAL_MERGE_INTO), write_target(table), table(table) {
 }
 
-LogicalMergeInto::LogicalMergeInto(ClientContext &context, const unique_ptr<CreateInfo> &table_info)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_MERGE_INTO),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
-                                                 table_info->Cast<CreateTableInfo>().table)) {
+LogicalMergeInto::LogicalMergeInto(ClientContext &context, const LogicalWriteTarget &write_target_p)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_MERGE_INTO), write_target(write_target_p),
+      table(write_target_p.Resolve(context)) {
 	auto binder = Binder::CreateBinder(context);
 	bound_constraints = binder->BindConstraints(table);
 }

--- a/external/duckdb/src/planner/operator/logical_repartition.cpp
+++ b/external/duckdb/src/planner/operator/logical_repartition.cpp
@@ -10,7 +10,35 @@
 
 #include "duckdb/planner/operator/logical_repartition.hpp"
 
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+
 namespace duckdb {
+
+namespace {
+
+//! Values in a serialized logical plan. These are deliberately independent of
+//! RepartitionSpec::Type so changing the in-memory enum cannot reinterpret a plan.
+enum class RepartitionWireType : uint8_t { HASH = 1, RANDOM = 2, INTO_PARTITIONS = 3, RANGE = 4 };
+
+static size_t ReadPartitionCount(uint64_t count) {
+	if (count > static_cast<uint64_t>(NumericLimits<size_t>::Maximum())) {
+		throw SerializationException("Logical repartition partition count is too large for this platform");
+	}
+	return static_cast<size_t>(count);
+}
+
+static void ValidatePartitionExpressions(const vector<unique_ptr<Expression>> &expressions) {
+	for (auto &expression : expressions) {
+		if (!expression) {
+			throw SerializationException("Logical repartition contains a null partition expression");
+		}
+	}
+}
+
+} // namespace
 
 LogicalRepartition::LogicalRepartition(std::shared_ptr<RepartitionSpec> repartition_spec_p)
     : LogicalOperator(LogicalOperatorType::LOGICAL_REPARTITION), repartition_spec(std::move(repartition_spec_p)) {
@@ -26,6 +54,123 @@ idx_t LogicalRepartition::EstimateCardinality(ClientContext &context) {
 
 void LogicalRepartition::ResolveTypes() {
 	types = children[0]->types;
+}
+
+void LogicalRepartition::Serialize(Serializer &serializer) const {
+	LogicalOperator::Serialize(serializer);
+	if (!repartition_spec) {
+		throw SerializationException("Logical repartition is missing its repartition specification");
+	}
+
+	RepartitionWireType wire_type;
+	uint64_t num_partitions;
+	switch (repartition_spec->type()) {
+	case RepartitionSpec::Type::Hash: {
+		wire_type = RepartitionWireType::HASH;
+		auto *hash_spec = dynamic_cast<HashRepartitionSpec *>(repartition_spec.get());
+		if (!hash_spec || !hash_spec->config()) {
+			throw SerializationException("Logical hash repartition has an invalid specification");
+		}
+		auto &config = *hash_spec->config();
+		if (expressions.empty() || config.by.empty() || expressions.size() != config.by.size()) {
+			throw SerializationException("Logical hash repartition has inconsistent partition expressions");
+		}
+		ValidatePartitionExpressions(expressions);
+		for (idx_t expression_idx = 0; expression_idx < config.by.size(); expression_idx++) {
+			auto &config_expression = config.by[expression_idx];
+			if (!config_expression) {
+				throw SerializationException("Logical hash repartition contains a null partition expression");
+			}
+			if (!config_expression->Equals(*expressions[expression_idx])) {
+				throw SerializationException("Logical hash repartition has inconsistent partition expressions");
+			}
+		}
+		num_partitions = static_cast<uint64_t>(config.num_partitions);
+		break;
+	}
+	case RepartitionSpec::Type::Random: {
+		wire_type = RepartitionWireType::RANDOM;
+		auto *random_spec = dynamic_cast<RandomRepartitionSpec *>(repartition_spec.get());
+		if (!random_spec || !random_spec->config()) {
+			throw SerializationException("Logical random repartition has an invalid specification");
+		}
+		if (!expressions.empty()) {
+			throw SerializationException("Logical random repartition must not contain partition expressions");
+		}
+		num_partitions = static_cast<uint64_t>(random_spec->config()->num_partitions);
+		break;
+	}
+	case RepartitionSpec::Type::IntoPartitions: {
+		wire_type = RepartitionWireType::INTO_PARTITIONS;
+		auto *into_spec = dynamic_cast<IntoPartitionsRepartitionSpec *>(repartition_spec.get());
+		if (!into_spec || !into_spec->config()) {
+			throw SerializationException("Logical into-partitions repartition has an invalid specification");
+		}
+		if (!expressions.empty()) {
+			throw SerializationException("Logical into-partitions repartition must not contain partition expressions");
+		}
+		if (into_spec->config()->num_partitions == 0) {
+			throw SerializationException("Logical into-partitions repartition requires a positive partition count");
+		}
+		num_partitions = static_cast<uint64_t>(into_spec->config()->num_partitions);
+		break;
+	}
+	case RepartitionSpec::Type::Range:
+		throw SerializationException("Range repartition cannot be serialized in a logical plan");
+	default:
+		throw SerializationException("Logical repartition has an unknown in-memory repartition type");
+	}
+
+	serializer.WriteProperty<uint8_t>(200, "repartition_type", static_cast<uint8_t>(wire_type));
+	serializer.WriteProperty<uint64_t>(201, "num_partitions", num_partitions);
+	serializer.WriteProperty<vector<unique_ptr<Expression>>>(202, "partition_by", expressions);
+}
+
+unique_ptr<LogicalOperator> LogicalRepartition::Deserialize(Deserializer &deserializer) {
+	auto wire_type = static_cast<RepartitionWireType>(deserializer.ReadProperty<uint8_t>(200, "repartition_type"));
+	auto num_partitions = ReadPartitionCount(deserializer.ReadProperty<uint64_t>(201, "num_partitions"));
+	auto partition_by = deserializer.ReadProperty<vector<unique_ptr<Expression>>>(202, "partition_by");
+	ValidatePartitionExpressions(partition_by);
+
+	std::shared_ptr<RepartitionSpec> spec;
+	switch (wire_type) {
+	case RepartitionWireType::HASH: {
+		if (partition_by.empty()) {
+			throw SerializationException("Logical hash repartition requires at least one partition expression");
+		}
+		vector<ExprRef> expression_refs;
+		expression_refs.reserve(partition_by.size());
+		for (auto &expression : partition_by) {
+			auto copy = expression->Copy();
+			expression_refs.emplace_back(copy.release());
+		}
+		spec = RepartitionSpec::create_hash(num_partitions, std::move(expression_refs));
+		break;
+	}
+	case RepartitionWireType::RANDOM:
+		if (!partition_by.empty()) {
+			throw SerializationException("Logical random repartition must not contain partition expressions");
+		}
+		spec = RepartitionSpec::create_random(num_partitions);
+		break;
+	case RepartitionWireType::INTO_PARTITIONS:
+		if (!partition_by.empty()) {
+			throw SerializationException("Logical into-partitions repartition must not contain partition expressions");
+		}
+		if (num_partitions == 0) {
+			throw SerializationException("Logical into-partitions repartition requires a positive partition count");
+		}
+		spec = RepartitionSpec::create_into_partitions(num_partitions);
+		break;
+	case RepartitionWireType::RANGE:
+		throw SerializationException("Range repartition cannot be deserialized from a logical plan");
+	default:
+		throw SerializationException("Logical repartition contains an unknown wire repartition type");
+	}
+
+	auto result = make_uniq<LogicalRepartition>(std::move(spec));
+	result->expressions = std::move(partition_by);
+	return std::move(result);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/planner/operator/logical_repartition.cpp
+++ b/external/duckdb/src/planner/operator/logical_repartition.cpp
@@ -72,19 +72,14 @@ void LogicalRepartition::Serialize(Serializer &serializer) const {
 			throw SerializationException("Logical hash repartition has an invalid specification");
 		}
 		auto &config = *hash_spec->config();
-		if (expressions.empty() || config.by.empty() || expressions.size() != config.by.size()) {
-			throw SerializationException("Logical hash repartition has inconsistent partition expressions");
+		if (expressions.empty()) {
+			throw SerializationException("Logical hash repartition requires at least one partition expression");
 		}
+		// LogicalOperator::expressions participates in optimizer rewrites, while
+		// HashRepartitionConfig::by is only the bind-time copy. The operator
+		// expressions are therefore authoritative for serialization and are used to
+		// rebuild the config during deserialization.
 		ValidatePartitionExpressions(expressions);
-		for (idx_t expression_idx = 0; expression_idx < config.by.size(); expression_idx++) {
-			auto &config_expression = config.by[expression_idx];
-			if (!config_expression) {
-				throw SerializationException("Logical hash repartition contains a null partition expression");
-			}
-			if (!config_expression->Equals(*expressions[expression_idx])) {
-				throw SerializationException("Logical hash repartition has inconsistent partition expressions");
-			}
-		}
 		num_partitions = static_cast<uint64_t>(config.num_partitions);
 		break;
 	}

--- a/external/duckdb/src/planner/operator/logical_update.cpp
+++ b/external/duckdb/src/planner/operator/logical_update.cpp
@@ -6,8 +6,8 @@
 
 namespace duckdb {
 
-LogicalUpdate::LogicalUpdate(TableCatalogEntry &table)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE), write_target(table), table(table), table_index(0),
+LogicalUpdate::LogicalUpdate(ClientContext &context, TableCatalogEntry &table)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE), write_target(context, table), table(table), table_index(0),
       return_chunk(false) {
 }
 

--- a/external/duckdb/src/planner/operator/logical_update.cpp
+++ b/external/duckdb/src/planner/operator/logical_update.cpp
@@ -2,19 +2,18 @@
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/main/config.hpp"
-#include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
 LogicalUpdate::LogicalUpdate(TableCatalogEntry &table)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE), table(table), table_index(0), return_chunk(false) {
+    : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE), write_target(table), table(table), table_index(0),
+      return_chunk(false) {
 }
 
-LogicalUpdate::LogicalUpdate(ClientContext &context, const unique_ptr<CreateInfo> &table_info)
-    : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE),
-      table(Catalog::GetEntry<TableCatalogEntry>(context, table_info->catalog, table_info->schema,
-                                                 table_info->Cast<CreateTableInfo>().table)) {
+LogicalUpdate::LogicalUpdate(ClientContext &context, const LogicalWriteTarget &write_target_p)
+    : LogicalOperator(LogicalOperatorType::LOGICAL_UPDATE), write_target(write_target_p),
+      table(write_target_p.Resolve(context)) {
 	auto binder = Binder::CreateBinder(context);
 	bound_constraints = binder->BindConstraints(table);
 }

--- a/external/duckdb/src/storage/data_table.cpp
+++ b/external/duckdb/src/storage/data_table.cpp
@@ -408,6 +408,7 @@ TableStorageInfo DataTable::GetStorageInfo() {
 	result.cardinality = GetTotalRows();
 	for (auto &index : info->indexes.Indexes()) {
 		IndexInfo index_info;
+		index_info.name = index.GetIndexName();
 		index_info.is_primary = index.IsPrimary();
 		index_info.is_unique = index.IsUnique() || index_info.is_primary;
 		index_info.is_foreign = index.IsForeign();

--- a/external/duckdb/src/storage/serialization/serialize_create_info.cpp
+++ b/external/duckdb/src/storage/serialization/serialize_create_info.cpp
@@ -171,6 +171,7 @@ void CreateTableInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(204, "partition_keys", partition_keys);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(205, "sort_keys", sort_keys);
 	serializer.WritePropertyWithDefault<case_insensitive_map_t<unique_ptr<ParsedExpression>>>(206, "options", options);
+	serializer.WritePropertyWithDefault<string>(207, "logical_write_target_identity", logical_write_target_identity);
 }
 
 unique_ptr<CreateInfo> CreateTableInfo::Deserialize(Deserializer &deserializer) {
@@ -182,6 +183,7 @@ unique_ptr<CreateInfo> CreateTableInfo::Deserialize(Deserializer &deserializer) 
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(204, "partition_keys", result->partition_keys);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<ParsedExpression>>>(205, "sort_keys", result->sort_keys);
 	deserializer.ReadPropertyWithDefault<case_insensitive_map_t<unique_ptr<ParsedExpression>>>(206, "options", result->options);
+	deserializer.ReadPropertyWithDefault<string>(207, "logical_write_target_identity", result->logical_write_target_identity);
 	return std::move(result);
 }
 

--- a/external/duckdb/src/storage/serialization/serialize_logical_operator.cpp
+++ b/external/duckdb/src/storage/serialization/serialize_logical_operator.cpp
@@ -6,8 +6,7 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/planner/operator/list.hpp"
-#include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/planner/logical_write_target.hpp"
 
 namespace duckdb {
 
@@ -118,9 +117,6 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 	case LogicalOperatorType::LOGICAL_FILTER:
 		result = LogicalFilter::Deserialize(deserializer);
 		break;
-	case LogicalOperatorType::LOGICAL_REPARTITION:
-		result = LogicalRepartition::Deserialize(deserializer);
-		break;
 	case LogicalOperatorType::LOGICAL_GET:
 		result = LogicalGet::Deserialize(deserializer);
 		break;
@@ -135,6 +131,9 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 		break;
 	case LogicalOperatorType::LOGICAL_LOAD:
 		result = LogicalSimple::Deserialize(deserializer);
+		break;
+	case LogicalOperatorType::LOGICAL_LOCAL_EXCHANGE:
+		result = LogicalLocalExchange::Deserialize(deserializer);
 		break;
 	case LogicalOperatorType::LOGICAL_MATERIALIZED_CTE:
 		result = LogicalMaterializedCTE::Deserialize(deserializer);
@@ -154,17 +153,11 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 	case LogicalOperatorType::LOGICAL_PROJECTION:
 		result = LogicalProjection::Deserialize(deserializer);
 		break;
-	case LogicalOperatorType::LOGICAL_VLLM_PROJECT:
-		result = LogicalVLLMProject::Deserialize(deserializer);
-		break;
-	case LogicalOperatorType::LOGICAL_UDF_PROJECT:
-		result = LogicalUDFProject::Deserialize(deserializer);
-		break;
-	case LogicalOperatorType::LOGICAL_LOCAL_EXCHANGE:
-		result = LogicalLocalExchange::Deserialize(deserializer);
-		break;
 	case LogicalOperatorType::LOGICAL_RECURSIVE_CTE:
 		result = LogicalRecursiveCTE::Deserialize(deserializer);
+		break;
+	case LogicalOperatorType::LOGICAL_REPARTITION:
+		result = LogicalRepartition::Deserialize(deserializer);
 		break;
 	case LogicalOperatorType::LOGICAL_RESET:
 		result = LogicalReset::Deserialize(deserializer);
@@ -181,6 +174,9 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 	case LogicalOperatorType::LOGICAL_TRANSACTION:
 		result = LogicalSimple::Deserialize(deserializer);
 		break;
+	case LogicalOperatorType::LOGICAL_UDF_PROJECT:
+		result = LogicalUDFProject::Deserialize(deserializer);
+		break;
 	case LogicalOperatorType::LOGICAL_UNION:
 		result = LogicalSetOperation::Deserialize(deserializer);
 		break;
@@ -192,6 +188,9 @@ unique_ptr<LogicalOperator> LogicalOperator::Deserialize(Deserializer &deseriali
 		break;
 	case LogicalOperatorType::LOGICAL_VACUUM:
 		result = LogicalVacuum::Deserialize(deserializer);
+		break;
+	case LogicalOperatorType::LOGICAL_VLLM_PROJECT:
+		result = LogicalVLLMProject::Deserialize(deserializer);
 		break;
 	case LogicalOperatorType::LOGICAL_WINDOW:
 		result = LogicalWindow::Deserialize(deserializer);
@@ -419,15 +418,15 @@ unique_ptr<LogicalOperator> LogicalCrossProduct::Deserialize(Deserializer &deser
 
 void LogicalDelete::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info", table.GetInfo());
+	serializer.WriteProperty<LogicalWriteTarget>(200, "write_target", write_target);
 	serializer.WritePropertyWithDefault<idx_t>(201, "table_index", table_index);
 	serializer.WritePropertyWithDefault<bool>(202, "return_chunk", return_chunk);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
 }
 
 unique_ptr<LogicalOperator> LogicalDelete::Deserialize(Deserializer &deserializer) {
-	auto table_info = deserializer.ReadPropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info");
-	auto result = duckdb::unique_ptr<LogicalDelete>(new LogicalDelete(deserializer.Get<ClientContext &>(), table_info));
+	auto write_target = deserializer.ReadProperty<LogicalWriteTarget>(200, "write_target");
+	auto result = duckdb::unique_ptr<LogicalDelete>(new LogicalDelete(deserializer.Get<ClientContext &>(), write_target));
 	deserializer.ReadPropertyWithDefault<idx_t>(201, "table_index", result->table_index);
 	deserializer.ReadPropertyWithDefault<bool>(202, "return_chunk", result->return_chunk);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
@@ -544,118 +543,9 @@ unique_ptr<LogicalOperator> LogicalFilter::Deserialize(Deserializer &deserialize
 	return std::move(result);
 }
 
-void LogicalRepartition::Serialize(Serializer &serializer) const {
-	LogicalOperator::Serialize(serializer);
-	auto repartition_type =
-	    repartition_spec ? static_cast<uint8_t>(repartition_spec->type())
-	                     : static_cast<uint8_t>(RepartitionSpec::Type::Random);
-	serializer.WriteProperty<uint8_t>(200, "repartition_type", repartition_type);
-
-	optional_idx num_partitions;
-	vector<unique_ptr<Expression>> partition_by;
-
-	if (!expressions.empty()) {
-		partition_by.reserve(expressions.size());
-		for (auto &expr : expressions) {
-			partition_by.push_back(expr->Copy());
-		}
-	}
-
-	if (repartition_spec) {
-		switch (static_cast<RepartitionSpec::Type>(repartition_type)) {
-		case RepartitionSpec::Type::Hash: {
-			auto *hash_spec = dynamic_cast<HashRepartitionSpec *>(repartition_spec.get());
-			if (!hash_spec) {
-				throw InternalException("Expected HashRepartitionSpec for LOGICAL_REPARTITION");
-			}
-			auto &config = hash_spec->config();
-			if (config->num_partitions) {
-				num_partitions = optional_idx(static_cast<idx_t>(config->num_partitions));
-			}
-			break;
-		}
-		case RepartitionSpec::Type::Random: {
-			auto *random_spec = dynamic_cast<RandomRepartitionSpec *>(repartition_spec.get());
-			if (!random_spec) {
-				throw InternalException("Expected RandomRepartitionSpec for LOGICAL_REPARTITION");
-			}
-			auto &config = random_spec->config();
-			if (config->num_partitions) {
-				num_partitions = optional_idx(static_cast<idx_t>(config->num_partitions));
-			}
-			break;
-		}
-		case RepartitionSpec::Type::IntoPartitions: {
-			auto *into_spec = dynamic_cast<IntoPartitionsRepartitionSpec *>(repartition_spec.get());
-			if (!into_spec) {
-				throw InternalException("Expected IntoPartitionsRepartitionSpec for LOGICAL_REPARTITION");
-			}
-			auto &config = into_spec->config();
-			num_partitions = optional_idx(static_cast<idx_t>(config->num_partitions));
-			break;
-		}
-		case RepartitionSpec::Type::Range:
-			throw NotImplementedException("Range repartition serialization is not supported");
-		}
-	}
-
-	serializer.WritePropertyWithDefault<optional_idx>(201, "num_partitions", num_partitions);
-	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(202, "partition_by", partition_by);
-}
-
-unique_ptr<LogicalOperator> LogicalRepartition::Deserialize(Deserializer &deserializer) {
-	auto repartition_type_val = deserializer.ReadProperty<uint8_t>(200, "repartition_type");
-	auto num_partitions = deserializer.ReadPropertyWithDefault<optional_idx>(201, "num_partitions");
-	auto partition_by = deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(202, "partition_by");
-
-	size_t num_partitions_val = 0;
-	if (num_partitions.IsValid()) {
-		num_partitions_val = static_cast<size_t>(num_partitions.GetIndex());
-	}
-
-	vector<unique_ptr<Expression>> bound_partition_exprs;
-	if (!partition_by.empty()) {
-		bound_partition_exprs.reserve(partition_by.size());
-		for (auto &expr : partition_by) {
-			bound_partition_exprs.push_back(expr->Copy());
-		}
-	}
-
-	std::shared_ptr<RepartitionSpec> spec;
-	auto repartition_type = static_cast<RepartitionSpec::Type>(repartition_type_val);
-	switch (repartition_type) {
-	case RepartitionSpec::Type::Hash: {
-		vector<ExprRef> expr_refs;
-		expr_refs.reserve(partition_by.size());
-		for (auto &expr : partition_by) {
-			expr_refs.emplace_back(expr.release());
-		}
-		spec = RepartitionSpec::create_hash(num_partitions_val, std::move(expr_refs));
-		break;
-	}
-	case RepartitionSpec::Type::Random:
-		spec = RepartitionSpec::create_random(num_partitions_val);
-		break;
-	case RepartitionSpec::Type::IntoPartitions:
-		if (!num_partitions_val) {
-			throw InternalException("Missing num_partitions for IntoPartitions repartition");
-		}
-		spec = RepartitionSpec::create_into_partitions(num_partitions_val);
-		break;
-	case RepartitionSpec::Type::Range:
-		throw NotImplementedException("Range repartition deserialization is not supported");
-	default:
-		throw InternalException("Unknown repartition type for LOGICAL_REPARTITION");
-	}
-
-	auto result = duckdb::unique_ptr<LogicalRepartition>(new LogicalRepartition(std::move(spec)));
-	result->expressions = std::move(bound_partition_exprs);
-	return std::move(result);
-}
-
 void LogicalInsert::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info", table.GetInfo());
+	serializer.WriteProperty<LogicalWriteTarget>(200, "write_target", write_target);
 	serializer.WritePropertyWithDefault<vector<vector<unique_ptr<Expression>>>>(201, "insert_values", insert_values);
 	serializer.WriteProperty<IndexVector<idx_t, PhysicalIndex>>(202, "column_index_map", column_index_map);
 	serializer.WritePropertyWithDefault<vector<LogicalType>>(203, "expected_types", expected_types);
@@ -677,8 +567,8 @@ void LogicalInsert::Serialize(Serializer &serializer) const {
 }
 
 unique_ptr<LogicalOperator> LogicalInsert::Deserialize(Deserializer &deserializer) {
-	auto table_info = deserializer.ReadPropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info");
-	auto result = duckdb::unique_ptr<LogicalInsert>(new LogicalInsert(deserializer.Get<ClientContext &>(), std::move(table_info)));
+	auto write_target = deserializer.ReadProperty<LogicalWriteTarget>(200, "write_target");
+	auto result = duckdb::unique_ptr<LogicalInsert>(new LogicalInsert(deserializer.Get<ClientContext &>(), write_target));
 	deserializer.ReadPropertyWithDefault<vector<vector<unique_ptr<Expression>>>>(201, "insert_values", result->insert_values);
 	deserializer.ReadProperty<IndexVector<idx_t, PhysicalIndex>>(202, "column_index_map", result->column_index_map);
 	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(203, "expected_types", result->expected_types);
@@ -732,7 +622,7 @@ unique_ptr<LogicalOperator> LogicalMaterializedCTE::Deserialize(Deserializer &de
 
 void LogicalMergeInto::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info", table.GetInfo());
+	serializer.WriteProperty<LogicalWriteTarget>(200, "write_target", write_target);
 	serializer.WritePropertyWithDefault<idx_t>(201, "table_index", table_index);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(202, "bound_defaults", bound_defaults);
 	serializer.WritePropertyWithDefault<idx_t>(203, "row_id_start", row_id_start);
@@ -742,8 +632,8 @@ void LogicalMergeInto::Serialize(Serializer &serializer) const {
 }
 
 unique_ptr<LogicalOperator> LogicalMergeInto::Deserialize(Deserializer &deserializer) {
-	auto table_info = deserializer.ReadPropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info");
-	auto result = duckdb::unique_ptr<LogicalMergeInto>(new LogicalMergeInto(deserializer.Get<ClientContext &>(), table_info));
+	auto write_target = deserializer.ReadProperty<LogicalWriteTarget>(200, "write_target");
+	auto result = duckdb::unique_ptr<LogicalMergeInto>(new LogicalMergeInto(deserializer.Get<ClientContext &>(), write_target));
 	deserializer.ReadPropertyWithDefault<idx_t>(201, "table_index", result->table_index);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(202, "bound_defaults", result->bound_defaults);
 	deserializer.ReadPropertyWithDefault<idx_t>(203, "row_id_start", result->row_id_start);
@@ -798,47 +688,6 @@ unique_ptr<LogicalOperator> LogicalProjection::Deserialize(Deserializer &deseria
 	auto table_index = deserializer.ReadPropertyWithDefault<idx_t>(200, "table_index");
 	auto expressions = deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(201, "expressions");
 	auto result = duckdb::unique_ptr<LogicalProjection>(new LogicalProjection(table_index, std::move(expressions)));
-	return std::move(result);
-}
-
-void LogicalVLLMProject::Serialize(Serializer &serializer) const {
-	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<idx_t>(200, "table_index", table_index);
-	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(201, "vllm_expr", vllm_expr);
-	serializer.WritePropertyWithDefault<string>(202, "output_column_name", output_column_name);
-}
-
-unique_ptr<LogicalOperator> LogicalVLLMProject::Deserialize(Deserializer &deserializer) {
-	auto table_index = deserializer.ReadPropertyWithDefault<idx_t>(200, "table_index");
-	auto vllm_expr = deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(201, "vllm_expr");
-	auto output_column_name = deserializer.ReadPropertyWithDefault<string>(202, "output_column_name");
-	auto result = duckdb::unique_ptr<LogicalVLLMProject>(new LogicalVLLMProject(table_index, std::move(vllm_expr), std::move(output_column_name)));
-	return std::move(result);
-}
-
-void LogicalUDFProject::Serialize(Serializer &serializer) const {
-	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<idx_t>(200, "table_index", table_index);
-	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(201, "udf_expr", udf_expr);
-	serializer.WritePropertyWithDefault<string>(202, "output_column_name", output_column_name);
-	serializer.WritePropertyWithDefault<bool>(203, "is_flat_map", is_flat_map);
-	serializer.WritePropertyWithDefault<vector<LogicalType>>(204, "flat_map_output_types", flat_map_output_types);
-	serializer.WritePropertyWithDefault<vector<string>>(205, "flat_map_output_names", flat_map_output_names);
-	serializer.WritePropertyWithDefault<bool>(206, "is_scalar_map", is_scalar_map);
-	serializer.WritePropertyWithDefault<bool>(207, "is_row_preserving_batch", is_row_preserving_batch);
-}
-
-unique_ptr<LogicalOperator> LogicalUDFProject::Deserialize(Deserializer &deserializer) {
-	auto table_index = deserializer.ReadPropertyWithDefault<idx_t>(200, "table_index");
-	auto udf_expr = deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(201, "udf_expr");
-	auto output_column_name = deserializer.ReadPropertyWithDefault<string>(202, "output_column_name");
-	auto result = duckdb::unique_ptr<LogicalUDFProject>(
-	    new LogicalUDFProject(table_index, std::move(udf_expr), std::move(output_column_name)));
-	result->is_flat_map = deserializer.ReadPropertyWithDefault<bool>(203, "is_flat_map");
-	result->flat_map_output_types = deserializer.ReadPropertyWithDefault<vector<LogicalType>>(204, "flat_map_output_types");
-	result->flat_map_output_names = deserializer.ReadPropertyWithDefault<vector<string>>(205, "flat_map_output_names");
-	result->is_scalar_map = deserializer.ReadPropertyWithDefault<bool>(206, "is_scalar_map");
-	result->is_row_preserving_batch = deserializer.ReadPropertyWithDefault<bool>(207, "is_row_preserving_batch");
 	return std::move(result);
 }
 
@@ -945,6 +794,31 @@ unique_ptr<LogicalOperator> LogicalTopN::Deserialize(Deserializer &deserializer)
 	return std::move(result);
 }
 
+void LogicalUDFProject::Serialize(Serializer &serializer) const {
+	LogicalOperator::Serialize(serializer);
+	serializer.WritePropertyWithDefault<idx_t>(200, "table_index", table_index);
+	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(201, "udf_expr", udf_expr);
+	serializer.WritePropertyWithDefault<string>(202, "output_column_name", output_column_name);
+	serializer.WritePropertyWithDefault<bool>(203, "is_flat_map", is_flat_map);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(204, "flat_map_output_types", flat_map_output_types);
+	serializer.WritePropertyWithDefault<vector<string>>(205, "flat_map_output_names", flat_map_output_names);
+	serializer.WritePropertyWithDefault<bool>(206, "is_scalar_map", is_scalar_map);
+	serializer.WritePropertyWithDefault<bool>(207, "is_row_preserving_batch", is_row_preserving_batch);
+}
+
+unique_ptr<LogicalOperator> LogicalUDFProject::Deserialize(Deserializer &deserializer) {
+	auto table_index = deserializer.ReadPropertyWithDefault<idx_t>(200, "table_index");
+	auto udf_expr = deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(201, "udf_expr");
+	auto output_column_name = deserializer.ReadPropertyWithDefault<string>(202, "output_column_name");
+	auto result = duckdb::unique_ptr<LogicalUDFProject>(new LogicalUDFProject(table_index, std::move(udf_expr), std::move(output_column_name)));
+	deserializer.ReadPropertyWithDefault<bool>(203, "is_flat_map", result->is_flat_map);
+	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(204, "flat_map_output_types", result->flat_map_output_types);
+	deserializer.ReadPropertyWithDefault<vector<string>>(205, "flat_map_output_names", result->flat_map_output_names);
+	deserializer.ReadPropertyWithDefault<bool>(206, "is_scalar_map", result->is_scalar_map);
+	deserializer.ReadPropertyWithDefault<bool>(207, "is_row_preserving_batch", result->is_row_preserving_batch);
+	return std::move(result);
+}
+
 void LogicalUnnest::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
 	serializer.WritePropertyWithDefault<idx_t>(200, "unnest_index", unnest_index);
@@ -960,7 +834,7 @@ unique_ptr<LogicalOperator> LogicalUnnest::Deserialize(Deserializer &deserialize
 
 void LogicalUpdate::Serialize(Serializer &serializer) const {
 	LogicalOperator::Serialize(serializer);
-	serializer.WritePropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info", table.GetInfo());
+	serializer.WriteProperty<LogicalWriteTarget>(200, "write_target", write_target);
 	serializer.WritePropertyWithDefault<idx_t>(201, "table_index", table_index);
 	serializer.WritePropertyWithDefault<bool>(202, "return_chunk", return_chunk);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", expressions);
@@ -970,14 +844,29 @@ void LogicalUpdate::Serialize(Serializer &serializer) const {
 }
 
 unique_ptr<LogicalOperator> LogicalUpdate::Deserialize(Deserializer &deserializer) {
-	auto table_info = deserializer.ReadPropertyWithDefault<unique_ptr<CreateInfo>>(200, "table_info");
-	auto result = duckdb::unique_ptr<LogicalUpdate>(new LogicalUpdate(deserializer.Get<ClientContext &>(), table_info));
+	auto write_target = deserializer.ReadProperty<LogicalWriteTarget>(200, "write_target");
+	auto result = duckdb::unique_ptr<LogicalUpdate>(new LogicalUpdate(deserializer.Get<ClientContext &>(), write_target));
 	deserializer.ReadPropertyWithDefault<idx_t>(201, "table_index", result->table_index);
 	deserializer.ReadPropertyWithDefault<bool>(202, "return_chunk", result->return_chunk);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(203, "expressions", result->expressions);
 	deserializer.ReadPropertyWithDefault<vector<PhysicalIndex>>(204, "columns", result->columns);
 	deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(205, "bound_defaults", result->bound_defaults);
 	deserializer.ReadPropertyWithDefault<bool>(206, "update_is_del_and_insert", result->update_is_del_and_insert);
+	return std::move(result);
+}
+
+void LogicalVLLMProject::Serialize(Serializer &serializer) const {
+	LogicalOperator::Serialize(serializer);
+	serializer.WritePropertyWithDefault<idx_t>(200, "table_index", table_index);
+	serializer.WritePropertyWithDefault<unique_ptr<Expression>>(201, "vllm_expr", vllm_expr);
+	serializer.WritePropertyWithDefault<string>(202, "output_column_name", output_column_name);
+}
+
+unique_ptr<LogicalOperator> LogicalVLLMProject::Deserialize(Deserializer &deserializer) {
+	auto table_index = deserializer.ReadPropertyWithDefault<idx_t>(200, "table_index");
+	auto vllm_expr = deserializer.ReadPropertyWithDefault<unique_ptr<Expression>>(201, "vllm_expr");
+	auto output_column_name = deserializer.ReadPropertyWithDefault<string>(202, "output_column_name");
+	auto result = duckdb::unique_ptr<LogicalVLLMProject>(new LogicalVLLMProject(table_index, std::move(vllm_expr), std::move(output_column_name)));
 	return std::move(result);
 }
 

--- a/external/duckdb/src/storage/serialization/serialize_parse_info.cpp
+++ b/external/duckdb/src/storage/serialization/serialize_parse_info.cpp
@@ -472,6 +472,7 @@ void RemoveColumnInfo::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(400, "removed_column", removed_column);
 	serializer.WritePropertyWithDefault<bool>(401, "if_column_exists", if_column_exists);
 	serializer.WritePropertyWithDefault<bool>(402, "cascade", cascade);
+	serializer.WritePropertyWithDefault<string>(403, "new_logical_write_target_identity", new_logical_write_target_identity);
 }
 
 unique_ptr<AlterTableInfo> RemoveColumnInfo::Deserialize(Deserializer &deserializer) {
@@ -479,6 +480,7 @@ unique_ptr<AlterTableInfo> RemoveColumnInfo::Deserialize(Deserializer &deseriali
 	deserializer.ReadPropertyWithDefault<string>(400, "removed_column", result->removed_column);
 	deserializer.ReadPropertyWithDefault<bool>(401, "if_column_exists", result->if_column_exists);
 	deserializer.ReadPropertyWithDefault<bool>(402, "cascade", result->cascade);
+	deserializer.ReadPropertyWithDefault<string>(403, "new_logical_write_target_identity", result->new_logical_write_target_identity);
 	return std::move(result);
 }
 

--- a/external/duckdb/test/api/test_plan_serialization.cpp
+++ b/external/duckdb/test/api/test_plan_serialization.cpp
@@ -5,18 +5,27 @@
 // Modified by Vane contributors.
 
 #include "catch.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/execution/operator/exchange/repartition.hpp"
 #include "duckdb/main/relation.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/planner/planner.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_local_exchange.hpp"
+#include "duckdb/planner/operator/logical_repartition.hpp"
+#include "duckdb/planner/logical_write_target.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/parser/parser.hpp"
 
 #include <map>
 #include <set>
+#include <tuple>
 
 using namespace duckdb;
 using namespace std;
@@ -35,6 +44,65 @@ static const LogicalLocalExchange *FindLocalExchange(const LogicalOperator &op) 
 		}
 	}
 	return nullptr;
+}
+
+static const LogicalRepartition *FindRepartition(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_REPARTITION) {
+		return &op.Cast<LogicalRepartition>();
+	}
+	for (auto &child : op.children) {
+		if (!child) {
+			continue;
+		}
+		auto result = FindRepartition(*child);
+		if (result) {
+			return result;
+		}
+	}
+	return nullptr;
+}
+
+static string SerializeUnoptimizedPlan(Connection &con, const string &sql) {
+	string serialized_plan;
+	con.context->RunFunctionInTransaction([&]() {
+		Parser parser;
+		parser.ParseQuery(sql);
+		if (parser.statements.size() != 1) {
+			throw InternalException("Expected exactly one statement in serialization test");
+		}
+		Planner planner(*con.context);
+		planner.CreatePlan(std::move(parser.statements[0]));
+
+		MemoryStream stream(Allocator::Get(*con.context));
+		SerializationOptions options;
+		options.serialization_compatibility = SerializationCompatibility::Latest();
+		options.serialize_default_values = true;
+		BinarySerializer::Serialize(*planner.plan, stream, options);
+		serialized_plan.assign(reinterpret_cast<const char *>(stream.GetData()), stream.GetPosition());
+	});
+	return serialized_plan;
+}
+
+static duckdb::unique_ptr<LogicalOperator> DeserializePlan(Connection &con, const string &serialized_plan) {
+	duckdb::unique_ptr<LogicalOperator> result;
+	con.context->RunFunctionInTransaction([&]() {
+		MemoryStream stream(Allocator::Get(*con.context));
+		stream.WriteData(const_data_ptr_cast(serialized_plan.data()), serialized_plan.size());
+		stream.Rewind();
+		bound_parameter_map_t parameters;
+		result = BinaryDeserializer::Deserialize<LogicalOperator>(stream, *con.context, parameters);
+	});
+	return result;
+}
+
+static string GetTableWriteIdentity(Connection &con, const string &table_name,
+                                    const string &catalog_name = INVALID_CATALOG) {
+	string result;
+	con.context->RunFunctionInTransaction([&]() {
+		auto &table = Catalog::GetEntry<TableCatalogEntry>(*con.context, catalog_name, DEFAULT_SCHEMA, table_name);
+		result = table.GetLogicalWriteTargetIdentity();
+	});
+	return result;
 }
 
 static void test_helper(string sql, duckdb::vector<string> fixtures = duckdb::vector<string>()) {
@@ -143,6 +211,200 @@ TEST_CASE("Test logical_delete", "[serialization]") {
 
 TEST_CASE("Test logical_update", "[serialization]") {
 	test_helper("UPDATE tbl SET foo=42", {"CREATE TABLE tbl (foo INTEGER)"});
+}
+
+TEST_CASE("Test logical_merge_into", "[serialization]") {
+	test_helper("MERGE INTO tbl USING (VALUES (1)) src(foo) USING (foo) WHEN MATCHED THEN UPDATE",
+	            {"CREATE TABLE tbl (foo INTEGER)"});
+}
+
+TEST_CASE("Serialized DML rejects a replacement at the same catalog path", "[serialization][dml]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
+
+	for (auto &sql : duckdb::vector<string> {
+	         "INSERT INTO target VALUES (1)",
+	         "UPDATE target SET i = 2",
+	         "DELETE FROM target",
+	         "MERGE INTO target USING (VALUES (1)) src(i) USING (i) WHEN MATCHED THEN UPDATE",
+	     }) {
+		auto serialized_plan = SerializeUnoptimizedPlan(con, sql);
+		REQUIRE_NO_FAIL(con.Query("DROP TABLE target"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
+		REQUIRE_THROWS_WITH(DeserializePlan(con, serialized_plan), Catch::Matchers::Contains("was replaced"));
+	}
+}
+
+TEST_CASE("Duck table write identity survives alter and persistence but not replacement", "[serialization][dml]") {
+	auto db_path = TestCreatePath("logical_write_target_identity.db");
+	string original_identity;
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
+		original_identity = GetTableWriteIdentity(con, "target");
+		REQUIRE(!original_identity.empty());
+
+		auto serialized_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET i = 2");
+		REQUIRE_NO_FAIL(con.Query("ALTER TABLE target ADD COLUMN j INTEGER"));
+		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+		REQUIRE(DeserializePlan(con, serialized_plan) != nullptr);
+		REQUIRE_NO_FAIL(con.Query("PRAGMA force_checkpoint"));
+	}
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+		REQUIRE_NO_FAIL(con.Query("SET wal_autocheckpoint = '1TB'"));
+		REQUIRE_NO_FAIL(con.Query("PRAGMA disable_checkpoint_on_shutdown"));
+		REQUIRE_NO_FAIL(con.Query("ALTER TABLE target RENAME COLUMN j TO k"));
+		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+	}
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+		REQUIRE_NO_FAIL(con.Query("DROP TABLE target"));
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
+		REQUIRE(GetTableWriteIdentity(con, "target") != original_identity);
+	}
+}
+
+TEST_CASE("Copy database assigns a new table write identity", "[serialization][dml]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("ATTACH ':memory:' AS source"));
+	REQUIRE_NO_FAIL(con.Query("ATTACH ':memory:' AS target"));
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE source.main.target(i INTEGER)"));
+
+	auto source_identity = GetTableWriteIdentity(con, "target", "source");
+	REQUIRE(!source_identity.empty());
+	REQUIRE_NO_FAIL(con.Query("COPY FROM DATABASE source TO target (SCHEMA)"));
+	auto copied_identity = GetTableWriteIdentity(con, "target", "target");
+	REQUIRE(!copied_identity.empty());
+	REQUIRE(copied_identity != source_identity);
+}
+
+TEST_CASE("Logical write targets require a non-empty identity", "[serialization][dml]") {
+	MemoryStream stream;
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	serializer.WriteProperty<string>(100, "catalog_name", "memory");
+	serializer.WriteProperty<string>(101, "schema_name", "main");
+	serializer.WriteProperty<string>(102, "table_name", "target");
+	serializer.WriteProperty<string>(103, "identity", "");
+	serializer.End();
+	stream.Rewind();
+
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	REQUIRE_THROWS_WITH(LogicalWriteTarget::Deserialize(deserializer),
+	                    Catch::Matchers::Contains("does not provide a logical write target identity"));
+}
+
+TEST_CASE("Logical repartition round-trips hash random and into-partitions modes", "[serialization][repartition]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE integers(i INTEGER)"));
+
+	for (auto &test_case : duckdb::vector<std::tuple<idx_t, duckdb::vector<string>, RepartitionSpec::Type>> {
+	         {3, {"i"}, RepartitionSpec::Type::Hash},
+	         {0, {"i"}, RepartitionSpec::Type::Hash},
+	         {3, {}, RepartitionSpec::Type::Random},
+	         {0, {}, RepartitionSpec::Type::Random},
+	     }) {
+		auto num_partitions = std::get<0>(test_case);
+		auto partition_by = std::get<1>(test_case);
+		auto expected_type = std::get<2>(test_case);
+		auto relation = con.Table("integers")->Repartition(num_partitions, partition_by);
+		con.context->RunFunctionInTransaction([&]() {
+			auto binder = Binder::CreateBinder(*con.context);
+			auto bound = relation->Bind(*binder);
+			auto copied_plan = bound.plan->Copy(*con.context);
+			auto repartition = FindRepartition(*copied_plan);
+			REQUIRE(repartition != nullptr);
+			REQUIRE(repartition->repartition_spec->type() == expected_type);
+			if (expected_type == RepartitionSpec::Type::Hash) {
+				auto *hash_spec = dynamic_cast<HashRepartitionSpec *>(repartition->repartition_spec.get());
+				REQUIRE(hash_spec != nullptr);
+				REQUIRE(hash_spec->config()->num_partitions == num_partitions);
+				REQUIRE(hash_spec->config()->by.size() == 1);
+				REQUIRE(repartition->expressions.size() == 1);
+			} else {
+				auto *random_spec = dynamic_cast<RandomRepartitionSpec *>(repartition->repartition_spec.get());
+				REQUIRE(random_spec != nullptr);
+				REQUIRE(random_spec->config()->num_partitions == num_partitions);
+				REQUIRE(repartition->expressions.empty());
+			}
+			PhysicalPlanGenerator physical_planner(*con.context);
+			REQUIRE(physical_planner.Plan(std::move(copied_plan)) != nullptr);
+		});
+	}
+
+	auto relation = con.Table("integers");
+	con.context->RunFunctionInTransaction([&]() {
+		auto binder = Binder::CreateBinder(*con.context);
+		auto bound = relation->Bind(*binder);
+		auto into = make_uniq<LogicalRepartition>(RepartitionSpec::create_into_partitions(5));
+		into->children.push_back(std::move(bound.plan));
+		auto copied_into = into->Copy(*con.context);
+		auto repartition = FindRepartition(*copied_into);
+		REQUIRE(repartition != nullptr);
+		REQUIRE(repartition->repartition_spec->type() == RepartitionSpec::Type::IntoPartitions);
+		auto *into_spec = dynamic_cast<IntoPartitionsRepartitionSpec *>(repartition->repartition_spec.get());
+		REQUIRE(into_spec != nullptr);
+		REQUIRE(into_spec->config()->num_partitions == 5);
+		REQUIRE(repartition->expressions.empty());
+		PhysicalPlanGenerator physical_planner(*con.context);
+		REQUIRE(physical_planner.Plan(std::move(copied_into)) != nullptr);
+	});
+}
+
+TEST_CASE("Logical repartition rejects unsupported and malformed wire states", "[serialization][repartition]") {
+	{
+		LogicalRepartition missing_spec(nullptr);
+		MemoryStream stream;
+		REQUIRE_THROWS_WITH(BinarySerializer::Serialize(missing_spec, stream),
+		                    Catch::Matchers::Contains("missing its repartition specification"));
+	}
+	{
+		duckdb::vector<ExprRef> config_expressions;
+		config_expressions.push_back(std::make_shared<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+		LogicalRepartition inconsistent_hash(RepartitionSpec::create_hash(2, std::move(config_expressions)));
+		inconsistent_hash.expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 1));
+		MemoryStream stream;
+		REQUIRE_THROWS_WITH(BinarySerializer::Serialize(inconsistent_hash, stream),
+		                    Catch::Matchers::Contains("inconsistent partition expressions"));
+	}
+	{
+		duckdb::vector<BoundOrderByNode> orders;
+		orders.emplace_back(OrderType::ASCENDING, OrderByNullType::NULLS_LAST,
+		                    make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+		LogicalRepartition range(RepartitionSpec::create_range(2, std::move(orders), {}));
+		MemoryStream stream;
+		REQUIRE_THROWS_WITH(BinarySerializer::Serialize(range, stream),
+		                    Catch::Matchers::Contains("Range repartition cannot be serialized"));
+	}
+
+	auto deserialize_wire = [](uint8_t wire_type, uint64_t num_partitions) {
+		MemoryStream stream;
+		BinarySerializer serializer(stream);
+		serializer.Begin();
+		serializer.WriteProperty<uint8_t>(200, "repartition_type", wire_type);
+		serializer.WriteProperty<uint64_t>(201, "num_partitions", num_partitions);
+		serializer.WriteProperty<duckdb::vector<duckdb::unique_ptr<Expression>>>(202, "partition_by", {});
+		serializer.End();
+		stream.Rewind();
+		BinaryDeserializer deserializer(stream);
+		deserializer.Begin();
+		return LogicalRepartition::Deserialize(deserializer);
+	};
+
+	REQUIRE_THROWS_WITH(deserialize_wire(1, 3), Catch::Matchers::Contains("requires at least one"));
+	REQUIRE_THROWS_WITH(deserialize_wire(3, 0), Catch::Matchers::Contains("requires a positive partition count"));
+	REQUIRE_THROWS_WITH(deserialize_wire(4, 3), Catch::Matchers::Contains("Range repartition cannot be deserialized"));
+	REQUIRE_THROWS_WITH(deserialize_wire(99, 3), Catch::Matchers::Contains("unknown wire repartition type"));
 }
 
 // TODO(stephwang): revisit this later since it doesn't work yet

--- a/external/duckdb/test/api/test_plan_serialization.cpp
+++ b/external/duckdb/test/api/test_plan_serialization.cpp
@@ -344,6 +344,21 @@ TEST_CASE("Serialized DML rejects changed index state", "[serialization][dml]") 
 	REQUIRE_THROWS_WITH(DeserializePlan(con, with_index_plan), Catch::Matchers::Contains("definition changed"));
 }
 
+TEST_CASE("Serialized DML rejects changed index expressions", "[serialization][dml]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(a INTEGER)"));
+	REQUIRE_NO_FAIL(con.Query("CREATE UNIQUE INDEX target_expr_idx ON target((a % 2))"));
+
+	auto modulo_two_definition = GetTableWriteDefinition(con, "target");
+	auto modulo_two_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET a = 99");
+	REQUIRE_NO_FAIL(con.Query("DROP INDEX target_expr_idx"));
+	REQUIRE_NO_FAIL(con.Query("CREATE UNIQUE INDEX target_expr_idx ON target((a % 3))"));
+
+	REQUIRE(GetTableWriteDefinition(con, "target") != modulo_two_definition);
+	REQUIRE_THROWS_WITH(DeserializePlan(con, modulo_two_plan), Catch::Matchers::Contains("definition changed"));
+}
+
 TEST_CASE("Copy database assigns a new table write identity", "[serialization][dml]") {
 	DuckDB db;
 	Connection con(db);

--- a/external/duckdb/test/api/test_plan_serialization.cpp
+++ b/external/duckdb/test/api/test_plan_serialization.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/planner/planner.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/operator/logical_local_exchange.hpp"
 #include "duckdb/planner/operator/logical_repartition.hpp"
 #include "duckdb/planner/logical_write_target.hpp"
@@ -97,6 +98,38 @@ static duckdb::unique_ptr<LogicalOperator> DeserializePlan(Connection &con, cons
 		result = BinaryDeserializer::Deserialize<LogicalOperator>(stream, *con.context, parameters);
 	});
 	return result;
+}
+
+static string SerializeCreatePlanWithIdentity(Connection &con, const string &identity) {
+	string serialized_plan;
+	con.context->RunFunctionInTransaction([&]() {
+		Parser parser;
+		parser.ParseQuery("CREATE TABLE target(a INTEGER)");
+		Planner planner(*con.context);
+		planner.CreatePlan(std::move(parser.statements[0]));
+		auto &create = planner.plan->Cast<LogicalCreateTable>();
+		create.info->Base().logical_write_target_identity = identity;
+
+		MemoryStream stream(Allocator::Get(*con.context));
+		SerializationOptions options;
+		options.serialization_compatibility = SerializationCompatibility::Latest();
+		options.serialize_default_values = true;
+		BinarySerializer::Serialize(*planner.plan, stream, options);
+		serialized_plan.assign(reinterpret_cast<const char *>(stream.GetData()), stream.GetPosition());
+	});
+	return serialized_plan;
+}
+
+static void MaterializeSerializedCreatePlan(Connection &con, const string &serialized_plan) {
+	auto plan = DeserializePlan(con, serialized_plan);
+	auto &create = plan->Cast<LogicalCreateTable>();
+	con.context->RunFunctionInTransaction([&]() {
+		auto &catalog = create.schema.catalog;
+		auto &transaction = MetaTransaction::Get(*con.context);
+		transaction.ModifyDatabase(catalog.GetAttached(), DatabaseModificationType::CREATE_CATALOG_ENTRY);
+		REQUIRE(catalog.CreateTable(catalog.GetCatalogTransaction(*con.context), create.schema, *create.info) !=
+		        nullptr);
+	});
 }
 
 static string GetTableWriteIdentity(Connection &con, const string &table_name,
@@ -250,6 +283,25 @@ TEST_CASE("Serialized DML rejects a replacement at the same catalog path", "[ser
 	}
 }
 
+TEST_CASE("Materializing a serialized CREATE TABLE assigns a fresh write identity", "[serialization][dml]") {
+	DuckDB db;
+	Connection con(db);
+	auto serialized_create = SerializeCreatePlanWithIdentity(con, "reused-serialized-identity");
+
+	MaterializeSerializedCreatePlan(con, serialized_create);
+	auto first_identity = GetTableWriteIdentity(con, "target");
+	REQUIRE(!first_identity.empty());
+	REQUIRE(first_identity != "reused-serialized-identity");
+	auto first_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET a = 2");
+
+	REQUIRE_NO_FAIL(con.Query("DROP TABLE target"));
+	MaterializeSerializedCreatePlan(con, serialized_create);
+	auto second_identity = GetTableWriteIdentity(con, "target");
+	REQUIRE(!second_identity.empty());
+	REQUIRE(second_identity != first_identity);
+	REQUIRE_THROWS_WITH(DeserializePlan(con, first_plan), Catch::Matchers::Contains("was replaced"));
+}
+
 TEST_CASE("Duck table write target state survives persistence and detects definition changes", "[serialization][dml]") {
 	auto db_path = TestCreatePath("logical_write_target_identity.db");
 	string original_identity;
@@ -324,6 +376,36 @@ TEST_CASE("Serialized DML rejects a remapped physical column", "[serialization][
 	REQUIRE(GetTableWriteIdentity(con, "target") != original_identity);
 	REQUIRE(GetTableWriteDefinition(con, "target") != original_definition);
 	REQUIRE_THROWS_WITH(DeserializePlan(con, serialized_plan), Catch::Matchers::Contains("was replaced"));
+}
+
+TEST_CASE("DROP COLUMN write identity survives WAL replay", "[serialization][dml]") {
+	auto db_path = TestCreatePath("logical_write_target_drop_column_wal.db");
+	string post_drop_identity;
+	string post_drop_definition;
+	string post_drop_plan;
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(a INTEGER, b INTEGER)"));
+		auto original_identity = GetTableWriteIdentity(con, "target");
+		REQUIRE_NO_FAIL(con.Query("PRAGMA force_checkpoint"));
+		REQUIRE_NO_FAIL(con.Query("SET wal_autocheckpoint = '1TB'"));
+		REQUIRE_NO_FAIL(con.Query("PRAGMA disable_checkpoint_on_shutdown"));
+		REQUIRE_NO_FAIL(con.Query("ALTER TABLE target DROP COLUMN a"));
+		post_drop_identity = GetTableWriteIdentity(con, "target");
+		REQUIRE(!post_drop_identity.empty());
+		REQUIRE(post_drop_identity != original_identity);
+		post_drop_definition = GetTableWriteDefinition(con, "target");
+		post_drop_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET b = 3");
+		REQUIRE(DeserializePlan(con, post_drop_plan) != nullptr);
+	}
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		REQUIRE(GetTableWriteIdentity(con, "target") == post_drop_identity);
+		REQUIRE(GetTableWriteDefinition(con, "target") == post_drop_definition);
+		REQUIRE(DeserializePlan(con, post_drop_plan) != nullptr);
+	}
 }
 
 TEST_CASE("Serialized DML rejects changed index state", "[serialization][dml]") {

--- a/external/duckdb/test/api/test_plan_serialization.cpp
+++ b/external/duckdb/test/api/test_plan_serialization.cpp
@@ -7,6 +7,7 @@
 #include "catch.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/enums/database_modification_type.hpp"
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/binary_serializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
@@ -20,8 +21,11 @@
 #include "duckdb/planner/operator/logical_local_exchange.hpp"
 #include "duckdb/planner/operator/logical_repartition.hpp"
 #include "duckdb/planner/logical_write_target.hpp"
+#include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
+#include "duckdb/transaction/meta_transaction.hpp"
 #include "test_helpers.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
 
 #include <map>
 #include <set>
@@ -101,6 +105,16 @@ static string GetTableWriteIdentity(Connection &con, const string &table_name,
 	con.context->RunFunctionInTransaction([&]() {
 		auto &table = Catalog::GetEntry<TableCatalogEntry>(*con.context, catalog_name, DEFAULT_SCHEMA, table_name);
 		result = table.GetLogicalWriteTargetIdentity();
+	});
+	return result;
+}
+
+static string GetTableWriteDefinition(Connection &con, const string &table_name,
+                                      const string &catalog_name = INVALID_CATALOG) {
+	string result;
+	con.context->RunFunctionInTransaction([&]() {
+		auto &table = Catalog::GetEntry<TableCatalogEntry>(*con.context, catalog_name, DEFAULT_SCHEMA, table_name);
+		result = table.GetLogicalWriteTargetDefinition(*con.context);
 	});
 	return result;
 }
@@ -236,39 +250,98 @@ TEST_CASE("Serialized DML rejects a replacement at the same catalog path", "[ser
 	}
 }
 
-TEST_CASE("Duck table write identity survives alter and persistence but not replacement", "[serialization][dml]") {
+TEST_CASE("Duck table write target state survives persistence and detects definition changes", "[serialization][dml]") {
 	auto db_path = TestCreatePath("logical_write_target_identity.db");
 	string original_identity;
+	string altered_definition;
+	string altered_plan;
+	string unindexed_definition;
+	string unindexed_plan;
+	string renamed_definition;
+	string renamed_plan;
 	{
 		DuckDB db(db_path);
 		Connection con(db);
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
 		original_identity = GetTableWriteIdentity(con, "target");
 		REQUIRE(!original_identity.empty());
+		auto original_definition = GetTableWriteDefinition(con, "target");
+		REQUIRE(!original_definition.empty());
 
 		auto serialized_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET i = 2");
 		REQUIRE_NO_FAIL(con.Query("ALTER TABLE target ADD COLUMN j INTEGER"));
+		REQUIRE_NO_FAIL(con.Query("CREATE INDEX target_i_idx ON target(i)"));
 		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
-		REQUIRE(DeserializePlan(con, serialized_plan) != nullptr);
+		altered_definition = GetTableWriteDefinition(con, "target");
+		REQUIRE(altered_definition != original_definition);
+		REQUIRE_THROWS_WITH(DeserializePlan(con, serialized_plan), Catch::Matchers::Contains("definition changed"));
+		altered_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET i = 3");
+		REQUIRE(DeserializePlan(con, altered_plan) != nullptr);
 		REQUIRE_NO_FAIL(con.Query("PRAGMA force_checkpoint"));
 	}
 	{
 		DuckDB db(db_path);
 		Connection con(db);
 		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+		REQUIRE(GetTableWriteDefinition(con, "target") == altered_definition);
+		REQUIRE(DeserializePlan(con, altered_plan) != nullptr);
 		REQUIRE_NO_FAIL(con.Query("SET wal_autocheckpoint = '1TB'"));
 		REQUIRE_NO_FAIL(con.Query("PRAGMA disable_checkpoint_on_shutdown"));
+		REQUIRE_NO_FAIL(con.Query("DROP INDEX target_i_idx"));
+		unindexed_definition = GetTableWriteDefinition(con, "target");
+		REQUIRE(unindexed_definition != altered_definition);
+		REQUIRE_THROWS_WITH(DeserializePlan(con, altered_plan), Catch::Matchers::Contains("definition changed"));
+		unindexed_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET i = 4");
+		REQUIRE(DeserializePlan(con, unindexed_plan) != nullptr);
 		REQUIRE_NO_FAIL(con.Query("ALTER TABLE target RENAME COLUMN j TO k"));
 		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+		renamed_definition = GetTableWriteDefinition(con, "target");
+		REQUIRE(renamed_definition != unindexed_definition);
+		REQUIRE_THROWS_WITH(DeserializePlan(con, unindexed_plan), Catch::Matchers::Contains("definition changed"));
+		renamed_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET i = 5");
 	}
 	{
 		DuckDB db(db_path);
 		Connection con(db);
 		REQUIRE(GetTableWriteIdentity(con, "target") == original_identity);
+		REQUIRE(GetTableWriteDefinition(con, "target") == renamed_definition);
+		REQUIRE(DeserializePlan(con, renamed_plan) != nullptr);
 		REQUIRE_NO_FAIL(con.Query("DROP TABLE target"));
 		REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(i INTEGER)"));
 		REQUIRE(GetTableWriteIdentity(con, "target") != original_identity);
 	}
+}
+
+TEST_CASE("Serialized DML rejects a remapped physical column", "[serialization][dml]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(a INTEGER, b INTEGER)"));
+
+	auto original_identity = GetTableWriteIdentity(con, "target");
+	auto original_definition = GetTableWriteDefinition(con, "target");
+	auto serialized_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET a = 99");
+	REQUIRE_NO_FAIL(con.Query("ALTER TABLE target DROP COLUMN a"));
+	REQUIRE(GetTableWriteIdentity(con, "target") != original_identity);
+	REQUIRE(GetTableWriteDefinition(con, "target") != original_definition);
+	REQUIRE_THROWS_WITH(DeserializePlan(con, serialized_plan), Catch::Matchers::Contains("was replaced"));
+}
+
+TEST_CASE("Serialized DML rejects changed index state", "[serialization][dml]") {
+	DuckDB db;
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE target(a INTEGER, b INTEGER)"));
+
+	auto without_index_definition = GetTableWriteDefinition(con, "target");
+	auto without_index_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET a = 99");
+	REQUIRE_NO_FAIL(con.Query("CREATE INDEX target_a_idx ON target(a)"));
+	auto with_index_definition = GetTableWriteDefinition(con, "target");
+	REQUIRE(with_index_definition != without_index_definition);
+	REQUIRE_THROWS_WITH(DeserializePlan(con, without_index_plan), Catch::Matchers::Contains("definition changed"));
+
+	auto with_index_plan = SerializeUnoptimizedPlan(con, "UPDATE target SET a = 100");
+	REQUIRE_NO_FAIL(con.Query("DROP INDEX target_a_idx"));
+	REQUIRE(GetTableWriteDefinition(con, "target") == without_index_definition);
+	REQUIRE_THROWS_WITH(DeserializePlan(con, with_index_plan), Catch::Matchers::Contains("definition changed"));
 }
 
 TEST_CASE("Copy database assigns a new table write identity", "[serialization][dml]") {
@@ -294,6 +367,7 @@ TEST_CASE("Logical write targets require a non-empty identity", "[serialization]
 	serializer.WriteProperty<string>(101, "schema_name", "main");
 	serializer.WriteProperty<string>(102, "table_name", "target");
 	serializer.WriteProperty<string>(103, "identity", "");
+	serializer.WriteProperty<string>(104, "definition", "CREATE TABLE memory.main.target(i INTEGER)");
 	serializer.End();
 	stream.Rewind();
 
@@ -301,6 +375,33 @@ TEST_CASE("Logical write targets require a non-empty identity", "[serialization]
 	deserializer.Begin();
 	REQUIRE_THROWS_WITH(LogicalWriteTarget::Deserialize(deserializer),
 	                    Catch::Matchers::Contains("does not provide a logical write target identity"));
+}
+
+TEST_CASE("Checkpoint-loaded tables without an identity remain unsupported", "[serialization][dml]") {
+	auto db_path = TestCreatePath("logical_write_target_legacy.db");
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		con.context->RunFunctionInTransaction([&]() {
+			auto &catalog = Catalog::GetCatalog(*con.context, "");
+			auto &transaction = MetaTransaction::Get(*con.context);
+			transaction.ModifyDatabase(catalog.GetAttached(), DatabaseModificationType::CREATE_CATALOG_ENTRY);
+			auto &schema = catalog.GetSchema(*con.context, DEFAULT_SCHEMA);
+			auto info = make_uniq<CreateTableInfo>(schema, "legacy_target");
+			info->columns.AddColumn(ColumnDefinition("i", LogicalType::INTEGER));
+			auto bound_info = Binder::BindCreateTableCheckpoint(std::move(info), schema);
+			REQUIRE(schema.ParentCatalog().CreateTable(*con.context, *bound_info) != nullptr);
+		});
+		REQUIRE(GetTableWriteIdentity(con, "legacy_target").empty());
+		REQUIRE_NO_FAIL(con.Query("PRAGMA force_checkpoint"));
+	}
+	{
+		DuckDB db(db_path);
+		Connection con(db);
+		REQUIRE(GetTableWriteIdentity(con, "legacy_target").empty());
+		REQUIRE_THROWS_WITH(SerializeUnoptimizedPlan(con, "UPDATE legacy_target SET i = 2"),
+		                    Catch::Matchers::Contains("does not provide a logical write target identity"));
+	}
 }
 
 TEST_CASE("Logical repartition round-trips hash random and into-partitions modes", "[serialization][repartition]") {
@@ -361,6 +462,26 @@ TEST_CASE("Logical repartition round-trips hash random and into-partitions modes
 	});
 }
 
+TEST_CASE("Logical repartition serializes rewritten operator expressions", "[serialization][repartition]") {
+	DuckDB db;
+	Connection con(db);
+	duckdb::vector<ExprRef> bind_expressions;
+	bind_expressions.push_back(std::make_shared<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+	LogicalRepartition repartition(RepartitionSpec::create_hash(2, std::move(bind_expressions)));
+
+	// Optimizers rewrite LogicalOperator::expressions without updating the bind-time
+	// HashRepartitionConfig copy. Serialization must follow the rewritten expression.
+	repartition.expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 1));
+	auto copied_plan = repartition.Copy(*con.context);
+	auto &copied_repartition = copied_plan->Cast<LogicalRepartition>();
+	auto *hash_spec = dynamic_cast<HashRepartitionSpec *>(copied_repartition.repartition_spec.get());
+	REQUIRE(hash_spec != nullptr);
+	REQUIRE(copied_repartition.expressions.size() == 1);
+	REQUIRE(hash_spec->config()->by.size() == 1);
+	REQUIRE(copied_repartition.expressions[0]->Cast<BoundReferenceExpression>().index == 1);
+	REQUIRE(hash_spec->config()->by[0]->Cast<BoundReferenceExpression>().index == 1);
+}
+
 TEST_CASE("Logical repartition rejects unsupported and malformed wire states", "[serialization][repartition]") {
 	{
 		LogicalRepartition missing_spec(nullptr);
@@ -371,11 +492,19 @@ TEST_CASE("Logical repartition rejects unsupported and malformed wire states", "
 	{
 		duckdb::vector<ExprRef> config_expressions;
 		config_expressions.push_back(std::make_shared<BoundReferenceExpression>(LogicalType::INTEGER, 0));
-		LogicalRepartition inconsistent_hash(RepartitionSpec::create_hash(2, std::move(config_expressions)));
-		inconsistent_hash.expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 1));
+		LogicalRepartition empty_hash(RepartitionSpec::create_hash(2, std::move(config_expressions)));
 		MemoryStream stream;
-		REQUIRE_THROWS_WITH(BinarySerializer::Serialize(inconsistent_hash, stream),
-		                    Catch::Matchers::Contains("inconsistent partition expressions"));
+		REQUIRE_THROWS_WITH(BinarySerializer::Serialize(empty_hash, stream),
+		                    Catch::Matchers::Contains("requires at least one partition expression"));
+	}
+	{
+		duckdb::vector<ExprRef> config_expressions;
+		config_expressions.push_back(std::make_shared<BoundReferenceExpression>(LogicalType::INTEGER, 0));
+		LogicalRepartition null_hash(RepartitionSpec::create_hash(2, std::move(config_expressions)));
+		null_hash.expressions.push_back(nullptr);
+		MemoryStream stream;
+		REQUIRE_THROWS_WITH(BinarySerializer::Serialize(null_hash, stream),
+		                    Catch::Matchers::Contains("null partition expression"));
 	}
 	{
 		duckdb::vector<BoundOrderByNode> orders;

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -993,7 +993,7 @@ PyPhysicalPlanWrapper PyLogicalPlan::to_physical_plan(py::object conn_obj, py::o
 	if (serialized_logical_plan_.empty()) {
 		throw duckdb::InternalException("PyLogicalPlan missing serialized logical plan");
 	}
-	const auto &logical_payload = serialized_logical_plan_;
+	auto logical_payload = DecodeLogicalPlanEnvelope(serialized_logical_plan_);
 
 	py::object planning_conn = ResolvePlanningConnectionForSnapshot(conn_obj, source_connection_, connection_snapshot_);
 	auto &conn_wrapper = ExtractPyConnectionWrapper(planning_conn);

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -5,6 +5,106 @@
 
 struct PyPhysicalPlanWrapper;
 
+static constexpr char LOGICAL_PLAN_ENVELOPE_MAGIC[] = {'V', 'A', 'N', 'E', 'P', 'L', 'A', 'N'};
+static constexpr idx_t LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE = sizeof(LOGICAL_PLAN_ENVELOPE_MAGIC);
+static constexpr uint32_t LOGICAL_PLAN_PROTOCOL_VERSION = 1;
+static constexpr uint32_t LOGICAL_PLAN_MAX_SOURCE_ID_SIZE = 4096;
+
+static void AppendUInt32LE(string &result, uint32_t value) {
+	for (idx_t byte_idx = 0; byte_idx < sizeof(value); byte_idx++) {
+		result.push_back(static_cast<char>((value >> (byte_idx * 8)) & 0xff));
+	}
+}
+
+static void AppendUInt64LE(string &result, uint64_t value) {
+	for (idx_t byte_idx = 0; byte_idx < sizeof(value); byte_idx++) {
+		result.push_back(static_cast<char>((value >> (byte_idx * 8)) & 0xff));
+	}
+}
+
+static uint32_t ReadUInt32LE(const string &envelope, idx_t &offset, const char *field_name) {
+	if (offset > envelope.size() || envelope.size() - offset < sizeof(uint32_t)) {
+		throw InvalidInputException("Logical plan envelope is truncated before %s", field_name);
+	}
+	uint32_t result = 0;
+	for (idx_t byte_idx = 0; byte_idx < sizeof(result); byte_idx++) {
+		result |= static_cast<uint32_t>(static_cast<uint8_t>(envelope[offset++])) << (byte_idx * 8);
+	}
+	return result;
+}
+
+static uint64_t ReadUInt64LE(const string &envelope, idx_t &offset, const char *field_name) {
+	if (offset > envelope.size() || envelope.size() - offset < sizeof(uint64_t)) {
+		throw InvalidInputException("Logical plan envelope is truncated before %s", field_name);
+	}
+	uint64_t result = 0;
+	for (idx_t byte_idx = 0; byte_idx < sizeof(result); byte_idx++) {
+		result |= static_cast<uint64_t>(static_cast<uint8_t>(envelope[offset++])) << (byte_idx * 8);
+	}
+	return result;
+}
+
+static string EncodeLogicalPlanEnvelope(const string &logical_payload) {
+	if (logical_payload.empty()) {
+		throw InternalException("Cannot encode an empty logical plan payload");
+	}
+	string source_id = DuckDB::SourceID();
+	if (source_id.empty() || source_id.size() > LOGICAL_PLAN_MAX_SOURCE_ID_SIZE) {
+		throw InternalException("DuckDB SourceID is empty or exceeds the logical plan envelope limit");
+	}
+
+	string envelope;
+	envelope.reserve(LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE + sizeof(uint32_t) * 2 + sizeof(uint64_t) + source_id.size() +
+	                 logical_payload.size());
+	envelope.append(LOGICAL_PLAN_ENVELOPE_MAGIC, LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE);
+	AppendUInt32LE(envelope, LOGICAL_PLAN_PROTOCOL_VERSION);
+	AppendUInt32LE(envelope, static_cast<uint32_t>(source_id.size()));
+	AppendUInt64LE(envelope, static_cast<uint64_t>(logical_payload.size()));
+	envelope.append(source_id);
+	envelope.append(logical_payload);
+	return envelope;
+}
+
+static string DecodeLogicalPlanEnvelope(const string &envelope) {
+	if (envelope.size() < LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE ||
+	    envelope.compare(0, LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE, LOGICAL_PLAN_ENVELOPE_MAGIC,
+	                     LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE) != 0) {
+		throw InvalidInputException("Logical plan payload is not a Vane logical plan envelope");
+	}
+
+	idx_t offset = LOGICAL_PLAN_ENVELOPE_MAGIC_SIZE;
+	auto protocol_version = ReadUInt32LE(envelope, offset, "protocol version");
+	if (protocol_version != LOGICAL_PLAN_PROTOCOL_VERSION) {
+		throw InvalidInputException("Unsupported logical plan protocol version %u (expected %u)", protocol_version,
+		                            LOGICAL_PLAN_PROTOCOL_VERSION);
+	}
+	auto source_id_size = ReadUInt32LE(envelope, offset, "SourceID length");
+	auto payload_size = ReadUInt64LE(envelope, offset, "payload length");
+	if (source_id_size == 0 || source_id_size > LOGICAL_PLAN_MAX_SOURCE_ID_SIZE) {
+		throw InvalidInputException("Logical plan envelope contains an invalid SourceID length");
+	}
+	if (offset > envelope.size() || source_id_size > envelope.size() - offset) {
+		throw InvalidInputException("Logical plan envelope is truncated inside the SourceID");
+	}
+
+	auto serialized_source_id = envelope.substr(offset, source_id_size);
+	offset += source_id_size;
+	string current_source_id = DuckDB::SourceID();
+	if (current_source_id.empty() || serialized_source_id != current_source_id) {
+		throw InvalidInputException("Logical plan SourceID mismatch: payload was built by %s, current engine is %s",
+		                            serialized_source_id, current_source_id);
+	}
+	if (payload_size == 0) {
+		throw InvalidInputException("Logical plan envelope contains an empty payload");
+	}
+	auto remaining_size = envelope.size() - offset;
+	if (payload_size != static_cast<uint64_t>(remaining_size)) {
+		throw InvalidInputException("Logical plan envelope payload length mismatch: declared %llu bytes, found %llu",
+		                            payload_size, static_cast<uint64_t>(remaining_size));
+	}
+	return envelope.substr(offset, remaining_size);
+}
+
 struct PyLogicalPlan {
 	string query_id_;
 	string serialized_logical_plan_;
@@ -59,7 +159,8 @@ static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::
 		if (data_size == 0) {
 			throw duckdb::InternalException("Logical plan serialization returned empty payload");
 		}
-		serialized_plan = string(reinterpret_cast<const char *>(data_ptr), data_size);
+		auto logical_payload = string(reinterpret_cast<const char *>(data_ptr), data_size);
+		serialized_plan = EncodeLogicalPlanEnvelope(logical_payload);
 	});
 	return serialized_plan;
 }

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -957,6 +957,7 @@ void register_ray_bindings(py::module_ &mod) {
 		        if (p.serialized_logical_plan_.empty()) {
 			        throw duckdb::InternalException("PyLogicalPlan missing serialized logical plan");
 		        }
+		        (void)DecodeLogicalPlanEnvelope(p.serialized_logical_plan_);
 		        return py::make_tuple(p.query_id_, py::bytes(p.serialized_logical_plan_), p.udf_registrations_,
 		                              p.connection_snapshot_);
 	        },
@@ -969,6 +970,7 @@ void register_ray_bindings(py::module_ &mod) {
 		        if (serialized_plan.empty()) {
 			        throw duckdb::InternalException("PyLogicalPlan deserialization failed: empty logical plan payload");
 		        }
+		        (void)DecodeLogicalPlanEnvelope(serialized_plan);
 		        PyLogicalPlan plan;
 		        plan.query_id_ = std::move(query_id);
 		        plan.serialized_logical_plan_ = std::move(serialized_plan);

--- a/tests/fast/test_logical_plan_envelope.py
+++ b/tests/fast/test_logical_plan_envelope.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pickle
+
+import pytest
+
+import vane
+
+_MAGIC = b"VANEPLAN"
+_SOURCE_ID_SIZE_OFFSET = 12
+_PAYLOAD_SIZE_OFFSET = 16
+_HEADER_SIZE = 24
+
+
+def _require_ray_cxx():
+    ray_cxx = getattr(vane, "ray_cxx", None)
+    if ray_cxx is None or not hasattr(ray_cxx, "PyLogicalPlan"):
+        pytest.skip("vane.ray_cxx.PyLogicalPlan not available in this environment")
+    return ray_cxx
+
+
+def _logical_plan_state():
+    ray_cxx = _require_ray_cxx()
+    connection = vane.connect()
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        connection.sql("SELECT 42 AS answer"),
+        "logical-plan-envelope",
+    )
+    return ray_cxx, connection, list(plan.__getstate__())
+
+
+def _restore(ray_cxx, state):
+    restored = ray_cxx.PyLogicalPlan.__new__(ray_cxx.PyLogicalPlan)
+    restored.__setstate__(tuple(state))
+    return restored
+
+
+def test_logical_plan_pickle_uses_a_versioned_envelope():
+    ray_cxx, connection, state = _logical_plan_state()
+    payload = state[1]
+
+    assert payload.startswith(_MAGIC)
+    assert int.from_bytes(payload[8:12], "little") == 1
+    source_id_size = int.from_bytes(payload[_SOURCE_ID_SIZE_OFFSET:_PAYLOAD_SIZE_OFFSET], "little")
+    logical_payload_size = int.from_bytes(payload[_PAYLOAD_SIZE_OFFSET:_HEADER_SIZE], "little")
+    assert source_id_size > 0
+    assert logical_payload_size > 0
+    assert len(payload) == _HEADER_SIZE + source_id_size + logical_payload_size
+
+    restored = pickle.loads(pickle.dumps(_restore(ray_cxx, state)))
+    assert restored.to_physical_plan(connection) is not None
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda payload: b"raw-logical-plan", "not a Vane logical plan envelope"),
+        (
+            lambda payload: payload[:8] + (2).to_bytes(4, "little") + payload[12:],
+            "Unsupported logical plan protocol version",
+        ),
+        (lambda payload: payload[:-1], "payload length mismatch"),
+        (lambda payload: payload + b"trailing-byte", "payload length mismatch"),
+    ],
+)
+def test_logical_plan_pickle_rejects_invalid_envelopes(mutate, message):
+    ray_cxx, _, state = _logical_plan_state()
+    state[1] = mutate(state[1])
+
+    with pytest.raises(Exception, match=message):
+        _restore(ray_cxx, state)
+
+
+def test_logical_plan_pickle_rejects_a_different_engine_source_id():
+    ray_cxx, _, state = _logical_plan_state()
+    payload = bytearray(state[1])
+    source_id_size = int.from_bytes(payload[_SOURCE_ID_SIZE_OFFSET:_PAYLOAD_SIZE_OFFSET], "little")
+    assert source_id_size > 0
+    payload[_HEADER_SIZE] ^= 1
+    state[1] = bytes(payload)
+
+    with pytest.raises(Exception, match="Logical plan SourceID mismatch"):
+        _restore(ray_cxx, state)


### PR DESCRIPTION
## Summary

- persist an opaque table-incarnation identity and canonical write definition for serialized INSERT, UPDATE, DELETE, and MERGE targets, rejecting table replacement, physical-column remapping, and write-relevant schema or index changes
- assign table identities at catalog materialization, preserve them only for checkpoint/WAL restoration, and record `DROP COLUMN` rotations in WAL so serialized CREATE reuse and recovery cannot create identity ABA bugs
- fingerprint standalone index type, constraint kind, key expressions, physical columns, and options through target-specific index lookups without scanning unrelated schema indexes
- fail closed for legacy tables or catalogs without a persisted logical-write identity; no compatibility or name-based fallback is provided
- serialize logical repartition through an explicit stable wire contract for hash, random, and into-partitions modes, using optimizer-owned operator expressions and rejecting range or malformed states
- wrap Python logical-plan payloads in a versioned envelope bound to the exact DuckDB SourceID, while keeping custom VLLM, UDF, local-exchange, and repartition serialization registered in the code-generation schema

## Related issue

close: #579

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The strict serialization contract and its compatibility impact are covered in the code, errors, tests, and this PR description.

## Validation

- two consecutive clean review rounds after the final fix, followed by one additional clean review after all builds and tests passed
- confirmed the branch is based on current `upstream/main` at `396bd10919af32fac40b1143292aed3c72714070`
- `git diff --check upstream/main...HEAD`
- `scripts/format workspace --from-ref upstream/main --check`
- Release wheel build with 14 parallel Ninja jobs via `uv pip install . --no-build-isolation`
- `cmake --build build/native-cxx20 --target unittest --parallel 14`
- `build/native-cxx20/test/unittest "[serialization]" --reporter compact`: 75 test cases and 10,994 assertions passed
- `tests/fast/test_logical_plan_envelope.py`: 6 tests passed across six isolated concurrent pytest shards
- `scripts/run_release_tests.sh`: 530 non-Ray tests and 11 real-Ray tests passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
