### PR TITLE
[feat](parquet) Expose bind state for wrapper extensions

### DIFF
--- a/external/duckdb/extension/parquet/include/parquet_multi_file_info.hpp
+++ b/external/duckdb/extension/parquet/include/parquet_multi_file_info.hpp
@@ -25,6 +25,16 @@ public:
 
 struct ParquetMultiFileInfo : MultiFileReaderInterface {
 	static unique_ptr<MultiFileReaderInterface> CreateInterface(ClientContext &context);
+	//! Export and restore the Parquet-owned state transported by parquet_scan's ordinary
+	//! bind serde. Extensions that wrap parquet_scan use these helpers from their own
+	//! bind serde. Before deserializing, the caller must install the outer bind's file
+	//! list, reader, and initialized interface. DeserializeBindData sets only
+	//! file_options and bind_data.
+	DUCKDB_API static ParquetOptionsSerialization SerializeBindData(const MultiFileBindData &bind_data,
+	                                                                idx_t &initial_file_row_groups,
+	                                                                idx_t &initial_file_cardinality);
+	DUCKDB_API static void DeserializeBindData(MultiFileBindData &bind_data, ParquetOptionsSerialization serialization,
+	                                           idx_t initial_file_row_groups, idx_t initial_file_cardinality);
 
 	unique_ptr<BaseFileReaderOptions> InitializeOptions(ClientContext &context,
 	                                                    optional_ptr<TableFunctionInfo> info) override;

--- a/external/duckdb/extension/parquet/include/parquet_reader.hpp
+++ b/external/duckdb/extension/parquet/include/parquet_reader.hpp
@@ -130,8 +130,8 @@ struct ParquetOptionsSerialization {
 	MultiFileOptions file_options;
 
 public:
-	void Serialize(Serializer &serializer) const;
-	static ParquetOptionsSerialization Deserialize(Deserializer &deserializer);
+	DUCKDB_API void Serialize(Serializer &serializer) const;
+	DUCKDB_API static ParquetOptionsSerialization Deserialize(Deserializer &deserializer);
 };
 
 struct ParquetUnionData : public BaseUnionData {

--- a/external/duckdb/extension/parquet/parquet_multi_file_info.cpp
+++ b/external/duckdb/extension/parquet/parquet_multi_file_info.cpp
@@ -347,7 +347,6 @@ static void VerifyParquetSchemaParameter(const Value &schema) {
 static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
                                  const TableFunction &function) {
 	auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
-	auto &parquet_data = bind_data.bind_data->Cast<ParquetReadBindData>();
 
 	vector<string> files;
 	for (auto &file : bind_data.file_list->GetAllFiles()) {
@@ -356,14 +355,17 @@ static void ParquetScanSerialize(Serializer &serializer, const optional_ptr<Func
 	serializer.WriteProperty(100, "files", files);
 	serializer.WriteProperty(101, "types", bind_data.types);
 	serializer.WriteProperty(102, "names", bind_data.names);
-	ParquetOptionsSerialization serialization(parquet_data.GetParquetOptions(), bind_data.file_options);
+	idx_t initial_file_row_groups;
+	idx_t initial_file_cardinality;
+	auto serialization =
+	    ParquetMultiFileInfo::SerializeBindData(bind_data, initial_file_row_groups, initial_file_cardinality);
 	serializer.WriteProperty(103, "parquet_options", serialization);
 	if (serializer.ShouldSerialize(3)) {
 		serializer.WriteProperty(104, "table_columns", bind_data.table_columns);
 	}
-	serializer.WritePropertyWithDefault<idx_t>(105, "initial_file_row_groups", parquet_data.initial_file_row_groups,
+	serializer.WritePropertyWithDefault<idx_t>(105, "initial_file_row_groups", initial_file_row_groups,
 	                                           static_cast<idx_t>(0));
-	serializer.WritePropertyWithDefault<idx_t>(106, "initial_file_cardinality", parquet_data.initial_file_cardinality,
+	serializer.WritePropertyWithDefault<idx_t>(106, "initial_file_cardinality", initial_file_cardinality,
 	                                           static_cast<idx_t>(0));
 	serializer.WriteProperty<MultiFileReaderBindData>(107, "reader_bind", bind_data.reader_bind);
 }
@@ -393,7 +395,6 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 		open_files.emplace_back(path);
 	}
 	shared_ptr<MultiFileList> file_list(new SimpleMultiFileList(std::move(open_files)));
-	auto parquet_options = make_uniq<ParquetFileReaderOptions>(std::move(serialization.parquet_options));
 	auto interface = make_uniq<ParquetMultiFileInfo>();
 	interface->InitializeInterface(context, *multi_file_reader, *file_list);
 
@@ -401,17 +402,15 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	auto result = make_uniq<MultiFileBindData>();
 	result->multi_file_reader = std::move(multi_file_reader);
 	result->file_list = std::move(file_list);
-	result->file_options = std::move(serialization.file_options);
 	result->interface = std::move(interface);
-	result->bind_data = result->interface->InitializeBindData(*result, std::move(parquet_options));
+	ParquetMultiFileInfo::DeserializeBindData(*result, std::move(serialization), initial_file_row_groups,
+	                                          initial_file_cardinality);
 	result->types = std::move(types);
 	result->names = std::move(names);
 	result->table_columns = std::move(table_columns);
 	result->reader_bind = std::move(reader_bind);
 
 	auto &parquet_bind = result->bind_data->Cast<ParquetReadBindData>();
-	parquet_bind.initial_file_row_groups = initial_file_row_groups;
-	parquet_bind.initial_file_cardinality = initial_file_cardinality;
 	auto &options = parquet_bind.GetParquetOptions();
 	if (!options.schema.empty()) {
 		bool match_by_field_id = false;
@@ -439,6 +438,25 @@ static unique_ptr<FunctionData> ParquetScanDeserialize(Deserializer &deserialize
 	result->virtual_columns = std::move(virtual_columns);
 	result->interface->FinalizeBindData(*result);
 	return std::move(result);
+}
+
+ParquetOptionsSerialization ParquetMultiFileInfo::SerializeBindData(const MultiFileBindData &bind_data,
+                                                                    idx_t &initial_file_row_groups,
+                                                                    idx_t &initial_file_cardinality) {
+	auto &parquet_data = bind_data.bind_data->Cast<ParquetReadBindData>();
+	initial_file_row_groups = parquet_data.initial_file_row_groups;
+	initial_file_cardinality = parquet_data.initial_file_cardinality;
+	return ParquetOptionsSerialization(parquet_data.GetParquetOptions(), bind_data.file_options);
+}
+
+void ParquetMultiFileInfo::DeserializeBindData(MultiFileBindData &bind_data, ParquetOptionsSerialization serialization,
+                                               idx_t initial_file_row_groups, idx_t initial_file_cardinality) {
+	bind_data.file_options = std::move(serialization.file_options);
+	auto parquet_options = make_uniq<ParquetFileReaderOptions>(std::move(serialization.parquet_options));
+	bind_data.bind_data = bind_data.interface->InitializeBindData(bind_data, std::move(parquet_options));
+	auto &parquet_bind = bind_data.bind_data->Cast<ParquetReadBindData>();
+	parquet_bind.initial_file_row_groups = initial_file_row_groups;
+	parquet_bind.initial_file_cardinality = initial_file_cardinality;
 }
 
 static vector<column_t> ParquetGetRowIdColumns(ClientContext &context, optional_ptr<FunctionData> bind_data) {

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -675,6 +675,53 @@ def test_execute_native_rejects_missing_distributed_scan_assignment(tmp_path):
         con.close()
 
 
+def test_parquet_bind_serde_preserves_worker_scan_options(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    partition_dir = tmp_path / "region=west"
+    partition_dir.mkdir()
+    source = partition_dir / "bind_state.parquet"
+    con = vane.connect()
+    try:
+        con.execute(f"COPY (SELECT 42::INTEGER AS value) TO '{source}' (FORMAT PARQUET)")
+        relation = con.sql(
+            f"""
+            SELECT value, region, filename, file_row_number
+            FROM read_parquet(
+                '{tmp_path}/*/*.parquet',
+                hive_partitioning = true,
+                filename = true,
+                file_row_number = true
+            )
+            """
+        )
+        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "parquet-wrapper-bind-serde",
+        ).to_physical_plan(con)
+        descriptor_map = plan.scan_task_descriptor_map()
+        assert len(descriptor_map) == 1
+        node_id, descriptors = next(iter(descriptor_map.items()))
+        assert len(descriptors) == 1
+
+        result = vane.ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            con.cursor(),
+            plan,
+            scan_task={str(node_id): bytes(descriptors[0])},
+        )
+
+        assert result.completion_status == "ok"
+        assert len(result.partition_payloads) == 1
+        table = result.partition_payloads[0]
+        assert isinstance(table, pa.Table)
+        assert table.num_columns == 4
+        assert table.column(0).to_pylist() == [42]
+        assert table.column(1).to_pylist() == ["west"]
+        assert table.column(2).to_pylist() == [str(source)]
+        assert table.column(3).to_pylist() == [0]
+    finally:
+        con.close()
+
+
 def test_execute_native_rejects_static_and_fte_exchange_assignment_for_same_node():
     con = vane.connect()
     plan = _make_test_physical_plan(con)


### PR DESCRIPTION
## Summary

- Expose `ParquetMultiFileInfo::SerializeBindData` and `DeserializeBindData` so Parquet-backed wrapper extensions can transport Parquet-owned bind state without duplicating private `parquet_scan` internals.
- Export the `ParquetOptionsSerialization` serde entry points needed by external wrapper extensions.
- Refactor the built-in `parquet_scan` serde path to use the same helpers while preserving property IDs 100-107 and existing behavior.
- Add a distributed worker-plan regression test covering hive partitioning, filename, and file row number state.

This PR is intentionally generic Parquet infrastructure. It contains no Iceberg-specific behavior, Avro revision change, or unrelated distributed-extension work.

## Related issue

N/A - this is a small, self-contained API extraction.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The public declarations document the caller preconditions and the exact state restored by the helper.

## Validation

- `scripts/format workspace --changed --check`
- Release native wheel build and install with `CMAKE_BUILD_PARALLEL_LEVEL=8`
- `scripts/run_installed_pytest.sh tests/fast/test_ray_cpp_bindings.py::test_parquet_bind_serde_preserves_worker_scan_options`
- `scripts/run_installed_pytest.sh tests/fast/test_ray_cpp_bindings.py::test_execute_native_rejects_static_and_fte_scan_assignment_for_same_node tests/fast/test_ray_cpp_bindings.py::test_execute_native_fte_dynamic_scan_queue_reads_parquet_after_blocking tests/fast/test_ray_cpp_bindings.py::test_scan_task_descriptors_have_stable_distinct_logical_partitions_for_duplicate_files`
- Two clean local review rounds after formatting; verified unchanged serialized property IDs and matching wrapper-extension call signatures.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. The change transports the same typed Parquet state as the existing serde path and adds no new input source.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.