### PR TITLE
[fix](ray) Stabilize query teardown admission regression test

### DIFF
--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -2692,9 +2692,7 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
         active = await runner_cls.acquire_query_task_lease(runner, active_request)
         assert active["granted"]
 
-        owner_thread_id = threading.get_ident()
         failed_pending = threading.Event()
-        allow_background_teardown = threading.Event()
         original_fail = runner_cls._fail_query_admission_requests.__get__(
             runner,
             runner_cls,
@@ -2703,8 +2701,6 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
         def controlled_fail(query_key):
             original_fail(query_key)
             failed_pending.set()
-            if threading.get_ident() != owner_thread_id:
-                assert allow_background_teardown.wait(timeout=1)
 
         runner._fail_query_admission_requests = controlled_fail
         teardown = asyncio.create_task(
@@ -2715,7 +2711,20 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
                 reason="test_background_teardown",
             )
         )
-        await asyncio.to_thread(failed_pending.wait, 1)
+        assert await asyncio.to_thread(failed_pending.wait, 1)
+
+        # Keep teardown before table purge until the late request observes the closing fence.
+        late_request = _task_request(
+            runner,
+            query_id,
+            "request:late",
+            "task:late",
+        )
+        denial = await asyncio.wait_for(
+            runner_cls.acquire_query_task_lease(runner, late_request),
+            timeout=0.2,
+        )
+
         assert await runner_cls.release_query_task_lease(
             runner,
             active_request["request_id"],
@@ -2736,19 +2745,7 @@ def test_background_query_teardown_fences_new_admission_before_table_purge():
             [SimpleNamespace(future=Future)],
         ) == {"scheduled": True}
 
-        late_request = _task_request(
-            runner,
-            query_id,
-            "request:late",
-            "task:late",
-        )
-        late_waiter = asyncio.create_task(runner_cls.acquire_query_task_lease(runner, late_request))
-        for _ in range(4):
-            await asyncio.sleep(0)
-        allow_background_teardown.set()
         await teardown
-
-        denial = await asyncio.wait_for(late_waiter, timeout=0.2)
         assert denial["granted"] is False
         assert denial["fatal"] is True
         assert denial["blocked_reason"] == "query_not_registered"


### PR DESCRIPTION
## Summary

The regression test released its active task lease before the late admission
request observed the query-closing fence. Teardown could therefore purge the
generation first, causing CI to intermittently return
`query_generation_inactive` instead of `query_not_registered`.

Keep the lease active until the late request observes the closing fence, and
remove the ineffective thread gate and scheduler-yield loop. This makes the
test deterministic without changing runtime behavior.

## Related context

Observed in CI for #576; that PR is otherwise unrelated.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed --check`
- `pre-commit run --show-diff-on-failure --files tests/fast/test_driver_query_leases.py`
- `scripts/run_installed_pytest.sh -q tests/fast/test_driver_query_leases.py` (45 passed)
- Target regression test in 20 independent pytest processes (20/20 passed)
- `scripts/run_release_tests.sh` (526 passed, 4 skipped; real-Ray shard: 11 passed)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
