### PR TITLE
[docs](readme) Remove production-readiness disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Vane unifies multimodal data, intelligence, and continuous learning with Python 
 > [!NOTE]
 > **Project status**
 >
-> - **Vane Data** — Supports most of the capabilities described below and is under active development, but is **not yet production-ready**. Its interfaces and internals may continue to evolve as the codebase is reviewed and hardened.
+> - **Vane Data** — Supports most of the capabilities described below and is under active development. Its interfaces and internals may continue to evolve as the codebase is reviewed and hardened.
 > - **Vane RL** and **Vane Agent** — In the early stages of design and implementation. Their source code will be released in future updates.
   - **Vibe Coding and Agentic Engineering** — Some parts of our system were initially built through Vibe Coding. We are now continuously analyzing, understanding, and improving the codebase, applying an Agentic Engineering approach to drive iterative optimization and enhance the quality, maintainability, and efficiency of the system.
 


### PR DESCRIPTION
## Summary

Remove the Vane Data README disclaimer that stated the project is not yet production-ready. This is a documentation-only wording change with no runtime or compatibility impact.

## Related issue

N/A

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The root README is updated in this PR.

## Validation

- `git diff --check`
- `pre-commit run --files README.md`
- Automated tests were not run because this changes README wording only.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.