### PR TITLE
[fix](distributed) Remove racy Flight read watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ A worker lazily starts one process-owned plaintext `grpc://` Flight service when
 
 Workers advertise their Ray private address by default. `VANE_FLIGHT_BIND_HOST` may select a different local bind address, including `0.0.0.0` in a container with appropriate network policy, while `VANE_FLIGHT_ADVERTISE_HOST` must always be a routable non-wildcard address. The advertised-host override is worker-local: set it in each worker node's environment rather than on the driver or in a Ray Job/actor runtime environment. `DUCKDB_FLIGHT_PORT` selects a fixed worker-local port; the default `0` lets the operating system allocate one. See [SECURITY.md](SECURITY.md) for the complete trust boundary.
 
-Cross-worker reads have a one-hour call deadline and a 60-second maximum duration for each blocking DoGet, schema, or batch-read operation by default. Override them with `VANE_FLIGHT_CALL_TIMEOUT_S` and `VANE_FLIGHT_READ_TIMEOUT_S`; either value may be set to `0` to disable that timeout. The read timeout measures the complete Arrow operation, not byte-level network idleness. Query interruption also cancels an in-flight Flight call, so stalled consumers release the producer-side stream and its shuffle-file read lease.
+Each cross-worker partition read has a five-minute deadline covering its complete Flight DoGet stream. Override it with `VANE_FLIGHT_CALL_TIMEOUT_S`, or set it to `0` to disable the deadline. The deadline is not reset when a schema or record batch arrives. Query interruption independently cancels an in-flight Flight call, so interrupted consumers release the producer-side stream and its shuffle-file read lease.
 
 ### More Resources
 

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -294,7 +294,7 @@ DuckDBResult<void> ConvertArrowRecordBatchToChunk(ClientContext &context, const 
 }
 
 // FlightClient::DoGet reads the initial schema before returning its FlightStreamReader. Use Arrow's exported
-// transport stream directly so the watchdog can obtain a cancellation handle before the first blocking read.
+// transport stream directly so query interruption can cancel the first blocking read.
 DuckDBResult<std::unique_ptr<arrow::flight::internal::ClientTransport>>
 ConnectFlightExchangeTransport(const std::string &location_string) {
 	auto location_res = arrow::flight::Location::Parse(location_string);
@@ -368,53 +368,14 @@ private:
 
 } // namespace
 
-enum class FlightWatchdogStopReason : uint8_t { NONE = 0, INTERRUPTED = 1, READ_TIMEOUT = 2 };
-
-class FlightStreamWatchdog {
+class FlightStreamInterrupter {
 public:
-	FlightStreamWatchdog(ClientContext &context, double read_timeout_seconds)
-	    : context_(context), read_timeout_seconds_(read_timeout_seconds), watchdog_thread_([this]() { Run(); }) {
+	explicit FlightStreamInterrupter(ClientContext &context)
+	    : context_(context), interrupt_thread_([this]() { Run(); }) {
 	}
 
-	~FlightStreamWatchdog() {
+	~FlightStreamInterrupter() {
 		Stop();
-	}
-
-	FlightWatchdogStopReason Arm() {
-		arrow::flight::internal::ClientDataStream *stream = nullptr;
-		FlightWatchdogStopReason reason = FlightWatchdogStopReason::NONE;
-		{
-			std::lock_guard<std::mutex> guard(mutex_);
-			if (stop_reason_ != FlightWatchdogStopReason::NONE || stopping_) {
-				return stop_reason_;
-			}
-			operation_active_ = true;
-			operation_generation_++;
-			if (read_timeout_seconds_ > 0.0) {
-				deadline_ = Clock::now() + std::chrono::duration_cast<Clock::duration>(
-				                               std::chrono::duration<double>(read_timeout_seconds_));
-			}
-			if (context_.IsInterrupted()) {
-				reason = FlightWatchdogStopReason::INTERRUPTED;
-				stop_reason_ = reason;
-				operation_active_ = false;
-				operation_generation_++;
-				stream = stream_;
-			}
-		}
-		condition_.notify_all();
-		if (reason != FlightWatchdogStopReason::NONE) {
-			RequestCancellation(stream);
-		}
-		return reason;
-	}
-
-	FlightWatchdogStopReason Disarm() {
-		std::lock_guard<std::mutex> guard(mutex_);
-		operation_active_ = false;
-		operation_generation_++;
-		condition_.notify_all();
-		return stop_reason_;
 	}
 
 	void SetStream(arrow::flight::internal::ClientDataStream *stream) {
@@ -422,8 +383,12 @@ public:
 		{
 			std::lock_guard<std::mutex> guard(mutex_);
 			stream_ = stream;
-			cancel_stream = stream_ && stop_reason_ != FlightWatchdogStopReason::NONE;
+			if (stream_ && (cancellation_requested_ || context_.IsInterrupted())) {
+				cancellation_requested_ = true;
+				cancel_stream = true;
+			}
 		}
+		condition_.notify_all();
 		if (cancel_stream) {
 			stream->TryCancel();
 		}
@@ -433,84 +398,46 @@ public:
 		{
 			std::lock_guard<std::mutex> guard(mutex_);
 			stopping_ = true;
-			operation_active_ = false;
-			operation_generation_++;
+			stream_ = nullptr;
 		}
 		condition_.notify_all();
-		if (watchdog_thread_.joinable()) {
-			watchdog_thread_.join();
+		if (interrupt_thread_.joinable()) {
+			interrupt_thread_.join();
 		}
 	}
 
 private:
-	using Clock = std::chrono::steady_clock;
 	static constexpr std::chrono::milliseconds INTERRUPT_POLL_INTERVAL {25};
-
-	void RequestCancellation(arrow::flight::internal::ClientDataStream *stream) {
-		if (stream) {
-			stream->TryCancel();
-		}
-	}
 
 	void Run() {
 		std::unique_lock<std::mutex> guard(mutex_);
 		while (!stopping_) {
-			if (!operation_active_) {
-				condition_.wait(guard, [&]() { return stopping_ || operation_active_; });
+			if (cancellation_requested_) {
+				condition_.wait(guard, [&]() { return stopping_; });
 				continue;
 			}
-
-			const auto generation = operation_generation_;
-			auto wake_at = Clock::now() + INTERRUPT_POLL_INTERVAL;
-			if (read_timeout_seconds_ > 0.0 && deadline_ < wake_at) {
-				wake_at = deadline_;
-			}
-			condition_.wait_until(guard, wake_at);
-			if (stopping_ || !operation_active_ || generation != operation_generation_) {
+			condition_.wait_for(guard, INTERRUPT_POLL_INTERVAL);
+			if (stopping_ || !context_.IsInterrupted()) {
 				continue;
 			}
-
-			FlightWatchdogStopReason reason = FlightWatchdogStopReason::NONE;
-			if (context_.IsInterrupted()) {
-				reason = FlightWatchdogStopReason::INTERRUPTED;
-			} else if (read_timeout_seconds_ > 0.0 && Clock::now() >= deadline_) {
-				reason = FlightWatchdogStopReason::READ_TIMEOUT;
-			}
-			if (reason == FlightWatchdogStopReason::NONE) {
-				continue;
-			}
-
-			stop_reason_ = reason;
-			operation_active_ = false;
-			operation_generation_++;
+			cancellation_requested_ = true;
 			auto *stream = stream_;
 			guard.unlock();
-			RequestCancellation(stream);
+			if (stream) {
+				stream->TryCancel();
+			}
 			guard.lock();
 		}
 	}
 
 	ClientContext &context_;
-	double read_timeout_seconds_;
 	std::mutex mutex_;
 	std::condition_variable condition_;
-	Clock::time_point deadline_;
 	arrow::flight::internal::ClientDataStream *stream_ = nullptr;
-	FlightWatchdogStopReason stop_reason_ = FlightWatchdogStopReason::NONE;
-	uint64_t operation_generation_ = 0;
-	bool operation_active_ = false;
+	bool cancellation_requested_ = false;
 	bool stopping_ = false;
-	std::thread watchdog_thread_;
+	std::thread interrupt_thread_;
 };
-
-DuckDBError FlightWatchdogError(FlightWatchdogStopReason reason, const char *operation, double read_timeout_seconds) {
-	if (reason == FlightWatchdogStopReason::INTERRUPTED) {
-		return DuckDBError::external_error(std::string(operation) + " canceled by query interruption");
-	}
-	std::ostringstream message;
-	message << operation << " timed out after " << read_timeout_seconds << " seconds";
-	return DuckDBError::external_error(message.str());
-}
 
 namespace {
 
@@ -1191,8 +1118,8 @@ struct FlightExchangeSource::PartitionStreamState {
 	enum class Kind : uint8_t { LOCAL_FILES = 1, FLIGHT = 2 };
 
 	~PartitionStreamState() {
-		if (flight_watchdog) {
-			flight_watchdog->Stop();
+		if (flight_interrupter) {
+			flight_interrupter->Stop();
 		}
 		if (flight_data_stream) {
 			flight_data_stream->TryCancel();
@@ -1216,7 +1143,7 @@ struct FlightExchangeSource::PartitionStreamState {
 	std::unique_ptr<arrow::flight::internal::ClientTransport> flight_transport;
 	std::shared_ptr<arrow::flight::internal::ClientDataStream> flight_data_stream;
 	std::shared_ptr<arrow::ipc::RecordBatchStreamReader> flight_reader;
-	unique_ptr<FlightStreamWatchdog> flight_watchdog;
+	unique_ptr<FlightStreamInterrupter> flight_interrupter;
 
 	unique_ptr<ArrowTableSchema> arrow_table;
 	vector<LogicalType> arrow_types;
@@ -1379,22 +1306,12 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 	if (config_.flight_timeout_seconds > 0.0) {
 		call_options.timeout = arrow::flight::TimeoutDuration(config_.flight_timeout_seconds);
 	}
-	stream->flight_watchdog = make_uniq<FlightStreamWatchdog>(*context_, config_.flight_read_timeout_seconds);
-	auto watchdog_reason = stream->flight_watchdog->Arm();
-	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_timeout_seconds));
-	}
+	stream->flight_interrupter = make_uniq<FlightStreamInterrupter>(*context_);
 	std::unique_ptr<arrow::flight::internal::ClientDataStream> data_stream;
 	auto do_get_status = stream->flight_transport->DoGet(call_options, flight_ticket, &data_stream);
 	if (data_stream) {
 		stream->flight_data_stream = std::move(data_stream);
-		stream->flight_watchdog->SetStream(stream->flight_data_stream.get());
-	}
-	watchdog_reason = stream->flight_watchdog->Disarm();
-	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight do_get", config_.flight_read_timeout_seconds));
+		stream->flight_interrupter->SetStream(stream->flight_data_stream.get());
 	}
 	if (!do_get_status.ok()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
@@ -1404,22 +1321,12 @@ FlightExchangeSource::OpenPartitionStream(const ExchangeSourceHandle &handle) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
 		    DuckDBError::external_error("flight do_get returned no data stream"));
 	}
-	watchdog_reason = stream->flight_watchdog->Arm();
-	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_timeout_seconds));
-	}
 	auto memory_manager = call_options.memory_manager;
 	if (!memory_manager) {
 		memory_manager = arrow::CPUDevice::Instance()->default_memory_manager();
 	}
 	auto message_reader = std::make_unique<FlightExchangeIpcMessageReader>(stream->flight_data_stream, memory_manager);
 	auto reader_res = arrow::ipc::RecordBatchStreamReader::Open(std::move(message_reader), call_options.read_options);
-	watchdog_reason = stream->flight_watchdog->Disarm();
-	if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
-		    FlightWatchdogError(watchdog_reason, "flight get schema", config_.flight_read_timeout_seconds));
-	}
 	if (!reader_res.ok()) {
 		return DuckDBResult<std::unique_ptr<PartitionStreamState>>::err(
 		    FlightExchangeArrowToError(reader_res.status(), "flight get schema"));
@@ -1444,18 +1351,8 @@ DuckDBResult<bool> FlightExchangeSource::ReadStreamChunk(DataChunk &chunk) {
 	}
 	if (stream_state_->kind == PartitionStreamState::Kind::FLIGHT) {
 		while (true) {
-			auto watchdog_reason = stream_state_->flight_watchdog->Arm();
-			if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-				return DuckDBResult<bool>::err(
-				    FlightWatchdogError(watchdog_reason, "flight read batch", config_.flight_read_timeout_seconds));
-			}
 			std::shared_ptr<arrow::RecordBatch> batch;
 			auto next_status = stream_state_->flight_reader->ReadNext(&batch);
-			watchdog_reason = stream_state_->flight_watchdog->Disarm();
-			if (watchdog_reason != FlightWatchdogStopReason::NONE) {
-				return DuckDBResult<bool>::err(
-				    FlightWatchdogError(watchdog_reason, "flight read batch", config_.flight_read_timeout_seconds));
-			}
 			if (!next_status.ok()) {
 				return DuckDBResult<bool>::err(FlightExchangeArrowToError(next_status, "flight read batch"));
 			}

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -353,7 +353,6 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
 	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
 	serializer.WriteProperty(117, "source_handle_task_partition_ids", handle_source_task_partition_ids);
-	serializer.WriteProperty(118, "flight_read_timeout_seconds", flight_config.flight_read_timeout_seconds);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -1243,13 +1243,10 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto source_handle_flight_hosts = deserializer.ReadProperty<vector<string>>(116, "source_handle_flight_hosts");
 		auto source_handle_task_partition_ids =
 		    deserializer.ReadProperty<vector<idx_t>>(117, "source_handle_task_partition_ids");
-		auto read_timeout_seconds = deserializer.ReadPropertyWithExplicitDefault<double>(
-		    118, "flight_read_timeout_seconds", distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
 		flight_config.flight_timeout_seconds = timeout_seconds;
-		flight_config.flight_read_timeout_seconds = read_timeout_seconds;
 		flight_config.expected_types = types;
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
 		auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -42,14 +42,12 @@ class ClientContext;
 namespace distributed {
 
 struct FlightExchangeConfig {
-	static constexpr double DEFAULT_FLIGHT_TIMEOUT_SECONDS = 3600.0;
-	static constexpr double DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS = 60.0;
+	static constexpr double DEFAULT_FLIGHT_TIMEOUT_SECONDS = 300.0;
 
 	std::vector<std::string> local_dirs; // shuffle directories for IPC files
 	std::string node_id;
+	// Maximum duration of one remote partition's complete DoGet stream.
 	double flight_timeout_seconds = DEFAULT_FLIGHT_TIMEOUT_SECONDS;
-	// Maximum duration of one DoGet, schema, or batch-read operation; not a byte-idle timer.
-	double flight_read_timeout_seconds = DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS;
 	std::vector<LogicalType> expected_types;
 };
 
@@ -206,8 +204,6 @@ inline FlightExchangeConfig ResolveFlightExchangeConfigFromEnv() {
 	config.local_dirs = ResolveFlightExchangeLocalDirsFromEnv();
 	config.flight_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
 	    "VANE_FLIGHT_CALL_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS);
-	config.flight_read_timeout_seconds = ResolveFlightExchangeEnvTimeoutSeconds(
-	    "VANE_FLIGHT_READ_TIMEOUT_S", FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 	return config;
 }
 

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -494,29 +494,24 @@ TEST_CASE("Exchange: FlightExchangeTicket parse errors", "[distributed][exchange
 	REQUIRE(FlightExchangeTicket::Parse("v1\nepoch\nexchange\nnode\n1\n2x").is_err());
 }
 
-TEST_CASE("Exchange: Flight timeouts resolve from the worker environment", "[distributed][exchange]") {
+TEST_CASE("Exchange: Flight call timeout resolves from the worker environment", "[distributed][exchange]") {
 	SECTION("configured values") {
 		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "12.5");
-		ScopedEnvVar read_timeout("VANE_FLIGHT_READ_TIMEOUT_S", "3.25");
 		auto config = ResolveFlightExchangeConfigFromEnv();
 		REQUIRE(config.flight_timeout_seconds == Approx(12.5));
-		REQUIRE(config.flight_read_timeout_seconds == Approx(3.25));
 	}
 
-	SECTION("zero explicitly disables a timeout") {
+	SECTION("zero explicitly disables the timeout") {
 		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "0");
-		ScopedEnvVar read_timeout("VANE_FLIGHT_READ_TIMEOUT_S", "0");
 		auto config = ResolveFlightExchangeConfigFromEnv();
 		REQUIRE(config.flight_timeout_seconds == 0.0);
-		REQUIRE(config.flight_read_timeout_seconds == 0.0);
 	}
 
-	SECTION("invalid values retain safe defaults") {
+	SECTION("invalid values retain the five-minute default") {
 		ScopedEnvVar call_timeout("VANE_FLIGHT_CALL_TIMEOUT_S", "not-a-timeout");
-		ScopedEnvVar read_timeout("VANE_FLIGHT_READ_TIMEOUT_S", "-1");
 		auto config = ResolveFlightExchangeConfigFromEnv();
-		REQUIRE(config.flight_timeout_seconds == FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS);
-		REQUIRE(config.flight_read_timeout_seconds == FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
+		REQUIRE(config.flight_timeout_seconds == Approx(300.0));
+		REQUIRE(FlightExchangeConfig::DEFAULT_FLIGHT_TIMEOUT_SECONDS == Approx(300.0));
 	}
 }
 
@@ -1145,7 +1140,7 @@ TEST_CASE("Exchange: process-local Flight shutdown is bounded and keeps its serv
 	REQUIRE(registry.RetireQuery(query_id).is_ok());
 }
 
-TEST_CASE("Exchange: Flight source read timeout cancels a stalled batch read", "[distributed][exchange]") {
+TEST_CASE("Exchange: Flight call deadline cancels a stalled batch read", "[distributed][exchange]") {
 	DuckDB db(nullptr);
 	Connection conn(db);
 	auto state = std::make_shared<BlockingFlightState>();
@@ -1153,11 +1148,10 @@ TEST_CASE("Exchange: Flight source read timeout cancels a stalled batch read", "
 	StartTestFlightServer(server);
 
 	FlightExchangeConfig config;
-	config.local_dirs = {TestCreatePath("flight_read_timeout")};
+	config.local_dirs = {TestCreatePath("flight_batch_call_deadline")};
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
-	config.flight_timeout_seconds = 5.0;
-	config.flight_read_timeout_seconds = 0.5;
+	config.flight_timeout_seconds = 0.5;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {
@@ -1178,44 +1172,7 @@ TEST_CASE("Exchange: Flight source read timeout cancels a stalled batch read", "
 
 	REQUIRE(read_started);
 	REQUIRE(read_stopped);
-	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight read batch timed out"));
-	REQUIRE(shutdown_status.ok());
-}
-
-TEST_CASE("Exchange: Flight source read timeout cancels a stalled initial schema", "[distributed][exchange]") {
-	DuckDB db(nullptr);
-	Connection conn(db);
-	auto state = std::make_shared<BlockingFlightState>();
-	BlockingDoGetFlightServer server(state);
-	StartTestFlightServer(server);
-
-	FlightExchangeConfig config;
-	config.local_dirs = {TestCreatePath("flight_schema_read_timeout")};
-	config.node_id = "reader-node";
-	config.expected_types = {LogicalType::INTEGER};
-	config.flight_timeout_seconds = 5.0;
-	config.flight_read_timeout_seconds = 0.5;
-	auto handle = MakeRemoteSourceHandle(server.port());
-	auto read_future = std::async(std::launch::async, [&]() {
-		try {
-			ReadSourceRows(*conn.context, config, {std::move(handle)});
-			return string();
-		} catch (const std::exception &ex) {
-			return string(ex.what());
-		}
-	});
-
-	const bool do_get_started = state->WaitUntilStarted(std::chrono::seconds(2));
-	const bool read_stopped =
-	    do_get_started && read_future.wait_for(std::chrono::seconds(2)) == std::future_status::ready;
-	state->Release();
-	REQUIRE(read_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready);
-	auto read_error = read_future.get();
-	auto shutdown_status = server.Shutdown();
-
-	REQUIRE(do_get_started);
-	REQUIRE(read_stopped);
-	REQUIRE_THAT(read_error, Catch::Matchers::Contains("flight get schema timed out"));
+	REQUIRE_THAT(read_error, Catch::Matchers::Contains("Deadline Exceeded"));
 	REQUIRE(shutdown_status.ok());
 }
 
@@ -1231,7 +1188,6 @@ TEST_CASE("Exchange: Flight call deadline bounds a stalled initial schema", "[di
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
 	config.flight_timeout_seconds = 0.5;
-	config.flight_read_timeout_seconds = 5.0;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {
@@ -1264,11 +1220,10 @@ TEST_CASE("Exchange: query interrupt cancels a stalled Flight DoGet", "[distribu
 	StartTestFlightServer(server);
 
 	FlightExchangeConfig config;
-	config.local_dirs = {TestCreatePath("flight_interrupt_watchdog")};
+	config.local_dirs = {TestCreatePath("flight_interrupt_cancellation")};
 	config.node_id = "reader-node";
 	config.expected_types = {LogicalType::INTEGER};
 	config.flight_timeout_seconds = 5.0;
-	config.flight_read_timeout_seconds = 5.0;
 	auto handle = MakeRemoteSourceHandle(server.port());
 	auto read_future = std::async(std::launch::async, [&]() {
 		try {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -195,40 +195,6 @@ void SerializePreStrictRemoteExchangeSource(Serializer &serializer) {
 	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
 }
 
-void SerializeRemoteExchangeSourceWithoutReadTimeout(Serializer &serializer) {
-	vector<LogicalType> types = {LogicalType::INTEGER};
-	vector<idx_t> partition_indices = {0};
-	vector<string> source_nodes = {"node-1"};
-	vector<idx_t> handle_partition_ids = {0};
-	vector<string> handle_node_ids = {"node-1"};
-	vector<string> handle_paths = {"exchange-id__sink_0__attempt_0"};
-	vector<int> handle_flight_ports = {6123};
-	vector<idx_t> handle_attempt_ids = {0};
-	vector<string> local_dirs = {"/tmp/vane-shuffle"};
-	vector<string> handle_server_epochs = {"epoch-1"};
-	vector<string> handle_flight_hosts = {"flight-node-1.internal"};
-	vector<idx_t> handle_task_partition_ids = {0};
-	serializer.WriteProperty(100, "type", PhysicalOperatorType::EXCHANGE_SOURCE);
-	serializer.WriteProperty(101, "types", types);
-	serializer.WriteProperty<idx_t>(102, "estimated_cardinality", 0);
-	serializer.WriteProperty(103, "exchange_id", string("exchange-id"));
-	serializer.WriteProperty(104, "partition_indices", partition_indices);
-	serializer.WriteProperty(105, "source_nodes", source_nodes);
-	serializer.WriteProperty<double>(106, "flight_timeout_seconds", 7.5);
-	serializer.WriteProperty(107, "source_handle_partition_ids", handle_partition_ids);
-	serializer.WriteProperty(108, "source_handle_node_ids", handle_node_ids);
-	serializer.WriteProperty(109, "source_handle_paths", handle_paths);
-	serializer.WriteProperty(110, "source_handle_flight_ports", handle_flight_ports);
-	serializer.WritePropertyWithDefault(111, "runtime_source_node_id", optional_idx(), optional_idx());
-	serializer.WriteProperty(112, "source_handle_attempt_ids", handle_attempt_ids);
-	serializer.WriteProperty(113, "local_dirs", local_dirs);
-	serializer.WriteProperty(114, "source_handle_flight_server_epochs", handle_server_epochs);
-	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
-	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
-	serializer.WriteProperty(117, "source_handle_task_partition_ids", handle_task_partition_ids);
-	serializer.WriteList(198, "children", 0, [](Serializer::List &, idx_t) {});
-}
-
 string SerializeSinkDescriptorWithoutFlightHost() {
 	MemoryStream stream(Allocator::DefaultAllocator());
 	BinarySerializer serializer(stream);
@@ -1952,7 +1918,6 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	distributed::FlightExchangeConfig flight_config;
 	flight_config.node_id = "node-1";
 	flight_config.flight_timeout_seconds = 7.5;
-	flight_config.flight_read_timeout_seconds = 3.25;
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "exchange", partition_indices, source_handles,
@@ -2009,31 +1974,6 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source_ptr->GetExchangeManager());
 	REQUIRE(roundtrip_manager != nullptr);
 	REQUIRE(roundtrip_manager->config().flight_timeout_seconds == 7.5);
-	REQUIRE(roundtrip_manager->config().flight_read_timeout_seconds == 3.25);
-}
-
-TEST_CASE("PhysicalRemoteExchangeSource defaults a missing Flight read timeout",
-          "[serialization][physical_plan][exchange]") {
-	Allocator allocator;
-	PhysicalPlan plan(allocator);
-	MemoryStream stream(allocator);
-	SerializationOptions options;
-	BinarySerializer serializer(stream, options);
-	serializer.Begin();
-	SerializeRemoteExchangeSourceWithoutReadTimeout(serializer);
-	serializer.End();
-
-	stream.Rewind();
-	BinaryDeserializer deserializer(stream);
-	deserializer.Begin();
-	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
-	REQUIRE(deserialized_op != nullptr);
-	auto source = dynamic_cast<PhysicalRemoteExchangeSource *>(deserialized_op.get());
-	REQUIRE(source != nullptr);
-	auto manager = std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source->GetExchangeManager());
-	REQUIRE(manager != nullptr);
-	REQUIRE(manager->config().flight_read_timeout_seconds ==
-	        distributed::FlightExchangeConfig::DEFAULT_FLIGHT_READ_TIMEOUT_SECONDS);
 }
 
 TEST_CASE("Remote exchange plans reject pre-strict endpoint payloads", "[serialization][physical_plan][exchange]") {


### PR DESCRIPTION
## Summary

- Remove the per-operation Flight read watchdog whose timeout/Disarm boundary could discard a schema or record batch that had already been read successfully.
- Keep query interruption responsive with a dedicated stream interrupter, and use the gRPC call deadline to bound the complete partition DoGet stream.
- Reduce the default whole-call deadline from one hour to five minutes.
- Remove VANE_FLIGHT_READ_TIMEOUT_S and the serialized flight_read_timeout_seconds property. This is an intentional compatibility break with no fallback.
- Update the Flight timeout tests and user-facing configuration documentation.

## Related issue

close: #593

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      AstroVela/vane-website.

README.md now documents the five-minute whole-DoGet deadline, its environment override, disable behavior, and independent query-interruption cancellation.

## Validation

- scripts/format workspace --changed --check
- SKBUILD_BUILD_DIR=$PWD/build/python-release SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation
- cmake --build build/native-cxx20 --target unittest loadable_extension_demo_loadable_extension loadable_extension_optimizer_demo_loadable_extension --parallel 8
- build/native-cxx20/test/unittest [exchange] — 69 test cases, 3985 assertions
- build/native-cxx20/test/unittest [distributed] — 191 test cases, 8382 assertions
- scripts/run_release_tests.sh — 530 non-Ray tests and 11 real-Ray tests passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.