### PR TITLE
[fix](ai) Bound local vLLM result waits by query deadlines

### DIFF
--- a/tests/fast/test_udf_executor_lifecycle.py
+++ b/tests/fast/test_udf_executor_lifecycle.py
@@ -709,6 +709,68 @@ def test_local_vllm_submit_fails_fast_when_engine_init_deadline_expires():
     assert ready.wait_calls == [pytest.approx(0.125)]
 
 
+def test_local_vllm_result_wait_uses_query_deadline(monkeypatch):
+    import vane.execution.vllm as vllm
+
+    class FakeCondition:
+        def __init__(self):
+            self.timeout = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def wait_for(self, predicate, timeout=None):
+            assert predicate() is False
+            self.timeout = timeout
+            return False
+
+    condition = FakeCondition()
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor._result_cv = condition
+    executor._wait_for_result_state = lambda _executor_id: (False, False)
+    monkeypatch.setattr(vllm.time, "time", lambda: 100.0)
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", "101.0")
+
+    with pytest.raises(TimeoutError, match="query deadline expired while waiting for vLLM result"):
+        executor.wait_for_result()
+
+    assert condition.timeout == pytest.approx(1.0)
+
+
+def test_local_vllm_result_wait_returns_buffered_result_without_rechecking_deadline(monkeypatch):
+    import vane.execution.vllm as vllm
+
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor._result_cv = threading.Condition()
+    executor._wait_for_result_state = lambda _executor_id: (True, False)
+    monkeypatch.setattr(vllm.time, "time", lambda: 100.0)
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", "99.0")
+
+    assert executor.wait_for_result() is True
+
+
+def test_local_vllm_result_wait_treats_shutdown_as_terminal():
+    import vane.execution.vllm as vllm
+
+    executor = vllm.LocalVLLMExecutor.__new__(vllm.LocalVLLMExecutor)
+    executor.completed_tasks = deque()
+    executor.error_message = None
+    executor._finished_submitting = True
+    executor._shutdown_called = True
+    executor.running_task_count = 1
+    executor._per_executor_deques = {}
+    executor._per_executor_running_task_count = {"executor": 1}
+    executor._per_executor_finished = set()
+    executor._per_executor_errors = {}
+    executor._per_executor_aborted = set()
+
+    assert executor._wait_for_result_state(None) == (False, True)
+    assert executor._wait_for_result_state("executor") == (False, True)
+
+
 def test_vllm_remote_submit_failure_rolls_back_inflight(monkeypatch):
     import vane.execution.vllm as vllm
 

--- a/tests/fast/test_vllm_native_regressions.py
+++ b/tests/fast/test_vllm_native_regressions.py
@@ -156,6 +156,68 @@ def _run_recording_sql(monkeypatch, prompts, options, *, executor=None, threads=
         con.close()
 
 
+def test_native_local_vllm_result_wait_honors_expired_query_deadline(monkeypatch):
+    import vane.execution.vllm as vllm
+
+    class DeadlineProbeCondition:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def wait_for(self, _predicate, timeout=None):
+            if timeout is None:
+                raise AssertionError("local result wait did not receive the query deadline")
+            return False
+
+        def notify_all(self) -> None:
+            pass
+
+    class StalledLocalExecutor(vllm.LocalVLLMExecutor):
+        def __init__(self) -> None:
+            self.submissions = []
+            self.completed_tasks = deque()
+            self.error_message = None
+            self.on_error = "raise"
+            self.running_task_count = 0
+            self.task_count_lock = threading.Lock()
+            self._result_cv = DeadlineProbeCondition()
+            self._finished_submitting = False
+            self._shutdown_called = False
+            self._per_executor_deques = {}
+            self._per_executor_running_task_count = {}
+            self._per_executor_finished = set()
+            self._per_executor_errors = {}
+            self._per_executor_aborted = set()
+            self._ensure_wakeup_state()
+
+        def submit(self, prefix, prompts, _rows) -> None:
+            prompt_values = tuple(prompts)
+            self.submissions.append((prefix, prompt_values))
+            with self.task_count_lock:
+                self.running_task_count += len(prompt_values)
+            self._notify_state_change(force=True)
+
+    executor = StalledLocalExecutor()
+    monkeypatch.setenv("VANE_QUERY_DEADLINE_EPOCH_S", "0")
+
+    with pytest.raises(Exception, match="query deadline expired before vLLM wait"):
+        _run_recording_sql(
+            monkeypatch,
+            ["alpha", "beta"],
+            {
+                "do_prefix_routing": False,
+                "batch_size": 1,
+                "inflight_limit": 1,
+            },
+            executor=executor,
+        )
+
+    assert executor.submissions == [(None, ("alpha",))]
+    assert executor._shutdown_called
+
+
 @pytest.mark.parametrize("do_prefix_routing", [False, True])
 def test_native_vllm_propagates_null_prompts_without_submitting_them(monkeypatch, do_prefix_routing):
     executor, rows = _run_recording_sql(

--- a/tests/fast/test_vllm_runtime_fixes.py
+++ b/tests/fast/test_vllm_runtime_fixes.py
@@ -423,6 +423,7 @@ def test_ray_actor_wait_raises_stored_executor_error():
     executor._per_executor_wait_tokens_observed = {}
     executor._async_waiter_lock = threading.Lock()
     executor._async_waiters = {}
+    executor._shutdown_called = False
     executor._notify_state_change = lambda **_kwargs: None
 
     with pytest.raises(RuntimeError, match="vllm task failed: sentinel request failure"):

--- a/vane/execution/vllm.py
+++ b/vane/execution/vllm.py
@@ -819,7 +819,13 @@ class LocalVLLMExecutor(VLLMExecutor):
 
     def _wait_for_result_blocking(self, executor_id: str | None = None) -> bool:
         with self._result_cv:
-            self._result_cv.wait_for(lambda: any(self._wait_for_result_state(executor_id)))
+            state = self._wait_for_result_state(executor_id)
+            if any(state):
+                return state[0]
+            timeout_s = _query_deadline_remaining_s()
+            ready = self._result_cv.wait_for(lambda: any(self._wait_for_result_state(executor_id)), timeout=timeout_s)
+            if not ready:
+                raise TimeoutError("query deadline expired while waiting for vLLM result")
             return self._wait_for_result_state(executor_id)[0]
 
     def _wait_for_result_state(self, executor_id: str | None) -> tuple[bool, bool]:
@@ -827,6 +833,8 @@ class LocalVLLMExecutor(VLLMExecutor):
             self._per_executor_deques.setdefault(executor_id, deque()) if executor_id else self.completed_tasks
         )
         has_result = bool(source_deque)
+        if self._shutdown_called:
+            return has_result, True
         if executor_id:
             terminal = (
                 executor_id in self._per_executor_errors


### PR DESCRIPTION
## Summary

`LocalVLLMExecutor.wait_for_result()` used an unbounded condition wait. When
local vLLM work stalled, native backpressure could remain blocked after the
query deadline, and shutdown notifications were not terminal while tasks
remained counted.

Bound the wait by the remaining query deadline, fail when it expires, and
treat shutdown as terminal while preserving already-buffered results. Add
unit and native SQL regression coverage.

## Related issue

close: #445

## Documentation impact

- [x] No user-facing documentation update is required.

This changes internal wait and cleanup behavior without changing the public API.

## Validation

- `scripts/format workspace --from-ref upstream/main --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Affected vLLM suites: 132 passed
- `scripts/run_release_tests.sh`: 549 passed, 4 skipped; real-Ray: 11 passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] No new dependencies, copied code, model assets, or datasets are added.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications have been considered.
- [x] This is a Python-only change and relevant checks passed.
