### PR TITLE
[fix](ai) Preserve vLLM actor request errors

### DIFF
--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -939,6 +939,7 @@ def test_vllm_actor_wait_for_result_finishes_per_executor_before_global_finish()
     import vane.execution.vllm as vllm
 
     executor = vllm.RayLocalVLLMExecutor.__new__(vllm.RayLocalVLLMExecutor)
+    executor.on_error = "raise"
     executor.completed_tasks = deque()
     executor.error_message = None
     executor._finished_submitting = False

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -408,6 +408,30 @@ def test_ray_actor_releases_only_terminal_per_executor_state():
     assert executor.release_executor("aborted") is True
 
 
+def test_ray_actor_wait_raises_stored_executor_error():
+    from vane.execution.vllm import RayLocalVLLMExecutor
+
+    executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+    executor.on_error = "raise"
+    executor.task_count_lock = threading.Lock()
+    executor._per_executor_deques = {"executor": deque()}
+    executor._per_executor_running_task_count = {"executor": 0}
+    executor._per_executor_finished = set()
+    executor._per_executor_errors = {"executor": "sentinel request failure"}
+    executor._per_executor_aborted = set()
+    executor._per_executor_waiters = {}
+    executor._per_executor_wait_tokens_observed = {}
+    executor._async_waiter_lock = threading.Lock()
+    executor._async_waiters = {}
+    executor._notify_state_change = lambda **_kwargs: None
+
+    with pytest.raises(RuntimeError, match="vllm task failed: sentinel request failure"):
+        asyncio.run(executor.wait_for_result("executor", "error-wait"))
+
+    assert executor._per_executor_waiters == {}
+    assert executor._per_executor_wait_tokens_observed == {"executor": "error-wait"}
+
+
 def test_ray_actor_batches_ready_results_to_standard_vector_size():
     import vane.execution.vllm as vllm
 
@@ -452,6 +476,7 @@ def test_ray_actor_abort_waiter_does_not_depend_on_default_thread_pool_capacity(
 
     executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
     executor.llm = None
+    executor.on_error = "raise"
     executor.completed_tasks = deque()
     executor.error_message = None
     executor._shutdown_called = False
@@ -509,6 +534,7 @@ def test_ray_actor_abort_waits_for_late_wait_token_before_releasing_state():
 
     executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
     executor.llm = None
+    executor.on_error = "raise"
     executor.completed_tasks = deque()
     executor.error_message = None
     executor._shutdown_called = False

--- a/tests/slow/test_vllm_ray_protocol_e2e.py
+++ b/tests/slow/test_vllm_ray_protocol_e2e.py
@@ -137,6 +137,7 @@ class _ThreadPoolSaturatedWaitActor:
     def __init__(self):
         executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
         executor.llm = None
+        executor.on_error = "raise"
         executor.completed_tasks = []
         executor.error_message = None
         executor._shutdown_called = False
@@ -185,6 +186,81 @@ class _ThreadPoolSaturatedWaitActor:
 
     async def release_default_pool(self):
         self.release_pool.set()
+
+
+class SyntheticVLLMRequestError(RuntimeError):
+    status_code = 503
+
+
+class _FailingRequestEngine:
+    async def generate(self, *_args, **_kwargs):
+        if False:
+            yield None
+        raise SyntheticVLLMRequestError("private upstream detail")
+
+    async def abort(self, _request_id):
+        return None
+
+
+class _RequestFailureVLLMActor:
+    """Run the production actor protocol around a deterministic request error."""
+
+    def __init__(self):
+        executor = RayLocalVLLMExecutor.__new__(RayLocalVLLMExecutor)
+        executor.model = "request-failure-model"
+        executor.llm = _FailingRequestEngine()
+        executor.engine_error_message = None
+        executor.sampling_params = object()
+        executor.generate_args = {}
+        executor.counter = 0
+        executor.counter_lock = threading.Lock()
+        executor.running_task_count = 0
+        executor.task_count_lock = threading.Lock()
+        executor.completed_tasks = []
+        executor.error_message = None
+        executor.error_lock = threading.Lock()
+        executor.on_error = "raise"
+        executor._result_cv = threading.Condition(threading.RLock())
+        executor._ensure_wakeup_state()
+        executor._ray_actor_mode = True
+        executor._finished_submitting = False
+        executor._shutdown_called = False
+        executor._per_executor_deques = {}
+        executor._per_executor_running_task_count = {}
+        executor._per_executor_finished = set()
+        executor._per_executor_request_ids = {}
+        executor._per_executor_tasks = {}
+        executor._per_executor_errors = {}
+        executor._per_executor_aborted = set()
+        executor._per_executor_waiters = {}
+        executor._per_executor_wait_tokens_observed = {}
+        executor._per_executor_abort_wait_tokens = {}
+        executor._async_waiter_lock = threading.Lock()
+        executor._async_waiters = {}
+        self.executor = executor
+        self._take_calls = 0
+
+    async def submit_async(self, prompts, rows, executor_id, reservation_id):
+        return await self.executor.submit_async(prompts, rows, executor_id, reservation_id)
+
+    async def wait_for_result(self, executor_id, wait_token):
+        return await self.executor.wait_for_result(executor_id, wait_token)
+
+    def take_ready_result(self, executor_id):
+        self._take_calls += 1
+        return self.executor.take_ready_result(executor_id)
+
+    def finished_executor(self, executor_id):
+        return self.executor.finished_executor(executor_id)
+
+    async def abort_executor(self, executor_id, wait_token):
+        return await self.executor.abort_executor(executor_id, wait_token)
+
+    def release_executor(self, executor_id):
+        return self.executor.release_executor(executor_id)
+
+    def take_calls(self):
+        return self._take_calls
 
 
 class _RayActorOwner:
@@ -238,6 +314,29 @@ def test_remote_executor_waits_for_all_real_ray_submit_acks_before_abort(ray_run
         events = ray_runtime.get(actor.events.remote())
         assert [event[0] for event in events] == ["submit-failed", "submit-settled", "abort"]
         assert len({event[1] for event in events}) == 1
+        assert ray_runtime.get(router.release_executor.remote(executor._executor_id)) == 0
+    finally:
+        executor.shutdown()
+
+
+def test_remote_executor_preserves_real_ray_actor_request_error(ray_runtime):
+    actor = ray_runtime.remote(max_concurrency=32)(_RequestFailureVLLMActor).remote()
+    router = ray_runtime.remote(PrefixRouter).remote([actor], 0)
+    owner = _RayActorOwner(ray_runtime, actor, router)
+    executor = RemoteVLLMExecutor(owner)
+
+    try:
+        executor.submit(None, ["prompt"], pa.table({"id": [1]}))
+        executor.finished_submitting()
+
+        with pytest.raises(RuntimeError, match="SyntheticVLLMRequestError") as exc_info:
+            executor.wait_for_result()
+
+        error_message = str(exc_info.value)
+        assert "status_code=503" in error_message
+        assert "private upstream detail" not in error_message
+        assert "finished without returning all submitted results" not in error_message
+        assert ray_runtime.get(actor.take_calls.remote()) == 0
         assert ray_runtime.get(router.release_executor.remote(executor._executor_id)) == 0
     finally:
         executor.shutdown()

--- a/vane/execution/vllm.py
+++ b/vane/execution/vllm.py
@@ -608,6 +608,13 @@ class LocalVLLMExecutor(VLLMExecutor):
 
         task.add_done_callback(discard)
 
+    def _raise_if_task_failed(self, executor_id: str | None = None) -> None:
+        if self.on_error != "raise":
+            return
+        error_message = self._per_executor_errors.get(executor_id) if executor_id else self.error_message
+        if error_message is not None:
+            raise RuntimeError(f"vllm task failed: {error_message}")
+
     @overload
     def take_ready_result(self, executor_id: None = None) -> tuple[list[str | None], pa.Table] | None: ...
 
@@ -617,10 +624,7 @@ class LocalVLLMExecutor(VLLMExecutor):
     ) -> tuple[list[str | None], pa.Table, list[tuple[str, int]]] | None: ...
 
     def take_ready_result(self, executor_id: str | None = None) -> tuple[Any, ...] | None:
-        if self.on_error == "raise":
-            error_message = self._per_executor_errors.get(executor_id) if executor_id else self.error_message
-            if error_message is not None:
-                raise RuntimeError(f"vllm task failed: {error_message}")
+        self._raise_if_task_failed(executor_id)
 
         source_deque = (
             self._per_executor_deques.setdefault(executor_id, deque()) if executor_id else self.completed_tasks
@@ -910,6 +914,7 @@ class RayLocalVLLMExecutor(LocalVLLMExecutor):
             while True:
                 has_result, terminal = self._wait_for_result_state(executor_id)
                 if has_result or terminal:
+                    self._raise_if_task_failed(executor_id)
                     return has_result
                 state_changed.clear()
                 has_result, terminal = self._wait_for_result_state(executor_id)


### PR DESCRIPTION
## Summary

`RayLocalVLLMExecutor.wait_for_result()` returned `False` after an actor-side
request failure. The remote executor interpreted this as incomplete output and
replaced the stored, sanitized provider error with a generic missing-results
error.

Raise the stored per-executor failure before the actor wait returns, preserving
the sanitized root cause across Ray. Add unit and real-Ray coverage for error
propagation, redaction, and reservation cleanup.

## Related issue

close: #444

## Documentation impact

- [x] No user-facing documentation update is required.

This corrects internal error propagation without changing the public API.

## Validation

- `scripts/format root --changed --check`
- Pre-commit checks: Ruff and mypy passed
- Affected fast tests: 381 passed
- Real-Ray protocol tests: 5 passed
- Release tests: 527 passed, 4 skipped; real-Ray shard: 11 passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] No new dependencies, copied code, model assets, or datasets are added.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications have been considered.
- [x] This is a Python-only change and relevant checks passed.
