### PR TITLE
[fix](release) Derive package versions from Git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
@@ -88,7 +89,7 @@ jobs:
           python scripts/check_release_artifacts.py dist/*.tar.gz
 
       - name: Apply private content rules to the source package
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
         env:
           RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
         run: |
@@ -161,6 +162,7 @@ jobs:
             "ninja>=1.10" \
             "pybind11[global]>=3.0.0" \
             "scikit-build-core>=0.11.4" \
+            "setuptools_scm>=8.0" \
             mypy \
             packaging \
             "pydantic>=2" \
@@ -180,7 +182,7 @@ jobs:
         run: python scripts/check_release_artifacts.py dist/*.tar.gz dist/*.whl
 
       - name: Apply private content rules to release artifacts
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
         env:
           RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             "ninja>=1.10" \
             "pybind11[global]>=3.0.0" \
             "scikit-build-core>=0.11.4" \
-            "setuptools_scm>=8.0" \
+            "setuptools-scm>=9.2.0" \
             mypy \
             packaging \
             "pydantic>=2" \

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
   workflow_dispatch:
     inputs:
       git_ref:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
   source-package:
     name: Build source package
     runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.package_version.outputs.version }}
     permissions:
       contents: write
     steps:
@@ -46,12 +48,47 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           test "$GITHUB_REF_TYPE" = "tag"
-          expected_tag="v$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
-          test "$GITHUB_REF_NAME" = "$expected_tag"
+          release_version="$(python - "${GITHUB_REF_NAME#v}" <<'PY'
+          import sys
 
-          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
+          from packaging.version import InvalidVersion, Version
+
+          raw_version = sys.argv[1]
+          try:
+              version = Version(raw_version)
+          except InvalidVersion:
+              raise SystemExit(f"release tag does not contain a valid PEP 440 version: {raw_version!r}") from None
+          if str(version) != raw_version:
+              raise SystemExit(f"release tag must use canonical PEP 440 spelling: v{version}")
+          if version.epoch != 0 or len(version.release) != 3:
+              raise SystemExit("release tags must use an X.Y.Z version without an epoch")
+          if version.is_devrelease or version.local is not None:
+              raise SystemExit("release tags cannot use development or local versions")
+          print(version)
+          PY
+          )"
+          test "$GITHUB_REF_NAME" = "v$release_version"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VANE_AI=$release_version" >> "$GITHUB_ENV"
+
           release_commit="$(git rev-parse HEAD^{commit})"
-          git merge-base --is-ancestor "$release_commit" refs/remotes/origin/main
+          release_branch="$(python - "$release_version" <<'PY'
+          import sys
+          from packaging.version import Version
+
+          version = Version(sys.argv[1])
+          major, minor, patch = version.release
+          if patch == 0 and version.post is None:
+              print("main")
+          else:
+              print(f"release/{major}.{minor}")
+          PY
+          )"
+          release_ref="refs/remotes/origin/$release_branch"
+          git fetch --no-tags origin "refs/heads/$release_branch:$release_ref"
+          git merge-base --is-ancestor "$release_commit" "$release_ref" || {
+            echo "v$release_version must be reachable from $release_branch" >&2
+            exit 1
+          }
 
           release_id="$(
             gh api --paginate \
@@ -90,13 +127,35 @@ jobs:
               raise SystemExit(f"vane-ai {sys.argv[1]} already exists on {index}")
           PY
 
-      - name: Build and validate the source package
+      - name: Build the source package
         run: |
           python -m build --sdist --outdir dist
-          python scripts/check_release_artifacts.py dist/*.tar.gz
+
+      - name: Record and validate the package version
+        id: package_version
+        env:
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          path="$(find dist -maxdepth 1 -type f -name '*.tar.gz' -print -quit)"
+          test -n "$path"
+          version="$(python - "$path" <<'PY'
+          import sys
+          from pathlib import Path
+
+          from packaging.utils import parse_sdist_filename
+
+          _, version = parse_sdist_filename(Path(sys.argv[1]).name)
+          print(version)
+          PY
+          )"
+          if test "$OPERATION" = "release"; then
+            test "$GITHUB_REF_NAME" = "v$version"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          python scripts/check_release_artifacts.py --expected-version "$version" "$path"
 
       - name: Apply private content rules to the source package
-        if: ${{ inputs.operation == 'release' || github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.operation == 'release' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
         env:
           RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
         run: |
@@ -104,6 +163,7 @@ jobs:
           printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
             python scripts/check_release_artifacts.py \
               --content-rules-manifest - \
+              --expected-version "${{ steps.package_version.outputs.version }}" \
               dist/*.tar.gz
 
       - name: Upload source package
@@ -153,9 +213,11 @@ jobs:
           config-file: "{package}/pyproject.toml"
 
       - name: Validate wheels
+        env:
+          EXPECTED_VERSION: ${{ needs['source-package'].outputs.version }}
         run: |
           test "$(find wheelhouse -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
-          python scripts/check_release_artifacts.py wheelhouse/*.whl
+          python scripts/check_release_artifacts.py --expected-version "$EXPECTED_VERSION" wheelhouse/*.whl
 
       - name: Verify the final CPython 3.12 wheel coexists with DuckDB
         run: |
@@ -165,14 +227,16 @@ jobs:
           python scripts/verify_duckdb_coexistence.py "$wheel"
 
       - name: Apply private content rules to wheels
-        if: ${{ inputs.operation == 'release' || github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.operation == 'release' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
         env:
+          EXPECTED_VERSION: ${{ needs['source-package'].outputs.version }}
           RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
         run: |
           test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
           printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
             python scripts/check_release_artifacts.py \
               --content-rules-manifest - \
+              --expected-version "$EXPECTED_VERSION" \
               wheelhouse/*.whl
 
       - name: Upload wheels
@@ -185,7 +249,7 @@ jobs:
 
   assemble:
     name: Validate, attest and sign artifacts
-    needs: wheels
+    needs: [source-package, wheels]
     runs-on: ubuntu-24.04
     permissions:
       attestations: write
@@ -219,20 +283,26 @@ jobs:
           path: packages
 
       - name: Validate the complete distribution set
+        env:
+          EXPECTED_VERSION: ${{ needs['source-package'].outputs.version }}
         run: |
           test "$(find packages -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
           test "$(find packages -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 5
-          python scripts/check_release_artifacts.py packages/*.tar.gz packages/*.whl
+          python scripts/check_release_artifacts.py \
+            --expected-version "$EXPECTED_VERSION" \
+            packages/*.tar.gz packages/*.whl
 
       - name: Apply private content rules to the distribution set
-        if: ${{ inputs.operation == 'release' || github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.operation == 'release' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') }}
         env:
+          EXPECTED_VERSION: ${{ needs['source-package'].outputs.version }}
           RELEASE_ARTIFACT_CONTENT_RULES: ${{ secrets.RELEASE_ARTIFACT_CONTENT_RULES }}
         run: |
           test -n "$RELEASE_ARTIFACT_CONTENT_RULES"
           printf '%s' "$RELEASE_ARTIFACT_CONTENT_RULES" |
             python scripts/check_release_artifacts.py \
               --content-rules-manifest - \
+              --expected-version "$EXPECTED_VERSION" \
               packages/*.tar.gz packages/*.whl
 
       - name: Generate checksums

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -83,7 +83,7 @@ jobs:
             "ninja>=1.10" \
             "pybind11[global]>=3.0.0" \
             "scikit-build-core>=0.11.4" \
-            "setuptools_scm>=8.0"
+            "setuptools-scm>=9.2.0"
 
       - name: Restore vcpkg binary cache
         if: matrix.language == 'c-cpp'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
   schedule:
     - cron: "43 2 * * 3"
   workflow_dispatch:
@@ -81,7 +82,8 @@ jobs:
             "cmake>=3.29" \
             "ninja>=1.10" \
             "pybind11[global]>=3.0.0" \
-            "scikit-build-core>=0.11.4"
+            "scikit-build-core>=0.11.4" \
+            "setuptools_scm>=8.0"
 
       - name: Restore vcpkg binary cache
         if: matrix.language == 'c-cpp'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,16 @@
 # Release process
 
 Vane releases are immutable source and binary artifacts derived from one
-reviewed commit on `main`. The GitHub Release body is the canonical public
-record of user-visible changes; the repository does not maintain a rolling
-changelog or a release-notes template.
+reviewed commit on `main` or a `release/X.Y` maintenance branch. The GitHub
+Release body is the canonical public record of user-visible changes; the
+repository does not maintain a rolling changelog or a release-notes template.
 
 ## Release invariants
 
 - The package version is a valid, previously unused PEP 440 version. Its tag is
   exactly `v<version>` and points to the reviewed commit tested for release.
+- An `X.Y.0` release, including its prereleases, comes from `main`. Patch
+  releases and post releases come from the matching `release/X.Y` branch.
 - One workflow run builds the sdist and all wheels once. The exact same files
   are promoted through TestPyPI, PyPI, and the GitHub Release.
 - A GitHub Release remains a draft until PyPI publication succeeds and all
@@ -18,13 +20,35 @@ changelog or a release-notes template.
   artifacts are never replaced. A bad release is superseded by a new version
   and yanked when necessary.
 
+## Version calculation
+
+Python package versions come from Git through `setuptools-scm`; there is no
+manually maintained version in `pyproject.toml`.
+
+- On `main`, development versions count from the latest `vX.Y.0` tag and use
+  the next minor series: commits after `v0.1.0` are `0.2.0.devN`. Restricting
+  the baseline to minor tags prevents a merged maintenance tag from resetting
+  `N`.
+- On `release/X.Y`, versions count from the latest tag on that release line and
+  use the next patch series: commits after `v0.2.0` are `0.2.1.devN`, and
+  commits after `v0.2.1` are `0.2.2.devN`.
+- Clean exact tags produce the tag version without a development suffix. The
+  release workflow validates the selected tag and supplies that exact version
+  to the isolated source build.
+
+Build from a full Git checkout with release tags available, or from the sdist
+produced by that checkout. For local feature branches based on a maintenance
+line, set `VANE_VERSION_BRANCH=release/X.Y`; pull-request CI infers the same
+line from its base branch.
+
 ## One-time repository configuration
 
 Repository administrators must:
 
 1. Keep `main` as the default branch and protect it with pull-request review,
    required CI and code-quality checks, resolved conversations, and deletion
-   and non-fast-forward update protection.
+   and non-fast-forward update protection. Apply the same protections to every
+   active `release/X.Y` branch.
 2. Create an active tag ruleset with no bypass actors for `refs/tags/v*`. Allow
    initial tag creation, but restrict deletion and block force pushes so the
    tag cannot move between workflow dispatch and publication. GitHub immutable
@@ -48,7 +72,9 @@ configuration has remained unchanged.
 
 ## Prepare the release pull request
 
-1. Set the final PEP 440 version in `pyproject.toml`.
+1. Choose a final canonical PEP 440 version with an `X.Y.Z` release segment.
+   Do not edit `pyproject.toml`; the release tag is the source of the final
+   version.
 2. Put the complete proposed GitHub Release notes in the pull-request
    description. Reviewers approve those notes together with the code; do not
    depend on an unreviewed local notes file.
@@ -71,8 +97,9 @@ configuration has remained unchanged.
    first-party critical or high-severity alert. Record the disposition of
    inherited and third-party findings that affect shipped code.
 8. Confirm that the version is absent from both TestPyPI and PyPI, review known
-   issues and the supported-platform statement, merge the pull request, and
-   record its exact commit SHA.
+   issues and the supported-platform statement, merge an `X.Y.0` pull request
+   into `main` or a patch/post pull request into `release/X.Y`, and record its
+   exact commit SHA.
 
 Run a build-only dry run from the reviewed commit with:
 
@@ -83,10 +110,14 @@ gh workflow run release.yml \
   -f operation=build-only
 ```
 
+For a maintenance release, replace `main` with the matching `release/X.Y`.
+
 ## Create the tag and draft release
 
-1. Confirm the recorded release commit is reachable from `main` and has not
-   changed since the release pull request passed its gates.
+1. Confirm the recorded `X.Y.0` release commit is reachable from `main`, or the
+   recorded patch/post release commit is reachable from the matching
+   `release/X.Y` branch. It must not have changed since the release pull request
+   passed its gates.
 2. Confirm the active `v*` tag ruleset restricts deletion and force pushes and
    has no bypass actors. Create and push the exact `v<version>` tag at the
    recorded commit, then verify that the remote tag resolves to that commit.
@@ -98,9 +129,9 @@ gh workflow run release.yml \
    and `operation=release`.
 
 The workflow rejects a release operation unless the selected ref is the
-matching version tag, the tagged commit is reachable from `main`, the GitHub
-Release exists and is still a draft, and the version is absent from both
-package indexes.
+matching version tag, the tagged commit is reachable from the branch required
+by its version line, the GitHub Release exists and is still a draft, and the
+version is absent from both package indexes.
 
 ## Build, stage, and publish
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,10 +25,11 @@ repository does not maintain a rolling changelog or a release-notes template.
 Python package versions come from Git through `setuptools-scm`; there is no
 manually maintained version in `pyproject.toml`.
 
-- On `main`, development versions count from the latest `vX.Y.0` tag and use
-  the next minor series: commits after `v0.1.0` are `0.2.0.devN`. Restricting
-  the baseline to minor tags prevents a merged maintenance tag from resetting
-  `N`.
+- On `main`, development versions count from the latest patch-zero final or
+  prerelease tag. Commits after `v0.1.0` are `0.2.0.devN`, commits after
+  `v0.2.0rc1` are `0.2.0rc2.devN`, and commits after the final `v0.2.0` start
+  `0.3.0.devN`. Restricting the baseline to patch-zero tags prevents a merged
+  maintenance or post-release tag from resetting `N`.
 - On `release/X.Y`, versions count from the latest tag on that release line and
   use the next patch series: commits after `v0.2.0` are `0.2.1.devN`, and
   commits after `v0.2.1` are `0.2.2.devN`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ backend-path = ["."]
 requires = [
     "scikit-build-core>=0.11.4",
 	"pybind11[global]>=3.0.0",
-    "setuptools_scm>=8.0",
+    "setuptools-scm>=9.2.0",
 ]
 
 [tool.scikit-build]
@@ -462,7 +462,7 @@ build = [
     "ninja>=1.10",
     "pybind11[global]>=3.0.0",
     "scikit_build_core>=0.11.4",
-    "setuptools_scm>=8.0",
+    "setuptools-scm>=9.2.0",
     "tomli>=1.1; python_version < '3.11'",
 ]
 dev = [ # tooling like uv will install this automatically when syncing the environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,10 +122,11 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 version_scheme = "vane_packaging.setuptools_scm_version:version_scheme"
 local_scheme = "no-local-version"
 
-# Main counts development distance from the latest minor release. Patch tags
-# merged into main therefore cannot reset the next-minor development series.
+# Initial discovery includes every Vane release tag so clean detached tag
+# checkouts keep their exact version. Non-exact commits are re-described by the
+# custom scheme against either the main or release-line tag set.
 [tool.setuptools_scm.scm.git]
-describe_command = "git describe --dirty --tags --long --abbrev=40 --match v*.*.0"
+describe_command = "git describe --dirty --tags --long --abbrev=40 --match v[0-9]*.[0-9]*.[0-9]*"
 pre_parse = "fail_on_shallow"
 
 [tool.scikit-build.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "vane-ai"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A distributed, multimodal data engine built on DuckDB and Ray"
 readme = "README.md"
 license = "Apache-2.0"
@@ -108,6 +108,7 @@ backend-path = ["."]
 requires = [
     "scikit-build-core>=0.11.4",
 	"pybind11[global]>=3.0.0",
+    "setuptools_scm>=8.0",
 ]
 
 [tool.scikit-build]
@@ -115,6 +116,17 @@ minimum-version = "0.10"
 cmake.version = ">=3.29.0"
 ninja.version = ">=1.10"
 ninja.make-fallback = false
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+
+[tool.setuptools_scm]
+version_scheme = "vane_packaging.setuptools_scm_version:version_scheme"
+local_scheme = "no-local-version"
+
+# Main counts development distance from the latest minor release. Patch tags
+# merged into main therefore cannot reset the next-minor development series.
+[tool.setuptools_scm.scm.git]
+describe_command = "git describe --dirty --tags --long --abbrev=40 --match v*.*.0"
+pre_parse = "fail_on_shallow"
 
 [tool.scikit-build.wheel]
 cmake = true
@@ -186,6 +198,7 @@ include = [
 
     # Build configuration
     "/build_backend.py",
+    "/vane_packaging/**",
     "/pyproject.toml",
     "/CMakeLists.txt",
     "/vcpkg.json",
@@ -448,6 +461,7 @@ build = [
     "ninja>=1.10",
     "pybind11[global]>=3.0.0",
     "scikit_build_core>=0.11.4",
+    "setuptools_scm>=8.0",
     "tomli>=1.1; python_version < '3.11'",
 ]
 dev = [ # tooling like uv will install this automatically when syncing the environment

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -26,7 +26,14 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Protocol
 
 from packaging.requirements import InvalidRequirement, Requirement
-from packaging.utils import canonicalize_name
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
+from packaging.version import InvalidVersion, Version
 
 try:
     import tomllib
@@ -36,7 +43,6 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_METADATA = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
 EXPECTED_NAME = str(PROJECT_METADATA["name"])
-EXPECTED_VERSION = str(PROJECT_METADATA["version"])
 MAX_ARTIFACT_BYTES = 100 * 1024 * 1024
 GIT_OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 DUCKDB_FORK_REVISION = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})(?:-dirty)?")
@@ -44,9 +50,6 @@ DUCKDB_UPSTREAM_VERSION = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+")
 CONTENT_RULE_ID = re.compile(r"[a-z0-9][a-z0-9._-]{0,63}")
 FORBIDDEN_DISTRIBUTION_ROOTS = {"adbc_driver_duckdb", "duckdb"}
 WHEEL_DISTRIBUTION = re.sub(r"[-_.]+", "_", EXPECTED_NAME)
-WHEEL_VERSION = re.sub(r"[^A-Za-z0-9.]+", "_", EXPECTED_VERSION)
-EXPECTED_ARCHIVE_ROOT = f"{WHEEL_DISTRIBUTION}-{WHEEL_VERSION}"
-EXPECTED_DIST_INFO_ROOT = f"{EXPECTED_ARCHIVE_ROOT}.dist-info"
 EXPECTED_LIBRARY_ROOT = f"{WHEEL_DISTRIBUTION}.libs"
 
 BANNED_PATH_PARTS = (
@@ -87,6 +90,24 @@ class ContentRule(Protocol):
 class ContentMatch:
     rule_id: str
     member_name: str
+
+
+@dataclass(frozen=True)
+class DistributionLayout:
+    version: Version
+    archive_root: str
+    dist_info_root: str
+
+
+def distribution_layout(version: Version | str) -> DistributionLayout:
+    parsed_version = version if isinstance(version, Version) else Version(version)
+    wheel_version = re.sub(r"[^A-Za-z0-9.]+", "_", str(parsed_version))
+    archive_root = f"{WHEEL_DISTRIBUTION}-{wheel_version}"
+    return DistributionLayout(
+        version=parsed_version,
+        archive_root=archive_root,
+        dist_info_root=f"{archive_root}.dist-info",
+    )
 
 
 @dataclass(frozen=True)
@@ -147,6 +168,22 @@ class SdistArtifact:
 
     def close(self) -> None:
         self.archive.close()
+
+
+def _artifact_version(path: Path) -> Version:
+    try:
+        if path.name.endswith(".tar.gz"):
+            name, version = parse_sdist_filename(path.name)
+        elif path.suffix == ".whl":
+            name, version, _, _ = parse_wheel_filename(path.name)
+        else:
+            raise ValueError(f"unsupported artifact type: {path}")
+    except (InvalidSdistFilename, InvalidWheelFilename):
+        raise ValueError(f"{path}: invalid Python distribution filename") from None
+
+    if canonicalize_name(name) != canonicalize_name(EXPECTED_NAME):
+        raise ValueError(f"{path}: unexpected project name {name!r}")
+    return version
 
 
 def _normalized(name: str) -> str:
@@ -324,14 +361,15 @@ def _metadata(artifact: Artifact, path: str):
     return BytesParser().parsebytes(artifact.read(name))
 
 
-def _check_metadata(artifact: Artifact, path: str):
+def _check_metadata(artifact: Artifact, path: str, layout: DistributionLayout):
     metadata = _metadata(artifact, path)
     if metadata["Name"] != EXPECTED_NAME:
         raise ValueError(f"{artifact.path}: unexpected project name {metadata['Name']!r}")
     if metadata["License-Expression"] != "Apache-2.0":
         raise ValueError(f"{artifact.path}: missing Apache-2.0 License-Expression")
-    if metadata["Version"] != EXPECTED_VERSION:
-        raise ValueError(f"{artifact.path}: expected version {EXPECTED_VERSION!r}, found {metadata['Version']!r}")
+    expected_version = str(layout.version)
+    if metadata["Version"] != expected_version:
+        raise ValueError(f"{artifact.path}: expected version {expected_version!r}, found {metadata['Version']!r}")
     return metadata
 
 
@@ -387,8 +425,12 @@ def _checkout_duckdb_fork_revision() -> str | None:
     return revision
 
 
-def _check_wheel_license_files(artifact: WheelArtifact, metadata) -> None:
-    metadata_name = _require_exact_path(artifact.names(), f"{EXPECTED_DIST_INFO_ROOT}/METADATA", artifact.path)
+def _check_wheel_license_files(
+    artifact: WheelArtifact,
+    metadata,
+    layout: DistributionLayout,
+) -> None:
+    metadata_name = _require_exact_path(artifact.names(), f"{layout.dist_info_root}/METADATA", artifact.path)
     license_root = PurePosixPath(metadata_name).parent / "licenses"
     names = artifact.names()
     for relative_path in metadata.get_all("License-File", []):
@@ -401,14 +443,14 @@ def _check_wheel_license_files(artifact: WheelArtifact, metadata) -> None:
             )
 
 
-def _check_sdist(artifact: SdistArtifact) -> None:
+def _check_sdist(artifact: SdistArtifact, layout: DistributionLayout) -> None:
     names = artifact.names()
     for name in names:
         parts = PurePosixPath(name).parts
         possible_source_roots = parts[:2]
         if any(_is_forbidden_import_root(source_root) for source_root in possible_source_roots):
             raise ValueError(f"{artifact.path}: Vane sdist contains conflicting Python package path {name!r}")
-        if not parts or parts[0] != EXPECTED_ARCHIVE_ROOT:
+        if not parts or parts[0] != layout.archive_root:
             raise ValueError(f"{artifact.path}: Vane sdist contains an unexpected archive root: {name!r}")
 
     required_paths = (
@@ -423,6 +465,8 @@ def _check_sdist(artifact: SdistArtifact) -> None:
         "LICENSES/vcpkg-binary-dependencies.txt",
         "external/duckdb/LICENSE",
         "build_backend.py",
+        "vane_packaging/__init__.py",
+        "vane_packaging/setuptools_scm_version.py",
         "scripts/resolve_duckdb_fork_version.py",
         "scripts/run_installed_pytest.sh",
         "scripts/run_release_tests.sh",
@@ -473,7 +517,7 @@ def _check_sdist(artifact: SdistArtifact) -> None:
             f"does not match checkout {checkout_upstream_version!r}"
         )
 
-    metadata = _check_metadata(artifact, f"{EXPECTED_ARCHIVE_ROOT}/PKG-INFO")
+    metadata = _check_metadata(artifact, f"{layout.archive_root}/PKG-INFO", layout)
     _check_no_official_duckdb_dependency(artifact, metadata)
     _check_sdist_license_files(artifact, metadata)
 
@@ -483,8 +527,8 @@ def _urlsafe_sha256(data: bytes) -> str:
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
-def _check_wheel_record(artifact: WheelArtifact) -> None:
-    record_name = _require_exact_path(artifact.names(), f"{EXPECTED_DIST_INFO_ROOT}/RECORD", artifact.path)
+def _check_wheel_record(artifact: WheelArtifact, layout: DistributionLayout) -> None:
+    record_name = _require_exact_path(artifact.names(), f"{layout.dist_info_root}/RECORD", artifact.path)
     try:
         rows = csv.reader(io.StringIO(artifact.read(record_name).decode("utf-8")))
     except UnicodeError:
@@ -513,12 +557,12 @@ def _check_wheel_record(artifact: WheelArtifact) -> None:
         raise ValueError(f"{artifact.path}: files missing from RECORD: {sorted(missing)}")
 
 
-def _check_wheel(artifact: WheelArtifact) -> None:
+def _check_wheel(artifact: WheelArtifact, layout: DistributionLayout) -> None:
     names = artifact.names()
     for name in names:
         parts = PurePosixPath(name).parts
         root = parts[0]
-        if root in {"vane", EXPECTED_DIST_INFO_ROOT, EXPECTED_LIBRARY_ROOT}:
+        if root in {"vane", layout.dist_info_root, EXPECTED_LIBRARY_ROOT}:
             continue
         raise ValueError(f"{artifact.path}: Vane wheel contains conflicting Python package path {name!r}")
 
@@ -542,25 +586,32 @@ def _check_wheel(artifact: WheelArtifact) -> None:
         "vane/_native/ray_cxx.pyi",
         "vane/sqltypes/__init__.pyi",
         "vane/udf.pyi",
-        f"{EXPECTED_DIST_INFO_ROOT}/METADATA",
-        f"{EXPECTED_DIST_INFO_ROOT}/WHEEL",
-        f"{EXPECTED_DIST_INFO_ROOT}/RECORD",
+        f"{layout.dist_info_root}/METADATA",
+        f"{layout.dist_info_root}/WHEEL",
+        f"{layout.dist_info_root}/RECORD",
     )
     for required_path in required_paths:
         _require_exact_path(names, required_path, artifact.path)
-    metadata = _check_metadata(artifact, f"{EXPECTED_DIST_INFO_ROOT}/METADATA")
+    metadata = _check_metadata(artifact, f"{layout.dist_info_root}/METADATA", layout)
     _check_no_official_duckdb_dependency(artifact, metadata)
-    _check_wheel_license_files(artifact, metadata)
-    _check_wheel_record(artifact)
+    _check_wheel_license_files(artifact, metadata, layout)
+    _check_wheel_record(artifact, layout)
 
 
 def check_artifact(
     path: Path,
     *,
+    expected_version: Version | str,
     content_rules: tuple[ContentRule, ...] = (),
     text_content_rules: tuple[ContentRule, ...] = (),
 ) -> None:
     """Validate one sdist or wheel."""
+    layout = distribution_layout(expected_version)
+    artifact_version = _artifact_version(path)
+    if artifact_version != layout.version:
+        raise ValueError(
+            f"{path}: expected version {layout.version}, found {artifact_version} in distribution filename"
+        )
     if path.stat().st_size > MAX_ARTIFACT_BYTES:
         raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
 
@@ -576,9 +627,19 @@ def check_artifact(
     try:
         _check_paths(artifact)
         _check_internal_content(artifact, content_rules, text_content_rules)
-        specific_check(artifact)
+        specific_check(artifact, layout)
     finally:
         artifact.close()
+
+
+def _canonical_version_argument(value: str) -> Version:
+    try:
+        version = Version(value)
+    except InvalidVersion:
+        raise argparse.ArgumentTypeError(f"invalid PEP 440 version: {value!r}") from None
+    if str(version) != value:
+        raise argparse.ArgumentTypeError(f"version must use canonical PEP 440 spelling: {version}")
+    return version
 
 
 def main() -> int:
@@ -588,6 +649,11 @@ def main() -> int:
         metavar="PATH",
         help="load private exact-content rules from PATH, or from standard input with '-'",
     )
+    parser.add_argument(
+        "--expected-version",
+        type=_canonical_version_argument,
+        help="require every artifact to carry this canonical PEP 440 version",
+    )
     parser.add_argument("artifacts", nargs="+", type=Path)
     args = parser.parse_args()
 
@@ -596,9 +662,11 @@ def main() -> int:
     if args.content_rules_manifest is not None:
         content_rules, text_content_rules = _load_content_rule_manifest(args.content_rules_manifest)
 
+    expected_version = args.expected_version or _artifact_version(args.artifacts[0])
     for artifact in args.artifacts:
         check_artifact(
             artifact,
+            expected_version=expected_version,
             content_rules=content_rules,
             text_content_rules=text_content_rules,
         )

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -14,6 +14,7 @@ import pytest
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
+from packaging.version import Version
 
 import vane
 
@@ -296,10 +297,13 @@ def _requirement_for_extra(extra, package, environment=None):
     return selected[0]
 
 
-def test_distribution_declares_release_version_and_apache_license_expression():
+def test_distribution_declares_canonical_version_and_apache_license_expression():
     package_metadata = metadata("vane-ai")
+    distribution_version = version("vane-ai")
 
-    assert version("vane-ai") == "0.1.0"
+    assert str(Version(distribution_version)) == distribution_version
+    assert package_metadata["Version"] == distribution_version
+    assert vane.__version__ == distribution_version
     assert package_metadata["License-Expression"] == "Apache-2.0"
     assert SpecifierSet(package_metadata["Requires-Python"]) == SpecifierSet(">=3.10,<3.15")
 

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -16,10 +16,13 @@ from email.message import Message
 from pathlib import Path
 
 import pytest
+from packaging.version import Version
 
 from scripts import check_release_artifacts, verify_duckdb_coexistence
 
-WHEEL_DATA_ROOT = f"{check_release_artifacts.EXPECTED_ARCHIVE_ROOT}.data"
+TEST_VERSION = Version("0.2.0.dev14")
+TEST_LAYOUT = check_release_artifacts.distribution_layout(TEST_VERSION)
+WHEEL_DATA_ROOT = f"{TEST_LAYOUT.archive_root}.data"
 REQUIRED_WHEEL_PATHS = (
     "vane/py.typed",
     "vane/_native/__init__.pyi",
@@ -28,9 +31,9 @@ REQUIRED_WHEEL_PATHS = (
     "vane/_native/ray_cxx.pyi",
     "vane/sqltypes/__init__.pyi",
     "vane/udf.pyi",
-    f"{check_release_artifacts.EXPECTED_DIST_INFO_ROOT}/METADATA",
-    f"{check_release_artifacts.EXPECTED_DIST_INFO_ROOT}/WHEEL",
-    f"{check_release_artifacts.EXPECTED_DIST_INFO_ROOT}/RECORD",
+    f"{TEST_LAYOUT.dist_info_root}/METADATA",
+    f"{TEST_LAYOUT.dist_info_root}/WHEEL",
+    f"{TEST_LAYOUT.dist_info_root}/RECORD",
 )
 
 
@@ -94,6 +97,14 @@ def _write_archive(path: Path, member_name: str, data: bytes) -> None:
         archive.writestr(member_name, data)
 
 
+def _artifact_path(tmp_path: Path, suffix: str, label: str) -> Path:
+    directory = tmp_path / label
+    directory.mkdir()
+    if suffix == ".tar.gz":
+        return directory / f"vane_ai-{TEST_VERSION}.tar.gz"
+    return directory / f"vane_ai-{TEST_VERSION}-py3-none-any.whl"
+
+
 def _rejected_by(callback: Callable[[], object]) -> ValueError:
     try:
         callback()
@@ -136,8 +147,8 @@ def _assert_metadata_only_error(
 
 @pytest.fixture
 def content_check_only(monkeypatch):
-    monkeypatch.setattr(check_release_artifacts, "_check_sdist", lambda _artifact: None)
-    monkeypatch.setattr(check_release_artifacts, "_check_wheel", lambda _artifact: None)
+    monkeypatch.setattr(check_release_artifacts, "_check_sdist", lambda _artifact, _layout: None)
+    monkeypatch.setattr(check_release_artifacts, "_check_wheel", lambda _artifact, _layout: None)
 
 
 def test_private_manifest_rejects_empty_rule_set():
@@ -221,7 +232,7 @@ def test_wheel_rejects_every_official_duckdb_import_location(member_name):
     artifact = _NamesOnlyArtifact([member_name])
 
     with pytest.raises(ValueError, match="conflicting Python package path"):
-        check_release_artifacts._check_wheel(artifact)
+        check_release_artifacts._check_wheel(artifact, TEST_LAYOUT)
 
 
 @pytest.mark.parametrize(
@@ -241,7 +252,7 @@ def test_wheel_rejects_every_import_or_distribution_root_not_owned_by_vane(membe
     artifact = _NamesOnlyArtifact([member_name])
 
     with pytest.raises(ValueError, match="conflicting Python package path"):
-        check_release_artifacts._check_wheel(artifact)
+        check_release_artifacts._check_wheel(artifact, TEST_LAYOUT)
 
 
 @pytest.mark.parametrize("required_path", REQUIRED_WHEEL_PATHS)
@@ -249,19 +260,19 @@ def test_wheel_required_files_must_use_their_exact_install_paths(required_path):
     decoy = (
         f"vane/decoy/{required_path}"
         if required_path.startswith("vane/")
-        else (f"{check_release_artifacts.EXPECTED_DIST_INFO_ROOT}/decoy/{required_path}")
+        else (f"{TEST_LAYOUT.dist_info_root}/decoy/{required_path}")
     )
     members = ["vane/_native.so", *REQUIRED_WHEEL_PATHS]
     members[members.index(required_path)] = decoy
     artifact = _NamesOnlyArtifact(members)
 
     with pytest.raises(ValueError, match="expected one archive member"):
-        check_release_artifacts._check_wheel(artifact)
+        check_release_artifacts._check_wheel(artifact, TEST_LAYOUT)
 
 
 @pytest.mark.parametrize("required_path", ["vane/sqltypes/__init__.pyi", "vane/udf.pyi"])
 def test_sdist_public_stubs_must_use_their_exact_project_paths(required_path):
-    decoy = f"{check_release_artifacts.EXPECTED_ARCHIVE_ROOT}/decoy/{required_path}"
+    decoy = f"{TEST_LAYOUT.archive_root}/decoy/{required_path}"
 
     with pytest.raises(ValueError, match="expected one project file"):
         check_release_artifacts._require_sdist_path([decoy], required_path, Path("test.tar.gz"))
@@ -271,7 +282,7 @@ def test_sdist_public_stubs_must_use_their_exact_project_paths(required_path):
     "member_name",
     [
         "vane/_native.pyi",
-        f"{check_release_artifacts.EXPECTED_ARCHIVE_ROOT}/vane/_native.pyi",
+        f"{TEST_LAYOUT.archive_root}/vane/_native.pyi",
     ],
 )
 def test_release_rejects_the_legacy_flat_native_stub(member_name):
@@ -282,11 +293,11 @@ def test_release_rejects_the_legacy_flat_native_stub(member_name):
 
 
 def test_sdist_metadata_must_use_the_root_project_path():
-    root = check_release_artifacts.EXPECTED_ARCHIVE_ROOT
+    root = TEST_LAYOUT.archive_root
     artifact = _NamesOnlyArtifact([f"{root}/decoy/PKG-INFO"])
 
     with pytest.raises(ValueError, match="expected one archive member"):
-        check_release_artifacts._check_metadata(artifact, f"{root}/PKG-INFO")
+        check_release_artifacts._check_metadata(artifact, f"{root}/PKG-INFO", TEST_LAYOUT)
 
 
 @pytest.mark.parametrize(
@@ -320,32 +331,51 @@ def test_release_metadata_rejects_invalid_requirements():
     [
         "duckdb/__init__.py",
         "DuckDB/__init__.py",
-        f"{check_release_artifacts.EXPECTED_ARCHIVE_ROOT}/duckdb/__init__.py",
-        f"{check_release_artifacts.EXPECTED_ARCHIVE_ROOT}/_duckdb.so",
-        f"{check_release_artifacts.EXPECTED_ARCHIVE_ROOT}/adbc_driver_duckdb/dbapi.py",
+        f"{TEST_LAYOUT.archive_root}/duckdb/__init__.py",
+        f"{TEST_LAYOUT.archive_root}/_duckdb.so",
+        f"{TEST_LAYOUT.archive_root}/adbc_driver_duckdb/dbapi.py",
     ],
 )
 def test_sdist_rejects_every_official_duckdb_import_location(member_name):
     artifact = _NamesOnlyArtifact([member_name])
 
     with pytest.raises(ValueError, match="conflicting Python package path"):
-        check_release_artifacts._check_sdist(artifact)
+        check_release_artifacts._check_sdist(artifact, TEST_LAYOUT)
 
 
 def test_wheel_record_rejects_duplicate_rows():
-    record_name = f"{check_release_artifacts.EXPECTED_DIST_INFO_ROOT}/RECORD"
+    record_name = f"{TEST_LAYOUT.dist_info_root}/RECORD"
     artifact = _MemoryWheelArtifact({record_name: f"{record_name},,\n{record_name},,\n".encode()})
 
     with pytest.raises(ValueError, match="duplicate RECORD entry"):
-        check_release_artifacts._check_wheel_record(artifact)
+        check_release_artifacts._check_wheel_record(artifact, TEST_LAYOUT)
 
 
 def test_wheel_record_must_not_hash_or_size_itself():
-    record_name = f"{check_release_artifacts.EXPECTED_DIST_INFO_ROOT}/RECORD"
+    record_name = f"{TEST_LAYOUT.dist_info_root}/RECORD"
     artifact = _MemoryWheelArtifact({record_name: f"{record_name},sha256=bogus,1\n".encode()})
 
     with pytest.raises(ValueError, match="must not hash or size itself"):
-        check_release_artifacts._check_wheel_record(artifact)
+        check_release_artifacts._check_wheel_record(artifact, TEST_LAYOUT)
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("vane_ai-0.2.0.dev14.tar.gz", TEST_VERSION),
+        ("vane_ai-0.2.0.dev14-cp312-cp312-manylinux_2_28_x86_64.whl", TEST_VERSION),
+    ],
+)
+def test_release_artifact_version_comes_from_distribution_filename(filename, expected):
+    assert check_release_artifacts._artifact_version(Path(filename)) == expected
+
+
+def test_release_artifact_filename_must_match_expected_version(tmp_path):
+    artifact = tmp_path / "vane_ai-0.2.1.tar.gz"
+    _write_archive(artifact, "vane_ai-0.2.1/PKG-INFO", b"")
+
+    with pytest.raises(ValueError, match="expected version 0.2.0.dev14, found 0.2.1"):
+        check_release_artifacts.check_artifact(artifact, expected_version=TEST_VERSION)
 
 
 def test_coexistence_subprocess_keeps_validation_assertions_under_pythonoptimize(monkeypatch, tmp_path):
@@ -375,8 +405,8 @@ def test_cli_loads_private_manifest_without_exposing_match(
     sentinel = sentinel_factory()
     rule_id = "runtime-sensitive-content"
     member_name = "project/security-probe.txt"
-    contaminated = tmp_path / f"contaminated{suffix}"
-    clean = tmp_path / f"clean{suffix}"
+    contaminated = _artifact_path(tmp_path, suffix, "contaminated")
+    clean = _artifact_path(tmp_path, suffix, "clean")
     manifest = tmp_path / "content-rules.json"
     _write_archive(contaminated, member_name, b"prefix-" + sentinel + b"-suffix")
     _write_archive(clean, member_name, b"clean artifact content")
@@ -424,7 +454,7 @@ def test_standalone_cli_reads_private_manifest_from_stdin(tmp_path, suffix):
     sentinel = _runtime_sentinel()
     rule_id = "runtime-sensitive-content"
     member_name = "project/security-probe.txt"
-    contaminated = tmp_path / f"contaminated{suffix}"
+    contaminated = _artifact_path(tmp_path, suffix, "contaminated")
     _write_archive(contaminated, member_name, b"prefix-" + sentinel + b"-suffix")
 
     result = subprocess.run(
@@ -459,12 +489,13 @@ def test_runtime_binary_rule_checks_members_with_nul_bytes(
     rule_id = "runtime-binary-content"
     member_name = "project/security-probe.bin"
     rule = check_release_artifacts.LiteralContentRule(rule_id, sentinel)
-    artifact = tmp_path / f"binary{suffix}"
+    artifact = _artifact_path(tmp_path, suffix, "binary")
     _write_archive(artifact, member_name, b"\0" + sentinel)
 
     error = _rejected_by(
         lambda: check_release_artifacts.check_artifact(
             artifact,
+            expected_version=TEST_VERSION,
             content_rules=(rule,),
             text_content_rules=(),
         )
@@ -490,14 +521,15 @@ def test_runtime_text_rule_preserves_binary_member_filter(
     rule_id = "runtime-text-content"
     member_name = "project/security-probe.bin"
     rule = check_release_artifacts.LiteralContentRule(rule_id, sentinel)
-    text_artifact = tmp_path / f"text{suffix}"
-    binary_artifact = tmp_path / f"binary{suffix}"
+    text_artifact = _artifact_path(tmp_path, suffix, "text")
+    binary_artifact = _artifact_path(tmp_path, suffix, "binary")
     _write_archive(text_artifact, member_name, sentinel)
     _write_archive(binary_artifact, member_name, b"\0" + sentinel)
 
     error = _rejected_by(
         lambda: check_release_artifacts.check_artifact(
             text_artifact,
+            expected_version=TEST_VERSION,
             content_rules=(),
             text_content_rules=(rule,),
         )
@@ -512,6 +544,7 @@ def test_runtime_text_rule_preserves_binary_member_filter(
     )
     check_release_artifacts.check_artifact(
         binary_artifact,
+        expected_version=TEST_VERSION,
         content_rules=(),
         text_content_rules=(rule,),
     )

--- a/tests/fast/test_scm_versioning.py
+++ b/tests/fast/test_scm_versioning.py
@@ -42,12 +42,16 @@ def _clear_branch_environment(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_main_development_version_advances_to_next_minor(monkeypatch):
-    version = _ScmVersion(tag=Version("0.1.0"), distance=14)
-    state = setuptools_scm_version._VersionState(Version("0.1.0"), 14, False)
+@pytest.mark.parametrize(
+    ("tag", "distance", "expected"),
+    [("0.1.0", 14, "0.2.0.dev14"), ("0.2.0rc1", 3, "0.2.0rc2.dev3")],
+)
+def test_main_development_version_advances_from_the_latest_main_tag(monkeypatch, tag, distance, expected):
+    version = _ScmVersion(tag=Version(tag), distance=distance)
+    state = setuptools_scm_version._VersionState(Version(tag), distance, False)
     monkeypatch.setattr(setuptools_scm_version, "_describe_main_line", lambda repository: state)
 
-    assert setuptools_scm_version.version_scheme(version) == "0.2.0.dev14"
+    assert setuptools_scm_version.version_scheme(version) == expected
 
 
 def test_project_metadata_uses_scm_without_a_fallback_version():
@@ -55,6 +59,8 @@ def test_project_metadata_uses_scm_without_a_fallback_version():
 
     assert configuration["project"]["dynamic"] == ["version"]
     assert "version" not in configuration["project"]
+    assert "setuptools-scm>=9.2.0" in configuration["build-system"]["requires"]
+    assert "setuptools-scm>=9.2.0" in configuration["dependency-groups"]["build"]
     assert configuration["tool"]["scikit-build"]["metadata"]["version"]["provider"] == (
         "scikit_build_core.metadata.setuptools_scm"
     )
@@ -117,6 +123,7 @@ def test_dirty_exact_tag_is_not_released_as_the_tagged_version():
         ("0.2.1", 0, "0.2.1"),
         ("0.2.2rc1", 2, "0.2.2rc2.dev2"),
         ("0.2.2.post1", 2, "0.2.2.post2.dev2"),
+        ("0.2.2rc1.post1", 2, "0.2.2rc1.post2.dev2"),
     ],
 )
 def test_release_branch_advances_patch_series(monkeypatch, tag, distance, expected):
@@ -156,19 +163,30 @@ def test_release_branch_uses_the_latest_tag_from_its_own_line(monkeypatch):
     }
 
 
-def test_main_uses_the_latest_minor_tag(monkeypatch):
+def test_main_uses_the_latest_patch_zero_final_or_prerelease_tag(monkeypatch):
     captured = {}
 
     def run(command, **kwargs):
         captured["command"] = command
-        return subprocess.CompletedProcess(command, 0, "v0.1.0-14-g0123456789abcdef0123456789abcdef01234567\n", "")
+        return subprocess.CompletedProcess(command, 0, "v0.2.0rc1-3-g0123456789abcdef0123456789abcdef01234567\n", "")
 
     monkeypatch.setattr(setuptools_scm_version.subprocess, "run", run)
 
     state = setuptools_scm_version._describe_main_line(Path("/repository"))
 
-    assert state == setuptools_scm_version._VersionState(Version("0.1.0"), 14, False)
-    assert captured["command"][-2:] == ["--match", "v*.*.0"]
+    assert state == setuptools_scm_version._VersionState(Version("0.2.0rc1"), 3, False)
+    command = captured["command"]
+    assert [command[index + 1] for index, argument in enumerate(command) if argument == "--match"] == [
+        "v[0-9]*.[0-9]*.0",
+        "v[0-9]*.[0-9]*.0a[0-9]*",
+        "v[0-9]*.[0-9]*.0b[0-9]*",
+        "v[0-9]*.[0-9]*.0rc[0-9]*",
+    ]
+    assert [command[index + 1] for index, argument in enumerate(command) if argument == "--exclude"] == [
+        "v*.post*",
+        "v*.dev*",
+        "v*+*",
+    ]
 
 
 def test_release_pull_request_uses_its_base_branch(monkeypatch):

--- a/tests/fast/test_scm_versioning.py
+++ b/tests/fast/test_scm_versioning.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -41,8 +42,10 @@ def _clear_branch_environment(monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
-def test_main_development_version_advances_to_next_minor():
+def test_main_development_version_advances_to_next_minor(monkeypatch):
     version = _ScmVersion(tag=Version("0.1.0"), distance=14)
+    state = setuptools_scm_version._VersionState(Version("0.1.0"), 14, False)
+    monkeypatch.setattr(setuptools_scm_version, "_describe_main_line", lambda repository: state)
 
     assert setuptools_scm_version.version_scheme(version) == "0.2.0.dev14"
 
@@ -59,14 +62,44 @@ def test_project_metadata_uses_scm_without_a_fallback_version():
     assert scm["version_scheme"] == "vane_packaging.setuptools_scm_version:version_scheme"
     assert scm["local_scheme"] == "no-local-version"
     assert "fallback_version" not in scm
-    assert scm["scm"]["git"]["describe_command"].endswith("--match v*.*.0")
+    assert scm["scm"]["git"]["describe_command"].endswith("--match v[0-9]*.[0-9]*.[0-9]*")
     assert scm["scm"]["git"]["pre_parse"] == "fail_on_shallow"
 
 
-def test_clean_exact_tag_is_the_release_version():
-    version = _ScmVersion(tag=Version("0.2.0"), distance=0, exact=True)
+@pytest.mark.parametrize("tag", ["0.2.0", "0.2.1", "0.2.0rc1"])
+def test_clean_exact_tag_is_the_release_version(tag):
+    version = _ScmVersion(tag=Version(tag), distance=0, exact=True, branch=None)
 
-    assert setuptools_scm_version.version_scheme(version) == "0.2.0"
+    assert setuptools_scm_version.version_scheme(version) == tag
+
+
+@pytest.mark.parametrize("tag", ["v0.2.1", "v0.2.0rc1"])
+def test_git_discovery_includes_exact_maintenance_tags(tmp_path, tag):
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
+    (tmp_path / "tracked.txt").write_text("release\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Vane Tests",
+            "-c",
+            "user.email=tests@vane.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "release",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(["git", "tag", tag], cwd=tmp_path, check=True)
+    configuration = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    command = shlex.split(configuration["tool"]["setuptools_scm"]["scm"]["git"]["describe_command"])
+
+    result = subprocess.run(command, cwd=tmp_path, check=True, capture_output=True, text=True)
+
+    assert result.stdout.startswith(f"{tag}-0-g")
 
 
 def test_dirty_exact_tag_is_not_released_as_the_tagged_version():
@@ -123,6 +156,21 @@ def test_release_branch_uses_the_latest_tag_from_its_own_line(monkeypatch):
     }
 
 
+def test_main_uses_the_latest_minor_tag(monkeypatch):
+    captured = {}
+
+    def run(command, **kwargs):
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, 0, "v0.1.0-14-g0123456789abcdef0123456789abcdef01234567\n", "")
+
+    monkeypatch.setattr(setuptools_scm_version.subprocess, "run", run)
+
+    state = setuptools_scm_version._describe_main_line(Path("/repository"))
+
+    assert state == setuptools_scm_version._VersionState(Version("0.1.0"), 14, False)
+    assert captured["command"][-2:] == ["--match", "v*.*.0"]
+
+
 def test_release_pull_request_uses_its_base_branch(monkeypatch):
     monkeypatch.setenv("GITHUB_BASE_REF", "release/1.4")
     version = _ScmVersion(tag=Version("1.4.0"), distance=1, branch="feature/fix")
@@ -130,9 +178,18 @@ def test_release_pull_request_uses_its_base_branch(monkeypatch):
     assert setuptools_scm_version._release_line(version) == (1, 4)
 
 
+def test_main_pull_request_does_not_use_its_release_head(monkeypatch):
+    monkeypatch.setenv("GITHUB_BASE_REF", "main")
+    monkeypatch.setenv("GITHUB_HEAD_REF", "release/1.4")
+    monkeypatch.setenv("GITHUB_REF_NAME", "release/1.4")
+    version = _ScmVersion(tag=Version("1.3.0"), distance=1, branch="release/1.4")
+
+    assert setuptools_scm_version._release_line(version) is None
+
+
 def test_explicit_version_branch_must_name_a_release_line(monkeypatch):
     monkeypatch.setenv("VANE_VERSION_BRANCH", "maintenance")
-    version = _ScmVersion(tag=Version("0.2.0"), distance=1)
+    version = _ScmVersion(tag=Version("0.2.0"), distance=0, exact=True)
 
     with pytest.raises(ValueError, match="release/X.Y"):
-        setuptools_scm_version._release_line(version)
+        setuptools_scm_version.version_scheme(version)

--- a/tests/fast/test_scm_versioning.py
+++ b/tests/fast/test_scm_versioning.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+from vane_packaging import setuptools_scm_version
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 compatibility
+    import tomli as tomllib
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass
+class _Configuration:
+    absolute_root: str = "/repository"
+
+
+@dataclass
+class _ScmVersion:
+    tag: object
+    distance: int | None
+    dirty: bool = False
+    exact: bool = False
+    branch: str | None = "main"
+    config: _Configuration = field(default_factory=_Configuration)
+
+
+@pytest.fixture(autouse=True)
+def _clear_branch_environment(monkeypatch):
+    for name in ("VANE_VERSION_BRANCH", "GITHUB_BASE_REF", "GITHUB_HEAD_REF", "GITHUB_REF_NAME"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_main_development_version_advances_to_next_minor():
+    version = _ScmVersion(tag=Version("0.1.0"), distance=14)
+
+    assert setuptools_scm_version.version_scheme(version) == "0.2.0.dev14"
+
+
+def test_project_metadata_uses_scm_without_a_fallback_version():
+    configuration = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert configuration["project"]["dynamic"] == ["version"]
+    assert "version" not in configuration["project"]
+    assert configuration["tool"]["scikit-build"]["metadata"]["version"]["provider"] == (
+        "scikit_build_core.metadata.setuptools_scm"
+    )
+    scm = configuration["tool"]["setuptools_scm"]
+    assert scm["version_scheme"] == "vane_packaging.setuptools_scm_version:version_scheme"
+    assert scm["local_scheme"] == "no-local-version"
+    assert "fallback_version" not in scm
+    assert scm["scm"]["git"]["describe_command"].endswith("--match v*.*.0")
+    assert scm["scm"]["git"]["pre_parse"] == "fail_on_shallow"
+
+
+def test_clean_exact_tag_is_the_release_version():
+    version = _ScmVersion(tag=Version("0.2.0"), distance=0, exact=True)
+
+    assert setuptools_scm_version.version_scheme(version) == "0.2.0"
+
+
+def test_dirty_exact_tag_is_not_released_as_the_tagged_version():
+    version = _ScmVersion(tag=Version("0.2.0"), distance=0, dirty=True, exact=True)
+
+    with pytest.raises(ValueError, match="positive Git commit distance"):
+        setuptools_scm_version.version_scheme(version)
+
+
+@pytest.mark.parametrize(
+    ("tag", "distance", "expected"),
+    [
+        ("0.2.0", 3, "0.2.1.dev3"),
+        ("0.2.1", 4, "0.2.2.dev4"),
+        ("0.2.1", 0, "0.2.1"),
+        ("0.2.2rc1", 2, "0.2.2rc2.dev2"),
+        ("0.2.2.post1", 2, "0.2.2.post2.dev2"),
+    ],
+)
+def test_release_branch_advances_patch_series(monkeypatch, tag, distance, expected):
+    version = _ScmVersion(tag=Version("0.2.0"), distance=99, branch="release/0.2")
+    state = setuptools_scm_version._VersionState(Version(tag), distance, False)
+    calls = []
+
+    def describe(repository, release_line):
+        calls.append((repository, release_line))
+        return state
+
+    monkeypatch.setattr(setuptools_scm_version, "_describe_release_line", describe)
+
+    assert setuptools_scm_version.version_scheme(version) == expected
+    assert calls == [(Path("/repository"), (0, 2))]
+
+
+def test_release_branch_uses_the_latest_tag_from_its_own_line(monkeypatch):
+    captured = {}
+
+    def run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(command, 0, "v0.2.1-3-g0123456789abcdef0123456789abcdef01234567\n", "")
+
+    monkeypatch.setattr(setuptools_scm_version.subprocess, "run", run)
+
+    state = setuptools_scm_version._describe_release_line(Path("/repository"), (0, 2))
+
+    assert state == setuptools_scm_version._VersionState(Version("0.2.1"), 3, False)
+    assert captured["command"][-2:] == ["--match", "v0.2.*"]
+    assert captured["kwargs"] == {
+        "cwd": Path("/repository"),
+        "check": True,
+        "capture_output": True,
+        "text": True,
+    }
+
+
+def test_release_pull_request_uses_its_base_branch(monkeypatch):
+    monkeypatch.setenv("GITHUB_BASE_REF", "release/1.4")
+    version = _ScmVersion(tag=Version("1.4.0"), distance=1, branch="feature/fix")
+
+    assert setuptools_scm_version._release_line(version) == (1, 4)
+
+
+def test_explicit_version_branch_must_name_a_release_line(monkeypatch):
+    monkeypatch.setenv("VANE_VERSION_BRANCH", "maintenance")
+    version = _ScmVersion(tag=Version("0.2.0"), distance=1)
+
+    with pytest.raises(ValueError, match="release/X.Y"):
+        setuptools_scm_version._release_line(version)

--- a/vane_packaging/__init__.py
+++ b/vane_packaging/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build-time helpers for Vane's Python distributions."""

--- a/vane_packaging/setuptools_scm_version.py
+++ b/vane_packaging/setuptools_scm_version.py
@@ -50,15 +50,20 @@ def version_scheme(version: _ScmVersion) -> str:
     if version.tag is None:
         raise ValueError("Vane builds require a version tag in Git history")
 
+    discovered = _VersionState(
+        tag=Version(str(version.tag)),
+        distance=int(version.distance or 0),
+        dirty=version.dirty,
+    )
     release_line = _release_line(version)
-    if release_line is None:
-        state = _VersionState(
-            tag=Version(str(version.tag)),
-            distance=int(version.distance or 0),
-            dirty=version.dirty,
-        )
+    if discovered.exact:
+        state = discovered
     else:
-        state = _describe_release_line(Path(version.config.absolute_root), release_line)
+        repository = Path(version.config.absolute_root)
+        if release_line is None:
+            state = _describe_main_line(repository)
+        else:
+            state = _describe_release_line(repository, release_line)
 
     if state.exact and not state.dirty:
         return str(state.tag)
@@ -87,12 +92,14 @@ def _release_line(version: _ScmVersion) -> tuple[int, int] | None:
             raise ValueError("VANE_VERSION_BRANCH must use the form release/X.Y")
         return int(match["major"]), int(match["minor"])
 
-    candidates = (
-        os.getenv("GITHUB_BASE_REF"),
-        os.getenv("GITHUB_HEAD_REF"),
-        os.getenv("GITHUB_REF_NAME"),
-        version.branch,
-    )
+    github_base = os.getenv("GITHUB_BASE_REF")
+    if github_base:
+        match = RELEASE_BRANCH.fullmatch(github_base)
+        if match is None:
+            return None
+        return int(match["major"]), int(match["minor"])
+
+    candidates = (os.getenv("GITHUB_REF_NAME"), version.branch)
     for branch in candidates:
         if not branch:
             continue
@@ -102,8 +109,22 @@ def _release_line(version: _ScmVersion) -> tuple[int, int] | None:
     return None
 
 
+def _describe_main_line(repository: Path) -> _VersionState:
+    state = _describe(repository, "v*.*.0")
+    if state.tag.release[2] != 0:
+        raise ValueError(f"tag {state.tag} is not a minor release")
+    return state
+
+
 def _describe_release_line(repository: Path, release_line: tuple[int, int]) -> _VersionState:
     major, minor = release_line
+    state = _describe(repository, f"v{major}.{minor}.*")
+    if state.tag.release[:2] != release_line:
+        raise ValueError(f"tag {state.tag} is outside release line {major}.{minor}")
+    return state
+
+
+def _describe(repository: Path, tag_pattern: str) -> _VersionState:
     result = subprocess.run(
         [
             "git",
@@ -113,7 +134,7 @@ def _describe_release_line(repository: Path, release_line: tuple[int, int]) -> _
             "--long",
             "--abbrev=40",
             "--match",
-            f"v{major}.{minor}.*",
+            tag_pattern,
         ],
         cwd=repository,
         check=True,
@@ -126,8 +147,6 @@ def _describe_release_line(repository: Path, release_line: tuple[int, int]) -> _
         raise ValueError(f"Git returned an invalid version description: {description!r}")
 
     tag = Version(match["tag"].removeprefix("v"))
-    if tag.release[:2] != release_line:
-        raise ValueError(f"tag {tag} is outside release line {major}.{minor}")
     return _VersionState(
         tag=tag,
         distance=int(match["distance"]),

--- a/vane_packaging/setuptools_scm_version.py
+++ b/vane_packaging/setuptools_scm_version.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Branch-aware setuptools-scm version scheme for Vane."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from packaging.version import Version
+
+RELEASE_BRANCH = re.compile(r"^(?:refs/heads/)?release/(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)$")
+GIT_DESCRIBE = re.compile(
+    r"^(?P<tag>.+)-(?P<distance>[0-9]+)-g[0-9a-f]{40}(?P<dirty>-dirty)?$",
+    re.IGNORECASE,
+)
+
+
+class _ScmConfiguration(Protocol):
+    absolute_root: str
+
+
+class _ScmVersion(Protocol):
+    tag: object
+    distance: int | None
+    dirty: bool
+    exact: bool
+    branch: str | None
+    config: _ScmConfiguration
+
+
+@dataclass(frozen=True)
+class _VersionState:
+    tag: Version
+    distance: int
+    dirty: bool
+
+    @property
+    def exact(self) -> bool:
+        return self.distance == 0
+
+
+def version_scheme(version: _ScmVersion) -> str:
+    """Return an exact tag or the next minor/patch development version."""
+    if version.tag is None:
+        raise ValueError("Vane builds require a version tag in Git history")
+
+    release_line = _release_line(version)
+    if release_line is None:
+        state = _VersionState(
+            tag=Version(str(version.tag)),
+            distance=int(version.distance or 0),
+            dirty=version.dirty,
+        )
+    else:
+        state = _describe_release_line(Path(version.config.absolute_root), release_line)
+
+    if state.exact and not state.dirty:
+        return str(state.tag)
+
+    if state.distance <= 0:
+        raise ValueError("a development build requires a positive Git commit distance")
+
+    major, minor, patch = state.tag.release
+    if state.tag.post is not None:
+        next_version = f"{major}.{minor}.{patch}.post{state.tag.post + 1}"
+    elif state.tag.pre is not None:
+        prerelease, number = state.tag.pre
+        next_version = f"{major}.{minor}.{patch}{prerelease}{number + 1}"
+    elif release_line is not None:
+        next_version = f"{major}.{minor}.{patch + 1}"
+    else:
+        next_version = f"{major}.{minor + 1}.0"
+    return f"{next_version}.dev{state.distance}"
+
+
+def _release_line(version: _ScmVersion) -> tuple[int, int] | None:
+    override = os.getenv("VANE_VERSION_BRANCH")
+    if override:
+        match = RELEASE_BRANCH.fullmatch(override)
+        if match is None:
+            raise ValueError("VANE_VERSION_BRANCH must use the form release/X.Y")
+        return int(match["major"]), int(match["minor"])
+
+    candidates = (
+        os.getenv("GITHUB_BASE_REF"),
+        os.getenv("GITHUB_HEAD_REF"),
+        os.getenv("GITHUB_REF_NAME"),
+        version.branch,
+    )
+    for branch in candidates:
+        if not branch:
+            continue
+        match = RELEASE_BRANCH.fullmatch(branch)
+        if match is not None:
+            return int(match["major"]), int(match["minor"])
+    return None
+
+
+def _describe_release_line(repository: Path, release_line: tuple[int, int]) -> _VersionState:
+    major, minor = release_line
+    result = subprocess.run(
+        [
+            "git",
+            "describe",
+            "--dirty",
+            "--tags",
+            "--long",
+            "--abbrev=40",
+            "--match",
+            f"v{major}.{minor}.*",
+        ],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    description = result.stdout.strip()
+    match = GIT_DESCRIBE.fullmatch(description)
+    if match is None:
+        raise ValueError(f"Git returned an invalid version description: {description!r}")
+
+    tag = Version(match["tag"].removeprefix("v"))
+    if tag.release[:2] != release_line:
+        raise ValueError(f"tag {tag} is outside release line {major}.{minor}")
+    return _VersionState(
+        tag=tag,
+        distance=int(match["distance"]),
+        dirty=match["dirty"] is not None,
+    )

--- a/vane_packaging/setuptools_scm_version.py
+++ b/vane_packaging/setuptools_scm_version.py
@@ -19,6 +19,13 @@ GIT_DESCRIBE = re.compile(
     r"^(?P<tag>.+)-(?P<distance>[0-9]+)-g[0-9a-f]{40}(?P<dirty>-dirty)?$",
     re.IGNORECASE,
 )
+MAIN_TAG_PATTERNS = (
+    "v[0-9]*.[0-9]*.0",
+    "v[0-9]*.[0-9]*.0a[0-9]*",
+    "v[0-9]*.[0-9]*.0b[0-9]*",
+    "v[0-9]*.[0-9]*.0rc[0-9]*",
+)
+MAIN_TAG_EXCLUDES = ("v*.post*", "v*.dev*", "v*+*")
 
 
 class _ScmConfiguration(Protocol):
@@ -73,7 +80,11 @@ def version_scheme(version: _ScmVersion) -> str:
 
     major, minor, patch = state.tag.release
     if state.tag.post is not None:
-        next_version = f"{major}.{minor}.{patch}.post{state.tag.post + 1}"
+        prerelease = ""
+        if state.tag.pre is not None:
+            prerelease_type, prerelease_number = state.tag.pre
+            prerelease = f"{prerelease_type}{prerelease_number}"
+        next_version = f"{major}.{minor}.{patch}{prerelease}.post{state.tag.post + 1}"
     elif state.tag.pre is not None:
         prerelease, number = state.tag.pre
         next_version = f"{major}.{minor}.{patch}{prerelease}{number + 1}"
@@ -110,9 +121,9 @@ def _release_line(version: _ScmVersion) -> tuple[int, int] | None:
 
 
 def _describe_main_line(repository: Path) -> _VersionState:
-    state = _describe(repository, "v*.*.0")
-    if state.tag.release[2] != 0:
-        raise ValueError(f"tag {state.tag} is not a minor release")
+    state = _describe(repository, MAIN_TAG_PATTERNS, exclude_patterns=MAIN_TAG_EXCLUDES)
+    if state.tag.release[2] != 0 or state.tag.post is not None:
+        raise ValueError(f"tag {state.tag} is not a main-line release")
     return state
 
 
@@ -124,18 +135,22 @@ def _describe_release_line(repository: Path, release_line: tuple[int, int]) -> _
     return state
 
 
-def _describe(repository: Path, tag_pattern: str) -> _VersionState:
+def _describe(
+    repository: Path,
+    tag_patterns: str | tuple[str, ...],
+    *,
+    exclude_patterns: tuple[str, ...] = (),
+) -> _VersionState:
+    if isinstance(tag_patterns, str):
+        tag_patterns = (tag_patterns,)
+    command = ["git", "describe", "--dirty", "--tags", "--long", "--abbrev=40"]
+    for pattern in tag_patterns:
+        command.extend(("--match", pattern))
+    for pattern in exclude_patterns:
+        command.extend(("--exclude", pattern))
+
     result = subprocess.run(
-        [
-            "git",
-            "describe",
-            "--dirty",
-            "--tags",
-            "--long",
-            "--abbrev=40",
-            "--match",
-            tag_pattern,
-        ],
+        command,
         cwd=repository,
         check=True,
         capture_output=True,


### PR DESCRIPTION
## Summary

- Derive the `vane-ai` package version from Git using DuckDB-style SCM versioning instead of the released `0.1.0` constant.
- On `main`, count from the latest patch-zero final or prerelease tag: commits after `v0.1.0` are `0.2.0.devN`, commits after `v0.2.0rc1` are `0.2.0rc2.devN`, and commits after the final `v0.2.0` start `0.3.0.devN`. On `release/X.Y`, advance the latest tag in that series to the next patch development version (for example, `release/0.2` produces `0.2.1.devN` after `v0.2.0`). Exact clean tags remain release versions, including detached maintenance and prerelease tag checkouts.
- Intentionally require a complete Git checkout or an official sdist; no compatibility fallback version is configured.
- Validate and propagate one canonical dynamic version across sdists, wheels, and release jobs, and require patch-zero releases from `main` while patch/post releases come from `release/X.Y`.
- Document the release-branch policy and add focused tests for main, prerelease/post-release, patch-series, pull-request base-branch, exact-tag, dirty-tree, and artifact-version behavior.

## Related issue

N/A

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`RELEASE.md` now documents SCM-derived versions, `release/X.Y` maintenance branches, and release-tag source requirements.

## Validation

- `scripts/format root --changed`
- `ruff check vane_packaging/setuptools_scm_version.py tests/fast/test_scm_versioning.py`
- Checked-in nested `scm.git` configuration loaded with the minimum supported `setuptools-scm==9.2.0`
- Isolated HEAD sdist build and `scripts/check_release_artifacts.py` validation (`vane_ai-0.2.0.dev17.tar.gz`)
- Wheel metadata generation from the unpacked HEAD sdist without Git metadata (`0.2.0.dev17`)
- Incremental native wheel build and artifact validation on the initial versioning commit (`vane_ai-0.2.0.dev15-cp312-cp312-linux_x86_64.whl`); the review follow-up changes only build-time Python logic and tests
- Installed-wheel smoke test: distribution/runtime version `0.2.0.dev15`, engine version `1.5.0-vane.7af9fc2fef`, SourceID `c3be867949`
- `scripts/run_installed_pytest.sh tests/fast/test_scm_versioning.py` after the latest review fixes (`20 passed`)
- `scripts/run_installed_pytest.sh tests/fast/test_scm_versioning.py tests/fast/test_release_artifact_security.py tests/fast/test_package_metadata.py` on the initial versioning commit (`110 passed`)
- `scripts/run_release_tests.sh` after the latest review fixes (`530 passed, 15 deselected`; real-Ray shard: `11 passed, 534 deselected`)
- Environment: Linux x86_64, Python 3.12, CPU-only

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (`setuptools-scm` is an MIT-licensed build dependency.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. (No runtime execution surface changes; artifact/version validation is stricter.)
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. (No native source changed; a native wheel was built and tested.)
