### PR TITLE
[fix](ray) Decouple stream completion from cleanup ACK

### DIFF
--- a/tests/fast/test_udf_stream_result_collector.py
+++ b/tests/fast/test_udf_stream_result_collector.py
@@ -1983,7 +1983,7 @@ def test_inflight_block_survives_temporary_downstream_backpressure():
         collector.shutdown()
 
 
-def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
+def test_terminal_stream_publishes_completion_after_cleanup_handoff(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     generator_holder = {}
@@ -2036,43 +2036,100 @@ def test_terminal_stream_is_retired_before_completion_is_published(monkeypatch):
     del source
     capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
     try:
-        events = []
-        deadline = time.monotonic() + 2.0
-        while not retire_started.is_set() and time.monotonic() < deadline:
-            events.extend(collector.drain_results(capacity))
-            time.sleep(0.005)
-        assert retire_started.is_set()
-        events.extend(collector.drain_results(capacity))
-
-        # Completion is the observable retirement boundary. Independent
-        # tickets may finish while one control Future remains pending, but the
-        # record cannot complete until the whole plan settles.
-        assert [item[2] for item in events] == ["data"]
-        assert collector._records
-        assert collector._cleanup_tickets
-        generator = generator_holder["generator"]
-        assert source_ref() is None
-        assert generator.deleted_streams == [generator.completion_ref]
-
-        data = next(item for item in events if item[2] == "data")
-        assert collector.release_output_block_lease(data[4], data[5]) is True
-        del data
-        del events
-
-        retirement.set_result(None)
         events = _drain_until(
             collector,
             capacity,
             predicate=lambda values: any(item[2] == "complete" for item in values),
         )
+        assert retire_started.is_set()
+        assert [item[2] for item in events] == ["data", "complete"]
+        assert retirement.done() is False
+        with collector._cv:
+            assert collector._records == {}
+            assert collector._cleanup_tickets
+            assert collector._cleanup_tickets_by_slot.get(2) is None
 
-        assert [item[2] for item in events] == ["complete"]
-        assert collector._records == {}
-        assert source_ref() is None
-        assert generator.deleted_streams == [generator.completion_ref]
+        generator = generator_holder["generator"]
+        _wait_until(lambda: source_ref() is None)
+        _wait_until(lambda: generator.deleted_streams == [generator.completion_ref])
+
+        data = next(item for item in events if item[2] == "data")
+        assert collector.release_output_block_lease(data[4], data[5]) is True
+        _wait_until(lambda: not collector.slot_has_pending(2))
+        assert collector.retire_slot(2) is None
+        with collector._cv:
+            assert collector._cleanup_tickets
+
+        retirement.set_result(None)
+        _wait_until(lambda: not collector._cleanup_tickets)
     finally:
         if not retirement.done():
             retirement.set_result(None)
+        collector.shutdown()
+
+
+def test_successful_stream_cleanup_timeout_preserves_data_and_completion(
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setenv("VANE_UDF_STREAM_CLEANUP_TIMEOUT_S", "0.08")
+    caplog.set_level("WARNING", logger=collector_module.__name__)
+    fake_ray = _FakeRay()
+    driver = _Driver()
+    release_ack = _Ref({"released": True}, ready=False)
+    driver.release_query_task_lease = _DelayedAckRemoteMethod(release_ack)
+    block_ref = _Ref("large-block", ready=False, is_block=True)
+    collector = UDFStreamResultCollector(ray_module=fake_ray)
+    collector.track_generator_ref(
+        2,
+        23,
+        _source(
+            fake_ray,
+            driver,
+            request_id="cleanup-timeout-after-success",
+            submitter=lambda lease: _Generator([block_ref, _Ref(_metadata(lease, size_bytes=64))]),
+        ),
+    )
+    capacity = {2: {"rows": 1, "bytes": 128, "item_bytes": 128}}
+
+    def queued_kinds():
+        with collector._cv:
+            return [event.kind for event in collector._ready_by_slot.get(2, ())]
+
+    try:
+        assert collector.drain_results(capacity) == []
+        fake_ray.make_ready(block_ref)
+        _wait_until(lambda: queued_kinds() == ["data", "complete"])
+        _wait_until(
+            lambda: any(
+                "cleanup did not settle after successful stream completion" in record.getMessage()
+                for record in caplog.records
+            )
+        )
+        _wait_until(lambda: not collector._cleanup_tickets)
+
+        assert release_ack.ready is False
+        assert queued_kinds() == ["data", "complete"]
+        warning_messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "slot=2, submit=23, scope=test-stream:cleanup-timeout-after-success" in message
+            and "TimeoutError: Ray UDF remote cleanup did not terminate within 0.08s" in message
+            for message in warning_messages
+        )
+        with collector._cv:
+            assert collector._records == {}
+            assert len(collector._active_output_leases) == 1
+            assert collector._terminal_cleanup_errors == []
+
+        events = collector.drain_results(capacity)
+        assert [item[2] for item in events] == ["data", "complete"]
+        assert all(item[2] != "error" for item in events)
+        data = events[0]
+        assert collector.release_output_block_lease(data[4], data[5]) is True
+        _wait_until(lambda: not collector.slot_has_pending(2))
+        assert collector.retire_slot(2) is None
+    finally:
+        fake_ray.make_ready(release_ack)
         collector.shutdown()
 
 
@@ -2292,7 +2349,7 @@ def test_blocked_terminal_retirement_does_not_stall_healthy_stream(monkeypatch):
         collector.shutdown()
 
 
-def test_slot_cancel_observes_claimed_terminal_retirement_without_waiting(monkeypatch):
+def test_slot_cancel_ignores_process_owned_terminal_cleanup(monkeypatch):
     fake_ray = _FakeRay()
     driver = _Driver()
     retire_started = threading.Event()
@@ -2336,11 +2393,17 @@ def test_slot_cancel_observes_claimed_terminal_retirement_without_waiting(monkey
         started_at = time.monotonic()
         collector.cancel_slot(4)
         assert time.monotonic() - started_at < 0.1
-        assert collector.slot_has_pending(4)
+        assert collector.slot_has_pending(4) is False
+        assert retirement.done() is False
+        with collector._cv:
+            assert collector._records == {}
+            assert collector._ready_by_slot.get(4) is None
+            assert collector._cleanup_tickets
+            assert collector._cleanup_tickets_by_slot.get(4) is None
+        collector.retire_slot(4)
 
         retirement.set_result(None)
-        _wait_until(lambda: not collector.slot_has_pending(4))
-        collector.retire_slot(4)
+        _wait_until(lambda: not collector._cleanup_tickets)
     finally:
         if not retirement.done():
             retirement.set_result(None)
@@ -2987,9 +3050,11 @@ def test_real_ray_generator_wait_is_non_consuming_and_preserves_pair_order():
         collector.shutdown()
 
 
-def test_empty_stream_completion_progresses_with_zero_data_capacity():
+def test_empty_stream_completion_does_not_wait_for_task_release_ack():
     fake_ray = _FakeRay()
     driver = _Driver()
+    release_ack = _Ref({"released": True}, ready=False)
+    driver.release_query_task_lease = _DelayedAckRemoteMethod(release_ack)
     collector = UDFStreamResultCollector(ray_module=fake_ray)
     collector.track_generator_ref(
         4,
@@ -3009,7 +3074,17 @@ def test_empty_stream_completion_progresses_with_zero_data_capacity():
         )
         assert events == [(4, 40, "complete", None)]
         assert len(driver.release_query_task_lease.calls) == 1
+        assert release_ack.ready is False
+        with collector._cv:
+            assert collector._cleanup_tickets
+            assert collector._cleanup_tickets_by_slot.get(4) is None
+        assert collector.slot_has_pending(4) is False
+        assert collector.retire_slot(4) is None
+
+        fake_ray.make_ready(release_ack)
+        _wait_until(lambda: not collector._cleanup_tickets)
     finally:
+        fake_ray.make_ready(release_ack)
         collector.shutdown()
 
 

--- a/vane/execution/udf_stream_result_collector.py
+++ b/vane/execution/udf_stream_result_collector.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import os
 import sys
@@ -44,6 +45,8 @@ _CLEANUP_RETRY_INITIAL_DELAY_S = 0.01
 _CLEANUP_RETRY_MAX_DELAY_S = 1.0
 _CLEANUP_RESPONSE_TIMEOUT_S = 1.0
 _CLEANUP_RESPONSE_TIMEOUT_MAX_S = 30.0
+
+logger = logging.getLogger(__name__)
 
 
 def _collector_debug_log(event: str, record: _StreamRecord, **fields: Any) -> None:
@@ -136,8 +139,6 @@ class _StreamRecord:
     next_ref_ready: bool = False
     ready_sequence: int | None = None
     cleanup_started: bool = False
-    cleanup_remaining: int = 0
-    cleanup_error: BaseException | None = None
 
 
 class _CleanupTicket:
@@ -2203,72 +2204,22 @@ class UDFStreamResultCollector:
             return
         record.adapter.mark_drained()
         key = (record.slot_id, record.submit_id)
+        slot_id = record.slot_id
+        submit_id = record.submit_id
+        submission_scope = record.adapter.submission_scope
 
-        def finish_retirement(error: BaseException | None) -> None:
-            with self._cleanup_handoff_lock:
-                with self._cv:
-                    if self._records.get(key) is not record:
-                        if error is not None:
-                            self._terminal_cleanup_errors.append(error)
-                            self._cv.notify_all()
-                        return
-                    dropped_tokens: list[_OutputLeaseToken] = []
-                    if error is not None:
-                        ready = self._ready_by_slot.get(record.slot_id)
-                        if ready is not None:
-                            for queued in ready:
-                                if queued.submit_id == record.submit_id and queued.kind == "data":
-                                    if queued.output_token is not None:
-                                        dropped_tokens.append(queued.output_token)
-                    claimed_tokens = self._claim_output_token_releases_locked(dropped_tokens)
-                try:
-                    self._submit_cleanup_operations(
-                        tuple(self._output_token_release_operation(token) for token in claimed_tokens),
-                        slot_ids=(record.slot_id,),
-                    )
-                except BaseException:
-                    self._restore_output_token_release_claims(claimed_tokens)
-                    raise
-                with self._cv:
-                    if self._records.pop(key, None) is not record:
-                        if error is not None:
-                            self._terminal_cleanup_errors.append(error)
-                            self._cv.notify_all()
-                        return
-                    if error is None:
-                        event = _ReadyEvent(record.slot_id, record.submit_id, "complete", None)
-                    else:
-                        ready = self._ready_by_slot.get(record.slot_id)
-                        if ready is not None:
-                            self._ready_by_slot[record.slot_id] = deque(
-                                queued
-                                for queued in ready
-                                if not (queued.submit_id == record.submit_id and queued.kind == "data")
-                            )
-                        for token in dropped_tokens:
-                            self._active_output_leases.pop((token.request_id, token.lease_id), None)
-                        event = _ReadyEvent(
-                            record.slot_id,
-                            record.submit_id,
-                            "error",
-                            f"{type(error).__name__}: {error}",
-                        )
-                    self._ready_by_slot[record.slot_id].append(event)
-                    self._cv.notify_all()
-            _collector_debug_log("retired" if error is None else "retire_failed", record)
-            self._notify_wakeup()
-
-        def finish_cleanup_operation(error: BaseException | None) -> None:
-            with self._cv:
-                if error is not None and record.cleanup_error is None:
-                    record.cleanup_error = error
-                record.cleanup_remaining -= 1
-                if record.cleanup_remaining < 0:
-                    raise RuntimeError("Ray UDF record cleanup count underflow")
-                if record.cleanup_remaining:
-                    return
-                cleanup_error = record.cleanup_error
-            finish_retirement(cleanup_error)
+        def report_cleanup_result(error: BaseException | None) -> None:
+            if error is None:
+                return
+            logger.warning(
+                "Ray UDF cleanup did not settle after successful stream completion "
+                "(slot=%s, submit=%s, scope=%s): %s: %s",
+                slot_id,
+                submit_id,
+                submission_scope,
+                type(error).__name__,
+                error,
+            )
 
         with self._cleanup_handoff_lock:
             with self._cv:
@@ -2278,26 +2229,29 @@ class UDFStreamResultCollector:
                 record.cleanup_started = True
                 self._signal_readiness_change_locked()
                 cleanup_operations = record.adapter.retire_operations()
-                record.cleanup_remaining = len(cleanup_operations)
-                record.cleanup_error = None
-            if cleanup_operations:
-                try:
-                    self._submit_cleanup_operations(
-                        cleanup_operations,
-                        on_each_done=finish_cleanup_operation,
-                        store_error=False,
-                        slot_ids=(record.slot_id,),
-                    )
-                except BaseException:
-                    with self._cv:
-                        if self._records.get(key) is record:
-                            record.cleanup_started = False
-                            record.cleanup_remaining = 0
-                            record.cleanup_error = None
-                            self._cv.notify_all()
-                    raise
-            else:
-                finish_retirement(None)
+            try:
+                # Data-plane success commits once the cleanup plan has durable
+                # process ownership. These tickets intentionally do not own the
+                # slot, and their control-plane acknowledgements cannot rewrite
+                # data events that have already been produced.
+                self._submit_cleanup_operations(
+                    cleanup_operations,
+                    on_each_done=report_cleanup_result,
+                    store_error=False,
+                )
+            except BaseException:
+                with self._cv:
+                    if self._records.get(key) is record:
+                        record.cleanup_started = False
+                        self._cv.notify_all()
+                raise
+            with self._cv:
+                if self._records.pop(key, None) is not record:
+                    return
+                self._ready_by_slot[slot_id].append(_ReadyEvent(slot_id, submit_id, "complete", None))
+                self._cv.notify_all()
+        _collector_debug_log("retired", record)
+        self._notify_wakeup()
 
     def _fail_record(self, record: _StreamRecord, exc: BaseException) -> None:
         key = (record.slot_id, record.submit_id)


### PR DESCRIPTION
## Summary

- Commit successful Ray UDF stream completion once the terminal cleanup plan has been transferred to the durable process-owned cleanup ledger.
- Keep post-handoff driver RPC acknowledgements and cleanup deadlines out of the query result path: failures remain visible as contextual warnings but cannot discard queued data or replace `complete` with `error`.
- Make successful terminal cleanup process-owned rather than slot-owned so slot retirement is not coupled to control-plane latency, while preserving slot ownership for cancellation and failure cleanup.
- Add regression coverage for blocked retirement, delayed task-release acknowledgements, total cleanup deadline expiry, and cancellation racing process-owned cleanup.

This intentionally changes the previous behavior: a cleanup failure after durable handoff is an operational cleanup warning, not a retroactive failure of an already successful data stream. Pre-handoff failures still fail the stream and replan owned cleanup.

## Related issue

N/A (follow-up to the cleanup deadline behavior introduced in #415).

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change corrects an internal lifecycle boundary and does not add or change a public configuration surface.

## Validation

- `scripts/format root --changed`
- Python 3.12.13, Linux x86-64, Release non-editable wheel build: `uv pip install . --no-build-isolation -v`
- `scripts/run_installed_pytest.sh tests/fast/test_udf_stream_result_collector.py` — 73 passed
- `scripts/run_installed_pytest.sh tests/fast/test_udf_process.py` — 20 passed
- `scripts/run_release_tests.sh` — non-Ray: 529 passed, 1 optional-dependency skip, 15 deselected; real-Ray: 11 passed, 534 deselected

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
