### PR TITLE
[fix](ray) Update recovery tests for admission fencing

### DIFF
--- a/tests/fast/test_query_resource_manager.py
+++ b/tests/fast/test_query_resource_manager.py
@@ -2112,7 +2112,6 @@ def test_recovery_descriptor_can_restart_root_behind_live_downstream_lease():
     assert unrelated_task.granted and not unrelated_task.liveness
     manager.update_allocation(
         _allocation(_r(store=20), generation=2),
-        admission_open=True,
     )
     retry = _task(
         root.resource_unit_id,
@@ -2322,7 +2321,7 @@ def test_recovery_descriptor_keeps_retiring_liveness_tokens_in_the_chain():
     )
     manager.update_allocation(
         _allocation(_r(), generation=2),
-        admission_open=True,
+        reopen_fence_epoch=manager.current_allocation_frontier()[1],
     )
     assert left_root.resource_unit_id not in manager.current_eligible_resource_unit_ids()
 


### PR DESCRIPTION
## Summary

- Update the FTE recovery tests to use the current allocation admission-fence API.
- Keep an ordinary allocation refresh from reopening admission, while explicitly acknowledging the current fence epoch after unit completion.
- Unblocks #605, whose non-Ray fast-test shard exposed the stale calls.

## Related issue

N/A — this is a small, self-contained test correction. Related: #605.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/run_installed_pytest.sh tests/fast/test_query_resource_manager.py::test_recovery_descriptor_can_restart_root_behind_live_downstream_lease tests/fast/test_query_resource_manager.py::test_recovery_descriptor_keeps_retiring_liveness_tokens_in_the_chain` — 2 passed.
- `scripts/run_installed_pytest.sh tests/fast/test_query_resource_manager.py` — 99 passed.
- `scripts/format root --changed --check` — passed.
- `pre-commit run --from-ref origin/main --to-ref HEAD` — passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.