### PR TITLE
[fix](ray) Keep phase admission fenced across rebalances

### DIFF
--- a/tests/fast/test_driver_query_leases.py
+++ b/tests/fast/test_driver_query_leases.py
@@ -2872,7 +2872,6 @@ def test_task_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
                 resources=resources,
                 generation=2,
             ),
-            admission_open=True,
         )
         runner_cls._run_query_task_admission_pump(runner, query_id)
 
@@ -2956,7 +2955,6 @@ def test_output_admission_pump_drains_a_bounded_batch_per_event_loop_turn():
                 resources=expanded_resources,
                 generation=2,
             ),
-            admission_open=True,
         )
         runner_cls._run_query_output_admission_pump(runner, query_id)
 

--- a/tests/fast/test_driver_query_resource_graph_registration.py
+++ b/tests/fast/test_driver_query_resource_graph_registration.py
@@ -1097,6 +1097,137 @@ def test_driver_keeps_aggregate_soft_reservation_when_capacity_moves_nodes():
     assert dropped == []
 
 
+def test_unrelated_rebalance_cannot_reopen_a_pending_phase_frontier():
+    from vane.runners.ray.cluster_resource_coordinator import (
+        ClusterQueryResourceCoordinator,
+    )
+    from vane.runners.ray.driver import RayQueryDriverActor
+    from vane.runners.ray.query_resource_graph import MaterializationBarrierSpec
+    from vane.runners.ray.query_resource_graph_builder import build_query_demand
+    from vane.runners.ray.query_resource_manager import TaskRequest
+    from vane.runners.ray.query_resource_runtime import register_query_resource_graph
+
+    runner_cls = RayQueryDriverActor.__ray_metadata__.modified_class
+    runner = object.__new__(runner_cls)
+    query_id = "query-phase-fence-rebalance"
+    upstream = ResourceUnitSpec(
+        query_id=query_id,
+        resource_unit_id=f"resource:{query_id}:upstream",
+        physical_node_id="node:upstream:udf",
+        unit_kind="ray_task_udf",
+        backend="ray_task",
+        input_unit_ids=(),
+        per_task=ResourceVector(cpu=1, heap_bytes=10),
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=None,
+    )
+    materializer = ResourceUnitSpec(
+        query_id=query_id,
+        resource_unit_id=f"resource:{query_id}:materializer",
+        physical_node_id="node:materializer:native-fragment",
+        unit_kind="native_fragment",
+        backend="ray_worker",
+        input_unit_ids=(upstream.resource_unit_id,),
+        per_task=ResourceVector(),
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=4,
+    )
+    downstream = ResourceUnitSpec(
+        query_id=query_id,
+        resource_unit_id=f"resource:{query_id}:downstream",
+        physical_node_id="node:downstream:udf",
+        unit_kind="ray_task_udf",
+        backend="ray_task",
+        input_unit_ids=(materializer.resource_unit_id,),
+        per_task=ResourceVector(cpu=1, heap_bytes=20),
+        target_output_block_bytes=0,
+        generator_buffer_blocks=0,
+        max_concurrency=None,
+    )
+    graph = QueryResourceGraph(
+        query_id=query_id,
+        plan_digest="sha256:phase-fence-rebalance",
+        units=(upstream, materializer, downstream),
+        terminal_unit_ids=(downstream.resource_unit_id,),
+        materialization_barriers=(
+            MaterializationBarrierSpec(
+                query_id=query_id,
+                barrier_id=f"barrier:{query_id}:node:materializer",
+                physical_node_id="materializer",
+                materializer_unit_id=materializer.resource_unit_id,
+                materialized_input_unit_ids=(upstream.resource_unit_id,),
+            ),
+        ),
+    )
+    node = NodeCapacity(
+        "node-a",
+        ResourceVector(cpu=2, heap_bytes=30, object_store_bytes=100),
+    )
+    coordinator = ClusterQueryResourceCoordinator((node,))
+    allocation = coordinator.register_query(build_query_demand(graph, (node,)), now=0)
+    transitions = []
+    manager = register_query_resource_graph(
+        graph,
+        allocation,
+        on_eligible_units_change=lambda eligible, fence_epoch: transitions.append((eligible, fence_epoch)),
+    )
+    for unit in graph.units:
+        manager.update_unit_state(unit.resource_unit_id, runnable=True)
+
+    runner._query_resource_coordinator = coordinator
+    runner._query_resource_graphs = {query_id: graph}
+    runner._query_allocations = {query_id: allocation}
+    runner._query_node_capacities = (node,)
+    runner._query_resource_last_capacity_refresh_at = 0.0
+    runner._query_resource_lock = threading.RLock()
+    runner._session_lock = threading.RLock()
+    runner._plan_teardown_condition = threading.Condition(runner._session_lock)
+    runner._plan_teardowns_in_progress = set()
+    runner._plan_session_ids = {query_id: _SESSION_ID}
+    runner._active_udf_actor_by_unit = {}
+    runner._active_udf_actors = []
+    runner._active_udf_actors_by_plan = {}
+    runner._signal_query_resource_change = lambda _query_id: None
+
+    assert manager.mark_materialization_barrier_completed_for_node("materializer")
+    assert len(transitions) == 1
+    eligible, fence_epoch = transitions[0]
+    assert manager.snapshot()["allocation_admission_open"] is False
+
+    runner_cls._maintain_query_resources_once(
+        runner,
+        capacities=(node,),
+        now=5,
+    )
+    unrelated_generation = coordinator.snapshot()["queries"][query_id]["allocation"]["generation"]
+    assert unrelated_generation > allocation.generation
+
+    blocked = manager.try_acquire_task(
+        TaskRequest(query_id, downstream.resource_unit_id, "before-phase-refresh", "0", None)
+    )
+    pending_snapshot = manager.snapshot()
+    assert pending_snapshot["allocation"]["generation"] == unrelated_generation
+    assert pending_snapshot["allocation_admission_open"] is False
+    assert not blocked.granted and blocked.blocked_reason == "allocation_pending"
+
+    runner_cls._transition_query_execution_phase(
+        runner,
+        query_id,
+        eligible,
+        fence_epoch,
+    )
+
+    opened = manager.try_acquire_task(
+        TaskRequest(query_id, downstream.resource_unit_id, "after-phase-refresh", "0", None)
+    )
+    opened_snapshot = manager.snapshot()
+    assert opened_snapshot["allocation"]["generation"] > unrelated_generation
+    assert opened_snapshot["allocation_admission_open"] is True
+    assert opened.granted
+
+
 def test_driver_keeps_drain_admission_open_after_soft_budget_shrink():
     from vane.runners.ray.driver import RayQueryDriverActor
     from vane.runners.ray.query_resource_manager import TaskRequest

--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -375,7 +375,7 @@ def test_barrier_completion_retires_old_eligible_units_and_opens_next_phase():
         downstream,
         resources=_r(cpu=2, heap=30),
         barriers=(barrier,),
-        on_eligible_units_change=transitions.append,
+        on_eligible_units_change=lambda eligible, fence_epoch: transitions.append((eligible, fence_epoch)),
     )
     _ready(
         manager,
@@ -389,7 +389,12 @@ def test_barrier_completion_retires_old_eligible_units_and_opens_next_phase():
 
     assert manager.mark_materialization_barrier_completed_for_node("materializer") is True
     assert manager.mark_materialization_barrier_completed_for_node("materializer") is False
-    assert transitions == [(materializer.resource_unit_id, downstream.resource_unit_id)]
+    assert transitions == [
+        (
+            (materializer.resource_unit_id, downstream.resource_unit_id),
+            1,
+        )
+    ]
     assert manager.current_eligible_resource_unit_ids() == (
         materializer.resource_unit_id,
         downstream.resource_unit_id,
@@ -399,9 +404,19 @@ def test_barrier_completion_retires_old_eligible_units_and_opens_next_phase():
     opened_downstream = manager.try_acquire_task(_task(downstream.resource_unit_id, 0))
     assert retired_upstream.blocked_reason == "allocation_pending"
     assert opened_downstream.blocked_reason == "allocation_pending"
+
+    # A newer allocation from an unrelated cluster rebalance must not reopen
+    # the phase handoff. Only the allocation refresh that owns this fence token
+    # can authorize the new frontier.
     manager.update_allocation(
         _allocation(_r(cpu=2, heap=30), generation=2),
-        admission_open=True,
+    )
+    assert manager.snapshot()["allocation_admission_open"] is False
+    assert manager.try_acquire_task(_task(downstream.resource_unit_id, 1)).blocked_reason == "allocation_pending"
+
+    manager.update_allocation(
+        _allocation(_r(cpu=2, heap=30), generation=3),
+        reopen_fence_epoch=transitions[-1][1],
     )
     retired_upstream = manager.try_acquire_task(_task(upstream.resource_unit_id, 0))
     final_materializer = manager.try_acquire_task(_task(materializer.resource_unit_id, 0, node_id="node-a"))
@@ -429,7 +444,7 @@ def test_unit_completion_fences_old_allocation_until_eligible_demand_refreshes()
         remaining,
         resources=_r(cpu=2, heap=20),
         terminals=(finished.resource_unit_id, remaining.resource_unit_id),
-        on_eligible_units_change=transitions.append,
+        on_eligible_units_change=lambda eligible, fence_epoch: transitions.append((eligible, fence_epoch)),
     )
     _ready(manager, finished.resource_unit_id, remaining.resource_unit_id)
 
@@ -439,15 +454,97 @@ def test_unit_completion_fences_old_allocation_until_eligible_demand_refreshes()
         completed=True,
     )
 
-    assert transitions == [(remaining.resource_unit_id,)]
+    assert transitions == [((remaining.resource_unit_id,), 1)]
     assert manager.snapshot()["allocation_admission_open"] is False
     assert manager.try_acquire_task(_task(remaining.resource_unit_id, 0)).blocked_reason == "allocation_pending"
 
     manager.update_allocation(
         _allocation(_r(cpu=2, heap=20), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=transitions[-1][1],
     )
     assert manager.try_acquire_task(_task(remaining.resource_unit_id, 0)).granted
+
+
+def test_stale_allocation_fence_epoch_cannot_reopen_a_newer_frontier():
+    first = _unit("resource:f:first", target=0, blocks=0)
+    second = _unit("resource:f:second", target=0, blocks=0)
+    remaining = _unit("resource:f:remaining", target=0, blocks=0)
+    transitions = []
+    manager = _manager(
+        first,
+        second,
+        remaining,
+        resources=_r(cpu=3, heap=30),
+        terminals=(first.resource_unit_id, second.resource_unit_id, remaining.resource_unit_id),
+        on_eligible_units_change=lambda eligible, fence_epoch: transitions.append((eligible, fence_epoch)),
+    )
+    _ready(manager, first.resource_unit_id, second.resource_unit_id, remaining.resource_unit_id)
+
+    manager.update_unit_state(first.resource_unit_id, runnable=False, completed=True)
+    manager.update_unit_state(second.resource_unit_id, runnable=False, completed=True)
+
+    assert [fence_epoch for _eligible, fence_epoch in transitions] == [1, 2]
+    manager.update_allocation(
+        _allocation(_r(cpu=3, heap=30), generation=2),
+        reopen_fence_epoch=transitions[0][1],
+    )
+    assert manager.snapshot()["allocation_admission_open"] is False
+
+    manager.update_allocation(
+        _allocation(_r(cpu=3, heap=30), generation=3),
+        reopen_fence_epoch=transitions[1][1],
+    )
+    assert manager.snapshot()["allocation_admission_open"] is True
+    assert manager.try_acquire_task(_task(remaining.resource_unit_id, 0)).granted
+
+
+def test_close_admission_invalidates_an_in_flight_frontier_refresh():
+    completed = _unit("resource:f:completed", target=0, blocks=0)
+    remaining = _unit("resource:f:remaining", target=0, blocks=0)
+    transitions = []
+    manager = _manager(
+        completed,
+        remaining,
+        resources=_r(cpu=2, heap=20),
+        terminals=(completed.resource_unit_id, remaining.resource_unit_id),
+        on_eligible_units_change=lambda eligible, fence_epoch: transitions.append((eligible, fence_epoch)),
+    )
+    _ready(manager, completed.resource_unit_id, remaining.resource_unit_id)
+
+    manager.update_unit_state(completed.resource_unit_id, runnable=False, completed=True)
+    phase_fence_epoch = transitions[-1][1]
+    manager.close_admission()
+
+    manager.update_allocation(
+        _allocation(_r(cpu=2, heap=20), generation=2),
+        reopen_fence_epoch=phase_fence_epoch,
+    )
+    snapshot = manager.snapshot()
+    assert snapshot["allocation_fence_epoch"] == phase_fence_epoch + 1
+    assert snapshot["allocation_admission_closed"] is True
+    assert snapshot["allocation_admission_open"] is False
+
+    manager.update_allocation(
+        _allocation(_r(cpu=2, heap=20), generation=3),
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
+    )
+    assert manager.snapshot()["allocation_admission_open"] is False
+
+
+def test_allocation_rejects_a_future_fence_epoch_without_mutation():
+    unit = _unit("resource:f:future-fence", target=0, blocks=0)
+    manager = _manager(unit, resources=_r(cpu=1, heap=10))
+    before = manager.snapshot()
+
+    with pytest.raises(ValueError, match="allocation fence epoch is from the future"):
+        manager.update_allocation(
+            _allocation(_r(cpu=2, heap=20), generation=2),
+            reopen_fence_epoch=before["allocation_fence_epoch"] + 1,
+        )
+
+    after = manager.snapshot()
+    assert after["allocation"] == before["allocation"]
+    assert after["allocation_admission_open"] is True
 
 
 def test_completed_resource_unit_cannot_be_reopened():
@@ -742,7 +839,6 @@ def test_failed_manager_fences_new_work_but_preserves_live_physical_usage():
 
     manager.update_allocation(
         _allocation(_r(cpu=1, heap=100, store=20), generation=2),
-        admission_open=True,
     )
     assert manager.snapshot()["allocation_admission_open"] is False
 
@@ -939,7 +1035,6 @@ def test_fixed_actor_soft_debt_does_not_block_zero_increment_invocations():
     manager.update_unit_state(actor.resource_unit_id, runnable=True)
     manager.update_allocation(
         _allocation(_r(cpu=0.5, gpu=0.5, heap=50), generation=2),
-        admission_open=True,
     )
 
     invocation = manager.try_acquire_task(_task(actor.resource_unit_id, 0))
@@ -991,7 +1086,6 @@ def test_persistent_soft_actor_debt_warns_once_after_ray_data_delay(monkeypatch,
     manager.set_submitted_actor_slots(actor.resource_unit_id, {0})
     manager.update_allocation(
         _allocation(_r(cpu=0.5, gpu=0.5, heap=50), generation=2),
-        admission_open=True,
     )
     clock = iter((0.0, 59.0, 60.0, 61.0))
     monkeypatch.setattr(manager_module.time, "monotonic", lambda: next(clock))
@@ -1057,7 +1151,6 @@ def test_allocation_shrink_keeps_live_lease_and_uses_liveness_after_drain():
 
     manager.update_allocation(
         _allocation(_r(cpu=0.5, heap=50), generation=2),
-        admission_open=True,
     )
     blocked = manager.try_acquire_task(_task(task.resource_unit_id, 1))
     snapshot = manager.snapshot()
@@ -1199,7 +1292,7 @@ def test_object_store_ledgers_remain_disjoint_through_a_mixed_lifecycle():
     manager.update_unit_state(upstream.resource_unit_id, runnable=False, completed=True)
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=100), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
     )
     _assert_object_store_budget_invariants(manager.snapshot())
 
@@ -1207,7 +1300,6 @@ def test_object_store_ledgers_remain_disjoint_through_a_mixed_lifecycle():
     assert downstream_task.granted
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=40), generation=3),
-        admission_open=True,
     )
     _assert_object_store_budget_invariants(manager.snapshot())
 
@@ -1326,7 +1418,6 @@ def test_object_store_ledgers_hold_across_seeded_lifecycle_traces():
                         ),
                         generation=allocation_generation,
                     ),
-                    admission_open=True,
                 )
             elif step >= 30:
                 completable = [
@@ -1342,7 +1433,7 @@ def test_object_store_ledgers_hold_across_seeded_lifecycle_traces():
                             _r(cpu=100, heap=1_000, store=randomizer.choice((7, 31, 64))),
                             generation=allocation_generation,
                         ),
-                        admission_open=True,
+                        reopen_fence_epoch=manager.current_allocation_frontier()[1],
                     )
 
             snapshot = manager.snapshot()
@@ -1512,7 +1603,7 @@ def test_ineligible_usage_at_or_above_the_limit_zeroes_current_reservations(reta
     manager.update_unit_state(completed.resource_unit_id, runnable=False, completed=True)
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=100), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
     )
 
     snapshot = manager.snapshot()
@@ -1554,7 +1645,7 @@ def test_completed_producer_can_handoff_an_already_waiting_output_without_a_rese
     manager.update_unit_state(unit.resource_unit_id, runnable=False, completed=True)
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=10), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
     )
     before = manager.snapshot()
     _assert_object_store_budget_invariants(before)
@@ -1587,7 +1678,6 @@ def test_allocation_shrink_preserves_output_credit_and_growth_restores_shared_cr
 
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=100), generation=2),
-        admission_open=True,
     )
     shrunk = manager.snapshot()
     assert shrunk["units"][unit.resource_unit_id]["object_store_budget"] == {
@@ -1616,7 +1706,6 @@ def test_allocation_shrink_preserves_output_credit_and_growth_restores_shared_cr
 
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=300), generation=3),
-        admission_open=True,
     )
     assert manager._normal_task_block_reason_locked(_task(unit.resource_unit_id, 1, retained=0))[0] is None
 
@@ -1637,7 +1726,7 @@ def test_completing_an_idle_unit_reassigns_its_protected_reservation():
     manager.update_unit_state(completed.resource_unit_id, runnable=False, completed=True)
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=100), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
     )
     after = manager.snapshot()
     assert after["units"][completed.resource_unit_id]["object_store_budget"]["task_reserved_bytes"] == 0
@@ -1894,7 +1983,7 @@ def test_ineligible_output_usage_reduces_current_phase_reservations():
     )
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=100, store=100), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
     )
 
     budget = manager.snapshot()["admission"]["object_store"]
@@ -2849,7 +2938,6 @@ def test_output_liveness_cannot_move_back_upstream():
     downstream_task = manager.try_acquire_task(_task(downstream.resource_unit_id, 0, retained=0))
     manager.update_allocation(
         _allocation(_r(cpu=10, heap=1_000, store=10), generation=2),
-        admission_open=True,
     )
 
     downstream_output = manager.try_acquire_output_block(

--- a/tests/fast/test_query_resource_runtime.py
+++ b/tests/fast/test_query_resource_runtime.py
@@ -133,7 +133,10 @@ def test_runtime_can_publish_pending_query_before_minimum_bundle_is_feasible():
     )
     assert blocked.blocked_reason == "allocation_pending"
 
-    manager.update_allocation(_allocation(generation=2), admission_open=True)
+    manager.update_allocation(
+        _allocation(generation=2),
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
+    )
     assert manager.try_acquire_task(
         TaskRequest(
             query_id="q",

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -7707,12 +7707,12 @@ def test_fte_denied_descriptor_is_not_registered_and_block_is_removed_when_aband
     query_id = "query-resource-waiter"
     fragment_id = _install_manual_test_fragment(query_id, "8")
     manager = get_query_resource_manager(query_id)
+    manager.close_admission()
     manager.update_allocation(
         QueryAllocation(
             resources=ResourceVector(),
             generation=2,
         ),
-        admission_open=False,
     )
 
     with pytest.raises(FteWorkerReservationUnavailable) as exc_info:

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -74,7 +74,7 @@ def _registered_low_level_plan(
     generation = 1
     manager_holder = {}
 
-    def _refresh_phase_allocation(_eligible_unit_ids):
+    def _refresh_phase_allocation(_eligible_unit_ids, allocation_fence_epoch):
         nonlocal generation
         if not refresh_phase_allocation:
             return
@@ -84,7 +84,7 @@ def _registered_low_level_plan(
                 resources=allocation_resources,
                 generation=generation,
             ),
-            admission_open=True,
+            reopen_fence_epoch=allocation_fence_epoch,
         )
 
     manager = register_query_resource_graph(

--- a/vane/runners/ray/driver.py
+++ b/vane/runners/ray/driver.py
@@ -2618,10 +2618,7 @@ class RayQueryDriverActor:
             manager = get_query_resource_manager(query_id)
             current = self._query_allocations[query_id]
             if allocation.generation > current.generation:
-                manager.update_allocation(
-                    allocation,
-                    admission_open=True,
-                )
+                manager.update_allocation(allocation)
                 self._query_allocations[query_id] = allocation
 
     def _apply_query_capacity_snapshot(
@@ -5091,9 +5088,10 @@ class RayQueryDriverActor:
                     admission_open=True,
                     reservation_ratio=float(os.environ.get("VANE_QUERY_RESOURCE_RESERVATION_RATIO", "0.5")),
                     on_change=lambda: self._signal_query_resource_change(graph.query_id),
-                    on_eligible_units_change=lambda eligible: self._transition_query_execution_phase(
+                    on_eligible_units_change=lambda eligible, fence_epoch: self._transition_query_execution_phase(
                         graph.query_id,
                         eligible,
+                        fence_epoch,
                     ),
                 )
                 manager_registered = True
@@ -5209,6 +5207,7 @@ class RayQueryDriverActor:
         self,
         query_id: str,
         eligible_unit_ids: tuple[str, ...],
+        allocation_fence_epoch: int,
     ) -> None:
         """Retire the old phase and recompute reservation for the new frontier."""
 
@@ -5224,11 +5223,12 @@ class RayQueryDriverActor:
                 if query_key not in self._plan_session_ids:
                     return
             eligible = tuple(str(resource_unit_id) for resource_unit_id in eligible_unit_ids)
+            fence_epoch = int(allocation_fence_epoch)
             manager = get_query_resource_manager(query_key)
-            # Validate before touching physical actors. The manager repeats this
-            # check atomically in begin_actor_pool_retirement() to close the race
-            # with a still newer barrier completion.
-            if eligible != manager.current_eligible_resource_unit_ids():
+            # Validate before touching physical actors. Each retirement target
+            # is checked atomically against the current eligible set, and the
+            # complete frontier token is checked again before allocation.
+            if (eligible, fence_epoch) != manager.current_allocation_frontier():
                 return
             self._retire_udf_actor_pools_outside_phase(query_key, eligible)
 
@@ -5238,8 +5238,7 @@ class RayQueryDriverActor:
                 if graph is None or allocation is None:
                     return
                 # Ignore a stale callback overtaken by another completion.
-                current_eligible = manager.current_eligible_resource_unit_ids()
-                if eligible != current_eligible:
+                if (eligible, fence_epoch) != manager.current_allocation_frontier():
                     return
                 demand = build_query_demand(
                     graph,
@@ -5249,12 +5248,17 @@ class RayQueryDriverActor:
                 observed_usage = manager.snapshot()["soft_allocation_usage"]
                 from vane.runners.ray.query_resource_graph import ResourceVector
 
-                self._query_resource_coordinator.refresh_query(
+                phase_allocation = self._query_resource_coordinator.refresh_query(
                     query_key,
                     observed_usage=ResourceVector.from_dict(observed_usage),
                     generation=allocation.generation,
                     demand=demand,
                 )
+                manager.update_allocation(
+                    phase_allocation,
+                    reopen_fence_epoch=fence_epoch,
+                )
+                self._query_allocations[query_key] = phase_allocation
                 self._synchronize_query_allocations()
             self._signal_query_resource_change(query_key)
 

--- a/vane/runners/ray/query_resource_manager.py
+++ b/vane/runners/ray/query_resource_manager.py
@@ -299,7 +299,7 @@ class RayQueryResourceManager:
         admission_open: bool = True,
         reservation_ratio: float = 0.5,
         on_change: Callable[[], None] | None = None,
-        on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
+        on_eligible_units_change: Callable[[tuple[str, ...], int], None] | None = None,
     ) -> None:
         ratio = float(reservation_ratio)
         if not math.isfinite(ratio) or ratio < 0 or ratio > 1:
@@ -307,11 +307,13 @@ class RayQueryResourceManager:
         self.graph = graph
         self.allocation = allocation
         self._allocation_admission_open = bool(admission_open)
+        self._allocation_admission_closed = False
         self.reservation_ratio = ratio
         self._on_change = on_change
         self._on_eligible_units_change = on_eligible_units_change
         self._lock = threading.RLock()
         self._admission_epoch = 0
+        self._allocation_fence_epoch = 0
         self._units = {
             unit.resource_unit_id: _ResourceUnitState(
                 spec=unit,
@@ -396,8 +398,9 @@ class RayQueryResourceManager:
         completed: bool = False,
     ) -> None:
         unit_key = str(resource_unit_id)
-        eligible_callback: Callable[[tuple[str, ...]], None] | None = None
+        eligible_callback: Callable[[tuple[str, ...], int], None] | None = None
         eligible_unit_ids: tuple[str, ...] = ()
+        allocation_fence_epoch = 0
         with self._lock:
             unit = self._units.get(unit_key)
             if unit is None:
@@ -432,20 +435,23 @@ class RayQueryResourceManager:
                     # coordinator can publish the corresponding allocation.
                     # Preserve live leases, but fence every new grant from the
                     # old generation during that handoff.
+                    self._allocation_fence_epoch += 1
                     self._allocation_admission_open = False
                 self._publish_change_locked()
                 if bool(completed) and not before[-1]:
                     eligible_callback = self._on_eligible_units_change
                     eligible_unit_ids = self._eligible_resource_unit_ids_locked()
+                    allocation_fence_epoch = self._allocation_fence_epoch
         if eligible_callback is not None:
-            eligible_callback(eligible_unit_ids)
+            eligible_callback(eligible_unit_ids, allocation_fence_epoch)
 
     def mark_materialization_barrier_completed_for_node(self, physical_node_id: str) -> bool:
         """Advance the execution phase after a true barrier completes."""
 
         barrier = self.graph.barrier_for_physical_node(str(physical_node_id))
-        eligible_callback: Callable[[tuple[str, ...]], None] | None = None
+        eligible_callback: Callable[[tuple[str, ...], int], None] | None = None
         eligible_unit_ids: tuple[str, ...] = ()
+        allocation_fence_epoch = 0
         with self._lock:
             if barrier.barrier_id in self._completed_materialization_barrier_ids:
                 return False
@@ -454,17 +460,25 @@ class RayQueryResourceManager:
             # next phase allocation. Fence only new grants during that short
             # handoff so downstream work cannot consume the previous phase's
             # reservation; live tasks and output leases continue unchanged.
+            self._allocation_fence_epoch += 1
             self._allocation_admission_open = False
             self._publish_change_locked()
             eligible_callback = self._on_eligible_units_change
             eligible_unit_ids = self._eligible_resource_unit_ids_locked()
+            allocation_fence_epoch = self._allocation_fence_epoch
         if eligible_callback is not None:
-            eligible_callback(eligible_unit_ids)
+            eligible_callback(eligible_unit_ids, allocation_fence_epoch)
         return True
 
     def current_eligible_resource_unit_ids(self) -> tuple[str, ...]:
         with self._lock:
             return self._eligible_resource_unit_ids_locked()
+
+    def current_allocation_frontier(self) -> tuple[tuple[str, ...], int]:
+        """Return the eligible units and the token authorized to reopen them."""
+
+        with self._lock:
+            return self._eligible_resource_unit_ids_locked(), int(self._allocation_fence_epoch)
 
     def _eligible_resource_unit_ids_locked(self) -> tuple[str, ...]:
         if self._cancelled:
@@ -939,23 +953,44 @@ class RayQueryResourceManager:
         self,
         allocation: QueryAllocation,
         *,
-        admission_open: bool,
+        reopen_fence_epoch: int | None = None,
     ) -> None:
+        """Apply a newer soft budget and optionally acknowledge its frontier.
+
+        Ordinary cluster rebalances preserve the current admission gate. Only
+        the phase transition that owns the current fence epoch may reopen it.
+        """
+
         with self._lock:
             if allocation.generation <= self.allocation.generation:
                 raise ValueError(
                     "allocation generation must increase: "
                     f"current={self.allocation.generation} new={allocation.generation}"
                 )
+            resolved_reopen_epoch = None if reopen_fence_epoch is None else int(reopen_fence_epoch)
+            if resolved_reopen_epoch is not None and resolved_reopen_epoch < 0:
+                raise ValueError("allocation fence epoch must be >= 0")
+            if resolved_reopen_epoch is not None and resolved_reopen_epoch > self._allocation_fence_epoch:
+                raise ValueError(
+                    "allocation fence epoch is from the future: "
+                    f"current={self._allocation_fence_epoch} reopen={resolved_reopen_epoch}"
+                )
             self.allocation = allocation
-            self._allocation_admission_open = bool(admission_open) and not self._failed and not self._cancelled
+            if resolved_reopen_epoch == self._allocation_fence_epoch:
+                self._allocation_admission_open = (
+                    not self._allocation_admission_closed and not self._failed and not self._cancelled
+                )
             self._publish_change_locked()
 
     def close_admission(self) -> None:
-        """Fence new grants while preserving live leases for ordered teardown."""
+        """Permanently fence new grants while preserving live leases for teardown."""
         with self._lock:
-            if not self._allocation_admission_open:
+            if self._allocation_admission_closed:
                 return
+            # Invalidate an in-flight phase callback even when another phase
+            # transition has already closed admission.
+            self._allocation_admission_closed = True
+            self._allocation_fence_epoch += 1
             self._allocation_admission_open = False
             self._publish_change_locked()
 
@@ -2647,6 +2682,8 @@ class RayQueryResourceManager:
                     soft_allocation_usage.object_store_bytes - self.allocation.resources.object_store_bytes,
                 ),
                 "allocation_admission_open": self._allocation_admission_open,
+                "allocation_admission_closed": self._allocation_admission_closed,
+                "allocation_fence_epoch": int(self._allocation_fence_epoch),
                 "admission_epoch": int(self._admission_epoch),
                 "reservation_ratio": self.reservation_ratio,
                 "execution_phase": {

--- a/vane/runners/ray/query_resource_runtime.py
+++ b/vane/runners/ray/query_resource_runtime.py
@@ -21,7 +21,7 @@ def register_query_resource_graph(
     admission_open: bool = True,
     reservation_ratio: float = 0.5,
     on_change: Callable[[], None] | None = None,
-    on_eligible_units_change: Callable[[tuple[str, ...]], None] | None = None,
+    on_eligible_units_change: Callable[[tuple[str, ...], int], None] | None = None,
 ) -> RayQueryResourceManager:
     """Atomically publish the driver-local resource manager for a query."""
 


### PR DESCRIPTION
## Summary

- Add a query-local allocation fence epoch so ordinary coordinator rebalances can publish newer soft budgets without changing the current admission gate.
- Carry the owning epoch through phase callbacks, validate it before and after actor retirement, and reopen admission only when the refreshed phase allocation acknowledges the exact current frontier.
- Make ordered-teardown admission closure permanent and cover maintenance rebalances, stale/future epochs, teardown races, and the successful phase handoff.

This addresses the third admission-fence report in #595 without changing the coordinator allocation protocol. It intentionally replaces the internal callback and allocation-update signatures; no compatibility fallback is retained.

## Related issue

Related: #595

Complements #597, which addresses the first two reports. Keep #595 open until both changes land.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change is internal to Ray query-resource phase admission.

## Validation

- Two consecutive clean source-review passes after the final change.
- `scripts/format root --changed`
- Release non-editable build: `SKBUILD_BUILD_DIR=build/python-release SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`, with the repository vcpkg Arrow/OpenSSL prefix supplied to CMake.
- `scripts/run_installed_pytest.sh tests/fast/test_query_resource_manager.py tests/fast/test_query_resource_runtime.py tests/fast/test_cluster_resource_coordinator.py tests/fast/test_driver_query_resource_graph_registration.py tests/fast/test_driver_query_leases.py tests/fast/test_ray_fragment_submission.py tests/fast/test_ray_result_contract.py` — 715 passed.
- `scripts/run_release_tests.sh` — non-Ray: 531 passed, 15 deselected; real-Ray: 11 passed, 535 deselected.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.