### PR TITLE
[fix](ray) Make FTE worker-loss reconciliation observable

### DIFF
--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -3282,7 +3282,7 @@ def test_ray_worker_failure_retirement_survives_query_close_and_stale_event(monk
             manager_instance_id=failed_handle.manager_instance_id,
             error=RuntimeError("planned worker failure during query close"),
         )
-        assert worker_failures.mark_fte_worker_failed_for_event(closing_event) == []
+        assert failed_handle._handles_for_worker_failed_event(closing_event) == []
         assert actors[0].killed
         assert ray_worker_handle._FTE_WORKER_HANDLES.get(failed_worker_id) is None
 
@@ -3300,7 +3300,7 @@ def test_ray_worker_failure_retirement_survives_query_close_and_stale_event(monk
             manager_instance_id=failed_handle.manager_instance_id,
             error=closing_event.error,
         )
-        assert worker_failures.mark_fte_worker_failed_for_event(delayed_event) == []
+        assert failed_handle._handles_for_worker_failed_event(delayed_event) == []
         assert ray_worker_handle._FTE_WORKER_HANDLES[failed_worker_id] is replacement
         assert replacement._fte_healthy is True
         assert actors[1].killed is False

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -6701,13 +6701,15 @@ def test_duplicate_fte_worker_failure_scheduler_observer_fences_without_blocking
     )
     reconciliation_started = threading.Event()
     release_reconciliation = threading.Event()
-    reconciliation_calls = []
+    reconciled_scheduler_batches = []
 
-    def reconcile_worker_failure(reported_event, **_kwargs):
-        reconciliation_calls.append(reported_event)
-        reconciliation_started.set()
-        assert release_reconciliation.wait(timeout=2.0)
-        return worker_failures_mod._FteWorkerFailureReconciliationResult((), schedulers)
+    def reconcile_worker_failure(_reported_event, *, reconciliation_batch, **_kwargs):
+        _initial_reconciliation, reconciled_schedulers = reconciliation_batch
+        reconciled_scheduler_batches.append(reconciled_schedulers)
+        if len(reconciled_scheduler_batches) == 1:
+            reconciliation_started.set()
+            assert release_reconciliation.wait(timeout=2.0)
+        return worker_failures_mod._FteWorkerFailureReconciliationResult((), reconciled_schedulers)
 
     monkeypatch.setattr(
         worker_failures_mod,
@@ -6733,7 +6735,7 @@ def test_duplicate_fte_worker_failure_scheduler_observer_fences_without_blocking
             release_reconciliation.set()
         assert owner.result(timeout=1.0) == []
 
-    assert reconciliation_calls == [events[0]]
+    assert reconciled_scheduler_batches == [(schedulers[0],), (schedulers[1],)]
     failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
 
 
@@ -6762,8 +6764,8 @@ def test_duplicate_fte_worker_failure_fences_join_owner_reconciliation(monkeypat
     )
     owner = worker_failures_mod.begin_fte_worker_failure_reconciliation(events[0])
     duplicate = worker_failures_mod.begin_fte_worker_failure_reconciliation(events[1])
-    assert owner is not None and owner.owns_reconciliation
-    assert duplicate is not None and not duplicate.owns_reconciliation
+    assert owner is not None and owner.owns_runner
+    assert duplicate is not None and not duplicate.owns_runner
     reconciled_query_ids = set()
 
     monkeypatch.setattr(worker_failures_mod, "quarantine_fte_worker", lambda *_args, **_kwargs: None)
@@ -6776,11 +6778,150 @@ def test_duplicate_fte_worker_failure_fences_join_owner_reconciliation(monkeypat
     monkeypatch.setattr(worker_failures_mod, "_mark_fte_worker_failed", mark_worker_failed)
 
     result = owner.reconcile()
-    owner.complete(None, schedulers=result.schedulers)
+    assert result is not None
+    pending_drain = Future()
+    pending_drain.set_result(None)
+    owner.complete_after_pending_drain(result.schedulers, pending_drain)
+    assert owner.reconcile() is None
+    assert owner.release_runner() is False
 
     assert reconciled_query_ids == {scheduler.query_id for scheduler in schedulers}
     assert {scheduler.query_id for scheduler in result.schedulers} == reconciled_query_ids
     assert duplicate.completion.result(timeout=1.0) is None
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+
+
+def test_duplicate_fte_worker_failure_reconciles_scheduler_joining_during_publication(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:late-duplicate-reconciliation",
+        manager_instance_id="manager-a",
+    )
+    schedulers = tuple(
+        worker_handle_mod._FTE_SCHEDULERS.get_or_create(f"query-late-duplicate-reconciliation-{suffix}")
+        for suffix in ("a", "b")
+    )
+    for scheduler in schedulers:
+        failed._bind_fte_scheduler_handlers(scheduler)
+    events = tuple(
+        WorkerFailed(
+            query_id=scheduler.query_id,
+            worker_id=failed.worker_id,
+            worker_incarnation_id=failed.worker_incarnation_id,
+            manager_instance_id=failed.manager_instance_id,
+            error=RuntimeError("planned duplicate failure"),
+        )
+        for scheduler in schedulers
+    )
+    reconciled_query_id_batches = []
+    pending_drains = []
+
+    monkeypatch.setattr(worker_failures_mod, "quarantine_fte_worker", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(worker_failures_mod, "_query_ids_owned_by_fte_workers", lambda *_args, **_kwargs: set())
+
+    def mark_worker_failed(*_args, query_id_filters, **_kwargs):
+        reconciled_query_id_batches.append(set(query_id_filters))
+        return []
+
+    def request_pending_drain():
+        completion = Future()
+        pending_drains.append(completion)
+        return [], completion
+
+    monkeypatch.setattr(worker_failures_mod, "_mark_fte_worker_failed", mark_worker_failed)
+    monkeypatch.setattr(
+        worker_events_mod,
+        "request_fte_pending_task_drain_with_completion",
+        request_pending_drain,
+    )
+
+    assert failed._handles_for_worker_failed_scheduler_event(events[0]) == []
+    assert reconciled_query_id_batches == [{schedulers[0].query_id}]
+    assert len(pending_drains) == 1
+    assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+
+    assert failed._handles_for_worker_failed_scheduler_event(events[1]) == []
+    assert reconciled_query_id_batches == [
+        {schedulers[0].query_id},
+        {schedulers[1].query_id},
+    ]
+    assert len(pending_drains) == 2
+    assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+
+    for pending_drain in pending_drains:
+        pending_drain.set_result(None)
+
+    failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+
+
+def test_fte_worker_failure_publication_error_waits_for_active_late_runner(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:late-runner-publication-error",
+        manager_instance_id="manager-a",
+    )
+    schedulers = tuple(
+        worker_handle_mod._FTE_SCHEDULERS.get_or_create(f"query-late-runner-publication-error-{suffix}")
+        for suffix in ("a", "b")
+    )
+    for scheduler in schedulers:
+        failed._bind_fte_scheduler_handlers(scheduler)
+    events = tuple(
+        WorkerFailed(
+            query_id=scheduler.query_id,
+            worker_id=failed.worker_id,
+            worker_incarnation_id=failed.worker_incarnation_id,
+            manager_instance_id=failed.manager_instance_id,
+            error=RuntimeError("planned duplicate failure"),
+        )
+        for scheduler in schedulers
+    )
+    late_reconciliation_started = threading.Event()
+    release_late_reconciliation = threading.Event()
+    pending_drains = []
+
+    monkeypatch.setattr(worker_failures_mod, "quarantine_fte_worker", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(worker_failures_mod, "_query_ids_owned_by_fte_workers", lambda *_args, **_kwargs: set())
+
+    def mark_worker_failed(*_args, query_id_filters, **_kwargs):
+        if query_id_filters == {schedulers[1].query_id}:
+            late_reconciliation_started.set()
+            assert release_late_reconciliation.wait(timeout=2.0)
+        return []
+
+    def request_pending_drain():
+        completion = Future()
+        pending_drains.append(completion)
+        return [], completion
+
+    monkeypatch.setattr(worker_failures_mod, "_mark_fte_worker_failed", mark_worker_failed)
+    monkeypatch.setattr(
+        worker_events_mod,
+        "request_fte_pending_task_drain_with_completion",
+        request_pending_drain,
+    )
+
+    assert failed._handles_for_worker_failed_scheduler_event(events[0]) == []
+    assert len(pending_drains) == 1
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        late_runner = executor.submit(failed._handles_for_worker_failed_scheduler_event, events[1])
+        assert late_reconciliation_started.wait(timeout=1.0)
+        pending_drains[0].set_exception(RuntimeError("planned asynchronous publication failure"))
+        try:
+            assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+            assert not late_runner.done()
+        finally:
+            release_late_reconciliation.set()
+        with pytest.raises(RuntimeError, match="planned asynchronous publication failure"):
+            late_runner.result(timeout=1.0)
+
+    assert {scheduler.stats().state for scheduler in schedulers} == {"FAILED"}
+    with pytest.raises(RuntimeError, match="planned asynchronous publication failure"):
+        failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
     assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
 
 
@@ -6865,6 +7006,11 @@ def test_fte_worker_failure_publication_error_fails_all_reconciled_schedulers(mo
         worker_failures_mod,
         "_reconcile_fte_worker_failure",
         lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult((), schedulers),
+    )
+    monkeypatch.setattr(
+        worker_failures_mod,
+        "_query_ids_owned_by_fte_workers",
+        lambda *_args, **_kwargs: {scheduler.query_id for scheduler in schedulers},
     )
 
     def fail_pending_drain():

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 import pytest
 
 import vane
+import vane.runners.fte.fte_scheduler as fte_scheduler_mod
 from vane._ray_errors import RemoteRayException
 
 ray = pytest.importorskip("ray")
@@ -6641,7 +6642,7 @@ def test_duplicate_fte_worker_failure_waits_for_active_reconciliation(monkeypatc
         reconciliation_started.set()
         assert release_reconciliation.wait(timeout=2.0)
         state_published.set()
-        return worker_failures_mod._FteWorkerFailureReconciliationResult((), (scheduler,))
+        return worker_failures_mod._FteWorkerFailureReconciliationResult((), (scheduler,), ())
 
     monkeypatch.setattr(worker_failures_mod, "Future", _ObservedReconciliation)
     monkeypatch.setattr(
@@ -6709,7 +6710,7 @@ def test_duplicate_fte_worker_failure_scheduler_observer_fences_without_blocking
         if len(reconciled_scheduler_batches) == 1:
             reconciliation_started.set()
             assert release_reconciliation.wait(timeout=2.0)
-        return worker_failures_mod._FteWorkerFailureReconciliationResult((), reconciled_schedulers)
+        return worker_failures_mod._FteWorkerFailureReconciliationResult((), reconciled_schedulers, ())
 
     monkeypatch.setattr(
         worker_failures_mod,
@@ -6781,7 +6782,11 @@ def test_duplicate_fte_worker_failure_fences_join_owner_reconciliation(monkeypat
     assert result is not None
     pending_drain = Future()
     pending_drain.set_result(None)
-    owner.complete_after_pending_drain(result.schedulers, pending_drain)
+    owner.complete_after_pending_drain(
+        result.schedulers,
+        pending_drain,
+        result.retry_delay_completions,
+    )
     assert owner.reconcile() is None
     assert owner.release_runner() is False
 
@@ -7001,11 +7006,16 @@ def test_fte_worker_failure_publication_error_fails_all_reconciled_schedulers(mo
         manager_instance_id=failed.manager_instance_id,
         error=RuntimeError("planned failure"),
     )
+    retry_delay_completion = Future()
 
     monkeypatch.setattr(
         worker_failures_mod,
         "_reconcile_fte_worker_failure",
-        lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult((), schedulers),
+        lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult(
+            (),
+            schedulers,
+            (retry_delay_completion,),
+        ),
     )
     monkeypatch.setattr(
         worker_failures_mod,
@@ -7014,7 +7024,9 @@ def test_fte_worker_failure_publication_error_fails_all_reconciled_schedulers(mo
     )
 
     def fail_pending_drain():
-        raise RuntimeError("planned publication failure")
+        completion = Future()
+        completion.set_exception(RuntimeError("planned publication failure"))
+        return [], completion
 
     monkeypatch.setattr(
         worker_events_mod,
@@ -7025,9 +7037,90 @@ def test_fte_worker_failure_publication_error_fails_all_reconciled_schedulers(mo
     with pytest.raises(RuntimeError, match="planned publication failure"):
         failed._handles_for_worker_failed_event(event)
 
+    assert retry_delay_completion.done() is False
     assert {scheduler.stats().state for scheduler in schedulers} == {"FAILED"}
     with pytest.raises(RuntimeError, match="planned publication failure"):
         failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+
+
+def test_fte_worker_failure_barrier_waits_for_armed_retry_delay(monkeypatch):
+    timers = []
+
+    class _ManualTimer:
+        def __init__(self, interval, function, args=()):
+            self.interval = interval
+            self.function = function
+            self.args = args
+            self.daemon = False
+            timers.append(self)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            pass
+
+        def fire(self):
+            self.function(*self.args)
+
+    monkeypatch.setattr(fte_scheduler_mod.threading, "Timer", _ManualTimer)
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:delayed-retry-failure-barrier",
+        manager_instance_id="manager-a",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-worker-failure-delayed-retry-barrier")
+    failed._bind_fte_scheduler_handlers(scheduler)
+    event = WorkerFailed(
+        query_id=scheduler.query_id,
+        worker_id=failed.worker_id,
+        worker_incarnation_id=failed.worker_incarnation_id,
+        manager_instance_id=failed.manager_instance_id,
+        error=RuntimeError("planned failure"),
+    )
+
+    monkeypatch.setattr(worker_failures_mod, "quarantine_fte_worker", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(worker_failures_mod, "_query_ids_owned_by_fte_workers", lambda *_args, **_kwargs: set())
+    monkeypatch.setattr(worker_failures_mod, "_mark_fte_worker_failed", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(worker_failures_mod, "_fte_retry_remaining_delay_s", lambda _query_id: 10.0)
+
+    retry_admission_completion = Future()
+    pending_drain_calls = []
+
+    def controlled_pending_drain():
+        pending_drain_calls.append(None)
+        if len(pending_drain_calls) == 2:
+            return [], retry_admission_completion
+        completion = Future()
+        completion.set_result(None)
+        return [], completion
+
+    monkeypatch.setattr(
+        worker_events_mod,
+        "request_fte_pending_task_drain_with_completion",
+        controlled_pending_drain,
+    )
+
+    scheduler.enqueue(event)
+    assert scheduler.drain() == []
+
+    assert len(timers) == 1
+    assert timers[0].interval == 10.0
+    assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+
+    timers[0].fire()
+
+    assert len(pending_drain_calls) == 2
+    assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+    retry_admission_completion.set_result(None)
+
+    failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+    assert scheduler.stats().event_counts == {
+        "WorkerFailed": 1,
+        "RetryDelayExpired": 1,
+    }
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
 
 
 def test_fte_worker_failure_barrier_waits_for_reentrant_scheduler_drain(monkeypatch):
@@ -7056,7 +7149,7 @@ def test_fte_worker_failure_barrier_waits_for_reentrant_scheduler_drain(monkeypa
     monkeypatch.setattr(
         worker_failures_mod,
         "_reconcile_fte_worker_failure",
-        lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult((), (scheduler,)),
+        lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult((), (scheduler,), ()),
     )
 
     def blocking_admission_drain(**_kwargs):
@@ -10175,6 +10268,27 @@ def test_fte_worker_failure_retry_waits_for_scheduling_delayer(monkeypatch):
     monkeypatch.setenv("VANE_FTE_RETRY_DELAY_SCALE_FACTOR", "2")
     now = [100.0]
     monkeypatch.setattr(worker_handle_mod.time, "monotonic", lambda: now[0])
+    timer_started = threading.Event()
+    timers = []
+
+    class _ManualTimer:
+        def __init__(self, interval, function, args=()):
+            self.interval = interval
+            self.function = function
+            self.args = args
+            self.daemon = False
+            timers.append(self)
+
+        def start(self):
+            timer_started.set()
+
+        def cancel(self):
+            pass
+
+        def fire(self):
+            self.function(*self.args)
+
+    monkeypatch.setattr(fte_scheduler_mod.threading, "Timer", _ManualTimer)
     monkeypatch.setattr(
         RayWorkerActorHandle,
         "_fte_task_handle_cls",
@@ -10198,26 +10312,28 @@ def test_fte_worker_failure_retry_waits_for_scheduling_delayer(monkeypatch):
         "query-fte-retry-delay.0.0.0"
     ]
 
-    retries = handle1.mark_fte_worker_failed(
-        "worker-0",
-        RuntimeError("actor died"),
-        worker_incarnation_id=handle0.worker_incarnation_id,
-    )
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        failure = executor.submit(
+            handle1.mark_fte_worker_failed,
+            "worker-0",
+            RuntimeError("actor died"),
+            worker_incarnation_id=handle0.worker_incarnation_id,
+        )
+        try:
+            assert timer_started.wait(timeout=1.0)
+            assert len(timers) == 1
+            assert timers[0].interval == 0.5
+            assert failure.done() is False
+            assert [call for call in actor1.fte_calls if call[0] == "create"] == []
+            assert handle1.pop_fte_result_handles("query-fte-retry-delay") == []
+        finally:
+            now[0] += 0.5
+            if timers:
+                timers[-1].fire()
+        retries = failure.result(timeout=1.0)
 
     assert retries == []
-    assert [call for call in actor1.fte_calls if call[0] == "create"] == []
-    assert handle1.pop_fte_result_handles("query-fte-retry-delay") == []
-
-    now[0] += 0.5
-    scheduler = worker_handle_mod._FTE_SCHEDULERS.get("query-fte-retry-delay")
-    assert scheduler is not None
-    scheduler.enqueue(
-        worker_handle_mod.RetryDelayExpired(
-            "query-fte-retry-delay",
-            scheduler.retry_delay_generation(),
-        )
-    )
-    scheduled = scheduler.drain()
+    scheduled = handle1.pop_fte_result_handles("query-fte-retry-delay")
 
     assert len(scheduled) == 1
     assert scheduled[0].worker_handle is handle1

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -20,6 +20,7 @@ ray = pytest.importorskip("ray")
 
 import vane.runners.fte.fte_execution as fte_execution_mod
 import vane.runners.ray.fragment_worker_commands as worker_commands_mod
+import vane.runners.ray.fragment_worker_events as worker_events_mod
 import vane.runners.ray.fragment_worker_failures as worker_failures_mod
 import vane.runners.ray.fragment_worker_placement as worker_placement_mod
 import vane.runners.ray.fragment_worker_selection as worker_selection_mod
@@ -6592,7 +6593,7 @@ def test_fte_worker_failure_event_rejects_cross_manager_scheduler(failed_manager
     scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-cross-manager-failure")
     owner._bind_fte_scheduler_handlers(scheduler)
 
-    scheduled = worker_failures_mod.mark_fte_worker_failed_for_event(
+    scheduled = failed._handles_for_worker_failed_event(
         WorkerFailed(
             query_id=scheduler.query_id,
             worker_id=failed.worker_id,
@@ -6640,7 +6641,7 @@ def test_duplicate_fte_worker_failure_waits_for_active_reconciliation(monkeypatc
         reconciliation_started.set()
         assert release_reconciliation.wait(timeout=2.0)
         state_published.set()
-        return []
+        return worker_failures_mod._FteWorkerFailureReconciliationResult((), (scheduler,))
 
     monkeypatch.setattr(worker_failures_mod, "Future", _ObservedReconciliation)
     monkeypatch.setattr(
@@ -6650,13 +6651,13 @@ def test_duplicate_fte_worker_failure_waits_for_active_reconciliation(monkeypatc
     )
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        owner = executor.submit(worker_failures_mod.mark_fte_worker_failed_for_event, event)
+        owner = executor.submit(failed._handles_for_worker_failed_event, event)
         assert reconciliation_started.wait(timeout=1.0)
         duplicate_entered = threading.Event()
 
         def report_duplicate_failure():
             duplicate_entered.set()
-            result = worker_failures_mod.mark_fte_worker_failed_for_event(event)
+            result = failed._handles_for_worker_failed_event(event)
             assert state_published.is_set()
             return result
 
@@ -6673,6 +6674,63 @@ def test_duplicate_fte_worker_failure_waits_for_active_reconciliation(monkeypatc
 
     assert reconciliation_calls == [event]
     assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+    failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+
+
+def test_duplicate_fte_worker_failure_scheduler_observer_does_not_block_drain(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:duplicate-scheduler-failure",
+        manager_instance_id="manager-a",
+    )
+    schedulers = tuple(
+        worker_handle_mod._FTE_SCHEDULERS.get_or_create(f"query-duplicate-scheduler-{suffix}") for suffix in ("a", "b")
+    )
+    for scheduler in schedulers:
+        failed._bind_fte_scheduler_handlers(scheduler)
+    events = tuple(
+        WorkerFailed(
+            query_id=scheduler.query_id,
+            worker_id=failed.worker_id,
+            worker_incarnation_id=failed.worker_incarnation_id,
+            manager_instance_id=failed.manager_instance_id,
+            error=RuntimeError("planned duplicate failure"),
+        )
+        for scheduler in schedulers
+    )
+    reconciliation_started = threading.Event()
+    release_reconciliation = threading.Event()
+    reconciliation_calls = []
+
+    def reconcile_worker_failure(reported_event, **_kwargs):
+        reconciliation_calls.append(reported_event)
+        reconciliation_started.set()
+        assert release_reconciliation.wait(timeout=2.0)
+        return worker_failures_mod._FteWorkerFailureReconciliationResult((), schedulers)
+
+    monkeypatch.setattr(
+        worker_failures_mod,
+        "_reconcile_fte_worker_failure",
+        reconcile_worker_failure,
+    )
+
+    def drain_event(scheduler, event):
+        scheduler.enqueue(event)
+        return scheduler.drain()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner = executor.submit(drain_event, schedulers[0], events[0])
+        assert reconciliation_started.wait(timeout=1.0)
+        duplicate = executor.submit(drain_event, schedulers[1], events[1])
+        try:
+            assert duplicate.result(timeout=1.0) == []
+        finally:
+            release_reconciliation.set()
+        assert owner.result(timeout=1.0) == []
+
+    assert reconciliation_calls == [events[0]]
+    failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
 
 
 def test_duplicate_fte_worker_failure_replays_reconciliation_error(monkeypatch):
@@ -6703,7 +6761,7 @@ def test_duplicate_fte_worker_failure_replays_reconciliation_error(monkeypatch):
     def fail_reconciliation(*_args, **_kwargs):
         reconciliation_started.set()
         assert release_reconciliation.wait(timeout=2.0)
-        raise RuntimeError("planned reconciliation failure")
+        raise TimeoutError("planned reconciliation failure")
 
     monkeypatch.setattr(worker_failures_mod, "Future", _ObservedReconciliation)
     monkeypatch.setattr(
@@ -6713,21 +6771,182 @@ def test_duplicate_fte_worker_failure_replays_reconciliation_error(monkeypatch):
     )
 
     with ThreadPoolExecutor(max_workers=2) as executor:
-        owner = executor.submit(worker_failures_mod.mark_fte_worker_failed_for_event, event)
+        owner = executor.submit(failed._handles_for_worker_failed_event, event)
         assert reconciliation_started.wait(timeout=1.0)
-        duplicate = executor.submit(worker_failures_mod.mark_fte_worker_failed_for_event, event)
+        duplicate = executor.submit(failed._handles_for_worker_failed_event, event)
         try:
             assert duplicate_joined.wait(timeout=1.0)
             assert not duplicate.done()
         finally:
             release_reconciliation.set()
 
-        with pytest.raises(RuntimeError, match="planned reconciliation failure"):
+        with pytest.raises(TimeoutError, match="planned reconciliation failure"):
             owner.result(timeout=1.0)
-        with pytest.raises(RuntimeError, match="planned reconciliation failure"):
+        with pytest.raises(TimeoutError, match="planned reconciliation failure"):
             duplicate.result(timeout=1.0)
 
     assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+    with pytest.raises(TimeoutError, match="planned reconciliation failure"):
+        failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+
+
+def test_fte_worker_failure_publication_error_fails_all_reconciled_schedulers(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:failure-publication-error",
+        manager_instance_id="manager-a",
+    )
+    schedulers = tuple(
+        worker_handle_mod._FTE_SCHEDULERS.get_or_create(f"query-worker-failure-error-{suffix}") for suffix in ("a", "b")
+    )
+    for scheduler in schedulers:
+        failed._bind_fte_scheduler_handlers(scheduler)
+    event = WorkerFailed(
+        query_id=schedulers[0].query_id,
+        worker_id=failed.worker_id,
+        worker_incarnation_id=failed.worker_incarnation_id,
+        manager_instance_id=failed.manager_instance_id,
+        error=RuntimeError("planned failure"),
+    )
+
+    monkeypatch.setattr(
+        worker_failures_mod,
+        "_reconcile_fte_worker_failure",
+        lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult((), schedulers),
+    )
+
+    def fail_pending_drain():
+        raise RuntimeError("planned publication failure")
+
+    monkeypatch.setattr(
+        worker_events_mod,
+        "request_fte_pending_task_drain_with_completion",
+        fail_pending_drain,
+    )
+
+    with pytest.raises(RuntimeError, match="planned publication failure"):
+        failed._handles_for_worker_failed_event(event)
+
+    assert {scheduler.stats().state for scheduler in schedulers} == {"FAILED"}
+    with pytest.raises(RuntimeError, match="planned publication failure"):
+        failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+
+
+def test_fte_worker_failure_barrier_waits_for_reentrant_scheduler_drain(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:reentrant-failure-barrier",
+        manager_instance_id="manager-a",
+    )
+    scheduler = worker_handle_mod._FTE_SCHEDULERS.get_or_create("query-worker-failure-reentrant-barrier")
+    event = WorkerFailed(
+        query_id=scheduler.query_id,
+        worker_id=failed.worker_id,
+        worker_incarnation_id=failed.worker_incarnation_id,
+        manager_instance_id=failed.manager_instance_id,
+        error=RuntimeError("planned failure"),
+    )
+    admission_started = threading.Event()
+    release_admission = threading.Event()
+    retry_event_enqueued = threading.Event()
+    retry_publication_started = threading.Event()
+    release_retry_publication = threading.Event()
+    retry_published = threading.Event()
+    barrier_wait_started = threading.Event()
+
+    monkeypatch.setattr(
+        worker_failures_mod,
+        "_reconcile_fte_worker_failure",
+        lambda *_args, **_kwargs: worker_failures_mod._FteWorkerFailureReconciliationResult((), (scheduler,)),
+    )
+
+    def blocking_admission_drain(**_kwargs):
+        if not retry_event_enqueued.is_set():
+            admission_started.set()
+            assert release_admission.wait(timeout=2.0)
+            scheduler.enqueue(
+                WorkerReservationCompleted(
+                    scheduler.query_id,
+                    1,
+                    "fragment-retry",
+                    0,
+                    1,
+                    worker_id="replacement-worker",
+                )
+            )
+            retry_event_enqueued.set()
+        return []
+
+    def publish_retry(_event):
+        retry_publication_started.set()
+        assert release_retry_publication.wait(timeout=2.0)
+        retry_published.set()
+        return []
+
+    monkeypatch.setattr(failed, "_drain_fte_pending_tasks", blocking_admission_drain)
+    monkeypatch.setattr(failed, "_handles_for_worker_reservation_completed_event", publish_retry)
+    failed._bind_fte_scheduler_handlers(scheduler)
+
+    def drain_failure_event():
+        scheduler.enqueue(event)
+        return scheduler.drain()
+
+    def wait_for_barrier():
+        barrier_wait_started.set()
+        failed.wait_fte_worker_failure_reconciliation(timeout_s=2.0)
+        assert retry_published.is_set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        owner = executor.submit(drain_failure_event)
+        assert admission_started.wait(timeout=1.0)
+        waiter = executor.submit(wait_for_barrier)
+        assert barrier_wait_started.wait(timeout=1.0)
+        try:
+            assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+            assert not waiter.done()
+        finally:
+            release_admission.set()
+        assert retry_publication_started.wait(timeout=1.0)
+        try:
+            assert failed._fte_worker_failure_reconciliation_complete.is_set() is False
+            assert not waiter.done()
+        finally:
+            release_retry_publication.set()
+
+        assert owner.result(timeout=1.0) == []
+        assert waiter.result(timeout=1.0) is None
+
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
+
+
+@pytest.mark.parametrize("timeout_s", [0, -1, float("nan"), float("inf")])
+def test_fte_worker_failure_barrier_rejects_invalid_timeout(timeout_s):
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:failure-barrier-timeout",
+        manager_instance_id="manager-a",
+    )
+
+    with pytest.raises(ValueError, match="timeout_s must be finite and > 0"):
+        handle.wait_fte_worker_failure_reconciliation(timeout_s=timeout_s)
+
+
+def test_fte_worker_failure_barrier_timeout_identifies_worker_incarnation():
+    handle = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:failure-barrier-timeout-context",
+        manager_instance_id="manager-a",
+    )
+
+    with pytest.raises(
+        TimeoutError,
+        match=rf"worker={handle.worker_id} incarnation={handle.worker_incarnation_id}",
+    ):
+        handle.wait_fte_worker_failure_reconciliation(timeout_s=0.01)
 
 
 def test_stale_worker_shutdown_does_not_fail_current_registry_owner(monkeypatch):

--- a/tests/fast/test_ray_fragment_submission.py
+++ b/tests/fast/test_ray_fragment_submission.py
@@ -6677,7 +6677,7 @@ def test_duplicate_fte_worker_failure_waits_for_active_reconciliation(monkeypatc
     failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
 
 
-def test_duplicate_fte_worker_failure_scheduler_observer_does_not_block_drain(monkeypatch):
+def test_duplicate_fte_worker_failure_scheduler_observer_fences_without_blocking_drain(monkeypatch):
     failed = RayWorkerActorHandle(
         _FakeActor(),
         memory_capacity_bytes=1 << 60,
@@ -6725,12 +6725,63 @@ def test_duplicate_fte_worker_failure_scheduler_observer_does_not_block_drain(mo
         duplicate = executor.submit(drain_event, schedulers[1], events[1])
         try:
             assert duplicate.result(timeout=1.0) == []
+            assert schedulers[1].worker_failure_is_recorded(
+                failed.worker_id,
+                worker_incarnation_id=failed.worker_incarnation_id,
+            )
         finally:
             release_reconciliation.set()
         assert owner.result(timeout=1.0) == []
 
     assert reconciliation_calls == [events[0]]
     failed.wait_fte_worker_failure_reconciliation(timeout_s=1.0)
+
+
+def test_duplicate_fte_worker_failure_fences_join_owner_reconciliation(monkeypatch):
+    failed = RayWorkerActorHandle(
+        _FakeActor(),
+        memory_capacity_bytes=1 << 60,
+        worker_id="manager-a:node-a:duplicate-scheduler-reconciliation",
+        manager_instance_id="manager-a",
+    )
+    schedulers = tuple(
+        worker_handle_mod._FTE_SCHEDULERS.get_or_create(f"query-duplicate-reconciliation-{suffix}")
+        for suffix in ("a", "b")
+    )
+    for scheduler in schedulers:
+        failed._bind_fte_scheduler_handlers(scheduler)
+    events = tuple(
+        WorkerFailed(
+            query_id=scheduler.query_id,
+            worker_id=failed.worker_id,
+            worker_incarnation_id=failed.worker_incarnation_id,
+            manager_instance_id=failed.manager_instance_id,
+            error=RuntimeError("planned duplicate failure"),
+        )
+        for scheduler in schedulers
+    )
+    owner = worker_failures_mod.begin_fte_worker_failure_reconciliation(events[0])
+    duplicate = worker_failures_mod.begin_fte_worker_failure_reconciliation(events[1])
+    assert owner is not None and owner.owns_reconciliation
+    assert duplicate is not None and not duplicate.owns_reconciliation
+    reconciled_query_ids = set()
+
+    monkeypatch.setattr(worker_failures_mod, "quarantine_fte_worker", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(worker_failures_mod, "_query_ids_owned_by_fte_workers", lambda *_args, **_kwargs: set())
+
+    def mark_worker_failed(*_args, query_id_filters, **_kwargs):
+        reconciled_query_ids.update(query_id_filters)
+        return []
+
+    monkeypatch.setattr(worker_failures_mod, "_mark_fte_worker_failed", mark_worker_failed)
+
+    result = owner.reconcile()
+    owner.complete(None, schedulers=result.schedulers)
+
+    assert reconciled_query_ids == {scheduler.query_id for scheduler in schedulers}
+    assert {scheduler.query_id for scheduler in result.schedulers} == reconciled_query_ids
+    assert duplicate.completion.result(timeout=1.0) is None
+    assert worker_failures_mod._WORKER_FAILURE_RECONCILIATIONS == {}
 
 
 def test_duplicate_fte_worker_failure_replays_reconciliation_error(monkeypatch):

--- a/tests/fast/test_ray_fte_event_scheduler.py
+++ b/tests/fast/test_ray_fte_event_scheduler.py
@@ -241,6 +241,149 @@ def test_event_scheduler_does_not_lose_enqueue_during_idle_handoff():
     assert scheduler.stats().queued_events == 0
 
 
+def test_event_scheduler_drain_barrier_includes_events_queued_before_it():
+    scheduler = FteQueryScheduler("query-drain-completion")
+    handler_started = threading.Event()
+    release_handler = threading.Event()
+    prior_handler_started = threading.Event()
+    release_prior_handler = threading.Event()
+    later_handler_started = threading.Event()
+    release_later_handler = threading.Event()
+    processed = []
+
+    def handle_events(events):
+        value = events[0]["value"]
+        processed.append(value)
+        if value == 1:
+            handler_started.set()
+            assert release_handler.wait(2.0)
+        elif value == 2:
+            prior_handler_started.set()
+            assert release_prior_handler.wait(2.0)
+        elif value == 3:
+            later_handler_started.set()
+            assert release_later_handler.wait(2.0)
+        return []
+
+    scheduler.set_handlers(FteEventHandlers(on_split_events=handle_events))
+    scheduler.enqueue(
+        SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": 1}],
+        )
+    )
+    drain_thread = threading.Thread(target=scheduler.drain)
+    drain_thread.start()
+    assert handler_started.wait(1.0)
+
+    scheduler.enqueue(
+        SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": 2}],
+        )
+    )
+    completion = scheduler.enqueue_drain_barrier()
+    scheduler.enqueue(
+        SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": 3}],
+        )
+    )
+    assert completion.done() is False
+
+    release_handler.set()
+    assert prior_handler_started.wait(1.0)
+    assert completion.done() is False
+    release_prior_handler.set()
+    assert later_handler_started.wait(1.0)
+    assert completion.result(timeout=1.0) is None
+    assert drain_thread.is_alive() is True
+    release_later_handler.set()
+    drain_thread.join(2.0)
+
+    assert drain_thread.is_alive() is False
+    assert processed == [1, 2, 3]
+
+
+def test_event_scheduler_drain_barrier_includes_causal_events_enqueued_after_it():
+    scheduler = FteQueryScheduler("query-causal-drain-completion")
+    initial_handler_started = threading.Event()
+    release_descendant_enqueue = threading.Event()
+    descendant_enqueued = threading.Event()
+    release_initial_handler = threading.Event()
+    descendant_handler_started = threading.Event()
+    release_descendant_handler = threading.Event()
+    later_handler_started = threading.Event()
+    release_later_handler = threading.Event()
+    processed = []
+
+    def event(value):
+        return SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": value}],
+        )
+
+    def handle_events(events):
+        value = events[0]["value"]
+        processed.append(value)
+        if value == 1:
+            initial_handler_started.set()
+            assert release_descendant_enqueue.wait(2.0)
+            scheduler.enqueue(event(2))
+            descendant_enqueued.set()
+            assert release_initial_handler.wait(2.0)
+        elif value == 2:
+            descendant_handler_started.set()
+            assert release_descendant_handler.wait(2.0)
+        elif value == 3:
+            later_handler_started.set()
+            assert release_later_handler.wait(2.0)
+        return []
+
+    scheduler.set_handlers(FteEventHandlers(on_split_events=handle_events))
+    scheduler.enqueue(event(1))
+    drain_thread = threading.Thread(target=scheduler.drain)
+    drain_thread.start()
+    assert initial_handler_started.wait(1.0)
+
+    completion = scheduler.enqueue_drain_barrier()
+    release_descendant_enqueue.set()
+    assert descendant_enqueued.wait(1.0)
+    scheduler.enqueue(event(3))
+    release_initial_handler.set()
+
+    assert descendant_handler_started.wait(1.0)
+    assert completion.done() is False
+    release_descendant_handler.set()
+    assert later_handler_started.wait(1.0)
+    assert completion.result(timeout=1.0) is None
+    assert drain_thread.is_alive() is True
+    release_later_handler.set()
+    drain_thread.join(2.0)
+
+    assert drain_thread.is_alive() is False
+    assert processed == [1, 2, 3]
+
+
+def test_event_scheduler_drain_barrier_replays_prior_handler_error():
+    scheduler = FteQueryScheduler("query-drain-barrier-error")
+    scheduler.enqueue(
+        SplitEventsSubmitted.from_events(
+            scheduler.query_id,
+            [{"query_id": scheduler.query_id, "value": 1}],
+        )
+    )
+    completion = scheduler.enqueue_drain_barrier()
+
+    def fail_handler(_events):
+        raise TimeoutError("planned handler failure")
+
+    with pytest.raises(TimeoutError, match="planned handler failure"):
+        scheduler.drain(FteEventHandlers(on_split_events=fail_handler))
+    with pytest.raises(TimeoutError, match="planned handler failure"):
+        completion.result(timeout=1.0)
+
+
 def test_scheduler_registry_pending_drain_is_single_flight_and_durable():
     registry = FteSchedulerRegistry()
     registry.get_or_create("query-a")
@@ -265,6 +408,44 @@ def test_scheduler_registry_pending_drain_is_single_flight_and_durable():
     assert registry.run_pending_drain(drain_round) == []
     assert calls == ["query-a", "query-b", "query-a", "query-b"]
     assert max_active_depth == 1
+
+
+def test_scheduler_registry_pending_drain_completion_tracks_request_generation():
+    registry = FteSchedulerRegistry()
+    registry.get_or_create("query-a")
+    drain_started = threading.Event()
+    release_drain = threading.Event()
+    rerun_started = threading.Event()
+    release_rerun = threading.Event()
+    rounds = []
+
+    def drain_round(query_ids):
+        rounds.append(tuple(query_ids))
+        if len(rounds) == 1:
+            drain_started.set()
+            assert release_drain.wait(2.0)
+        elif len(rounds) == 2:
+            rerun_started.set()
+            assert release_rerun.wait(2.0)
+        return []
+
+    drain_thread = threading.Thread(target=registry.run_pending_drain, args=(drain_round,))
+    drain_thread.start()
+    assert drain_started.wait(1.0)
+
+    outputs, completion = registry.run_pending_drain_with_completion(drain_round)
+    assert outputs == []
+    assert completion.done() is False
+
+    release_drain.set()
+    assert rerun_started.wait(1.0)
+    assert completion.done() is False
+    release_rerun.set()
+    drain_thread.join(2.0)
+
+    assert drain_thread.is_alive() is False
+    assert completion.result(timeout=1.0) is None
+    assert rounds == [("query-a",), ("query-a",)]
 
 
 def test_event_scheduler_coalesces_pending_internal_admission_pulses():

--- a/tests/fast/test_ray_fte_event_scheduler.py
+++ b/tests/fast/test_ray_fte_event_scheduler.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import threading
 import time
 from collections import deque
+from concurrent.futures import Future
 
 import pytest
 
+import vane.runners.fte.fte_scheduler as fte_scheduler_mod
 from vane.runners.fte import FteTaskAttemptId, FteTaskId
 from vane.runners.fte.fte_events import (
     MemoryPressureDetected,
@@ -26,6 +28,7 @@ from vane.runners.fte.fte_scheduler import (
     FteEventDrivenTaskSource,
     FteEventHandlers,
     FteQueryScheduler,
+    FteRetryDelayResult,
     FteSchedulerRegistry,
 )
 from vane.runners.ray.safe_get import QueryDeadlineExceeded
@@ -759,25 +762,106 @@ def test_event_scheduler_close_resumes_paused_task_source():
 def test_event_scheduler_dispatches_current_retry_delay_generation_only():
     scheduler = FteSchedulerRegistry().get_or_create("query-retry-delay")
     calls = []
-    stale_generation = scheduler.arm_retry_delay(0)
-    current_generation = scheduler.arm_retry_delay(0)
+    scheduler.arm_retry_delay(0)
+    stale_generation = scheduler.retry_delay_generation()
+    scheduler.arm_retry_delay(0)
+    current_generation = scheduler.retry_delay_generation()
 
     scheduler.enqueue(RetryDelayExpired("query-retry-delay", stale_generation))
     scheduler.enqueue(RetryDelayExpired("query-retry-delay", current_generation))
 
-    outputs = scheduler.drain(
-        FteEventHandlers(
-            on_retry_delay_expired=lambda event: calls.append(event.generation) or ["retry"],
-        )
-    )
+    completion = Future()
+    completion.set_result(None)
+
+    def retry_delay_expired(event):
+        calls.append(event.generation)
+        return FteRetryDelayResult(("retry",), completion)
+
+    outputs = scheduler.drain(FteEventHandlers(on_retry_delay_expired=retry_delay_expired))
 
     assert outputs == ["retry"]
     assert calls == [current_generation]
 
 
+def test_event_scheduler_retry_delay_completion_follows_latest_generation(monkeypatch):
+    timers = []
+
+    class _ManualTimer:
+        def __init__(self, interval, function, args=()):
+            self.interval = interval
+            self.function = function
+            self.args = args
+            self.daemon = False
+            self.cancelled = False
+            timers.append(self)
+
+        def start(self):
+            pass
+
+        def cancel(self):
+            self.cancelled = True
+
+        def fire(self):
+            self.function(*self.args)
+
+    monkeypatch.setattr(fte_scheduler_mod.threading, "Timer", _ManualTimer)
+    scheduler = FteSchedulerRegistry().get_or_create("query-retry-delay-completion")
+    calls = []
+    admission_completion = Future()
+
+    def retry_delay_expired(event):
+        calls.append(("retry", event.generation))
+        scheduler.enqueue(
+            ResourceAdmissionChanged(
+                scheduler.query_id,
+                execution_class="retry-descendant",
+            )
+        )
+        return FteRetryDelayResult((), admission_completion)
+
+    scheduler.set_handlers(
+        FteEventHandlers(
+            on_retry_delay_expired=retry_delay_expired,
+            on_resource_admission_changed=lambda event: calls.append(("descendant", event.execution_class)) or [],
+        )
+    )
+
+    first_completion = scheduler.arm_retry_delay(10)
+    first_generation = scheduler.retry_delay_generation()
+    second_completion = scheduler.arm_retry_delay(20)
+    second_generation = scheduler.retry_delay_generation()
+
+    assert timers[0].cancelled is True
+    assert first_completion.done() is False
+    assert second_completion.done() is False
+
+    timers[0].fire()
+
+    assert calls == []
+    assert first_completion.done() is False
+    assert second_completion.done() is False
+
+    timers[1].fire()
+
+    assert first_completion.done() is False
+    assert second_completion.done() is False
+    admission_completion.set_result(None)
+
+    assert first_completion.result(timeout=1.0) is None
+    assert second_completion.result(timeout=1.0) is None
+    assert first_generation != second_generation
+    assert calls == [
+        ("retry", second_generation),
+        ("descendant", "retry-descendant"),
+    ]
+
+
 def test_event_scheduler_retry_delay_timer_records_handler_failure():
     scheduler = FteSchedulerRegistry().get_or_create("query-retry-delay-failure")
-    generation = scheduler.arm_retry_delay(0)
+    completion = scheduler.arm_retry_delay(60)
+    generation = scheduler.retry_delay_generation()
+    assert scheduler._retry_delay_timer is not None
+    scheduler._retry_delay_timer.cancel()
 
     def fail_retry_delay(_event):
         raise RuntimeError("retry drain failed")
@@ -785,6 +869,8 @@ def test_event_scheduler_retry_delay_timer_records_handler_failure():
     scheduler.set_handlers(FteEventHandlers(on_retry_delay_expired=fail_retry_delay))
     scheduler._fire_retry_delay(generation)
 
+    with pytest.raises(RuntimeError, match="retry drain failed"):
+        completion.result(timeout=1.0)
     stats = scheduler.stats().to_dict()
     assert stats["state"] == "FAILED"
     assert stats["queued_events"] == 0

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -154,6 +154,9 @@ class _FteControlFaultActor:
         self.statuses.clear()
         return {"tasks_removed": 0, "tasks_canceled": 0, "fragments_removed": 0}
 
+    def prepare_shutdown(self):
+        """Acknowledge the production worker quiescence handshake."""
+
     def created_requests(self):
         return [
             {

--- a/tests/fast/test_ray_fte_fault_injection.py
+++ b/tests/fast/test_ray_fte_fault_injection.py
@@ -458,25 +458,6 @@ def _build_native_scan_task(
     )
 
 
-def _wait_for_result_handles(
-    handle: RayWorkerActorHandle,
-    query_id: str,
-    expected_count: int,
-    *,
-    timeout_s: float = 10.0,
-) -> list:
-    deadline = time.monotonic() + timeout_s
-    handles = []
-    while time.monotonic() < deadline:
-        handles.extend(handle.pop_fte_result_handles(query_id))
-        if len(handles) >= expected_count:
-            return handles
-        time.sleep(0.05)
-    raise AssertionError(
-        f"expected {expected_count} result handles for {query_id}, got {[str(h.task_id) for h in handles]}"
-    )
-
-
 def test_real_ray_actor_kill_replays_fte_task_on_replacement(monkeypatch):
     monkeypatch.setenv("VANE_FTE_STATUS_WAIT_TIMEOUT_S", "5")
     monkeypatch.setenv("VANE_FTE_CONTROL_RPC_INITIAL_BACKOFF_S", "0")
@@ -507,7 +488,10 @@ def test_real_ray_actor_kill_replays_fte_task_on_replacement(monkeypatch):
         ray.kill(actor0, no_restart=True)
         with pytest.raises(Exception):
             asyncio.run(asyncio.wait_for(task_handle.get_result(), timeout=10.0))
-        retry_handle = _wait_for_result_handles(handle0, "query-real-kill", 1)[0]
+        handle0.wait_fte_worker_failure_reconciliation(timeout_s=10.0)
+        retry_handles = handle0.pop_fte_result_handles("query-real-kill")
+        assert len(retry_handles) == 1
+        retry_handle = retry_handles[0]
         result = asyncio.run(asyncio.wait_for(retry_handle.get_result(), timeout=10.0))
         retry_requests = ray.get(actor1.created_requests.remote())
 
@@ -554,6 +538,7 @@ def test_real_ray_actor_kill_without_replacement_fails_fte_fragment_execution(mo
         ray.kill(actor0, no_restart=True)
         with pytest.raises(Exception):
             asyncio.run(asyncio.wait_for(task_handle.get_result(), timeout=10.0))
+        handle0.wait_fte_worker_failure_reconciliation(timeout_s=10.0)
 
         assert "worker-solo" not in worker_handle_mod._FTE_WORKER_HANDLES
         assert (
@@ -634,7 +619,10 @@ def test_real_ray_actor_kill_replays_native_dynamic_scan_on_replacement(monkeypa
 
         with pytest.raises(Exception):
             asyncio.run(asyncio.wait_for(task_handle.get_result(), timeout=10.0))
-        retry_handle = _wait_for_result_handles(handle1, "query-native-kill", 1)[0]
+        handle0.wait_fte_worker_failure_reconciliation(timeout_s=10.0)
+        retry_handles = handle1.pop_fte_result_handles("query-native-kill")
+        assert len(retry_handles) == 1
+        retry_handle = retry_handles[0]
 
         retry_info = ray.get(actor1.fte_get_task_info.remote(retry_handle.task_id.to_dict()))
         if retry_info["status"].get("state") == "RUNNING":
@@ -732,7 +720,10 @@ def test_real_ray_full_query_worker_loss_uses_retry_output(monkeypatch, tmp_path
 
         with pytest.raises(Exception):
             asyncio.run(asyncio.wait_for(task_handle.get_result(), timeout=10.0))
-        retry_handle = _wait_for_result_handles(handle1, "query-full-kill", 1)[0]
+        handle0.wait_fte_worker_failure_reconciliation(timeout_s=10.0)
+        retry_handles = handle1.pop_fte_result_handles("query-full-kill")
+        assert len(retry_handles) == 1
+        retry_handle = retry_handles[0]
 
         retry_info = ray.get(actor1.fte_get_task_info.remote(retry_handle.task_id.to_dict()))
         if retry_info["status"].get("state") == "RUNNING":
@@ -845,7 +836,9 @@ def test_real_ray_host_loss_replays_all_owned_full_query_outputs(monkeypatch, tm
         for task_handle in task_handles:
             with pytest.raises(Exception):
                 asyncio.run(asyncio.wait_for(task_handle.get_result(), timeout=10.0))
-        retry_handles = _wait_for_result_handles(handle1, query_id, 2)
+        handle0.wait_fte_worker_failure_reconciliation(timeout_s=10.0)
+        retry_handles = handle1.pop_fte_result_handles(query_id)
+        assert len(retry_handles) == 2
 
         handle1.task_input_stream_exhausted([source_a, source_b])
         results = [

--- a/vane/runners/fte/fte_scheduler.py
+++ b/vane/runners/fte/fte_scheduler.py
@@ -430,6 +430,12 @@ class FteAttemptStatusWatcher:
             self._stop.wait(self.poll_interval_s)
 
 
+@dataclass(frozen=True)
+class FteRetryDelayResult:
+    outputs: tuple[Any, ...]
+    completion: Future[None]
+
+
 @dataclass
 class FteEventHandlers:
     on_split_events: Callable[[list[dict[str, Any]]], list[Any] | None] | None = None
@@ -439,7 +445,7 @@ class FteEventHandlers:
     on_memory_pressure_detected: Callable[[MemoryPressureDetected], list[Any] | None] | None = None
     on_resource_admission_changed: Callable[[ResourceAdmissionChanged], list[Any] | None] | None = None
     on_worker_reservation_completed: Callable[[WorkerReservationCompleted], list[Any] | None] | None = None
-    on_retry_delay_expired: Callable[[RetryDelayExpired], list[Any] | None] | None = None
+    on_retry_delay_expired: Callable[[RetryDelayExpired], FteRetryDelayResult | None] | None = None
     on_exchange_selector_updated: Callable[[ExchangeSelectorUpdated], list[Any] | None] | None = None
     on_query_abort: Callable[[QueryAbort], list[Any] | None] | None = None
 
@@ -592,6 +598,8 @@ class FteQueryScheduler:
         self._failure_reason: str | None = None
         self._retry_delay_generation = 0
         self._retry_delay_timer: threading.Timer | None = None
+        self._retry_delay_completions: list[Future[None]] = []
+        self._retry_delay_effect_completions: list[Future[None]] = []
         self._draining = False
         self._drainer_thread_id: int | None = None
         self._active_causal_generation: int | None = None
@@ -822,6 +830,7 @@ class FteQueryScheduler:
     def fail(self, reason: Any = None) -> None:
         callbacks: list[Callable[[], None]] = []
         barriers: list[Future[None]] = []
+        retry_delay_completions: list[Future[None]] = []
         with self._lock:
             if self._state in {"CLOSED", "FAILED"}:
                 return
@@ -829,20 +838,19 @@ class FteQueryScheduler:
             self._failure_reason = "" if reason is None else str(reason)
             barriers = self._clear_queued_events_locked()
             self._queued_internal_admission_classes.clear()
-            if self._retry_delay_timer is not None:
-                self._retry_delay_timer.cancel()
-                self._retry_delay_timer = None
+            retry_delay_completions = self._cancel_retry_delay_locked()
             callbacks.extend(self._task_source_resume_callbacks_locked())
         try:
             self._run_task_source_callbacks(callbacks)
         except BaseException as exc:
-            _settle_futures(barriers, exc)
+            _settle_futures([*barriers, *retry_delay_completions], exc)
             raise
-        _settle_futures(barriers)
+        _settle_futures([*barriers, *retry_delay_completions])
 
     def close(self) -> None:
         callbacks: list[Callable[[], None]] = []
         barriers: list[Future[None]] = []
+        retry_delay_completions: list[Future[None]] = []
         with self._lock:
             for registration in self._task_sources.values():
                 if registration.paused and registration.resume is not None:
@@ -854,15 +862,13 @@ class FteQueryScheduler:
             self._fragment_states.clear()
             self._failed_worker_incarnations.clear()
             self._task_sources.clear()
-            if self._retry_delay_timer is not None:
-                self._retry_delay_timer.cancel()
-                self._retry_delay_timer = None
+            retry_delay_completions = self._cancel_retry_delay_locked()
         try:
             self._run_task_source_callbacks(callbacks)
         except BaseException as exc:
-            _settle_futures(barriers, exc)
+            _settle_futures([*barriers, *retry_delay_completions], exc)
             raise
-        _settle_futures(barriers)
+        _settle_futures([*barriers, *retry_delay_completions])
 
     def stats(self) -> FteSchedulerStats:
         with self._lock:
@@ -929,21 +935,41 @@ class FteQueryScheduler:
         with self._lock:
             return self._retry_delay_generation
 
-    def arm_retry_delay(self, delay_s: float) -> int:
+    def arm_retry_delay(self, delay_s: float) -> Future[None]:
+        """Complete after the latest delay, handler effect, and causal drain."""
+
         delay_s = max(0.0, float(delay_s))
+        completion: Future[None] = Future()
+        completed_delays: list[Future[None]] = []
         with self._lock:
             self._retry_delay_generation += 1
             generation = self._retry_delay_generation
             if self._retry_delay_timer is not None:
                 self._retry_delay_timer.cancel()
                 self._retry_delay_timer = None
+            self._retry_delay_effect_completions.clear()
+            self._retry_delay_completions.append(completion)
             if delay_s <= 0 or self._state != "RUNNING":
-                return generation
-            timer = threading.Timer(delay_s, self._fire_retry_delay, args=(generation,))
-            timer.daemon = True
-            self._retry_delay_timer = timer
-            timer.start()
-            return generation
+                completed_delays = self._take_retry_delay_completions_locked()
+            else:
+                timer = threading.Timer(delay_s, self._fire_retry_delay, args=(generation,))
+                timer.daemon = True
+                self._retry_delay_timer = timer
+                timer.start()
+        _settle_futures(completed_delays)
+        return completion
+
+    def _take_retry_delay_completions_locked(self) -> list[Future[None]]:
+        completions = self._retry_delay_completions
+        self._retry_delay_completions = []
+        return completions
+
+    def _cancel_retry_delay_locked(self) -> list[Future[None]]:
+        if self._retry_delay_timer is not None:
+            self._retry_delay_timer.cancel()
+            self._retry_delay_timer = None
+        self._retry_delay_effect_completions.clear()
+        return self._take_retry_delay_completions_locked()
 
     def _task_source_pause_callbacks_locked(self) -> list[Callable[[], None]]:
         queue_size = self._queued_event_count_locked()
@@ -977,7 +1003,95 @@ class FteQueryScheduler:
             self.enqueue(RetryDelayExpired(self.query_id, generation))
             self.drain()
         except Exception as exc:
+            self._settle_retry_delay(generation, exc)
             self.fail(f"FTE retry delay handler failed: {exc}")
+
+    def _complete_retry_delay(
+        self,
+        generation: int,
+        drain_completion: Future[None],
+    ) -> None:
+        try:
+            drain_completion.result()
+        except BaseException as exc:
+            error: BaseException | None = exc
+        else:
+            error = None
+        if error is not None:
+            self._settle_retry_delay(generation, error)
+            return
+        with self._lock:
+            if generation != self._retry_delay_generation:
+                return
+            effect_completions = tuple(self._retry_delay_effect_completions)
+        if not effect_completions:
+            self._settle_retry_delay(generation, None)
+            return
+
+        effect_lock = threading.Lock()
+        remaining_effects = len(effect_completions)
+        effects_finished = False
+
+        def finish_effects(error: BaseException | None) -> None:
+            nonlocal effects_finished
+            with effect_lock:
+                if effects_finished:
+                    return
+                effects_finished = True
+            if error is not None:
+                self._settle_retry_delay(generation, error)
+                return
+            # An external admission round can complete after enqueueing back
+            # into this still-active scheduler.  Checkpoint once more so that
+            # re-entrant event is published before the retry delay completes.
+            checkpoint = self.enqueue_drain_barrier()
+            checkpoint.add_done_callback(
+                lambda completion: self._settle_retry_delay_after_checkpoint(generation, completion)
+            )
+
+        def effect_completed(completion: Future[None]) -> None:
+            nonlocal remaining_effects
+            try:
+                completion.result()
+            except BaseException as exc:
+                effect_error: BaseException | None = exc
+            else:
+                effect_error = None
+            with effect_lock:
+                remaining_effects -= 1
+                all_completed = remaining_effects == 0
+            if effect_error is not None:
+                finish_effects(effect_error)
+            elif all_completed:
+                finish_effects(None)
+
+        for effect_completion in effect_completions:
+            effect_completion.add_done_callback(effect_completed)
+
+    def _settle_retry_delay_after_checkpoint(
+        self,
+        generation: int,
+        checkpoint: Future[None],
+    ) -> None:
+        try:
+            checkpoint.result()
+        except BaseException as exc:
+            error: BaseException | None = exc
+        else:
+            error = None
+        self._settle_retry_delay(generation, error)
+
+    def _settle_retry_delay(
+        self,
+        generation: int,
+        error: BaseException | None,
+    ) -> None:
+        with self._lock:
+            if generation != self._retry_delay_generation:
+                return
+            self._retry_delay_effect_completions.clear()
+            completions = self._take_retry_delay_completions_locked()
+        _settle_futures(completions, error)
 
     def _handle_event(
         self,
@@ -1025,25 +1139,35 @@ class FteQueryScheduler:
                 if event.generation != self._retry_delay_generation:
                     return []
                 self._retry_delay_timer = None
+            checkpoint = self.enqueue_drain_barrier()
+            checkpoint.add_done_callback(lambda completion: self._complete_retry_delay(event.generation, completion))
             if handlers.on_retry_delay_expired is None:
                 return []
-            return list(handlers.on_retry_delay_expired(event) or [])
+            result = handlers.on_retry_delay_expired(event)
+            if result is None:
+                return []
+            with self._lock:
+                if event.generation == self._retry_delay_generation:
+                    self._retry_delay_effect_completions.append(result.completion)
+            return list(result.outputs)
         if isinstance(event, ExchangeSelectorUpdated):
             if handlers.on_exchange_selector_updated is None:
                 return []
             return list(handlers.on_exchange_selector_updated(event) or [])
         if isinstance(event, QueryAbort):
             barriers: list[Future[None]] = []
+            retry_delay_completions: list[Future[None]] = []
             with self._lock:
                 self._state = "ABORTED"
                 barriers = self._clear_queued_events_locked()
                 self._queued_internal_admission_classes.clear()
+                retry_delay_completions = self._cancel_retry_delay_locked()
             try:
                 outputs = [] if handlers.on_query_abort is None else list(handlers.on_query_abort(event) or [])
             except BaseException as exc:
-                _settle_futures(barriers, exc)
+                _settle_futures([*barriers, *retry_delay_completions], exc)
                 raise
-            _settle_futures(barriers)
+            _settle_futures([*barriers, *retry_delay_completions])
             return outputs
         return []
 

--- a/vane/runners/fte/fte_scheduler.py
+++ b/vane/runners/fte/fte_scheduler.py
@@ -7,6 +7,7 @@ import threading
 import time
 from collections import deque
 from collections.abc import Mapping
+from concurrent.futures import Future
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -48,6 +49,28 @@ class FteSplitQueueTerminal(RuntimeError):
         self.attempt_id = attempt_id
         self.status = dict(status)
         super().__init__(f"split queue task {attempt_id} became terminal with state {self.status.get('state')}")
+
+
+def _settle_futures(futures: list[Future[None]], error: BaseException | None = None) -> None:
+    for future in futures:
+        if future.done():
+            continue
+        if error is None:
+            future.set_result(None)
+        else:
+            future.set_exception(error)
+
+
+@dataclass(frozen=True)
+class _FteSchedulerDrainBarrier:
+    completion: Future[None]
+    target_causal_generation: int
+
+
+@dataclass(frozen=True)
+class _FteSchedulerQueuedEvent:
+    event: FteEvent
+    causal_generation: int
 
 
 class FteWorkerCommandExecutor:
@@ -555,7 +578,8 @@ class FteQueryScheduler:
         if not query_id:
             raise ValueError("query_id must be non-empty")
         self.query_id = query_id
-        self._events: deque[FteEvent] = deque()
+        self._events: deque[_FteSchedulerQueuedEvent | _FteSchedulerDrainBarrier] = deque()
+        self._queued_drain_barrier_count = 0
         self._lock = threading.RLock()
         self._state = "RUNNING"
         self._processed_events = 0
@@ -569,6 +593,9 @@ class FteQueryScheduler:
         self._retry_delay_generation = 0
         self._retry_delay_timer: threading.Timer | None = None
         self._draining = False
+        self._drainer_thread_id: int | None = None
+        self._active_causal_generation: int | None = None
+        self._next_causal_generation = 0
         self._queued_internal_admission_classes: set[str | None] = set()
         self._failed_worker_incarnations: set[tuple[str, str]] = set()
         self._task_sources: dict[str, FteTaskSourceRegistration] = {}
@@ -653,10 +680,19 @@ class FteQueryScheduler:
                 if event.execution_class in self._queued_internal_admission_classes:
                     return
                 self._queued_internal_admission_classes.add(event.execution_class)
-            if priority:
-                self._events.appendleft(event)
+            if self._drainer_thread_id == threading.get_ident() and self._active_causal_generation is not None:
+                causal_generation = self._active_causal_generation
             else:
-                self._events.append(event)
+                self._next_causal_generation += 1
+                causal_generation = self._next_causal_generation
+            queued_event = _FteSchedulerQueuedEvent(
+                event=event,
+                causal_generation=causal_generation,
+            )
+            if priority:
+                self._events.appendleft(queued_event)
+            else:
+                self._events.append(queued_event)
             callbacks.extend(self._task_source_pause_callbacks_locked())
         self._run_task_source_callbacks(callbacks)
 
@@ -666,64 +702,152 @@ class FteQueryScheduler:
             if self._draining:
                 return outputs
             self._draining = True
+            self._drainer_thread_id = threading.get_ident()
         try:
             while True:
                 callbacks: list[Callable[[], None]] = []
+                barrier_deferred = False
                 with self._lock:
                     if not self._events:
                         # Publish idle in the same critical section as the
                         # empty observation.  An enqueue after this point
                         # either becomes the next drainer or is seen here.
                         self._draining = False
+                        self._drainer_thread_id = None
                         callbacks.extend(self._task_source_resume_callbacks_locked())
                         event = None
                         event_handlers = None
                     else:
-                        event = self._events.popleft()
+                        queued = self._events.popleft()
+                        if isinstance(queued, _FteSchedulerDrainBarrier):
+                            if self._defer_drain_barrier_behind_causal_events_locked(queued):
+                                barrier_deferred = True
+                                event = None
+                            else:
+                                self._queued_drain_barrier_count -= 1
+                                event = queued
+                            event_handlers = None
+                        else:
+                            event = queued.event
+                            self._active_causal_generation = queued.causal_generation
+                            event_handlers = handlers or self._handlers
                         if isinstance(event, ResourceAdmissionChanged) and event.internal:
                             self._queued_internal_admission_classes.discard(event.execution_class)
-                        event_handlers = handlers or self._handlers
-                self._run_task_source_callbacks(callbacks)
+                if barrier_deferred:
+                    continue
                 if event is None:
+                    self._run_task_source_callbacks(callbacks)
                     return outputs
+                self._run_task_source_callbacks(callbacks)
+                if isinstance(event, _FteSchedulerDrainBarrier):
+                    _settle_futures([event.completion])
+                    continue
                 assert event_handlers is not None
-                outputs.extend(self._handle_event(event, event_handlers))
+                try:
+                    outputs.extend(self._handle_event(event, event_handlers))
+                finally:
+                    with self._lock:
+                        self._active_causal_generation = None
                 callbacks = []
                 with self._lock:
                     callbacks.extend(self._task_source_resume_callbacks_locked())
                 self._run_task_source_callbacks(callbacks)
-        except BaseException:
+        except BaseException as exc:
             callbacks = []
             with self._lock:
                 self._draining = False
+                self._drainer_thread_id = None
+                self._active_causal_generation = None
+                barriers = self._remove_queued_drain_barriers_locked()
                 callbacks.extend(self._task_source_resume_callbacks_locked())
-            self._run_task_source_callbacks(callbacks)
+            try:
+                self._run_task_source_callbacks(callbacks)
+            except BaseException as callback_exc:
+                _settle_futures(barriers, callback_exc)
+                raise
+            _settle_futures(barriers, exc)
             raise
+
+    def enqueue_drain_barrier(self) -> Future[None]:
+        """Complete after queued events and their synchronous descendants."""
+
+        completion: Future[None] = Future()
+        with self._lock:
+            if self._draining or self._events:
+                self._events.append(
+                    _FteSchedulerDrainBarrier(
+                        completion=completion,
+                        target_causal_generation=self._next_causal_generation,
+                    )
+                )
+                self._queued_drain_barrier_count += 1
+                return completion
+        completion.set_result(None)
+        return completion
+
+    def _defer_drain_barrier_behind_causal_events_locked(
+        self,
+        barrier: _FteSchedulerDrainBarrier,
+    ) -> bool:
+        last_causal_index = None
+        for index, queued in enumerate(self._events):
+            if (
+                isinstance(queued, _FteSchedulerQueuedEvent)
+                and queued.causal_generation <= barrier.target_causal_generation
+            ):
+                last_causal_index = index
+        if last_causal_index is None:
+            return False
+        self._events.insert(last_causal_index + 1, barrier)
+        return True
+
+    def _clear_queued_events_locked(self) -> list[Future[None]]:
+        barriers = [event.completion for event in self._events if isinstance(event, _FteSchedulerDrainBarrier)]
+        self._events.clear()
+        self._queued_drain_barrier_count = 0
+        return barriers
+
+    def _remove_queued_drain_barriers_locked(self) -> list[Future[None]]:
+        barriers = [event.completion for event in self._events if isinstance(event, _FteSchedulerDrainBarrier)]
+        if barriers:
+            self._events = deque(event for event in self._events if not isinstance(event, _FteSchedulerDrainBarrier))
+            self._queued_drain_barrier_count = 0
+        return barriers
+
+    def _queued_event_count_locked(self) -> int:
+        return len(self._events) - self._queued_drain_barrier_count
 
     def fail(self, reason: Any = None) -> None:
         callbacks: list[Callable[[], None]] = []
+        barriers: list[Future[None]] = []
         with self._lock:
             if self._state in {"CLOSED", "FAILED"}:
                 return
             self._state = "FAILED"
             self._failure_reason = "" if reason is None else str(reason)
-            self._events.clear()
+            barriers = self._clear_queued_events_locked()
             self._queued_internal_admission_classes.clear()
             if self._retry_delay_timer is not None:
                 self._retry_delay_timer.cancel()
                 self._retry_delay_timer = None
             callbacks.extend(self._task_source_resume_callbacks_locked())
-        self._run_task_source_callbacks(callbacks)
+        try:
+            self._run_task_source_callbacks(callbacks)
+        except BaseException as exc:
+            _settle_futures(barriers, exc)
+            raise
+        _settle_futures(barriers)
 
     def close(self) -> None:
         callbacks: list[Callable[[], None]] = []
+        barriers: list[Future[None]] = []
         with self._lock:
             for registration in self._task_sources.values():
                 if registration.paused and registration.resume is not None:
                     callbacks.append(registration.resume)
             self._state = "CLOSED"
             self._failure_reason = None
-            self._events.clear()
+            barriers = self._clear_queued_events_locked()
             self._queued_internal_admission_classes.clear()
             self._fragment_states.clear()
             self._failed_worker_incarnations.clear()
@@ -731,7 +855,12 @@ class FteQueryScheduler:
             if self._retry_delay_timer is not None:
                 self._retry_delay_timer.cancel()
                 self._retry_delay_timer = None
-        self._run_task_source_callbacks(callbacks)
+        try:
+            self._run_task_source_callbacks(callbacks)
+        except BaseException as exc:
+            _settle_futures(barriers, exc)
+            raise
+        _settle_futures(barriers)
 
     def stats(self) -> FteSchedulerStats:
         with self._lock:
@@ -741,7 +870,7 @@ class FteQueryScheduler:
             return FteSchedulerStats(
                 query_id=self.query_id,
                 state=self._state,
-                queued_events=len(self._events),
+                queued_events=self._queued_event_count_locked(),
                 processed_events=self._processed_events,
                 last_event_type=self._last_event_type,
                 last_progress_ms=last_progress_ms,
@@ -815,7 +944,7 @@ class FteQueryScheduler:
             return generation
 
     def _task_source_pause_callbacks_locked(self) -> list[Callable[[], None]]:
-        queue_size = len(self._events)
+        queue_size = self._queued_event_count_locked()
         callbacks: list[Callable[[], None]] = []
         for registration in self._task_sources.values():
             if registration.paused or queue_size < registration.high_watermark:
@@ -826,7 +955,7 @@ class FteQueryScheduler:
         return callbacks
 
     def _task_source_resume_callbacks_locked(self) -> list[Callable[[], None]]:
-        queue_size = len(self._events)
+        queue_size = self._queued_event_count_locked()
         callbacks: list[Callable[[], None]] = []
         for registration in self._task_sources.values():
             if not registration.paused or queue_size > registration.low_watermark:
@@ -902,13 +1031,18 @@ class FteQueryScheduler:
                 return []
             return list(handlers.on_exchange_selector_updated(event) or [])
         if isinstance(event, QueryAbort):
+            barriers: list[Future[None]] = []
             with self._lock:
                 self._state = "ABORTED"
-                self._events.clear()
+                barriers = self._clear_queued_events_locked()
                 self._queued_internal_admission_classes.clear()
-            if handlers.on_query_abort is None:
-                return []
-            return list(handlers.on_query_abort(event) or [])
+            try:
+                outputs = [] if handlers.on_query_abort is None else list(handlers.on_query_abort(event) or [])
+            except BaseException as exc:
+                _settle_futures(barriers, exc)
+                raise
+            _settle_futures(barriers)
+            return outputs
         return []
 
 
@@ -919,6 +1053,8 @@ class FteSchedulerRegistry:
         self._pending_drain_cursor_query_id: str | None = None
         self._pending_drain_running = False
         self._pending_drain_dirty = False
+        self._pending_drain_requested_generation = 0
+        self._pending_drain_completions: list[tuple[int, Future[None]]] = []
 
     def get_or_create(self, query_id: str) -> FteQueryScheduler:
         query_id = str(query_id or "").strip()
@@ -954,38 +1090,85 @@ class FteSchedulerRegistry:
             self._schedulers.clear()
             self._pending_drain_cursor_query_id = None
             self._pending_drain_dirty = False
-        for scheduler in schedulers:
-            scheduler.close()
+            completions = [future for _generation, future in self._pending_drain_completions]
+            self._pending_drain_completions = []
+        try:
+            for scheduler in schedulers:
+                scheduler.close()
+        except BaseException as exc:
+            _settle_futures(completions, exc)
+            raise
+        _settle_futures(completions)
 
     def run_pending_drain(
         self,
         drain_round: Callable[[list[str]], list[Any]],
     ) -> list[Any]:
+        outputs, _completion = self._run_pending_drain(drain_round, completion=None)
+        return outputs
+
+    def run_pending_drain_with_completion(
+        self,
+        drain_round: Callable[[list[str]], list[Any]],
+    ) -> tuple[list[Any], Future[None]]:
+        completion: Future[None] = Future()
+        outputs, tracked_completion = self._run_pending_drain(drain_round, completion=completion)
+        assert tracked_completion is completion
+        return outputs, completion
+
+    def _run_pending_drain(
+        self,
+        drain_round: Callable[[list[str]], list[Any]],
+        *,
+        completion: Future[None] | None,
+    ) -> tuple[list[Any], Future[None] | None]:
         """Run the global admission pump without entering queries directly.
 
         Each turn delegates one quantum to every query's own scheduler.
         Re-entrant capacity notifications only dirty the active pump; the
-        leader observes that bit before atomically publishing itself idle.
+        returned future completes after the round containing this request.
         """
         outputs: list[Any] = []
         with self._lock:
+            self._pending_drain_requested_generation += 1
+            request_generation = self._pending_drain_requested_generation
+            if completion is not None:
+                self._pending_drain_completions.append((request_generation, completion))
             self._pending_drain_dirty = True
             if self._pending_drain_running:
-                return outputs
+                return outputs, completion
             self._pending_drain_running = True
         try:
             while True:
                 with self._lock:
                     if not self._pending_drain_dirty:
                         self._pending_drain_running = False
-                        return outputs
+                        break
                     self._pending_drain_dirty = False
+                    round_generation = self._pending_drain_requested_generation
                     query_ids = self.ordered_pending_drain_query_ids(list(self._schedulers))
                 outputs.extend(drain_round(query_ids))
-        except BaseException:
+                with self._lock:
+                    completed = [
+                        future
+                        for generation, future in self._pending_drain_completions
+                        if generation <= round_generation
+                    ]
+                    self._pending_drain_completions = [
+                        (generation, future)
+                        for generation, future in self._pending_drain_completions
+                        if generation > round_generation
+                    ]
+                _settle_futures(completed)
+        except BaseException as exc:
             with self._lock:
                 self._pending_drain_running = False
+                self._pending_drain_dirty = False
+                completions = [future for _generation, future in self._pending_drain_completions]
+                self._pending_drain_completions = []
+            _settle_futures(completions, exc)
             raise
+        return outputs, completion
 
     def record_pending_drain_progress(self, query_id: str) -> None:
         query_id = str(query_id or "").strip()

--- a/vane/runners/fte/fte_scheduler.py
+++ b/vane/runners/fte/fte_scheduler.py
@@ -707,6 +707,8 @@ class FteQueryScheduler:
             while True:
                 callbacks: list[Callable[[], None]] = []
                 barrier_deferred = False
+                event: FteEvent | _FteSchedulerDrainBarrier | None
+                event_handlers: FteEventHandlers | None
                 with self._lock:
                     if not self._events:
                         # Publish idle in the same critical section as the

--- a/vane/runners/ray/fragment_worker_client.py
+++ b/vane/runners/ray/fragment_worker_client.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import threading
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -94,6 +95,9 @@ class RayWorkerActorHandle(
         self._fragment_drop_incomplete_queries: set[str] = set()
         self._worker_shutdown_started = False
         self._fte_failure_retirement_completed = False
+        self._fte_worker_failure_reconciliation_lock = threading.Lock()
+        self._fte_worker_failure_reconciliation_complete = threading.Event()
+        self._fte_worker_failure_reconciliation_error: BaseException | None = None
         with _FTE_REGISTRY_LOCK:
             current = _FTE_WORKER_HANDLES.get(worker_id)
             if current is not None and current is not self:
@@ -103,6 +107,29 @@ class RayWorkerActorHandle(
     @property
     def worker_incarnation_id(self) -> str:
         return self._worker_incarnation_id
+
+    def wait_fte_worker_failure_reconciliation(self, *, timeout_s: float) -> None:
+        """Wait until this worker incarnation's failure side effects are published."""
+
+        timeout = float(timeout_s)
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError("timeout_s must be finite and > 0")
+        if not self._fte_worker_failure_reconciliation_complete.wait(timeout):
+            raise TimeoutError(
+                "timed out waiting for FTE worker failure reconciliation: "
+                f"worker={self.worker_id} incarnation={self.worker_incarnation_id}"
+            )
+        with self._fte_worker_failure_reconciliation_lock:
+            error = self._fte_worker_failure_reconciliation_error
+        if error is not None:
+            raise error
+
+    def _complete_fte_worker_failure_reconciliation(self, error: BaseException | None) -> None:
+        with self._fte_worker_failure_reconciliation_lock:
+            if self._fte_worker_failure_reconciliation_complete.is_set():
+                return
+            self._fte_worker_failure_reconciliation_error = error
+            self._fte_worker_failure_reconciliation_complete.set()
 
     def close_session(self, session_id: str) -> None:
         import ray

--- a/vane/runners/ray/fragment_worker_events.py
+++ b/vane/runners/ray/fragment_worker_events.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from concurrent.futures import Future
 
     from vane.runners.fte.fte_events import ExchangeSelectorUpdated, TaskStatusChanged, WorkerReservationCompleted
+    from vane.runners.fte.fte_scheduler import FteQueryScheduler
 
 
 class FteWorkerEventHandlingMixin:
@@ -107,27 +108,34 @@ class FteWorkerEventHandlingMixin:
         reconciliation = begin_fte_worker_failure_reconciliation(event)
         if reconciliation is None:
             return [], None
-        if not reconciliation.owns_reconciliation:
+        if not reconciliation.owns_runner:
             return [], reconciliation.completion
         handles: list[Any] = []
-        result = None
-        pending_drain_completion = None
         try:
-            try:
-                result = reconciliation.reconcile()
-                scheduled_by_fragment = result.scheduled_by_fragment
-                if scheduled_by_fragment:
-                    handles.extend(self._handles_for_marked_fte_worker_failed(list(scheduled_by_fragment)))
-            finally:
-                drain_handles, pending_drain_completion = request_fte_pending_task_drain_with_completion()
-                handles.extend(drain_handles)
+            while True:
+                reconciled_schedulers: list[FteQueryScheduler] = []
+                try:
+                    while True:
+                        result = reconciliation.reconcile()
+                        if result is None:
+                            break
+                        reconciled_schedulers.extend(result.schedulers)
+                        if result.scheduled_by_fragment:
+                            handles.extend(
+                                self._handles_for_marked_fte_worker_failed(list(result.scheduled_by_fragment))
+                            )
+                finally:
+                    drain_handles, pending_drain_completion = request_fte_pending_task_drain_with_completion()
+                    handles.extend(drain_handles)
+                reconciliation.complete_after_pending_drain(
+                    tuple(reconciled_schedulers),
+                    pending_drain_completion,
+                )
+                if not reconciliation.release_runner():
+                    break
         except BaseException as exc:
-            schedulers = () if result is None else result.schedulers
-            reconciliation.complete(exc, schedulers=schedulers)
+            reconciliation.fail(exc)
             raise
-        assert result is not None
-        assert pending_drain_completion is not None
-        reconciliation.complete_after_pending_drain(result.schedulers, pending_drain_completion)
         return handles, reconciliation.completion
 
     def _handles_for_worker_failed_event(self, event: WorkerFailed) -> list[Any]:

--- a/vane/runners/ray/fragment_worker_events.py
+++ b/vane/runners/ray/fragment_worker_events.py
@@ -11,7 +11,7 @@ from vane.runners.fte import (
     FteWorkerReservationUnavailable,
 )
 from vane.runners.fte.fte_events import WorkerFailed
-from vane.runners.fte.fte_scheduler import FteEventHandlers
+from vane.runners.fte.fte_scheduler import FteEventHandlers, FteRetryDelayResult
 from vane.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
     _FTE_FRAGMENT_EXECUTIONS,
@@ -114,12 +114,14 @@ class FteWorkerEventHandlingMixin:
         try:
             while True:
                 reconciled_schedulers: list[FteQueryScheduler] = []
+                retry_delay_completions: list[Future[None]] = []
                 try:
                     while True:
                         result = reconciliation.reconcile()
                         if result is None:
                             break
                         reconciled_schedulers.extend(result.schedulers)
+                        retry_delay_completions.extend(result.retry_delay_completions)
                         if result.scheduled_by_fragment:
                             handles.extend(
                                 self._handles_for_marked_fte_worker_failed(list(result.scheduled_by_fragment))
@@ -130,6 +132,7 @@ class FteWorkerEventHandlingMixin:
                 reconciliation.complete_after_pending_drain(
                     tuple(reconciled_schedulers),
                     pending_drain_completion,
+                    tuple(retry_delay_completions),
                 )
                 if not reconciliation.release_runner():
                     break
@@ -375,6 +378,10 @@ class FteWorkerEventHandlingMixin:
                 query_id_filter=scheduler.query_id,
             )
 
+        def on_retry_delay_expired(_event: Any) -> FteRetryDelayResult:
+            handles, completion = request_fte_pending_task_drain_with_completion()
+            return FteRetryDelayResult(tuple(handles), completion)
+
         scheduler.bind_manager_instance(
             self.manager_instance_id,
             handlers=FteEventHandlers(
@@ -392,7 +399,7 @@ class FteWorkerEventHandlingMixin:
                     execution_class_filter=event.execution_class,
                 ),
                 on_worker_reservation_completed=self._handles_for_worker_reservation_completed_event,
-                on_retry_delay_expired=lambda _event: request_fte_pending_task_drain(),
+                on_retry_delay_expired=on_retry_delay_expired,
                 on_exchange_selector_updated=self._handles_for_exchange_selector_updated_event,
             ),
         )

--- a/vane/runners/ray/fragment_worker_events.py
+++ b/vane/runners/ray/fragment_worker_events.py
@@ -23,7 +23,7 @@ from vane.runners.ray.fragment_registry import (
 )
 from vane.runners.ray.fragment_worker_exchange import apply_exchange_selector_update
 from vane.runners.ray.fragment_worker_failures import (
-    mark_fte_worker_failed_for_event,
+    begin_fte_worker_failure_reconciliation,
 )
 from vane.runners.ray.fragment_worker_ordering import fragment_execution_key_for_fte_attempt
 from vane.runners.ray.fragment_worker_reservations import (
@@ -34,10 +34,12 @@ from vane.runners.ray.fte_fragment_scheduler import (
     FteWorkerPlacementManager,
     _sync_write_sink_unit_for_fragment,
     request_fte_pending_task_drain,
+    request_fte_pending_task_drain_with_completion,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from concurrent.futures import Future
 
     from vane.runners.fte.fte_events import ExchangeSelectorUpdated, TaskStatusChanged, WorkerReservationCompleted
 
@@ -63,7 +65,7 @@ class FteWorkerEventHandlingMixin:
         """Fence a failed worker before queued work can observe it as live."""
 
         try:
-            return self._handles_for_worker_failed_event(
+            return self._handles_for_worker_failed_scheduler_event(
                 WorkerFailed(
                     query_id=failure.attempt_id.task_id.query_id,
                     worker_id=failure.worker_id,
@@ -101,14 +103,41 @@ class FteWorkerEventHandlingMixin:
             )
         return handles
 
-    def _handles_for_worker_failed_event(self, event: WorkerFailed) -> list[Any]:
+    def _start_worker_failed_event(self, event: WorkerFailed) -> tuple[list[Any], Future[None] | None]:
+        reconciliation = begin_fte_worker_failure_reconciliation(event)
+        if reconciliation is None:
+            return [], None
+        if not reconciliation.owns_reconciliation:
+            return [], reconciliation.completion
         handles: list[Any] = []
+        result = None
+        pending_drain_completion = None
         try:
-            scheduled_by_fragment = mark_fte_worker_failed_for_event(event)
-            if scheduled_by_fragment:
-                handles.extend(self._handles_for_marked_fte_worker_failed(scheduled_by_fragment))
-        finally:
-            handles.extend(request_fte_pending_task_drain())
+            try:
+                result = reconciliation.reconcile()
+                scheduled_by_fragment = result.scheduled_by_fragment
+                if scheduled_by_fragment:
+                    handles.extend(self._handles_for_marked_fte_worker_failed(list(scheduled_by_fragment)))
+            finally:
+                drain_handles, pending_drain_completion = request_fte_pending_task_drain_with_completion()
+                handles.extend(drain_handles)
+        except BaseException as exc:
+            schedulers = () if result is None else result.schedulers
+            reconciliation.complete(exc, schedulers=schedulers)
+            raise
+        assert result is not None
+        assert pending_drain_completion is not None
+        reconciliation.complete_after_pending_drain(result.schedulers, pending_drain_completion)
+        return handles, reconciliation.completion
+
+    def _handles_for_worker_failed_event(self, event: WorkerFailed) -> list[Any]:
+        handles, completion = self._start_worker_failed_event(event)
+        if completion is not None:
+            completion.result()
+        return handles
+
+    def _handles_for_worker_failed_scheduler_event(self, event: WorkerFailed) -> list[Any]:
+        handles, _completion = self._start_worker_failed_event(event)
         return handles
 
     def _handles_for_worker_reservation_completed_event(self, event: WorkerReservationCompleted) -> list[Any]:
@@ -344,7 +373,7 @@ class FteWorkerEventHandlingMixin:
                 on_split_events=self._submit_fte_pending_tasks,
                 on_source_input_exhausted=on_source_input_exhausted,
                 on_task_status_changed=self._handles_for_task_status_changed_event,
-                on_worker_failed=self._handles_for_worker_failed_event,
+                on_worker_failed=self._handles_for_worker_failed_scheduler_event,
                 on_memory_pressure_detected=lambda event: self._revoke_fte_speculative_tasks_for_memory_pressure_direct(
                     max_count_per_worker=event.max_count_per_worker,
                     query_id_filter=event.query_id,

--- a/vane/runners/ray/fragment_worker_failures.py
+++ b/vane/runners/ray/fragment_worker_failures.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import threading
 from concurrent.futures import Future
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from vane.runners.ray.fragment_registry import (
     _FTE_CLOSING_QUERIES,
@@ -22,8 +22,10 @@ from vane.runners.ray.fte_fragment_scheduler import (
     _worker_failure_payload,
 )
 
+if TYPE_CHECKING:
+    from vane.runners.fte.fte_scheduler import FteQueryScheduler
+
 _WORKER_FAILURE_RECONCILIATION_LOCK = threading.Lock()
-_WORKER_FAILURE_RECONCILIATIONS: dict[tuple[str, str, str], Future[None]] = {}
 
 
 def _worker_failure_reconciliation_target(
@@ -46,7 +48,43 @@ def _worker_failure_reconciliation_target(
 @dataclass(frozen=True)
 class _FteWorkerFailureReconciliationResult:
     scheduled_by_fragment: tuple[tuple[str, str, list[Any], list[Any]], ...]
-    schedulers: tuple[Any, ...]
+    schedulers: tuple[FteQueryScheduler, ...]
+
+
+class _FteWorkerFailureReconciliationState:
+    """Share local failure fences across one global reconciliation."""
+
+    def __init__(self, failure_key: tuple[str, str, str]) -> None:
+        self.failure_key = failure_key
+        self.completion: Future[None] = Future()
+        self._lock = threading.Lock()
+        self._schedulers: dict[int, FteQueryScheduler] = {}
+
+    def fence_scheduler(self, scheduler: FteQueryScheduler) -> bool:
+        """Record and claim a scheduler fence atomically for this reconciliation."""
+
+        scheduler_identity = id(scheduler)
+        _manager_instance_id, worker_id, worker_incarnation_id = self.failure_key
+        with self._lock:
+            if scheduler_identity in self._schedulers:
+                return True
+            if not scheduler.record_worker_failure(
+                worker_id,
+                worker_incarnation_id=worker_incarnation_id,
+            ):
+                return False
+            self._schedulers[scheduler_identity] = scheduler
+            return True
+
+    def schedulers(self) -> tuple[FteQueryScheduler, ...]:
+        with self._lock:
+            return tuple(self._schedulers.values())
+
+
+_WORKER_FAILURE_RECONCILIATIONS: dict[
+    tuple[str, str, str],
+    _FteWorkerFailureReconciliationState,
+] = {}
 
 
 class _FteWorkerFailureReconciliation:
@@ -56,24 +94,31 @@ class _FteWorkerFailureReconciliation:
         self,
         event: Any,
         *,
-        failure_key: tuple[str, str, str],
-        completion: Future[None],
+        state: _FteWorkerFailureReconciliationState,
         target: Any | None,
         owns_reconciliation: bool,
     ) -> None:
         self.event = event
-        self.failure_key = failure_key
-        self.completion = completion
+        self.state = state
+        self.failure_key = state.failure_key
+        self.completion = state.completion
         self.target = target
         self.owns_reconciliation = owns_reconciliation
         self._completion_lock = threading.Lock()
         self._completed = False
 
+    def _registered_schedulers(
+        self,
+        schedulers: tuple[FteQueryScheduler, ...] = (),
+    ) -> tuple[FteQueryScheduler, ...]:
+        registered = (*schedulers, *self.state.schedulers())
+        return tuple({id(scheduler): scheduler for scheduler in registered}.values())
+
     def complete(
         self,
         error: BaseException | None,
         *,
-        schedulers: tuple[Any, ...] = (),
+        schedulers: tuple[FteQueryScheduler, ...] = (),
     ) -> None:
         if not self.owns_reconciliation:
             raise RuntimeError("only the reconciliation owner can publish completion")
@@ -81,6 +126,7 @@ class _FteWorkerFailureReconciliation:
             if self._completed:
                 return
             self._completed = True
+        schedulers = self._registered_schedulers(schedulers)
         if error is not None:
             scheduler_errors: list[Exception] = []
             for scheduler in schedulers:
@@ -103,14 +149,14 @@ class _FteWorkerFailureReconciliation:
                 self.completion.set_exception(error)
         finally:
             with _WORKER_FAILURE_RECONCILIATION_LOCK:
-                if _WORKER_FAILURE_RECONCILIATIONS.get(self.failure_key) is self.completion:
+                if _WORKER_FAILURE_RECONCILIATIONS.get(self.failure_key) is self.state:
                     _WORKER_FAILURE_RECONCILIATIONS.pop(self.failure_key, None)
 
     def _complete_after_futures(
         self,
         futures: list[Future[None]],
         *,
-        schedulers: tuple[Any, ...],
+        schedulers: tuple[FteQueryScheduler, ...],
     ) -> None:
         if not futures:
             self.complete(None)
@@ -121,6 +167,7 @@ class _FteWorkerFailureReconciliation:
 
         def completed(future: Future[None]) -> None:
             nonlocal remaining, first_error
+            error: BaseException | None
             try:
                 future.result()
             except BaseException as exc:
@@ -141,17 +188,14 @@ class _FteWorkerFailureReconciliation:
 
     def complete_after_pending_drain(
         self,
-        schedulers: tuple[Any, ...],
+        schedulers: tuple[FteQueryScheduler, ...],
         pending_drain: Future[None],
     ) -> None:
         if not self.owns_reconciliation:
             raise RuntimeError("only the reconciliation owner can publish completion")
-        unique_schedulers = tuple({id(scheduler): scheduler for scheduler in schedulers}.values())
-        if not unique_schedulers:
-            self.complete(None)
-            return
 
         def pending_drain_completed(completion: Future[None]) -> None:
+            unique_schedulers = self._registered_schedulers(schedulers)
             try:
                 completion.result()
                 drain_completions = [scheduler.enqueue_drain_barrier() for scheduler in unique_schedulers]
@@ -172,6 +216,7 @@ class _FteWorkerFailureReconciliation:
             manager_instance_id=manager_instance_id,
             worker_incarnation_id=worker_incarnation_id,
             event_query_id=str(self.event.query_id),
+            reconciliation_state=self.state,
         )
 
 
@@ -194,23 +239,20 @@ def begin_fte_worker_failure_reconciliation(event: Any) -> _FteWorkerFailureReco
     )
     failure_key = (manager_instance_id, worker_id, worker_incarnation_id)
     with _WORKER_FAILURE_RECONCILIATION_LOCK:
-        completion = _WORKER_FAILURE_RECONCILIATIONS.get(failure_key)
-        if completion is None:
-            completion = Future()
-            _WORKER_FAILURE_RECONCILIATIONS[failure_key] = completion
-            return _FteWorkerFailureReconciliation(
-                event,
-                failure_key=failure_key,
-                completion=completion,
-                target=target,
-                owns_reconciliation=True,
-            )
+        state = _WORKER_FAILURE_RECONCILIATIONS.get(failure_key)
+        owns_reconciliation = state is None
+        if state is None:
+            state = _FteWorkerFailureReconciliationState(failure_key)
+            _WORKER_FAILURE_RECONCILIATIONS[failure_key] = state
+        if event_scheduler is not None:
+            # The local fence must be visible before a duplicate scheduler is
+            # allowed to process a causally following CANCELED/ABORTED event.
+            state.fence_scheduler(event_scheduler)
         return _FteWorkerFailureReconciliation(
             event,
-            failure_key=failure_key,
-            completion=completion,
-            target=None,
-            owns_reconciliation=False,
+            state=state,
+            target=target if owns_reconciliation else None,
+            owns_reconciliation=owns_reconciliation,
         )
 
 
@@ -281,6 +323,7 @@ def _reconcile_fte_worker_failure(
     manager_instance_id: str,
     worker_incarnation_id: str,
     event_query_id: str,
+    reconciliation_state: _FteWorkerFailureReconciliationState,
 ) -> _FteWorkerFailureReconciliationResult:
     failure = _worker_failure_payload(
         event.worker_id,
@@ -297,7 +340,6 @@ def _reconcile_fte_worker_failure(
         {str(event.worker_id): worker_incarnation_id},
     )
     affected_query_ids.add(event_query_id)
-    reconciliation_schedulers = {}
     for query_id in sorted(affected_query_ids):
         with _FTE_REGISTRY_LOCK:
             if query_id in _FTE_CLOSING_QUERIES:
@@ -305,31 +347,35 @@ def _reconcile_fte_worker_failure(
             scheduler = _FTE_SCHEDULERS.get(query_id)
         if scheduler is None or not scheduler.is_owned_by_manager_instance(manager_instance_id):
             continue
-        if scheduler.record_worker_failure(
-            event.worker_id,
-            worker_incarnation_id=worker_incarnation_id,
-        ):
-            reconciliation_schedulers[query_id] = scheduler
+        reconciliation_state.fence_scheduler(scheduler)
+    reconciliation_schedulers: dict[str, FteQueryScheduler] = {}
+    for registered_scheduler in reconciliation_state.schedulers():
+        query_id = str(registered_scheduler.query_id)
+        with _FTE_REGISTRY_LOCK:
+            current_scheduler = _FTE_SCHEDULERS.get(query_id)
+            if (
+                query_id in _FTE_CLOSING_QUERIES
+                or current_scheduler is None
+                or current_scheduler is not registered_scheduler
+            ):
+                continue
+        if current_scheduler.is_owned_by_manager_instance(manager_instance_id):
+            reconciliation_schedulers[query_id] = current_scheduler
     reconciliation_query_ids = set(reconciliation_schedulers)
-    try:
-        scheduled_by_fragment = _mark_fte_worker_failed(
-            event.worker_id,
-            failure,
-            query_id_filters=reconciliation_query_ids,
-            manager_instance_id=manager_instance_id,
-            worker_incarnation_id=worker_incarnation_id,
-            primary_worker_process_terminated=_worker_actor_death_confirms_quiescence(event.error),
-            reconcile_query=bool(reconciliation_query_ids),
-        )
-    except BaseException as exc:
-        for scheduler in reconciliation_schedulers.values():
-            scheduler.fail(f"FTE worker failure handling failed: {exc}")
-        raise
+    scheduled_by_fragment = _mark_fte_worker_failed(
+        event.worker_id,
+        failure,
+        query_id_filters=reconciliation_query_ids,
+        manager_instance_id=manager_instance_id,
+        worker_incarnation_id=worker_incarnation_id,
+        primary_worker_process_terminated=_worker_actor_death_confirms_quiescence(event.error),
+        reconcile_query=bool(reconciliation_query_ids),
+    )
     for query_id, scheduler in reconciliation_schedulers.items():
         delay_s = _fte_retry_remaining_delay_s(query_id)
         if delay_s > 0:
             scheduler.arm_retry_delay(delay_s)
     return _FteWorkerFailureReconciliationResult(
         scheduled_by_fragment=tuple(scheduled_by_fragment),
-        schedulers=tuple(reconciliation_schedulers.values()),
+        schedulers=reconciliation_state.schedulers(),
     )

--- a/vane/runners/ray/fragment_worker_failures.py
+++ b/vane/runners/ray/fragment_worker_failures.py
@@ -25,7 +25,7 @@ from vane.runners.ray.fte_fragment_scheduler import (
 if TYPE_CHECKING:
     from vane.runners.fte.fte_scheduler import FteQueryScheduler
 
-_WORKER_FAILURE_RECONCILIATION_LOCK = threading.Lock()
+_WORKER_FAILURE_RECONCILIATION_LOCK = threading.RLock()
 
 
 def _worker_failure_reconciliation_target(
@@ -52,20 +52,33 @@ class _FteWorkerFailureReconciliationResult:
 
 
 class _FteWorkerFailureReconciliationState:
-    """Share local failure fences across one global reconciliation."""
+    """Serialize a dynamically growing worker-failure reconciliation."""
 
-    def __init__(self, failure_key: tuple[str, str, str]) -> None:
+    def __init__(
+        self,
+        failure_key: tuple[str, str, str],
+        *,
+        target: Any | None,
+    ) -> None:
         self.failure_key = failure_key
+        self.target = target
         self.completion: Future[None] = Future()
-        self._lock = threading.Lock()
         self._schedulers: dict[int, FteQueryScheduler] = {}
+        self._pending_schedulers: dict[int, FteQueryScheduler] = {}
+        self._initial_reconciliation_pending = True
+        self._runner_active = False
+        self._pending_publications = 0
+        self._error: BaseException | None = None
+        self._closed = False
 
     def fence_scheduler(self, scheduler: FteQueryScheduler) -> bool:
-        """Record and claim a scheduler fence atomically for this reconciliation."""
+        """Fence a scheduler and enqueue it for reconciliation exactly once."""
 
         scheduler_identity = id(scheduler)
         _manager_instance_id, worker_id, worker_incarnation_id = self.failure_key
-        with self._lock:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed:
+                return False
             if scheduler_identity in self._schedulers:
                 return True
             if not scheduler.record_worker_failure(
@@ -74,11 +87,131 @@ class _FteWorkerFailureReconciliationState:
             ):
                 return False
             self._schedulers[scheduler_identity] = scheduler
+            self._pending_schedulers[scheduler_identity] = scheduler
             return True
 
     def schedulers(self) -> tuple[FteQueryScheduler, ...]:
-        with self._lock:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
             return tuple(self._schedulers.values())
+
+    def try_claim_runner(self) -> bool:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed or self._error is not None or self._runner_active:
+                return False
+            if not self._initial_reconciliation_pending and not self._pending_schedulers:
+                return False
+            self._runner_active = True
+            return True
+
+    def take_reconciliation_batch(self) -> tuple[bool, tuple[FteQueryScheduler, ...]] | None:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed or not self._runner_active:
+                return None
+            if self._error is not None:
+                raise self._error
+            initial_reconciliation = self._initial_reconciliation_pending
+            self._initial_reconciliation_pending = False
+            schedulers = tuple(self._pending_schedulers.values())
+            self._pending_schedulers.clear()
+            if not initial_reconciliation and not schedulers:
+                return None
+            return initial_reconciliation, schedulers
+
+    def add_publication(
+        self,
+        pending_drain: Future[None],
+        schedulers: tuple[FteQueryScheduler, ...],
+    ) -> None:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed or self._error is not None:
+                return
+            self._pending_publications += 1
+
+        publication_lock = threading.Lock()
+        publication_finished = False
+
+        def finish_publication(error: BaseException | None) -> None:
+            nonlocal publication_finished
+            with publication_lock:
+                if publication_finished:
+                    return
+                publication_finished = True
+            self._finish_publication(error)
+
+        def pending_drain_completed(completion: Future[None]) -> None:
+            try:
+                completion.result()
+                drain_completions = [scheduler.enqueue_drain_barrier() for scheduler in schedulers]
+            except BaseException as exc:
+                finish_publication(exc)
+                return
+            if not drain_completions:
+                finish_publication(None)
+                return
+
+            barrier_lock = threading.Lock()
+            remaining = len(drain_completions)
+            first_error: BaseException | None = None
+
+            def drain_completed(drain_completion: Future[None]) -> None:
+                nonlocal remaining, first_error
+                try:
+                    drain_completion.result()
+                except BaseException as exc:
+                    error: BaseException | None = exc
+                else:
+                    error = None
+                with barrier_lock:
+                    if first_error is None and error is not None:
+                        first_error = error
+                    remaining -= 1
+                    all_completed = remaining == 0
+                if all_completed:
+                    finish_publication(first_error)
+
+            for drain_completion in drain_completions:
+                drain_completion.add_done_callback(drain_completed)
+
+        pending_drain.add_done_callback(pending_drain_completed)
+
+    def _finish_publication(self, error: BaseException | None) -> None:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed:
+                return
+            self._pending_publications -= 1
+            if self._error is None and error is not None:
+                self._error = error
+            publication = _close_reconciliation_if_ready_locked(self)
+            if publication is not None:
+                _publish_reconciliation_completion(*publication)
+
+    def release_runner(self) -> bool:
+        """Keep the runner when work arrived, otherwise make completion eligible."""
+
+        publication: _ReconciliationPublication | None
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed:
+                return False
+            if self._error is not None:
+                self._runner_active = False
+                publication = _close_reconciliation_locked(self, self._error)
+            elif self._initial_reconciliation_pending or self._pending_schedulers:
+                return True
+            else:
+                self._runner_active = False
+                publication = _close_reconciliation_if_ready_locked(self)
+            if publication is not None:
+                _publish_reconciliation_completion(*publication)
+        return False
+
+    def fail(self, error: BaseException) -> None:
+        with _WORKER_FAILURE_RECONCILIATION_LOCK:
+            if self._closed:
+                return
+            if self._error is None:
+                self._error = error
+            publication = _close_reconciliation_locked(self, self._error)
+            _publish_reconciliation_completion(*publication)
 
 
 _WORKER_FAILURE_RECONCILIATIONS: dict[
@@ -87,137 +220,146 @@ _WORKER_FAILURE_RECONCILIATIONS: dict[
 ] = {}
 
 
+_ReconciliationPublication = tuple[
+    _FteWorkerFailureReconciliationState,
+    BaseException | None,
+    tuple["FteQueryScheduler", ...],
+]
+
+
+def _close_reconciliation_locked(
+    state: _FteWorkerFailureReconciliationState,
+    error: BaseException | None,
+) -> _ReconciliationPublication:
+    state._closed = True
+    state._runner_active = False
+    state._pending_schedulers.clear()
+    if _WORKER_FAILURE_RECONCILIATIONS.get(state.failure_key) is state:
+        _WORKER_FAILURE_RECONCILIATIONS.pop(state.failure_key, None)
+    return state, error, tuple(state._schedulers.values())
+
+
+def _close_reconciliation_if_ready_locked(
+    state: _FteWorkerFailureReconciliationState,
+) -> _ReconciliationPublication | None:
+    if state._closed or state._runner_active:
+        return None
+    if state._error is not None:
+        return _close_reconciliation_locked(state, state._error)
+    if state._initial_reconciliation_pending or state._pending_schedulers or state._pending_publications:
+        return None
+    return _close_reconciliation_locked(state, None)
+
+
+def _publish_reconciliation_completion(
+    state: _FteWorkerFailureReconciliationState,
+    error: BaseException | None,
+    schedulers: tuple[FteQueryScheduler, ...],
+) -> None:
+    # Closing, publishing, and removing the state share the global lock.  An
+    # observer therefore joins either this state before its linearization
+    # point or a successor after completion, never an unpublished gap.
+    if error is not None:
+        scheduler_errors: list[Exception] = []
+        for scheduler in schedulers:
+            try:
+                scheduler.fail(f"FTE worker failure handling failed: {error}")
+            except Exception as scheduler_error:
+                # The scheduler state transition precedes its callbacks;
+                # completion must still unblock every failure observer.
+                scheduler_errors.append(scheduler_error)
+        if scheduler_errors:
+            original_error = error
+            error = RuntimeError(f"{error}; scheduler failure callback also failed: {scheduler_errors[0]}")
+            error.__cause__ = original_error
+    try:
+        if state.target is not None:
+            state.target._complete_fte_worker_failure_reconciliation(error)
+    except BaseException as exc:
+        if error is None:
+            error = exc
+            for scheduler in schedulers:
+                try:
+                    scheduler.fail(f"FTE worker failure completion publication failed: {exc}")
+                except Exception:
+                    pass
+        else:
+            original_error = error
+            error = RuntimeError(f"{error}; worker failure completion publication also failed: {exc}")
+            error.__cause__ = original_error
+    if error is None:
+        state.completion.set_result(None)
+    else:
+        state.completion.set_exception(error)
+
+
 class _FteWorkerFailureReconciliation:
-    """Own one worker-incarnation failure through final side-effect publication."""
+    """Run one serialized slice of a shared worker-incarnation failure."""
 
     def __init__(
         self,
         event: Any,
         *,
         state: _FteWorkerFailureReconciliationState,
-        target: Any | None,
-        owns_reconciliation: bool,
+        owns_runner: bool,
     ) -> None:
         self.event = event
         self.state = state
         self.failure_key = state.failure_key
         self.completion = state.completion
-        self.target = target
-        self.owns_reconciliation = owns_reconciliation
-        self._completion_lock = threading.Lock()
-        self._completed = False
-
-    def _registered_schedulers(
-        self,
-        schedulers: tuple[FteQueryScheduler, ...] = (),
-    ) -> tuple[FteQueryScheduler, ...]:
-        registered = (*schedulers, *self.state.schedulers())
-        return tuple({id(scheduler): scheduler for scheduler in registered}.values())
-
-    def complete(
-        self,
-        error: BaseException | None,
-        *,
-        schedulers: tuple[FteQueryScheduler, ...] = (),
-    ) -> None:
-        if not self.owns_reconciliation:
-            raise RuntimeError("only the reconciliation owner can publish completion")
-        with self._completion_lock:
-            if self._completed:
-                return
-            self._completed = True
-        schedulers = self._registered_schedulers(schedulers)
-        if error is not None:
-            scheduler_errors: list[Exception] = []
-            for scheduler in schedulers:
-                try:
-                    scheduler.fail(f"FTE worker failure handling failed: {error}")
-                except Exception as scheduler_error:
-                    # The scheduler state transition precedes its callbacks;
-                    # completion must still unblock every failure observer.
-                    scheduler_errors.append(scheduler_error)
-            if scheduler_errors:
-                original_error = error
-                error = RuntimeError(f"{error}; scheduler failure callback also failed: {scheduler_errors[0]}")
-                error.__cause__ = original_error
-        try:
-            if self.target is not None:
-                self.target._complete_fte_worker_failure_reconciliation(error)
-            if error is None:
-                self.completion.set_result(None)
-            else:
-                self.completion.set_exception(error)
-        finally:
-            with _WORKER_FAILURE_RECONCILIATION_LOCK:
-                if _WORKER_FAILURE_RECONCILIATIONS.get(self.failure_key) is self.state:
-                    _WORKER_FAILURE_RECONCILIATIONS.pop(self.failure_key, None)
-
-    def _complete_after_futures(
-        self,
-        futures: list[Future[None]],
-        *,
-        schedulers: tuple[FteQueryScheduler, ...],
-    ) -> None:
-        if not futures:
-            self.complete(None)
-            return
-        lock = threading.Lock()
-        remaining = len(futures)
-        first_error: BaseException | None = None
-
-        def completed(future: Future[None]) -> None:
-            nonlocal remaining, first_error
-            error: BaseException | None
-            try:
-                future.result()
-            except BaseException as exc:
-                error = exc
-            else:
-                error = None
-            should_complete = False
-            with lock:
-                if first_error is None and error is not None:
-                    first_error = error
-                remaining -= 1
-                should_complete = remaining == 0
-            if should_complete:
-                self.complete(first_error, schedulers=schedulers)
-
-        for future in futures:
-            future.add_done_callback(completed)
+        self.owns_runner = owns_runner
 
     def complete_after_pending_drain(
         self,
         schedulers: tuple[FteQueryScheduler, ...],
         pending_drain: Future[None],
     ) -> None:
-        if not self.owns_reconciliation:
-            raise RuntimeError("only the reconciliation owner can publish completion")
+        if not self.owns_runner:
+            raise RuntimeError("only the active reconciliation runner can publish progress")
+        unique_schedulers = tuple({id(scheduler): scheduler for scheduler in schedulers}.values())
+        self.state.add_publication(pending_drain, unique_schedulers)
 
-        def pending_drain_completed(completion: Future[None]) -> None:
-            unique_schedulers = self._registered_schedulers(schedulers)
-            try:
-                completion.result()
-                drain_completions = [scheduler.enqueue_drain_barrier() for scheduler in unique_schedulers]
-            except BaseException as exc:
-                self.complete(exc, schedulers=unique_schedulers)
-                return
-            self._complete_after_futures(
-                drain_completions,
-                schedulers=unique_schedulers,
-            )
-
-        pending_drain.add_done_callback(pending_drain_completed)
-
-    def reconcile(self) -> _FteWorkerFailureReconciliationResult:
+    def reconcile(self) -> _FteWorkerFailureReconciliationResult | None:
+        if not self.owns_runner:
+            raise RuntimeError("only the active reconciliation runner can reconcile")
         manager_instance_id, _worker_id, worker_incarnation_id = self.failure_key
+        quarantine_fte_worker(
+            self.event.worker_id,
+            manager_instance_id=manager_instance_id,
+            worker_incarnation_id=worker_incarnation_id,
+        )
+        affected_query_ids = _query_ids_owned_by_fte_workers(
+            {str(self.event.worker_id)},
+            {str(self.event.worker_id): worker_incarnation_id},
+        )
+        affected_query_ids.add(str(self.event.query_id))
+        for query_id in sorted(affected_query_ids):
+            with _FTE_REGISTRY_LOCK:
+                if query_id in _FTE_CLOSING_QUERIES:
+                    continue
+                scheduler = _FTE_SCHEDULERS.get(query_id)
+            if scheduler is None or not scheduler.is_owned_by_manager_instance(manager_instance_id):
+                continue
+            self.state.fence_scheduler(scheduler)
+        reconciliation_batch = self.state.take_reconciliation_batch()
+        if reconciliation_batch is None:
+            return None
         return _reconcile_fte_worker_failure(
             self.event,
             manager_instance_id=manager_instance_id,
             worker_incarnation_id=worker_incarnation_id,
-            event_query_id=str(self.event.query_id),
-            reconciliation_state=self.state,
+            reconciliation_batch=reconciliation_batch,
         )
+
+    def release_runner(self) -> bool:
+        if not self.owns_runner:
+            raise RuntimeError("only the active reconciliation runner can release ownership")
+        return self.state.release_runner()
+
+    def fail(self, error: BaseException) -> None:
+        if not self.owns_runner:
+            raise RuntimeError("only the active reconciliation runner can fail reconciliation")
+        self.state.fail(error)
 
 
 def begin_fte_worker_failure_reconciliation(event: Any) -> _FteWorkerFailureReconciliation | None:
@@ -240,19 +382,18 @@ def begin_fte_worker_failure_reconciliation(event: Any) -> _FteWorkerFailureReco
     failure_key = (manager_instance_id, worker_id, worker_incarnation_id)
     with _WORKER_FAILURE_RECONCILIATION_LOCK:
         state = _WORKER_FAILURE_RECONCILIATIONS.get(failure_key)
-        owns_reconciliation = state is None
         if state is None:
-            state = _FteWorkerFailureReconciliationState(failure_key)
+            state = _FteWorkerFailureReconciliationState(failure_key, target=target)
             _WORKER_FAILURE_RECONCILIATIONS[failure_key] = state
         if event_scheduler is not None:
             # The local fence must be visible before a duplicate scheduler is
             # allowed to process a causally following CANCELED/ABORTED event.
             state.fence_scheduler(event_scheduler)
+        owns_runner = state.try_claim_runner()
         return _FteWorkerFailureReconciliation(
             event,
             state=state,
-            target=target if owns_reconciliation else None,
-            owns_reconciliation=owns_reconciliation,
+            owns_runner=owns_runner,
         )
 
 
@@ -322,34 +463,16 @@ def _reconcile_fte_worker_failure(
     *,
     manager_instance_id: str,
     worker_incarnation_id: str,
-    event_query_id: str,
-    reconciliation_state: _FteWorkerFailureReconciliationState,
+    reconciliation_batch: tuple[bool, tuple[FteQueryScheduler, ...]],
 ) -> _FteWorkerFailureReconciliationResult:
     failure = _worker_failure_payload(
         event.worker_id,
         event.error,
         worker_incarnation_id=worker_incarnation_id,
     )
-    quarantine_fte_worker(
-        event.worker_id,
-        manager_instance_id=manager_instance_id,
-        worker_incarnation_id=worker_incarnation_id,
-    )
-    affected_query_ids = _query_ids_owned_by_fte_workers(
-        {str(event.worker_id)},
-        {str(event.worker_id): worker_incarnation_id},
-    )
-    affected_query_ids.add(event_query_id)
-    for query_id in sorted(affected_query_ids):
-        with _FTE_REGISTRY_LOCK:
-            if query_id in _FTE_CLOSING_QUERIES:
-                continue
-            scheduler = _FTE_SCHEDULERS.get(query_id)
-        if scheduler is None or not scheduler.is_owned_by_manager_instance(manager_instance_id):
-            continue
-        reconciliation_state.fence_scheduler(scheduler)
+    initial_reconciliation, registered_schedulers = reconciliation_batch
     reconciliation_schedulers: dict[str, FteQueryScheduler] = {}
-    for registered_scheduler in reconciliation_state.schedulers():
+    for registered_scheduler in registered_schedulers:
         query_id = str(registered_scheduler.query_id)
         with _FTE_REGISTRY_LOCK:
             current_scheduler = _FTE_SCHEDULERS.get(query_id)
@@ -362,20 +485,23 @@ def _reconcile_fte_worker_failure(
         if current_scheduler.is_owned_by_manager_instance(manager_instance_id):
             reconciliation_schedulers[query_id] = current_scheduler
     reconciliation_query_ids = set(reconciliation_schedulers)
-    scheduled_by_fragment = _mark_fte_worker_failed(
-        event.worker_id,
-        failure,
-        query_id_filters=reconciliation_query_ids,
-        manager_instance_id=manager_instance_id,
-        worker_incarnation_id=worker_incarnation_id,
-        primary_worker_process_terminated=_worker_actor_death_confirms_quiescence(event.error),
-        reconcile_query=bool(reconciliation_query_ids),
-    )
+    if initial_reconciliation or reconciliation_query_ids:
+        scheduled_by_fragment = _mark_fte_worker_failed(
+            event.worker_id,
+            failure,
+            query_id_filters=reconciliation_query_ids,
+            manager_instance_id=manager_instance_id,
+            worker_incarnation_id=worker_incarnation_id,
+            primary_worker_process_terminated=_worker_actor_death_confirms_quiescence(event.error),
+            reconcile_query=bool(reconciliation_query_ids),
+        )
+    else:
+        scheduled_by_fragment = []
     for query_id, scheduler in reconciliation_schedulers.items():
         delay_s = _fte_retry_remaining_delay_s(query_id)
         if delay_s > 0:
             scheduler.arm_retry_delay(delay_s)
     return _FteWorkerFailureReconciliationResult(
         scheduled_by_fragment=tuple(scheduled_by_fragment),
-        schedulers=reconciliation_state.schedulers(),
+        schedulers=tuple(reconciliation_schedulers.values()),
     )

--- a/vane/runners/ray/fragment_worker_failures.py
+++ b/vane/runners/ray/fragment_worker_failures.py
@@ -49,6 +49,7 @@ def _worker_failure_reconciliation_target(
 class _FteWorkerFailureReconciliationResult:
     scheduled_by_fragment: tuple[tuple[str, str, list[Any], list[Any]], ...]
     schedulers: tuple[FteQueryScheduler, ...]
+    retry_delay_completions: tuple[Future[None], ...]
 
 
 class _FteWorkerFailureReconciliationState:
@@ -121,6 +122,7 @@ class _FteWorkerFailureReconciliationState:
         self,
         pending_drain: Future[None],
         schedulers: tuple[FteQueryScheduler, ...],
+        retry_delay_completions: tuple[Future[None], ...],
     ) -> None:
         with _WORKER_FAILURE_RECONCILIATION_LOCK:
             if self._closed or self._error is not None:
@@ -138,9 +140,11 @@ class _FteWorkerFailureReconciliationState:
                 publication_finished = True
             self._finish_publication(error)
 
-        def pending_drain_completed(completion: Future[None]) -> None:
+        def prerequisites_completed(error: BaseException | None) -> None:
+            if error is not None:
+                finish_publication(error)
+                return
             try:
-                completion.result()
                 drain_completions = [scheduler.enqueue_drain_barrier() for scheduler in schedulers]
             except BaseException as exc:
                 finish_publication(exc)
@@ -172,7 +176,27 @@ class _FteWorkerFailureReconciliationState:
             for drain_completion in drain_completions:
                 drain_completion.add_done_callback(drain_completed)
 
-        pending_drain.add_done_callback(pending_drain_completed)
+        prerequisite_lock = threading.Lock()
+        remaining_prerequisites = 1 + len(retry_delay_completions)
+
+        def prerequisite_completed(completion: Future[None]) -> None:
+            nonlocal remaining_prerequisites
+            try:
+                completion.result()
+            except BaseException as exc:
+                error: BaseException | None = exc
+            else:
+                error = None
+            with prerequisite_lock:
+                remaining_prerequisites -= 1
+                all_completed = remaining_prerequisites == 0
+            if error is not None:
+                finish_publication(error)
+            elif all_completed:
+                prerequisites_completed(None)
+
+        for prerequisite in (pending_drain, *retry_delay_completions):
+            prerequisite.add_done_callback(prerequisite_completed)
 
     def _finish_publication(self, error: BaseException | None) -> None:
         with _WORKER_FAILURE_RECONCILIATION_LOCK:
@@ -313,11 +337,19 @@ class _FteWorkerFailureReconciliation:
         self,
         schedulers: tuple[FteQueryScheduler, ...],
         pending_drain: Future[None],
+        retry_delay_completions: tuple[Future[None], ...],
     ) -> None:
         if not self.owns_runner:
             raise RuntimeError("only the active reconciliation runner can publish progress")
         unique_schedulers = tuple({id(scheduler): scheduler for scheduler in schedulers}.values())
-        self.state.add_publication(pending_drain, unique_schedulers)
+        unique_retry_delay_completions = tuple(
+            {id(completion): completion for completion in retry_delay_completions}.values()
+        )
+        self.state.add_publication(
+            pending_drain,
+            unique_schedulers,
+            unique_retry_delay_completions,
+        )
 
     def reconcile(self) -> _FteWorkerFailureReconciliationResult | None:
         if not self.owns_runner:
@@ -497,11 +529,13 @@ def _reconcile_fte_worker_failure(
         )
     else:
         scheduled_by_fragment = []
+    retry_delay_completions: list[Future[None]] = []
     for query_id, scheduler in reconciliation_schedulers.items():
         delay_s = _fte_retry_remaining_delay_s(query_id)
         if delay_s > 0:
-            scheduler.arm_retry_delay(delay_s)
+            retry_delay_completions.append(scheduler.arm_retry_delay(delay_s))
     return _FteWorkerFailureReconciliationResult(
         scheduled_by_fragment=tuple(scheduled_by_fragment),
         schedulers=tuple(reconciliation_schedulers.values()),
+        retry_delay_completions=tuple(retry_delay_completions),
     )

--- a/vane/runners/ray/fragment_worker_failures.py
+++ b/vane/runners/ray/fragment_worker_failures.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import threading
 from concurrent.futures import Future
+from dataclasses import dataclass
 from typing import Any
 
 from vane.runners.ray.fragment_registry import (
@@ -23,6 +24,194 @@ from vane.runners.ray.fte_fragment_scheduler import (
 
 _WORKER_FAILURE_RECONCILIATION_LOCK = threading.Lock()
 _WORKER_FAILURE_RECONCILIATIONS: dict[tuple[str, str, str], Future[None]] = {}
+
+
+def _worker_failure_reconciliation_target(
+    worker_id: str,
+    *,
+    manager_instance_id: str,
+    worker_incarnation_id: str,
+) -> Any | None:
+    with _FTE_REGISTRY_LOCK:
+        handle = _FTE_WORKER_HANDLES.get(str(worker_id))
+        if handle is None:
+            return None
+        if str(handle.manager_instance_id) != str(manager_instance_id):
+            return None
+        if str(handle.worker_incarnation_id) != str(worker_incarnation_id):
+            return None
+        return handle
+
+
+@dataclass(frozen=True)
+class _FteWorkerFailureReconciliationResult:
+    scheduled_by_fragment: tuple[tuple[str, str, list[Any], list[Any]], ...]
+    schedulers: tuple[Any, ...]
+
+
+class _FteWorkerFailureReconciliation:
+    """Own one worker-incarnation failure through final side-effect publication."""
+
+    def __init__(
+        self,
+        event: Any,
+        *,
+        failure_key: tuple[str, str, str],
+        completion: Future[None],
+        target: Any | None,
+        owns_reconciliation: bool,
+    ) -> None:
+        self.event = event
+        self.failure_key = failure_key
+        self.completion = completion
+        self.target = target
+        self.owns_reconciliation = owns_reconciliation
+        self._completion_lock = threading.Lock()
+        self._completed = False
+
+    def complete(
+        self,
+        error: BaseException | None,
+        *,
+        schedulers: tuple[Any, ...] = (),
+    ) -> None:
+        if not self.owns_reconciliation:
+            raise RuntimeError("only the reconciliation owner can publish completion")
+        with self._completion_lock:
+            if self._completed:
+                return
+            self._completed = True
+        if error is not None:
+            scheduler_errors: list[Exception] = []
+            for scheduler in schedulers:
+                try:
+                    scheduler.fail(f"FTE worker failure handling failed: {error}")
+                except Exception as scheduler_error:
+                    # The scheduler state transition precedes its callbacks;
+                    # completion must still unblock every failure observer.
+                    scheduler_errors.append(scheduler_error)
+            if scheduler_errors:
+                original_error = error
+                error = RuntimeError(f"{error}; scheduler failure callback also failed: {scheduler_errors[0]}")
+                error.__cause__ = original_error
+        try:
+            if self.target is not None:
+                self.target._complete_fte_worker_failure_reconciliation(error)
+            if error is None:
+                self.completion.set_result(None)
+            else:
+                self.completion.set_exception(error)
+        finally:
+            with _WORKER_FAILURE_RECONCILIATION_LOCK:
+                if _WORKER_FAILURE_RECONCILIATIONS.get(self.failure_key) is self.completion:
+                    _WORKER_FAILURE_RECONCILIATIONS.pop(self.failure_key, None)
+
+    def _complete_after_futures(
+        self,
+        futures: list[Future[None]],
+        *,
+        schedulers: tuple[Any, ...],
+    ) -> None:
+        if not futures:
+            self.complete(None)
+            return
+        lock = threading.Lock()
+        remaining = len(futures)
+        first_error: BaseException | None = None
+
+        def completed(future: Future[None]) -> None:
+            nonlocal remaining, first_error
+            try:
+                future.result()
+            except BaseException as exc:
+                error = exc
+            else:
+                error = None
+            should_complete = False
+            with lock:
+                if first_error is None and error is not None:
+                    first_error = error
+                remaining -= 1
+                should_complete = remaining == 0
+            if should_complete:
+                self.complete(first_error, schedulers=schedulers)
+
+        for future in futures:
+            future.add_done_callback(completed)
+
+    def complete_after_pending_drain(
+        self,
+        schedulers: tuple[Any, ...],
+        pending_drain: Future[None],
+    ) -> None:
+        if not self.owns_reconciliation:
+            raise RuntimeError("only the reconciliation owner can publish completion")
+        unique_schedulers = tuple({id(scheduler): scheduler for scheduler in schedulers}.values())
+        if not unique_schedulers:
+            self.complete(None)
+            return
+
+        def pending_drain_completed(completion: Future[None]) -> None:
+            try:
+                completion.result()
+                drain_completions = [scheduler.enqueue_drain_barrier() for scheduler in unique_schedulers]
+            except BaseException as exc:
+                self.complete(exc, schedulers=unique_schedulers)
+                return
+            self._complete_after_futures(
+                drain_completions,
+                schedulers=unique_schedulers,
+            )
+
+        pending_drain.add_done_callback(pending_drain_completed)
+
+    def reconcile(self) -> _FteWorkerFailureReconciliationResult:
+        manager_instance_id, _worker_id, worker_incarnation_id = self.failure_key
+        return _reconcile_fte_worker_failure(
+            self.event,
+            manager_instance_id=manager_instance_id,
+            worker_incarnation_id=worker_incarnation_id,
+            event_query_id=str(self.event.query_id),
+        )
+
+
+def begin_fte_worker_failure_reconciliation(event: Any) -> _FteWorkerFailureReconciliation | None:
+    """Elect one full failure publisher; duplicate observers join its barrier."""
+
+    manager_instance_id = str(event.manager_instance_id)
+    worker_id = str(event.worker_id)
+    worker_incarnation_id = str(event.worker_incarnation_id)
+    event_query_id = str(event.query_id)
+    with _FTE_REGISTRY_LOCK:
+        event_scheduler = _FTE_SCHEDULERS.get(event_query_id)
+    if event_scheduler is not None and not event_scheduler.is_owned_by_manager_instance(manager_instance_id):
+        return None
+
+    target = _worker_failure_reconciliation_target(
+        worker_id,
+        manager_instance_id=manager_instance_id,
+        worker_incarnation_id=worker_incarnation_id,
+    )
+    failure_key = (manager_instance_id, worker_id, worker_incarnation_id)
+    with _WORKER_FAILURE_RECONCILIATION_LOCK:
+        completion = _WORKER_FAILURE_RECONCILIATIONS.get(failure_key)
+        if completion is None:
+            completion = Future()
+            _WORKER_FAILURE_RECONCILIATIONS[failure_key] = completion
+            return _FteWorkerFailureReconciliation(
+                event,
+                failure_key=failure_key,
+                completion=completion,
+                target=target,
+                owns_reconciliation=True,
+            )
+        return _FteWorkerFailureReconciliation(
+            event,
+            failure_key=failure_key,
+            completion=completion,
+            target=None,
+            owns_reconciliation=False,
+        )
 
 
 def quarantine_fte_worker(
@@ -58,19 +247,32 @@ def retire_fte_worker_for_failure(
     manager_instance_id: str,
     worker_incarnation_id: str,
 ) -> None:
+    target = _worker_failure_reconciliation_target(
+        worker_id,
+        manager_instance_id=manager_instance_id,
+        worker_incarnation_id=worker_incarnation_id,
+    )
     failure = _worker_failure_payload(
         worker_id,
         error,
         worker_incarnation_id=worker_incarnation_id,
     )
-    _mark_fte_worker_failed(
-        worker_id,
-        failure,
-        manager_instance_id=manager_instance_id,
-        worker_incarnation_id=worker_incarnation_id,
-        primary_worker_process_terminated=_worker_actor_death_confirms_quiescence(error),
-        reconcile_query=False,
-    )
+    try:
+        _mark_fte_worker_failed(
+            worker_id,
+            failure,
+            manager_instance_id=manager_instance_id,
+            worker_incarnation_id=worker_incarnation_id,
+            primary_worker_process_terminated=_worker_actor_death_confirms_quiescence(error),
+            reconcile_query=False,
+        )
+    except BaseException as exc:
+        if target is not None:
+            target._complete_fte_worker_failure_reconciliation(exc)
+        raise
+    else:
+        if target is not None:
+            target._complete_fte_worker_failure_reconciliation(None)
 
 
 def _reconcile_fte_worker_failure(
@@ -79,7 +281,7 @@ def _reconcile_fte_worker_failure(
     manager_instance_id: str,
     worker_incarnation_id: str,
     event_query_id: str,
-) -> list[tuple[str, str, list[Any], list[Any]]]:
+) -> _FteWorkerFailureReconciliationResult:
     failure = _worker_failure_payload(
         event.worker_id,
         event.error,
@@ -127,46 +329,7 @@ def _reconcile_fte_worker_failure(
         delay_s = _fte_retry_remaining_delay_s(query_id)
         if delay_s > 0:
             scheduler.arm_retry_delay(delay_s)
-    return scheduled_by_fragment
-
-
-def mark_fte_worker_failed_for_event(event: Any) -> list[tuple[str, str, list[Any], list[Any]]]:
-    manager_instance_id = str(event.manager_instance_id)
-    worker_incarnation_id = str(event.worker_incarnation_id)
-    event_query_id = str(event.query_id)
-    with _FTE_REGISTRY_LOCK:
-        event_scheduler = _FTE_SCHEDULERS.get(event_query_id)
-    if event_scheduler is not None and not event_scheduler.is_owned_by_manager_instance(manager_instance_id):
-        return []
-
-    # Independent status watchers can observe the same actor death. Only the
-    # owner mutates fragment state; later observers join its completion.
-    failure_key = (manager_instance_id, str(event.worker_id), worker_incarnation_id)
-    with _WORKER_FAILURE_RECONCILIATION_LOCK:
-        reconciliation = _WORKER_FAILURE_RECONCILIATIONS.get(failure_key)
-        owns_reconciliation = reconciliation is None
-        if owns_reconciliation:
-            reconciliation = Future()
-            _WORKER_FAILURE_RECONCILIATIONS[failure_key] = reconciliation
-    assert reconciliation is not None
-    if not owns_reconciliation:
-        reconciliation.result()
-        return []
-
-    try:
-        scheduled_by_fragment = _reconcile_fte_worker_failure(
-            event,
-            manager_instance_id=manager_instance_id,
-            worker_incarnation_id=worker_incarnation_id,
-            event_query_id=event_query_id,
-        )
-    except BaseException as exc:
-        reconciliation.set_exception(exc)
-        raise
-    else:
-        reconciliation.set_result(None)
-        return scheduled_by_fragment
-    finally:
-        with _WORKER_FAILURE_RECONCILIATION_LOCK:
-            if _WORKER_FAILURE_RECONCILIATIONS.get(failure_key) is reconciliation:
-                _WORKER_FAILURE_RECONCILIATIONS.pop(failure_key, None)
+    return _FteWorkerFailureReconciliationResult(
+        scheduled_by_fragment=tuple(scheduled_by_fragment),
+        schedulers=tuple(reconciliation_schedulers.values()),
+    )

--- a/vane/runners/ray/fte_fragment_scheduler.py
+++ b/vane/runners/ray/fte_fragment_scheduler.py
@@ -9,6 +9,7 @@ import math
 import threading
 import time
 from collections.abc import Callable, Iterable, Mapping
+from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any
 
 from vane import OutOfMemoryException
@@ -868,8 +869,10 @@ def _store_fte_result_handles(
         _FTE_RESULT_HANDLES_BY_QUERY.setdefault(str(query_id), []).extend(handles)
 
 
-def request_fte_pending_task_drain() -> list[Any]:
-    """Signal and, when elected leader, run the single-flight admission pump."""
+def _request_fte_pending_task_drain(
+    *,
+    with_completion: bool,
+) -> tuple[list[Any], Future[None] | None]:
     from vane.runners.fte.fte_events import ResourceAdmissionChanged
 
     def drain_query(
@@ -919,7 +922,24 @@ def request_fte_pending_task_drain() -> list[Any]:
             drain_execution_class(FteTaskExecutionClass.SPECULATIVE)
         return handles
 
-    return _FTE_SCHEDULERS.run_pending_drain(drain_round)
+    if with_completion:
+        return _FTE_SCHEDULERS.run_pending_drain_with_completion(drain_round)
+    return _FTE_SCHEDULERS.run_pending_drain(drain_round), None
+
+
+def request_fte_pending_task_drain() -> list[Any]:
+    """Signal and, when elected leader, run the single-flight admission pump."""
+
+    handles, _completion = _request_fte_pending_task_drain(with_completion=False)
+    return handles
+
+
+def request_fte_pending_task_drain_with_completion() -> tuple[list[Any], Future[None]]:
+    """Return handles and the completion of the drain round for this request."""
+
+    handles, completion = _request_fte_pending_task_drain(with_completion=True)
+    assert completion is not None
+    return handles, completion
 
 
 def _fte_execution_queries_waiting_for_resource(


### PR DESCRIPTION
## Summary

- Add a bounded, per-worker-incarnation completion barrier for FTE worker-loss reconciliation, with duplicate reporters joining the same publication.
- Use a two-phase failure protocol: every observing query scheduler atomically records its local worker-incarnation fence before its drain continues, while a shared single-flight work queue serializes every scheduler that joins before completion, including observers arriving during asynchronous publication.
- Track the exact global admission-drain generation and per-query causal scheduler checkpoints so completion is published only after retry or terminal side effects, including synchronously emitted reservation events and result handles.
- Make retry-delay arming observable across backoff prolongation: completion follows the latest effective generation and waits for the expiry handler's admission round plus a final scheduler checkpoint before worker-loss reconciliation is published.
- Replace result-handle polling in the real-Ray actor- and host-loss tests with the observable reconciliation barrier, and make the fault actor implement the production quiescence handshake.

The scheduler checkpoint includes events already queued and their synchronous descendants without waiting for unrelated events submitted after the checkpoint. The internal worker-failure and retry-handler contracts are intentionally replaced; no compatibility path or fallback is retained.

## Related issue

Related: #574

This addresses the FTE actor-loss reconciliation symptom. The independent datasource lifetime symptom remains open in #574.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change is internal to Ray FTE scheduling and failure reconciliation.

## Validation

- Two consecutive clean source-review passes after the final production and test changes.
- `scripts/format root --changed`
- Changed-file pre-commit gate, including ruff and mypy.
- Release non-editable build: `SKBUILD_BUILD_DIR=build/python-release SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`.
- Installed-package affected tests for `test_ray_fte_event_scheduler.py` and `test_ray_fragment_submission.py` — 341 passed.
- Five focused real-Ray actor/host-loss tests in `tests/fast/test_ray_fte_fault_injection.py` — 5 passed.
- `scripts/run_release_tests.sh` — non-Ray: 531 passed, 15 deselected; real-Ray: 11 passed, 535 deselected.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.