### PR TITLE
[fix](ray) Coordinate FTE query lifecycle teardown

### DIFF
--- a/src/vane_py/ray/CMakeLists.txt
+++ b/src/vane_py/ray/CMakeLists.txt
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build object library for ray Python glue
-add_library(python_ray OBJECT ray_module.cpp task.cpp worker.cpp
-                              worker_manager.cpp)
+add_library(python_ray OBJECT query_lifecycle_coordinator.cpp ray_module.cpp
+                              task.cpp worker.cpp worker_manager.cpp)
 
 target_include_directories(
   python_ray

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -1164,49 +1164,21 @@ public:
 	using DuckDBResult = duckdb::distributed::DuckDBResult<T>;
 	using DuckDBError = duckdb::distributed::DuckDBError;
 	using QueryCleanup = std::function<void(const string &)>;
+	using QueryLifecycleCoordinator = duckdb::distributed::python::ray::QueryLifecycleCoordinator;
 
 	explicit PyBackendWorkerManager(py::object backend, QueryCleanup query_cleanup)
-	    : backend_(std::move(backend)), query_cleanup_(std::move(query_cleanup)) {
+	    : backend_(std::move(backend)), query_cleanup_(std::move(query_cleanup)), query_lifecycles_("Python backend") {
 	}
 
 	void register_query_owner(const string &query_id, const string &owner_query_id,
 	                          const std::function<void(const py::error_already_set &)> &publish_registration_error = {},
 	                          bool *lifecycle_published = nullptr) {
+		auto registration = query_lifecycles_.BeginRegistration(query_id, owner_query_id);
 		if (lifecycle_published) {
-			*lifecycle_published = false;
+			*lifecycle_published = registration.publish;
 		}
-		if (query_id.empty() || owner_query_id.empty()) {
-			throw std::invalid_argument("FTE query ownership requires non-empty query and owner IDs");
-		}
-		{
-			lock_guard<mutex> guard(mutex_);
-			auto existing_owner = result_handle_owner_by_query_.find(query_id);
-			if (existing_owner != result_handle_owner_by_query_.end() && existing_owner->second != owner_query_id) {
-				throw std::runtime_error("FTE query result owner changed while active: query=" + query_id +
-				                         " existing=" + existing_owner->second + " requested=" + owner_query_id);
-			}
-			if (all_result_handle_ingress_closed_ ||
-			    closed_result_handle_queries_.find(query_id) != closed_result_handle_queries_.end() ||
-			    closed_result_handle_query_owners_.find(owner_query_id) != closed_result_handle_query_owners_.end() ||
-			    dropping_result_handle_query_owners_.find(owner_query_id) !=
-			        dropping_result_handle_query_owners_.end()) {
-				throw std::runtime_error("cannot register closing FTE query lifecycle: " + query_id);
-			}
-			if (registering_result_handle_owner_by_query_.find(query_id) !=
-			    registering_result_handle_owner_by_query_.end()) {
-				throw std::runtime_error("FTE query lifecycle registration is already in progress: " + query_id);
-			}
-			if (existing_owner != result_handle_owner_by_query_.end()) {
-				return;
-			}
-			// Publish the ownership edge before invoking Python. Abort and shutdown
-			// can resolve the resource owner immediately, but wait on the
-			// registration transition below before starting their sweep.
-			result_handle_owner_by_query_[query_id] = owner_query_id;
-			registering_result_handle_owner_by_query_[query_id] = owner_query_id;
-			if (lifecycle_published) {
-				*lifecycle_published = true;
-			}
+		if (!registration.publish) {
+			return;
 		}
 		try {
 			duckdb::PythonGILWrapper gil;
@@ -1221,30 +1193,16 @@ public:
 					publication_error = std::current_exception();
 				}
 			}
-			{
-				lock_guard<mutex> guard(mutex_);
-				closed_result_handle_query_owners_.insert(owner_query_id);
-				registering_result_handle_owner_by_query_.erase(query_id);
-			}
-			result_handle_condition_.notify_all();
+			query_lifecycles_.CompleteRegistration(registration, false);
 			if (publication_error) {
 				std::rethrow_exception(publication_error);
 			}
 			throw;
 		} catch (...) {
-			{
-				lock_guard<mutex> guard(mutex_);
-				closed_result_handle_query_owners_.insert(owner_query_id);
-				registering_result_handle_owner_by_query_.erase(query_id);
-			}
-			result_handle_condition_.notify_all();
+			query_lifecycles_.CompleteRegistration(registration, false);
 			throw;
 		}
-		{
-			lock_guard<mutex> guard(mutex_);
-			registering_result_handle_owner_by_query_.erase(query_id);
-		}
-		result_handle_condition_.notify_all();
+		query_lifecycles_.CompleteRegistration(registration, true);
 	}
 
 	DuckDBResult<std::vector<duckdb::distributed::WorkerSnapshot>> worker_snapshots() const override {
@@ -1283,9 +1241,15 @@ public:
 		if (!BeginResultHandleShutdown()) {
 			return DuckDBResult<void>::ok();
 		}
-		bool shutdown_succeeded = false;
-		PyBackendResultOperationGuard shutdown_guard(
-		    [this, &shutdown_succeeded]() { EndResultHandleShutdown(shutdown_succeeded); });
+		bool shutdown_completed = false;
+		PyBackendResultOperationGuard shutdown_guard([this, &shutdown_completed]() {
+			if (!shutdown_completed) {
+				try {
+					query_lifecycles_.FinishShutdown(false);
+				} catch (...) {
+				}
+			}
+		});
 		auto clear_handles = [&](const char *phase) -> std::optional<string> {
 			try {
 				ClearAllResultHandles();
@@ -1315,15 +1279,7 @@ public:
 		std::vector<string> owner_cleanup_errors;
 		std::vector<string> ordered_owner_query_ids;
 		if (!backend_shutdown_error && !final_cleanup_error) {
-			std::unordered_set<string> owner_query_ids;
-			{
-				lock_guard<mutex> guard(mutex_);
-				for (const auto &entry : result_handle_owner_by_query_) {
-					owner_query_ids.insert(entry.second);
-				}
-			}
-			ordered_owner_query_ids.assign(owner_query_ids.begin(), owner_query_ids.end());
-			std::sort(ordered_owner_query_ids.begin(), ordered_owner_query_ids.end());
+			ordered_owner_query_ids = query_lifecycles_.OwnerQueryIds();
 			for (const auto &owner_query_id : ordered_owner_query_ids) {
 				try {
 					query_cleanup_(owner_query_id);
@@ -1345,6 +1301,13 @@ public:
 		for (const auto &owner_cleanup_error : owner_cleanup_errors) {
 			errors.push_back("query owner cleanup: " + owner_cleanup_error);
 		}
+		{
+			lock_guard<mutex> guard(mutex_);
+			if (!result_handles_by_query_.empty() || !retained_result_handles_by_query_.empty() ||
+			    !cleanup_retry_result_handles_by_query_.empty()) {
+				errors.push_back("result cleanup left pending backend handles");
+			}
+		}
 		if (!errors.empty()) {
 			string message = "Python backend shutdown failed";
 			for (const auto &error : errors) {
@@ -1355,8 +1318,8 @@ public:
 		for (const auto &owner_query_id : ordered_owner_query_ids) {
 			submission_errors_.Discard(owner_query_id);
 		}
-		FinishResultHandleShutdown();
-		shutdown_succeeded = true;
+		query_lifecycles_.FinishShutdown(true);
+		shutdown_completed = true;
 		return DuckDBResult<void>::ok();
 	}
 
@@ -1385,7 +1348,7 @@ public:
 				    "FTE task submission rejected because its resource query is closing: " + submission_error_owner));
 			}
 			PyBackendResultOperationGuard operation(
-			    [this, owner = *active_owner]() { EndResultHandleOperation(owner); });
+			    [this, active = *active_owner]() { query_lifecycles_.EndOperation(active); });
 			try {
 				duckdb::PythonGILWrapper gil;
 				py::list py_tasks;
@@ -1395,17 +1358,17 @@ public:
 				}
 				auto backend = backend_.get();
 				py::object raw_handles = backend.attr("submit_tasks")(py_tasks);
-				StorePythonResultHandles(query_id, *active_owner, std::move(raw_handles));
+				StorePythonResultHandles(query_id, active_owner->lifecycle, std::move(raw_handles));
 				return DuckDBResult<void>::ok();
 			} catch (const py::error_already_set &e) {
 				// Keep exception publication inside the active-operation boundary so
 				// shutdown cannot clear the owner and then receive a late exception.
-				CloseResultHandleOwnerIngress(*active_owner);
-				submission_errors_.Store(*active_owner, e);
+				query_lifecycles_.Close(active_owner->lifecycle);
+				submission_errors_.Store(active_owner->lifecycle.owner_query_id, e);
 				return DuckDBResult<void>::err(
 				    DuckDBError(string("Python backend submit_fte_task_events failed: ") + e.what()));
 			} catch (const std::exception &e) {
-				CloseResultHandleOwnerIngress(*active_owner);
+				query_lifecycles_.Close(active_owner->lifecycle);
 				return DuckDBResult<void>::err(DuckDBError(string("submit_fte_task_events failed: ") + e.what()));
 			}
 		} catch (const py::error_already_set &e) {
@@ -1429,7 +1392,7 @@ public:
 				    DuckDBError::invalid_state_error("Python backend FTE query input stream is closing: " + query_id));
 			}
 			PyBackendResultOperationGuard operation(
-			    [this, owner = *active_owner]() { EndResultHandleOperation(owner); });
+			    [this, active = *active_owner]() { query_lifecycles_.EndOperation(active); });
 			duckdb::PythonGILWrapper gil;
 			py::list py_source_node_ids;
 			for (auto source_node_id : source_node_ids) {
@@ -1437,7 +1400,7 @@ public:
 			}
 			auto backend = backend_.get();
 			py::object raw_handles = backend.attr("task_input_stream_exhausted")(query_id, py_source_node_ids);
-			StorePythonResultHandles(query_id, *active_owner, std::move(raw_handles));
+			StorePythonResultHandles(query_id, active_owner->lifecycle, std::move(raw_handles));
 			return DuckDBResult<void>::ok();
 		} catch (const std::exception &e) {
 			return DuckDBResult<void>::err(
@@ -1458,7 +1421,7 @@ public:
 				    "Python backend FTE query materialization barrier is closing: " + query_id));
 			}
 			PyBackendResultOperationGuard operation(
-			    [this, owner = *active_owner]() { EndResultHandleOperation(owner); });
+			    [this, active = *active_owner]() { query_lifecycles_.EndOperation(active); });
 			duckdb::PythonGILWrapper gil;
 			auto backend = backend_.get();
 			backend.attr("materialization_barrier_completed")(query_id, std::to_string(node_id));
@@ -1494,7 +1457,8 @@ public:
 			return DuckDBResult<std::vector<duckdb::distributed::MaterializedOutput>>::err(
 			    DuckDBError::external_error("Python backend FTE query is closing: " + query_id));
 		}
-		PyBackendResultOperationGuard operation([this, owner = *active_owner]() { EndResultHandleOperation(owner); });
+		PyBackendResultOperationGuard operation(
+		    [this, active = *active_owner]() { query_lifecycles_.EndOperation(active); });
 
 		std::unordered_set<string> selected_attempt_task_ids;
 		const bool has_deadline = timeout_s > 0.0;
@@ -1599,72 +1563,13 @@ public:
 		if (query_id.empty()) {
 			return DuckDBResult<void>::err(DuckDBError::value_error("FTE query abort requires non-empty query_id"));
 		}
-		std::optional<ResultHandleQuiesce> active_quiesce;
 		try {
-			active_quiesce = BeginResultHandleQuiesce(query_id);
+			return ExecuteResultHandleAbort(BeginResultHandleAbort(query_id));
 		} catch (const std::exception &ex) {
 			return DuckDBResult<void>::err(DuckDBError::external_error(ex.what()));
 		} catch (...) {
 			return DuckDBResult<void>::err(
 			    DuckDBError::external_error("unknown error while starting Python backend resource query abort"));
-		}
-		if (!active_quiesce) {
-			return DuckDBResult<void>::ok();
-		}
-
-		bool succeeded = false;
-		PyBackendResultOperationGuard quiesce_guard(
-		    [&]() { EndResultHandleQuiesce(active_quiesce->owner_query_id, active_quiesce->token, succeeded); });
-		try {
-			std::vector<std::pair<string, std::exception_ptr>> backend_drop_errors;
-			auto drop_execution_queries = [&]() {
-				try {
-					duckdb::PythonGILWrapper gil;
-					auto backend = backend_.get();
-					auto drop_query = backend.attr("drop_query");
-					for (const auto &execution_query_id : active_quiesce->execution_query_ids) {
-						try {
-							drop_query(execution_query_id);
-						} catch (...) {
-							backend_drop_errors.emplace_back(execution_query_id, std::current_exception());
-						}
-					}
-				} catch (...) {
-					backend_drop_errors.emplace_back(active_quiesce->owner_query_id, std::current_exception());
-				}
-			};
-			drop_execution_queries();
-			if (backend_drop_errors.empty()) {
-				WaitForResultHandleOperations(active_quiesce->owner_query_id);
-				if (active_quiesce->had_active_operations) {
-					drop_execution_queries();
-				}
-			}
-			succeeded = backend_drop_errors.empty();
-			if (succeeded) {
-				return DuckDBResult<void>::ok();
-			}
-
-			auto exception_message = [](const std::exception_ptr &error) {
-				try {
-					std::rethrow_exception(error);
-				} catch (const std::exception &ex) {
-					return string(ex.what());
-				} catch (...) {
-					return string("unknown exception");
-				}
-			};
-			string message = "Python backend resource query abort barrier failed";
-			for (const auto &error : backend_drop_errors) {
-				message += "; " + error.first + "=" + exception_message(error.second);
-			}
-			return DuckDBResult<void>::err(DuckDBError::external_error(std::move(message)));
-		} catch (const std::exception &ex) {
-			return DuckDBResult<void>::err(DuckDBError::external_error(
-			    string("Python backend resource query abort orchestration failed: ") + ex.what()));
-		} catch (...) {
-			return DuckDBResult<void>::err(
-			    DuckDBError::external_error("Python backend resource query abort orchestration failed: unknown error"));
 		}
 	}
 
@@ -1672,81 +1577,60 @@ public:
 		if (query_id.empty()) {
 			return;
 		}
-		auto quiesce_res = abort_and_quiesce_query(query_id);
-		if (quiesce_res.is_err()) {
-			throw std::runtime_error(quiesce_res.error().what());
-		}
-		auto active_drop_owner = BeginResultHandleDrop(query_id);
-		if (!active_drop_owner) {
+		auto teardown = BeginResultHandleTeardown(query_id);
+		if (!teardown) {
 			return;
 		}
-		const auto owner_query_id = active_drop_owner->owner_query_id;
-		const auto drop_token = active_drop_owner->token;
-		PyBackendResultOperationGuard drop_guard(
-		    [this, owner_query_id, drop_token]() { EndResultHandleDrop(owner_query_id, drop_token); });
-		std::exception_ptr initial_cleanup_error;
-		std::exception_ptr final_cleanup_error;
-		std::exception_ptr owner_cleanup_error;
-		WaitForResultHandleOperations(owner_query_id);
 		try {
-			ClearResultHandlesForOwner(owner_query_id);
+			auto abort_res = ExecuteResultHandleAbort(BeginResultHandleAbort(*teardown));
+			if (abort_res.is_err()) {
+				throw std::runtime_error(abort_res.error().what());
+			}
+			query_lifecycles_.MarkDropping(*teardown);
+			std::exception_ptr initial_cleanup_error;
+			std::exception_ptr final_cleanup_error;
+			try {
+				ClearResultHandlesForLifecycle(*teardown);
+			} catch (...) {
+				initial_cleanup_error = std::current_exception();
+			}
+			if (initial_cleanup_error) {
+				try {
+					ClearResultHandlesForLifecycle(*teardown);
+				} catch (...) {
+					final_cleanup_error = std::current_exception();
+				}
+			}
+			if (final_cleanup_error) {
+				string message = "Python backend query result cleanup failed";
+				if (initial_cleanup_error) {
+					message += "; initial result cleanup=" + ExceptionMessage(initial_cleanup_error);
+				}
+				message += "; final result cleanup=" + ExceptionMessage(final_cleanup_error);
+				throw std::runtime_error(std::move(message));
+			}
+			if (LifecycleHasResultHandles(teardown->lifecycle)) {
+				throw std::runtime_error("cannot finish FTE query lifecycle with pending result cleanup: " +
+				                         teardown->lifecycle.owner_query_id);
+			}
+			query_cleanup_(teardown->lifecycle.owner_query_id);
+			submission_errors_.Discard(teardown->lifecycle.owner_query_id);
+			query_lifecycles_.CompleteTeardown(*teardown, std::nullopt);
 		} catch (...) {
-			initial_cleanup_error = std::current_exception();
-		}
-		if (initial_cleanup_error) {
+			auto failure = ExceptionMessage(std::current_exception());
 			try {
-				ClearResultHandlesForOwner(owner_query_id);
+				query_lifecycles_.CompleteTeardown(*teardown, failure);
+			} catch (const std::exception &ex) {
+				failure += "; lifecycle completion: " + string(ex.what());
 			} catch (...) {
-				final_cleanup_error = std::current_exception();
+				failure += "; lifecycle completion: unknown error";
 			}
+			throw std::runtime_error(std::move(failure));
 		}
-		if (!final_cleanup_error) {
-			try {
-				query_cleanup_(owner_query_id);
-			} catch (...) {
-				owner_cleanup_error = std::current_exception();
-			}
-		}
-		if (!final_cleanup_error && !owner_cleanup_error) {
-			submission_errors_.Discard(owner_query_id);
-			FinishResultHandleIngress(owner_query_id, drop_token);
-			return;
-		}
-		std::vector<std::pair<const char *, std::exception_ptr>> errors;
-		if (initial_cleanup_error && final_cleanup_error) {
-			errors.emplace_back("initial result cleanup", initial_cleanup_error);
-		}
-		if (final_cleanup_error) {
-			errors.emplace_back("final result cleanup", final_cleanup_error);
-		}
-		if (owner_cleanup_error) {
-			errors.emplace_back("query owner cleanup", owner_cleanup_error);
-		}
-		if (errors.size() == 1) {
-			std::rethrow_exception(errors.front().second);
-		}
-		auto exception_message = [](const std::exception_ptr &error) {
-			try {
-				std::rethrow_exception(error);
-			} catch (const std::exception &e) {
-				return string(e.what());
-			} catch (...) {
-				return string("unknown exception");
-			}
-		};
-		string message = "Python backend query teardown failed";
-		for (const auto &error : errors) {
-			message += string("; ") + error.first + "=" + exception_message(error.second);
-		}
-		throw std::runtime_error(std::move(message));
 	}
 
 	void rethrow_submission_error(const string &query_id, const string &details = string()) {
-		string owner_query_id;
-		{
-			lock_guard<mutex> guard(mutex_);
-			owner_query_id = ResultHandleOwnerForQueryLocked(query_id);
-		}
+		const auto owner_query_id = query_lifecycles_.OwnerForQuery(query_id);
 		auto message = string("distributed worker task submission failed for query_id=") + query_id;
 		if (!details.empty()) {
 			message += "; execution error: " + details;
@@ -1793,21 +1677,10 @@ public:
 	}
 
 private:
-	struct ResultHandleDrop {
-		string owner_query_id;
-		uint64_t token;
-	};
-	struct ResultHandleQuiesce {
-		string owner_query_id;
-		std::vector<string> execution_query_ids;
-		uint64_t token;
-		bool had_active_operations;
-	};
-
 	mutable mutex mutex_;
-	std::condition_variable result_handle_condition_;
 	duckdb::distributed::python::ray::SafePyObject backend_;
 	QueryCleanup query_cleanup_;
+	QueryLifecycleCoordinator query_lifecycles_;
 	duckdb::distributed::python::ray::PythonExceptionStore submission_errors_;
 	std::unordered_map<string, std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>>>
 	    result_handles_by_query_;
@@ -1815,20 +1688,6 @@ private:
 	    retained_result_handles_by_query_;
 	std::unordered_map<string, std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>>>
 	    cleanup_retry_result_handles_by_query_;
-	std::unordered_map<string, string> result_handle_owner_by_query_;
-	std::unordered_map<string, string> registering_result_handle_owner_by_query_;
-	std::unordered_map<string, idx_t> active_result_handle_operations_by_owner_;
-	std::unordered_set<string> closed_result_handle_queries_;
-	std::unordered_set<string> closed_result_handle_query_owners_;
-	std::unordered_set<string> quiesced_result_handle_query_owners_;
-	std::unordered_map<string, uint64_t> quiescing_result_handle_query_owners_;
-	std::unordered_map<string, idx_t> result_handle_quiesce_waiters_by_owner_;
-	std::unordered_map<string, uint64_t> dropping_result_handle_query_owners_;
-	uint64_t next_result_handle_quiesce_token_ = 1;
-	uint64_t next_result_handle_drop_token_ = 1;
-	bool all_result_handle_ingress_closed_ = false;
-	bool result_handle_shutdown_running_ = false;
-	bool result_handle_shutdown_finished_ = false;
 
 	static string QueryIdFromTaskEvents(const std::vector<duckdb::distributed::WorkerTask> &tasks) {
 		std::string query_id;
@@ -1849,414 +1708,133 @@ private:
 		return query_id;
 	}
 
-	string ResultHandleOwnerForQueryLocked(const string &query_id) const {
-		auto owner = result_handle_owner_by_query_.find(query_id);
-		return owner == result_handle_owner_by_query_.end() ? query_id : owner->second;
-	}
-
-	void CloseResultHandleOwnerIngress(const string &owner_query_id) {
-		{
-			lock_guard<mutex> guard(mutex_);
-			closed_result_handle_query_owners_.insert(owner_query_id);
-		}
-		result_handle_condition_.notify_all();
-	}
-
-	std::optional<ResultHandleQuiesce> BeginResultHandleQuiesceWithoutGIL(const string &query_id) {
-		std::unique_lock<mutex> guard(mutex_);
-		auto mapped_owner = result_handle_owner_by_query_.find(query_id);
-		auto registering_owner = registering_result_handle_owner_by_query_.find(query_id);
-		string owner_query_id;
-		if (mapped_owner != result_handle_owner_by_query_.end()) {
-			owner_query_id = mapped_owner->second;
-		} else if (registering_owner != registering_result_handle_owner_by_query_.end()) {
-			owner_query_id = registering_owner->second;
-		} else {
-			const bool known_owner =
-			    std::any_of(result_handle_owner_by_query_.begin(), result_handle_owner_by_query_.end(),
-			                [&](const auto &entry) { return entry.second == query_id; }) ||
-			    std::any_of(registering_result_handle_owner_by_query_.begin(),
-			                registering_result_handle_owner_by_query_.end(),
-			                [&](const auto &entry) { return entry.second == query_id; });
-			if (!known_owner) {
-				return std::nullopt;
-			}
-			owner_query_id = query_id;
-		}
-
-		while (true) {
-			auto active_quiesce = quiescing_result_handle_query_owners_.find(owner_query_id);
-			if (active_quiesce == quiescing_result_handle_query_owners_.end()) {
-				break;
-			}
-			const auto active_token = active_quiesce->second;
-			result_handle_quiesce_waiters_by_owner_[owner_query_id]++;
-			result_handle_condition_.wait(guard, [&]() {
-				auto current = quiescing_result_handle_query_owners_.find(owner_query_id);
-				return current == quiescing_result_handle_query_owners_.end() || current->second != active_token;
-			});
-			auto waiter = result_handle_quiesce_waiters_by_owner_.find(owner_query_id);
-			D_ASSERT(waiter != result_handle_quiesce_waiters_by_owner_.end());
-			D_ASSERT(waiter->second > 0);
-			if (--waiter->second == 0) {
-				result_handle_quiesce_waiters_by_owner_.erase(waiter);
-			}
-			result_handle_condition_.notify_all();
-			if (quiesced_result_handle_query_owners_.find(owner_query_id) !=
-			    quiesced_result_handle_query_owners_.end()) {
-				return std::nullopt;
-			}
-		}
-		if (quiesced_result_handle_query_owners_.find(owner_query_id) != quiesced_result_handle_query_owners_.end()) {
-			return std::nullopt;
-		}
-		if (all_result_handle_ingress_closed_) {
-			while (result_handle_shutdown_running_) {
-				result_handle_condition_.wait(guard);
-			}
-			if (result_handle_shutdown_finished_) {
-				return std::nullopt;
-			}
-			throw std::runtime_error("cannot abort FTE query after Python backend shutdown failed: " + query_id);
-		}
-
-		closed_result_handle_queries_.insert(query_id);
-		closed_result_handle_query_owners_.insert(owner_query_id);
-		const auto token = next_result_handle_quiesce_token_++;
-		if (next_result_handle_quiesce_token_ == 0) {
-			next_result_handle_quiesce_token_ = 1;
-		}
-		quiescing_result_handle_query_owners_[owner_query_id] = token;
-		auto owner_registration_in_progress = [&]() {
-			return std::any_of(
-			    registering_result_handle_owner_by_query_.begin(), registering_result_handle_owner_by_query_.end(),
-			    [&](const auto &entry) { return entry.first == owner_query_id || entry.second == owner_query_id; });
-		};
-		result_handle_condition_.wait(guard, [&]() { return !owner_registration_in_progress(); });
-		const bool had_active_operations = active_result_handle_operations_by_owner_.find(owner_query_id) !=
-		                                   active_result_handle_operations_by_owner_.end();
-		auto query_ids = ResultHandleQueryIdsForOwnerLocked(owner_query_id);
-		std::vector<string> ordered_query_ids(query_ids.begin(), query_ids.end());
-		std::sort(ordered_query_ids.begin(), ordered_query_ids.end(), [&](const string &lhs, const string &rhs) {
-			if ((lhs == owner_query_id) != (rhs == owner_query_id)) {
-				return lhs != owner_query_id;
-			}
-			return lhs < rhs;
-		});
-		return ResultHandleQuiesce {owner_query_id, std::move(ordered_query_ids), token, had_active_operations};
-	}
-
-	std::optional<ResultHandleQuiesce> BeginResultHandleQuiesce(const string &query_id) {
+	std::optional<QueryLifecycleCoordinator::Abort> BeginResultHandleAbort(const string &query_id) {
 		if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
 			py::gil_scoped_release release;
-			return BeginResultHandleQuiesceWithoutGIL(query_id);
+			return query_lifecycles_.BeginAbort(query_id);
 		}
-		return BeginResultHandleQuiesceWithoutGIL(query_id);
+		return query_lifecycles_.BeginAbort(query_id);
 	}
 
-	void EndResultHandleQuiesce(const string &owner_query_id, uint64_t token, bool succeeded) {
-		{
-			lock_guard<mutex> guard(mutex_);
-			auto current = quiescing_result_handle_query_owners_.find(owner_query_id);
-			if (current != quiescing_result_handle_query_owners_.end() && current->second == token) {
-				quiescing_result_handle_query_owners_.erase(current);
-				if (succeeded) {
-					quiesced_result_handle_query_owners_.insert(owner_query_id);
-				}
-			}
-		}
-		result_handle_condition_.notify_all();
-	}
-
-	std::optional<string> BeginResultHandleOperation(const string &query_id,
-	                                                 const string &requested_owner_query_id = string()) {
-		if (query_id.empty()) {
-			throw std::invalid_argument("result-handle operation requires non-empty query_id");
-		}
-		lock_guard<mutex> guard(mutex_);
-		auto existing_owner = result_handle_owner_by_query_.find(query_id);
-		if (existing_owner == result_handle_owner_by_query_.end()) {
-			return std::nullopt;
-		}
-		const auto owner_query_id =
-		    requested_owner_query_id.empty() ? existing_owner->second : requested_owner_query_id;
-		if (owner_query_id.empty()) {
-			throw std::invalid_argument("result-handle operation requires non-empty owner query_id");
-		}
-		if (existing_owner->second != owner_query_id) {
-			throw std::runtime_error("FTE query result owner changed while active: query=" + query_id +
-			                         " existing=" + existing_owner->second + " requested=" + owner_query_id);
-		}
-		if (all_result_handle_ingress_closed_ ||
-		    closed_result_handle_queries_.find(query_id) != closed_result_handle_queries_.end() ||
-		    closed_result_handle_query_owners_.find(owner_query_id) != closed_result_handle_query_owners_.end() ||
-		    dropping_result_handle_query_owners_.find(owner_query_id) != dropping_result_handle_query_owners_.end()) {
-			return std::nullopt;
-		}
-		result_handle_owner_by_query_[query_id] = owner_query_id;
-		active_result_handle_operations_by_owner_[owner_query_id]++;
-		return owner_query_id;
-	}
-
-	void EndResultHandleOperation(const string &owner_query_id) {
-		{
-			lock_guard<mutex> guard(mutex_);
-			auto active = active_result_handle_operations_by_owner_.find(owner_query_id);
-			D_ASSERT(active != active_result_handle_operations_by_owner_.end());
-			D_ASSERT(active->second > 0);
-			if (--active->second == 0) {
-				active_result_handle_operations_by_owner_.erase(active);
-			}
-		}
-		result_handle_condition_.notify_all();
-	}
-
-	void WaitForResultHandleOperationsWithoutGIL(const string &owner_query_id) {
-		std::unique_lock<mutex> guard(mutex_);
-		result_handle_condition_.wait(guard, [&]() {
-			return active_result_handle_operations_by_owner_.find(owner_query_id) ==
-			       active_result_handle_operations_by_owner_.end();
-		});
-	}
-
-	void WaitForResultHandleOperations(const string &owner_query_id) {
+	std::optional<QueryLifecycleCoordinator::Abort>
+	BeginResultHandleAbort(const QueryLifecycleCoordinator::Teardown &teardown) {
 		if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
 			py::gil_scoped_release release;
-			WaitForResultHandleOperationsWithoutGIL(owner_query_id);
+			return query_lifecycles_.BeginAbort(teardown);
+		}
+		return query_lifecycles_.BeginAbort(teardown);
+	}
+
+	std::optional<QueryLifecycleCoordinator::Operation>
+	BeginResultHandleOperation(const string &query_id, const string &requested_owner_query_id = string()) {
+		return query_lifecycles_.BeginOperation(query_id, requested_owner_query_id, false);
+	}
+
+	void WaitForResultHandleOperations(const QueryLifecycleCoordinator::LifecycleRef &lifecycle) {
+		if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
+			py::gil_scoped_release release;
+			query_lifecycles_.WaitForOperations(lifecycle);
 			return;
 		}
-		WaitForResultHandleOperationsWithoutGIL(owner_query_id);
-	}
-
-	void WaitForAllResultHandleOperationsWithoutGIL() {
-		std::unique_lock<mutex> guard(mutex_);
-		result_handle_condition_.wait(guard, [&]() { return active_result_handle_operations_by_owner_.empty(); });
+		query_lifecycles_.WaitForOperations(lifecycle);
 	}
 
 	void WaitForAllResultHandleOperations() {
 		if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
 			py::gil_scoped_release release;
-			WaitForAllResultHandleOperationsWithoutGIL();
+			query_lifecycles_.WaitForAllOperations();
 			return;
 		}
-		WaitForAllResultHandleOperationsWithoutGIL();
+		query_lifecycles_.WaitForAllOperations();
 	}
 
-	std::unordered_set<string> ResultHandleQueryIdsForOwnerLocked(const string &owner_query_id) const {
-		std::unordered_set<string> query_ids {owner_query_id};
-		for (const auto &entry : result_handle_owner_by_query_) {
-			if (entry.second == owner_query_id) {
-				query_ids.insert(entry.first);
-			}
-		}
-		auto collect_owned_keys = [&](const auto &handles_by_query) {
-			for (const auto &entry : handles_by_query) {
-				if (ResultHandleOwnerForQueryLocked(entry.first) == owner_query_id) {
-					query_ids.insert(entry.first);
-				}
-			}
-		};
-		collect_owned_keys(result_handles_by_query_);
-		collect_owned_keys(retained_result_handles_by_query_);
-		collect_owned_keys(cleanup_retry_result_handles_by_query_);
-		return query_ids;
-	}
-
-	bool ResultHandleOwnerHasHandlesLocked(const string &owner_query_id) const {
-		auto has_owned_handles = [&](const auto &handles_by_query) {
-			for (const auto &entry : handles_by_query) {
-				if (!entry.second.empty() && ResultHandleOwnerForQueryLocked(entry.first) == owner_query_id) {
-					return true;
-				}
-			}
-			return false;
-		};
-		return has_owned_handles(result_handles_by_query_) || has_owned_handles(retained_result_handles_by_query_) ||
-		       has_owned_handles(cleanup_retry_result_handles_by_query_);
-	}
-
-	std::optional<ResultHandleDrop> BeginResultHandleDropWithoutGIL(const string &query_id) {
-		std::unique_lock<mutex> guard(mutex_);
-		auto registration_in_progress = [&]() {
-			return std::any_of(registering_result_handle_owner_by_query_.begin(),
-			                   registering_result_handle_owner_by_query_.end(),
-			                   [&](const auto &entry) { return entry.first == query_id || entry.second == query_id; });
-		};
-		result_handle_condition_.wait(guard, [&]() { return !registration_in_progress(); });
-		auto mapped_owner = result_handle_owner_by_query_.find(query_id);
-		string owner_query_id;
-		if (mapped_owner != result_handle_owner_by_query_.end()) {
-			owner_query_id = mapped_owner->second;
-		} else {
-			const bool known_owner =
-			    std::any_of(result_handle_owner_by_query_.begin(), result_handle_owner_by_query_.end(),
-			                [&](const auto &entry) { return entry.second == query_id; });
-			if (!known_owner &&
-			    dropping_result_handle_query_owners_.find(query_id) == dropping_result_handle_query_owners_.end()) {
-				return std::nullopt;
-			}
-			owner_query_id = query_id;
-		}
-		auto owner_registration_in_progress = [&]() {
-			return std::any_of(
-			    registering_result_handle_owner_by_query_.begin(), registering_result_handle_owner_by_query_.end(),
-			    [&](const auto &entry) { return entry.first == owner_query_id || entry.second == owner_query_id; });
-		};
-		result_handle_condition_.wait(guard, [&]() { return !owner_registration_in_progress(); });
-		result_handle_condition_.wait(guard, [&]() {
-			return result_handle_quiesce_waiters_by_owner_.find(owner_query_id) ==
-			       result_handle_quiesce_waiters_by_owner_.end();
-		});
-		auto joined_drop = dropping_result_handle_query_owners_.find(owner_query_id);
-		if (joined_drop != dropping_result_handle_query_owners_.end()) {
-			const auto joined_drop_token = joined_drop->second;
-			result_handle_condition_.wait(guard, [&]() {
-				auto current = dropping_result_handle_query_owners_.find(owner_query_id);
-				return current == dropping_result_handle_query_owners_.end() || current->second != joined_drop_token;
-			});
-			if (closed_result_handle_query_owners_.find(owner_query_id) == closed_result_handle_query_owners_.end()) {
-				return std::nullopt;
-			}
-			if (dropping_result_handle_query_owners_.find(owner_query_id) !=
-			    dropping_result_handle_query_owners_.end()) {
-				return std::nullopt;
-			}
-		}
-		if (all_result_handle_ingress_closed_) {
-			while (result_handle_shutdown_running_) {
-				result_handle_condition_.wait(guard);
-			}
-			if (result_handle_shutdown_finished_) {
-				return std::nullopt;
-			}
-			throw std::runtime_error("cannot drop FTE query after Python backend shutdown failed: " + query_id);
-		}
-		if (quiesced_result_handle_query_owners_.find(owner_query_id) == quiesced_result_handle_query_owners_.end()) {
-			throw std::runtime_error("cannot drop FTE query before its abort barrier: " + query_id);
-		}
-		closed_result_handle_queries_.insert(query_id);
-		closed_result_handle_query_owners_.insert(owner_query_id);
-		const auto drop_token = next_result_handle_drop_token_++;
-		if (next_result_handle_drop_token_ == 0) {
-			next_result_handle_drop_token_ = 1;
-		}
-		dropping_result_handle_query_owners_[owner_query_id] = drop_token;
-		return ResultHandleDrop {owner_query_id, drop_token};
-	}
-
-	std::optional<ResultHandleDrop> BeginResultHandleDrop(const string &query_id) {
+	std::optional<QueryLifecycleCoordinator::Teardown> BeginResultHandleTeardown(const string &query_id) {
 		if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
 			py::gil_scoped_release release;
-			return BeginResultHandleDropWithoutGIL(query_id);
+			return query_lifecycles_.BeginTeardown(query_id);
 		}
-		return BeginResultHandleDropWithoutGIL(query_id);
-	}
-
-	void EndResultHandleDrop(const string &owner_query_id, uint64_t drop_token) {
-		{
-			lock_guard<mutex> guard(mutex_);
-			auto current = dropping_result_handle_query_owners_.find(owner_query_id);
-			if (current != dropping_result_handle_query_owners_.end() && current->second == drop_token) {
-				dropping_result_handle_query_owners_.erase(current);
-			}
-		}
-		result_handle_condition_.notify_all();
-	}
-
-	bool BeginResultHandleShutdownWithoutGIL() {
-		std::unique_lock<mutex> guard(mutex_);
-		while (result_handle_shutdown_running_) {
-			result_handle_condition_.wait(guard);
-		}
-		if (result_handle_shutdown_finished_) {
-			return false;
-		}
-		all_result_handle_ingress_closed_ = true;
-		result_handle_shutdown_running_ = true;
-		result_handle_condition_.wait(guard, [&]() {
-			return registering_result_handle_owner_by_query_.empty() && quiescing_result_handle_query_owners_.empty() &&
-			       result_handle_quiesce_waiters_by_owner_.empty() && dropping_result_handle_query_owners_.empty();
-		});
-		return true;
+		return query_lifecycles_.BeginTeardown(query_id);
 	}
 
 	bool BeginResultHandleShutdown() {
 		if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
 			py::gil_scoped_release release;
-			return BeginResultHandleShutdownWithoutGIL();
+			return query_lifecycles_.BeginShutdown();
 		}
-		return BeginResultHandleShutdownWithoutGIL();
+		return query_lifecycles_.BeginShutdown();
 	}
 
-	void EndResultHandleShutdown(bool succeeded) {
-		{
-			lock_guard<mutex> guard(mutex_);
-			result_handle_shutdown_finished_ = succeeded;
-			result_handle_shutdown_running_ = false;
+	static string ExceptionMessage(const std::exception_ptr &error) {
+		try {
+			std::rethrow_exception(error);
+		} catch (const std::exception &ex) {
+			return ex.what();
+		} catch (...) {
+			return "unknown exception";
 		}
-		result_handle_condition_.notify_all();
 	}
 
-	void FinishResultHandleIngress(const string &owner_query_id, uint64_t drop_token) {
-		{
-			lock_guard<mutex> guard(mutex_);
-			auto current_drop = dropping_result_handle_query_owners_.find(owner_query_id);
-			if (current_drop == dropping_result_handle_query_owners_.end() || current_drop->second != drop_token) {
-				throw std::runtime_error("cannot finish stale FTE query result drop: " + owner_query_id);
-			}
-			if (active_result_handle_operations_by_owner_.find(owner_query_id) !=
-			    active_result_handle_operations_by_owner_.end()) {
-				throw std::runtime_error("cannot finish active FTE query result lifecycle: " + owner_query_id);
-			}
-			if (ResultHandleOwnerHasHandlesLocked(owner_query_id)) {
-				throw std::runtime_error("cannot finish FTE query lifecycle with pending result cleanup: " +
-				                         owner_query_id);
-			}
-			if (quiesced_result_handle_query_owners_.find(owner_query_id) ==
-			    quiesced_result_handle_query_owners_.end()) {
-				throw std::runtime_error("cannot finish FTE query lifecycle before quiescence: " + owner_query_id);
-			}
-			if (result_handle_quiesce_waiters_by_owner_.find(owner_query_id) !=
-			    result_handle_quiesce_waiters_by_owner_.end()) {
-				throw std::runtime_error("cannot finish FTE query lifecycle with active abort waiters: " +
-				                         owner_query_id);
-			}
-			std::unordered_set<string> owned_query_ids {owner_query_id};
-			for (auto entry = result_handle_owner_by_query_.begin(); entry != result_handle_owner_by_query_.end();) {
-				if (entry->second == owner_query_id) {
-					owned_query_ids.insert(entry->first);
-					entry = result_handle_owner_by_query_.erase(entry);
-				} else {
-					++entry;
+	DuckDBResult<void> ExecuteResultHandleAbort(std::optional<QueryLifecycleCoordinator::Abort> active_abort) {
+		if (!active_abort) {
+			return DuckDBResult<void>::ok();
+		}
+
+		std::optional<string> failure;
+		try {
+			std::vector<std::pair<string, std::exception_ptr>> backend_drop_errors;
+			auto drop_execution_queries = [&]() {
+				try {
+					duckdb::PythonGILWrapper gil;
+					auto backend = backend_.get();
+					auto drop_query = backend.attr("drop_query");
+					for (const auto &execution_query_id : active_abort->execution_query_ids) {
+						try {
+							drop_query(execution_query_id);
+						} catch (...) {
+							backend_drop_errors.emplace_back(execution_query_id, std::current_exception());
+						}
+					}
+				} catch (...) {
+					backend_drop_errors.emplace_back(active_abort->lifecycle.owner_query_id, std::current_exception());
+				}
+			};
+			drop_execution_queries();
+			if (backend_drop_errors.empty()) {
+				WaitForResultHandleOperations(active_abort->lifecycle);
+				if (active_abort->had_active_operations) {
+					drop_execution_queries();
 				}
 			}
-			for (const auto &query_id : owned_query_ids) {
-				closed_result_handle_queries_.erase(query_id);
+			if (!backend_drop_errors.empty()) {
+				failure = "Python backend resource query abort barrier failed";
+				for (const auto &error : backend_drop_errors) {
+					*failure += "; " + error.first + "=" + ExceptionMessage(error.second);
+				}
 			}
-			closed_result_handle_query_owners_.erase(owner_query_id);
-			quiesced_result_handle_query_owners_.erase(owner_query_id);
-			dropping_result_handle_query_owners_.erase(current_drop);
+		} catch (const std::exception &ex) {
+			failure = string("Python backend resource query abort orchestration failed: ") + ex.what();
+		} catch (...) {
+			failure = "Python backend resource query abort orchestration failed: unknown error";
 		}
-		result_handle_condition_.notify_all();
-	}
-
-	void FinishResultHandleShutdown() {
-		lock_guard<mutex> guard(mutex_);
-		if (!registering_result_handle_owner_by_query_.empty() || !quiescing_result_handle_query_owners_.empty() ||
-		    !result_handle_quiesce_waiters_by_owner_.empty() || !dropping_result_handle_query_owners_.empty()) {
-			throw std::runtime_error("cannot finish Python backend shutdown with active lifecycle transitions");
+		try {
+			query_lifecycles_.CompleteAbort(*active_abort, failure);
+		} catch (const std::exception &ex) {
+			if (failure) {
+				*failure += "; lifecycle completion: " + string(ex.what());
+			} else {
+				failure = string("Python backend abort lifecycle completion failed: ") + ex.what();
+			}
+		} catch (...) {
+			if (failure) {
+				*failure += "; lifecycle completion: unknown error";
+			} else {
+				failure = "Python backend abort lifecycle completion failed: unknown error";
+			}
 		}
-		if (!active_result_handle_operations_by_owner_.empty()) {
-			throw std::runtime_error("cannot finish Python backend shutdown with active result operations");
+		if (failure) {
+			return DuckDBResult<void>::err(DuckDBError::external_error(std::move(*failure)));
 		}
-		if (!result_handles_by_query_.empty() || !retained_result_handles_by_query_.empty() ||
-		    !cleanup_retry_result_handles_by_query_.empty()) {
-			throw std::runtime_error("cannot finish Python backend shutdown with pending result cleanup");
-		}
-		result_handle_owner_by_query_.clear();
-		closed_result_handle_queries_.clear();
-		closed_result_handle_query_owners_.clear();
-		quiesced_result_handle_query_owners_.clear();
+		return DuckDBResult<void>::ok();
 	}
 
 	static string PyStringField(const py::dict &dict, const char *field_name, const string &default_value) {
@@ -2347,7 +1925,8 @@ private:
 		return selected;
 	}
 
-	void StorePythonResultHandles(const string &query_id, const string &owner_query_id, py::object raw_handles) {
+	void StorePythonResultHandles(const string &query_id, const QueryLifecycleCoordinator::LifecycleRef &lifecycle,
+	                              py::object raw_handles) {
 		if (query_id.empty() || raw_handles.is_none()) {
 			return;
 		}
@@ -2360,12 +1939,9 @@ private:
 		if (wrapped.empty()) {
 			return;
 		}
-		bool query_closed = false;
+		const bool query_closed = query_lifecycles_.IsClosing(lifecycle);
 		{
 			lock_guard<mutex> guard(mutex_);
-			query_closed =
-			    all_result_handle_ingress_closed_ ||
-			    closed_result_handle_query_owners_.find(owner_query_id) != closed_result_handle_query_owners_.end();
 			if (!query_closed) {
 				auto &stored = result_handles_by_query_[query_id];
 				stored.reserve(stored.size() + wrapped.size());
@@ -2385,13 +1961,9 @@ private:
 		if (query_id.empty() || handles.empty()) {
 			return;
 		}
-		bool query_closed = false;
+		const bool query_closed = query_lifecycles_.IsQueryClosing(query_id);
 		{
 			lock_guard<mutex> guard(mutex_);
-			const auto owner_query_id = ResultHandleOwnerForQueryLocked(query_id);
-			query_closed =
-			    all_result_handle_ingress_closed_ ||
-			    closed_result_handle_query_owners_.find(owner_query_id) != closed_result_handle_query_owners_.end();
 			if (!query_closed) {
 				auto &stored = result_handles_by_query_[query_id];
 				stored.reserve(stored.size() + handles.size());
@@ -2468,13 +2040,9 @@ private:
 		std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>> handles;
 		std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>> retained_handles;
 		std::vector<std::unique_ptr<duckdb::distributed::python::ray::PythonTaskResultHandle>> cleanup_retry_handles;
-		bool query_closed = false;
+		const bool query_closed = query_lifecycles_.IsQueryClosing(query_id);
 		{
 			lock_guard<mutex> guard(mutex_);
-			const auto owner_query_id = ResultHandleOwnerForQueryLocked(query_id);
-			query_closed =
-			    all_result_handle_ingress_closed_ ||
-			    closed_result_handle_query_owners_.find(owner_query_id) != closed_result_handle_query_owners_.end();
 			auto it = result_handles_by_query_.find(query_id);
 			if (it != result_handles_by_query_.end()) {
 				handles = std::move(it->second);
@@ -2523,14 +2091,9 @@ private:
 		}
 	}
 
-	void ClearResultHandlesForOwner(const string &owner_query_id) {
-		std::unordered_set<string> query_ids;
-		{
-			lock_guard<mutex> guard(mutex_);
-			query_ids = ResultHandleQueryIdsForOwnerLocked(owner_query_id);
-		}
+	void ClearResultHandlesForLifecycle(const QueryLifecycleCoordinator::Teardown &teardown) {
 		std::vector<string> errors;
-		for (const auto &query_id : query_ids) {
+		for (const auto &query_id : teardown.execution_query_ids) {
 			try {
 				ClearResultHandles(query_id);
 			} catch (const std::exception &ex) {
@@ -2540,12 +2103,30 @@ private:
 			}
 		}
 		if (!errors.empty()) {
-			string message = "failed to clear Python backend result handles for owner " + owner_query_id;
+			string message =
+			    "failed to clear Python backend result handles for owner " + teardown.lifecycle.owner_query_id;
 			for (const auto &error : errors) {
 				message += "; " + error;
 			}
 			throw std::runtime_error(message);
 		}
+	}
+
+	bool LifecycleHasResultHandles(const QueryLifecycleCoordinator::LifecycleRef &lifecycle) const {
+		const auto query_ids = query_lifecycles_.QueryIds(lifecycle);
+		lock_guard<mutex> guard(mutex_);
+		auto has_handles = [&](const auto &handles_by_query, const string &query_id) {
+			auto entry = handles_by_query.find(query_id);
+			return entry != handles_by_query.end() && !entry->second.empty();
+		};
+		for (const auto &query_id : query_ids) {
+			if (has_handles(result_handles_by_query_, query_id) ||
+			    has_handles(retained_result_handles_by_query_, query_id) ||
+			    has_handles(cleanup_retry_result_handles_by_query_, query_id)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	void ClearAllResultHandles() {

--- a/src/vane_py/ray/query_lifecycle_coordinator.cpp
+++ b/src/vane_py/ray/query_lifecycle_coordinator.cpp
@@ -324,14 +324,18 @@ std::vector<std::string> QueryLifecycleCoordinator::OwnerQueryIds() const {
 	return owners;
 }
 
-bool QueryLifecycleCoordinator::WaitForShutdownLocked(std::unique_lock<std::mutex> &guard, const std::string &query_id,
-                                                      const char *operation) const {
+void QueryLifecycleCoordinator::EnsureTransitionAllowedLocked(const std::string &query_id,
+                                                              const char *operation) const {
 	if (!shutdown_started_) {
-		return true;
+		return;
 	}
-	condition_.wait(guard, [&]() { return !shutdown_running_; });
 	if (shutdown_finished_) {
-		return false;
+		throw std::runtime_error("cannot " + std::string(operation) + " FTE query after " + component_name_ +
+		                         " shutdown: " + query_id);
+	}
+	if (shutdown_running_) {
+		throw std::runtime_error("cannot " + std::string(operation) + " FTE query while " + component_name_ +
+		                         " is shutting down: " + query_id);
 	}
 	throw std::runtime_error("cannot " + std::string(operation) + " FTE query after " + component_name_ +
 	                         " shutdown failed: " + query_id);
@@ -396,9 +400,7 @@ std::optional<QueryLifecycleCoordinator::Abort> QueryLifecycleCoordinator::Begin
 	if (lifecycle->abort_attempt) {
 		return BeginAbortLocked(guard, lifecycle);
 	}
-	if (!WaitForShutdownLocked(guard, query_id, "abort")) {
-		return std::nullopt;
-	}
+	EnsureTransitionAllowedLocked(query_id, "abort");
 	return BeginAbortLocked(guard, lifecycle);
 }
 
@@ -445,9 +447,7 @@ QueryLifecycleCoordinator::BeginTeardown(const std::string &query_id) {
 		}
 		return std::nullopt;
 	}
-	if (!WaitForShutdownLocked(guard, query_id, "tear down")) {
-		return std::nullopt;
-	}
+	EnsureTransitionAllowedLocked(query_id, "tear down");
 	if (lifecycle->phase == Phase::OPEN) {
 		lifecycle->phase = Phase::CLOSING;
 	}

--- a/src/vane_py/ray/query_lifecycle_coordinator.cpp
+++ b/src/vane_py/ray/query_lifecycle_coordinator.cpp
@@ -1,0 +1,575 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "query_lifecycle_coordinator.hpp"
+
+#include <algorithm>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+
+namespace duckdb {
+namespace distributed {
+namespace python {
+namespace ray {
+
+QueryLifecycleCoordinator::QueryLifecycleCoordinator(std::string component_name)
+    : component_name_(std::move(component_name)) {
+	if (component_name_.empty()) {
+		throw std::invalid_argument("query lifecycle component name must not be empty");
+	}
+}
+
+uint64_t QueryLifecycleCoordinator::NextToken(uint64_t &counter) {
+	const auto token = counter++;
+	if (counter == 0) {
+		counter = 1;
+	}
+	return token;
+}
+
+bool QueryLifecycleCoordinator::SameLifecycle(const LifecycleRef &lhs, const LifecycleRef &rhs) {
+	return lhs.owner_query_id == rhs.owner_query_id && lhs.generation == rhs.generation;
+}
+
+std::vector<std::string> QueryLifecycleCoordinator::OrderedQueryIds(const LifecycleState &lifecycle) {
+	std::vector<std::string> query_ids(lifecycle.query_ids.begin(), lifecycle.query_ids.end());
+	std::sort(query_ids.begin(), query_ids.end(), [&](const std::string &lhs, const std::string &rhs) {
+		if ((lhs == lifecycle.ref.owner_query_id) != (rhs == lifecycle.ref.owner_query_id)) {
+			return lhs != lifecycle.ref.owner_query_id;
+		}
+		return lhs < rhs;
+	});
+	return query_ids;
+}
+
+std::shared_ptr<QueryLifecycleCoordinator::LifecycleState>
+QueryLifecycleCoordinator::FindLifecycleLocked(const LifecycleRef &lifecycle) const {
+	auto current = lifecycles_by_owner_.find(lifecycle.owner_query_id);
+	if (current == lifecycles_by_owner_.end() || current->second->ref.generation != lifecycle.generation) {
+		return nullptr;
+	}
+	return current->second;
+}
+
+std::shared_ptr<QueryLifecycleCoordinator::LifecycleState>
+QueryLifecycleCoordinator::ResolveLocked(const std::string &query_id) const {
+	auto binding = query_bindings_.find(query_id);
+	if (binding == query_bindings_.end()) {
+		return nullptr;
+	}
+	return FindLifecycleLocked(binding->second);
+}
+
+std::shared_ptr<QueryLifecycleCoordinator::LifecycleState>
+QueryLifecycleCoordinator::ResolveOwnerLocked(const std::string &owner_query_id) const {
+	auto lifecycle = lifecycles_by_owner_.find(owner_query_id);
+	return lifecycle == lifecycles_by_owner_.end() ? nullptr : lifecycle->second;
+}
+
+std::shared_ptr<QueryLifecycleCoordinator::LifecycleState>
+QueryLifecycleCoordinator::CreateLifecycleLocked(const std::string &owner_query_id) {
+	if (ResolveLocked(owner_query_id) || ResolveOwnerLocked(owner_query_id)) {
+		throw std::runtime_error("cannot replace active FTE query lifecycle: " + owner_query_id);
+	}
+	auto lifecycle = std::make_shared<LifecycleState>();
+	lifecycle->ref = LifecycleRef {owner_query_id, NextToken(next_generation_)};
+	auto lifecycle_inserted = lifecycles_by_owner_.emplace(owner_query_id, lifecycle);
+	if (!lifecycle_inserted.second) {
+		throw std::runtime_error("cannot publish FTE query lifecycle: " + owner_query_id);
+	}
+	bool binding_published = false;
+	try {
+		auto binding_inserted = query_bindings_.emplace(owner_query_id, lifecycle->ref);
+		if (!binding_inserted.second) {
+			throw std::runtime_error("cannot publish FTE query lifecycle: " + owner_query_id);
+		}
+		binding_published = true;
+		lifecycle->query_ids.insert(owner_query_id);
+	} catch (...) {
+		if (binding_published) {
+			query_bindings_.erase(owner_query_id);
+		}
+		lifecycles_by_owner_.erase(lifecycle_inserted.first);
+		throw;
+	}
+	return lifecycle;
+}
+
+void QueryLifecycleCoordinator::BindQueryLocked(const std::shared_ptr<LifecycleState> &lifecycle,
+                                                const std::string &query_id) {
+	auto binding = query_bindings_.find(query_id);
+	if (binding != query_bindings_.end() && !SameLifecycle(binding->second, lifecycle->ref)) {
+		throw std::runtime_error("FTE query owner changed while active: query=" + query_id + " existing=" +
+		                         binding->second.owner_query_id + " requested=" + lifecycle->ref.owner_query_id);
+	}
+	if (binding != query_bindings_.end()) {
+		lifecycle->query_ids.insert(query_id);
+		return;
+	}
+	auto query_id_inserted = lifecycle->query_ids.insert(query_id);
+	try {
+		auto binding_inserted = query_bindings_.emplace(query_id, lifecycle->ref);
+		if (!binding_inserted.second) {
+			throw std::runtime_error("cannot publish FTE query binding: " + query_id);
+		}
+	} catch (...) {
+		if (query_id_inserted.second) {
+			lifecycle->query_ids.erase(query_id_inserted.first);
+		}
+		throw;
+	}
+}
+
+QueryLifecycleCoordinator::Registration
+QueryLifecycleCoordinator::BeginRegistration(const std::string &query_id, const std::string &owner_query_id) {
+	if (query_id.empty() || owner_query_id.empty()) {
+		throw std::invalid_argument("FTE query ownership requires non-empty query and owner IDs");
+	}
+	std::lock_guard<std::mutex> guard(mutex_);
+	if (shutdown_started_) {
+		throw std::runtime_error("cannot register FTE query ownership after " + component_name_ +
+		                         " shutdown: " + query_id);
+	}
+
+	auto query_lifecycle = ResolveLocked(query_id);
+	if (query_lifecycle && query_lifecycle->ref.owner_query_id != owner_query_id) {
+		throw std::runtime_error("FTE query owner changed while active: query=" + query_id +
+		                         " existing=" + query_lifecycle->ref.owner_query_id + " requested=" + owner_query_id);
+	}
+	auto owner_binding = ResolveLocked(owner_query_id);
+	if (owner_binding && owner_binding->ref.owner_query_id != owner_query_id) {
+		throw std::runtime_error("FTE resource query is already owned by another query: " + owner_query_id);
+	}
+	auto owner_lifecycle = ResolveOwnerLocked(owner_query_id);
+	if (owner_binding && (!owner_lifecycle || !SameLifecycle(owner_binding->ref, owner_lifecycle->ref))) {
+		throw std::runtime_error("FTE resource query lifecycle is inconsistent: " + owner_query_id);
+	}
+	if (query_lifecycle && owner_lifecycle && !SameLifecycle(query_lifecycle->ref, owner_lifecycle->ref)) {
+		throw std::runtime_error("FTE query lifecycle generation changed while registering: " + query_id);
+	}
+
+	auto lifecycle = query_lifecycle ? query_lifecycle : owner_lifecycle;
+	if (!lifecycle) {
+		lifecycle = CreateLifecycleLocked(owner_query_id);
+	}
+	if (lifecycle->phase != Phase::OPEN) {
+		throw std::runtime_error("cannot register closing FTE query lifecycle: " + query_id);
+	}
+	if (lifecycle->pending_registrations.find(query_id) != lifecycle->pending_registrations.end()) {
+		throw std::runtime_error("FTE query lifecycle registration is already in progress: " + query_id);
+	}
+	if (lifecycle->registered_query_ids.find(query_id) != lifecycle->registered_query_ids.end()) {
+		return Registration {lifecycle->ref, query_id, 0, false};
+	}
+
+	BindQueryLocked(lifecycle, query_id);
+	const auto token = NextToken(next_registration_token_);
+	lifecycle->pending_registrations[query_id] = token;
+	return Registration {lifecycle->ref, query_id, token, true};
+}
+
+void QueryLifecycleCoordinator::CompleteRegistration(const Registration &registration, bool succeeded) {
+	if (!registration.publish) {
+		return;
+	}
+	{
+		std::lock_guard<std::mutex> guard(mutex_);
+		auto lifecycle = FindLifecycleLocked(registration.lifecycle);
+		if (!lifecycle) {
+			throw std::runtime_error("cannot finish stale FTE query registration: " + registration.query_id);
+		}
+		auto pending = lifecycle->pending_registrations.find(registration.query_id);
+		if (pending == lifecycle->pending_registrations.end() || pending->second != registration.token) {
+			throw std::runtime_error("cannot finish stale FTE query registration attempt: " + registration.query_id);
+		}
+		lifecycle->pending_registrations.erase(pending);
+		if (succeeded) {
+			lifecycle->registered_query_ids.insert(registration.query_id);
+		} else if (lifecycle->phase == Phase::OPEN) {
+			lifecycle->phase = Phase::CLOSING;
+		}
+	}
+	condition_.notify_all();
+}
+
+void QueryLifecycleCoordinator::RegisterImmediate(const std::string &query_id, const std::string &owner_query_id) {
+	auto registration = BeginRegistration(query_id, owner_query_id);
+	CompleteRegistration(registration, true);
+}
+
+std::optional<QueryLifecycleCoordinator::Operation>
+QueryLifecycleCoordinator::BeginOperation(const std::string &query_id, const std::string &requested_owner_query_id,
+                                          bool create_if_missing) {
+	if (query_id.empty()) {
+		throw std::invalid_argument("FTE query operation requires non-empty query_id");
+	}
+	std::lock_guard<std::mutex> guard(mutex_);
+	if (shutdown_started_) {
+		return std::nullopt;
+	}
+
+	auto lifecycle = ResolveLocked(query_id);
+	if (!lifecycle && requested_owner_query_id.empty()) {
+		return std::nullopt;
+	}
+	if (!lifecycle) {
+		if (!create_if_missing) {
+			return std::nullopt;
+		}
+		auto owner_binding = ResolveLocked(requested_owner_query_id);
+		if (owner_binding && owner_binding->ref.owner_query_id != requested_owner_query_id) {
+			throw std::runtime_error("FTE resource query is already owned by another query: " +
+			                         requested_owner_query_id);
+		}
+		auto owner_lifecycle = ResolveOwnerLocked(requested_owner_query_id);
+		if (owner_binding && (!owner_lifecycle || !SameLifecycle(owner_binding->ref, owner_lifecycle->ref))) {
+			throw std::runtime_error("FTE resource query lifecycle is inconsistent: " + requested_owner_query_id);
+		}
+		lifecycle = owner_lifecycle ? owner_lifecycle : CreateLifecycleLocked(requested_owner_query_id);
+		if (lifecycle->phase != Phase::OPEN) {
+			return std::nullopt;
+		}
+		BindQueryLocked(lifecycle, query_id);
+		lifecycle->registered_query_ids.insert(query_id);
+	}
+
+	const auto owner_query_id =
+	    requested_owner_query_id.empty() ? lifecycle->ref.owner_query_id : requested_owner_query_id;
+	if (owner_query_id.empty()) {
+		throw std::invalid_argument("FTE query operation requires non-empty resource_query_id");
+	}
+	if (lifecycle->ref.owner_query_id != owner_query_id) {
+		throw std::runtime_error("FTE query owner changed while active: query=" + query_id +
+		                         " existing=" + lifecycle->ref.owner_query_id + " requested=" + owner_query_id);
+	}
+	if (lifecycle->phase != Phase::OPEN) {
+		return std::nullopt;
+	}
+	lifecycle->active_operations++;
+	return Operation {lifecycle->ref};
+}
+
+void QueryLifecycleCoordinator::EndOperation(const Operation &operation) noexcept {
+	{
+		std::lock_guard<std::mutex> guard(mutex_);
+		auto lifecycle = FindLifecycleLocked(operation.lifecycle);
+		if (!lifecycle || lifecycle->active_operations == 0) {
+			std::terminate();
+		}
+		lifecycle->active_operations--;
+	}
+	condition_.notify_all();
+}
+
+void QueryLifecycleCoordinator::Close(const LifecycleRef &lifecycle_ref) {
+	{
+		std::lock_guard<std::mutex> guard(mutex_);
+		auto lifecycle = FindLifecycleLocked(lifecycle_ref);
+		if (lifecycle && lifecycle->phase == Phase::OPEN) {
+			lifecycle->phase = Phase::CLOSING;
+		}
+	}
+	condition_.notify_all();
+}
+
+void QueryLifecycleCoordinator::WaitForOperations(const LifecycleRef &lifecycle_ref) {
+	std::unique_lock<std::mutex> guard(mutex_);
+	condition_.wait(guard, [&]() {
+		auto lifecycle = FindLifecycleLocked(lifecycle_ref);
+		return !lifecycle || lifecycle->active_operations == 0;
+	});
+}
+
+void QueryLifecycleCoordinator::WaitForAllOperations() {
+	std::unique_lock<std::mutex> guard(mutex_);
+	condition_.wait(guard, [&]() {
+		return std::all_of(lifecycles_by_owner_.begin(), lifecycles_by_owner_.end(),
+		                   [](const auto &entry) { return entry.second->active_operations == 0; });
+	});
+}
+
+std::string QueryLifecycleCoordinator::OwnerForQuery(const std::string &query_id) const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	auto lifecycle = ResolveLocked(query_id);
+	return lifecycle ? lifecycle->ref.owner_query_id : query_id;
+}
+
+bool QueryLifecycleCoordinator::IsClosing(const LifecycleRef &lifecycle_ref) const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	auto lifecycle = FindLifecycleLocked(lifecycle_ref);
+	return shutdown_started_ || !lifecycle || lifecycle->phase != Phase::OPEN;
+}
+
+bool QueryLifecycleCoordinator::IsQueryClosing(const std::string &query_id) const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	auto lifecycle = ResolveLocked(query_id);
+	return shutdown_started_ || !lifecycle || lifecycle->phase != Phase::OPEN;
+}
+
+std::vector<std::string> QueryLifecycleCoordinator::QueryIds(const LifecycleRef &lifecycle_ref) const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	auto lifecycle = FindLifecycleLocked(lifecycle_ref);
+	return lifecycle ? OrderedQueryIds(*lifecycle) : std::vector<std::string> {};
+}
+
+std::vector<std::string> QueryLifecycleCoordinator::OwnerQueryIds() const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	std::vector<std::string> owners;
+	owners.reserve(lifecycles_by_owner_.size());
+	for (const auto &entry : lifecycles_by_owner_) {
+		owners.push_back(entry.first);
+	}
+	std::sort(owners.begin(), owners.end());
+	return owners;
+}
+
+bool QueryLifecycleCoordinator::WaitForShutdownLocked(std::unique_lock<std::mutex> &guard, const std::string &query_id,
+                                                      const char *operation) const {
+	if (!shutdown_started_) {
+		return true;
+	}
+	condition_.wait(guard, [&]() { return !shutdown_running_; });
+	if (shutdown_finished_) {
+		return false;
+	}
+	throw std::runtime_error("cannot " + std::string(operation) + " FTE query after " + component_name_ +
+	                         " shutdown failed: " + query_id);
+}
+
+void QueryLifecycleCoordinator::EnsureAttemptLeader(const Attempt &attempt, const std::string &operation,
+                                                    const std::string &owner_query_id) {
+	if (attempt.leader != std::this_thread::get_id()) {
+		throw std::runtime_error("cannot " + operation + " from a non-leader thread: " + owner_query_id);
+	}
+}
+
+void QueryLifecycleCoordinator::WaitForAttemptLocked(std::unique_lock<std::mutex> &guard,
+                                                     const std::shared_ptr<Attempt> &attempt,
+                                                     const std::string &operation, const std::string &owner_query_id) {
+	if (attempt->leader == std::this_thread::get_id()) {
+		throw std::runtime_error("cannot join a " + operation + " from its leader thread: " + owner_query_id);
+	}
+	attempt->waiters++;
+	try {
+		condition_.wait(guard, [&]() { return attempt->complete; });
+	} catch (...) {
+		attempt->waiters--;
+		throw;
+	}
+	attempt->waiters--;
+}
+
+std::optional<QueryLifecycleCoordinator::Abort>
+QueryLifecycleCoordinator::BeginAbortLocked(std::unique_lock<std::mutex> &guard,
+                                            const std::shared_ptr<LifecycleState> &lifecycle) {
+	if (lifecycle->phase == Phase::QUIESCED || lifecycle->phase == Phase::DROPPING) {
+		return std::nullopt;
+	}
+	if (lifecycle->abort_attempt) {
+		auto attempt = lifecycle->abort_attempt;
+		WaitForAttemptLocked(guard, attempt, "FTE query abort", lifecycle->ref.owner_query_id);
+		if (attempt->error) {
+			throw std::runtime_error(*attempt->error);
+		}
+		return std::nullopt;
+	}
+
+	if (lifecycle->phase == Phase::OPEN) {
+		lifecycle->phase = Phase::CLOSING;
+	}
+	auto attempt = std::make_shared<Attempt>();
+	attempt->token = NextToken(next_abort_token_);
+	attempt->leader = std::this_thread::get_id();
+	lifecycle->abort_attempt = attempt;
+	lifecycle->phase = Phase::QUIESCING;
+	condition_.wait(guard, [&]() { return lifecycle->pending_registrations.empty(); });
+	return Abort {lifecycle->ref, OrderedQueryIds(*lifecycle), attempt->token, lifecycle->active_operations != 0};
+}
+
+std::optional<QueryLifecycleCoordinator::Abort> QueryLifecycleCoordinator::BeginAbort(const std::string &query_id) {
+	std::unique_lock<std::mutex> guard(mutex_);
+	auto lifecycle = ResolveLocked(query_id);
+	if (!lifecycle) {
+		return std::nullopt;
+	}
+	if (lifecycle->abort_attempt) {
+		return BeginAbortLocked(guard, lifecycle);
+	}
+	if (!WaitForShutdownLocked(guard, query_id, "abort")) {
+		return std::nullopt;
+	}
+	return BeginAbortLocked(guard, lifecycle);
+}
+
+std::optional<QueryLifecycleCoordinator::Abort> QueryLifecycleCoordinator::BeginAbort(const Teardown &teardown) {
+	std::unique_lock<std::mutex> guard(mutex_);
+	auto lifecycle = FindLifecycleLocked(teardown.lifecycle);
+	if (!lifecycle || !lifecycle->teardown_attempt || lifecycle->teardown_attempt->token != teardown.token) {
+		throw std::runtime_error("cannot abort stale FTE query teardown: " + teardown.lifecycle.owner_query_id);
+	}
+	EnsureAttemptLeader(*lifecycle->teardown_attempt, "advance FTE query teardown", teardown.lifecycle.owner_query_id);
+	return BeginAbortLocked(guard, lifecycle);
+}
+
+void QueryLifecycleCoordinator::CompleteAbort(const Abort &abort, const std::optional<std::string> &error) {
+	std::shared_ptr<Attempt> attempt;
+	{
+		std::lock_guard<std::mutex> guard(mutex_);
+		auto lifecycle = FindLifecycleLocked(abort.lifecycle);
+		if (!lifecycle || !lifecycle->abort_attempt || lifecycle->abort_attempt->token != abort.token) {
+			throw std::runtime_error("cannot finish stale FTE query abort: " + abort.lifecycle.owner_query_id);
+		}
+		attempt = lifecycle->abort_attempt;
+		EnsureAttemptLeader(*attempt, "finish FTE query abort", abort.lifecycle.owner_query_id);
+		attempt->error = error;
+		attempt->complete = true;
+		lifecycle->abort_attempt.reset();
+		lifecycle->phase = error ? Phase::CLOSING : Phase::QUIESCED;
+	}
+	condition_.notify_all();
+}
+
+std::optional<QueryLifecycleCoordinator::Teardown>
+QueryLifecycleCoordinator::BeginTeardown(const std::string &query_id) {
+	std::unique_lock<std::mutex> guard(mutex_);
+	auto lifecycle = ResolveLocked(query_id);
+	if (!lifecycle) {
+		return std::nullopt;
+	}
+	if (lifecycle->teardown_attempt) {
+		auto attempt = lifecycle->teardown_attempt;
+		WaitForAttemptLocked(guard, attempt, "FTE query teardown", lifecycle->ref.owner_query_id);
+		if (attempt->error) {
+			throw std::runtime_error(*attempt->error);
+		}
+		return std::nullopt;
+	}
+	if (!WaitForShutdownLocked(guard, query_id, "tear down")) {
+		return std::nullopt;
+	}
+	if (lifecycle->phase == Phase::OPEN) {
+		lifecycle->phase = Phase::CLOSING;
+	}
+	auto attempt = std::make_shared<Attempt>();
+	attempt->token = NextToken(next_teardown_token_);
+	attempt->leader = std::this_thread::get_id();
+	lifecycle->teardown_attempt = attempt;
+	condition_.wait(guard, [&]() { return lifecycle->pending_registrations.empty(); });
+	return Teardown {lifecycle->ref, OrderedQueryIds(*lifecycle), attempt->token};
+}
+
+void QueryLifecycleCoordinator::MarkDropping(const Teardown &teardown) {
+	std::lock_guard<std::mutex> guard(mutex_);
+	auto lifecycle = FindLifecycleLocked(teardown.lifecycle);
+	if (!lifecycle || !lifecycle->teardown_attempt || lifecycle->teardown_attempt->token != teardown.token) {
+		throw std::runtime_error("cannot start stale FTE query drop: " + teardown.lifecycle.owner_query_id);
+	}
+	EnsureAttemptLeader(*lifecycle->teardown_attempt, "start FTE query drop", teardown.lifecycle.owner_query_id);
+	if (lifecycle->phase != Phase::QUIESCED) {
+		throw std::runtime_error("cannot drop FTE query before its abort barrier: " +
+		                         teardown.lifecycle.owner_query_id);
+	}
+	if (lifecycle->active_operations != 0 || lifecycle->abort_attempt) {
+		throw std::runtime_error("cannot drop FTE query with an active abort barrier: " +
+		                         teardown.lifecycle.owner_query_id);
+	}
+	lifecycle->phase = Phase::DROPPING;
+}
+
+void QueryLifecycleCoordinator::CompleteTeardown(const Teardown &teardown, const std::optional<std::string> &error) {
+	std::shared_ptr<Attempt> attempt;
+	{
+		std::lock_guard<std::mutex> guard(mutex_);
+		auto lifecycle = FindLifecycleLocked(teardown.lifecycle);
+		if (!lifecycle || !lifecycle->teardown_attempt || lifecycle->teardown_attempt->token != teardown.token) {
+			throw std::runtime_error("cannot finish stale FTE query teardown: " + teardown.lifecycle.owner_query_id);
+		}
+		attempt = lifecycle->teardown_attempt;
+		EnsureAttemptLeader(*attempt, "finish FTE query teardown", teardown.lifecycle.owner_query_id);
+		if (error) {
+			attempt->error = error;
+			attempt->complete = true;
+			lifecycle->teardown_attempt.reset();
+			if (lifecycle->phase == Phase::DROPPING) {
+				lifecycle->phase = Phase::QUIESCED;
+			} else if (lifecycle->phase != Phase::QUIESCED) {
+				lifecycle->phase = Phase::CLOSING;
+			}
+		} else {
+			if (lifecycle->phase != Phase::DROPPING) {
+				throw std::runtime_error("cannot finish FTE query lifecycle before drop ownership: " +
+				                         teardown.lifecycle.owner_query_id);
+			}
+			if (lifecycle->active_operations != 0) {
+				throw std::runtime_error("cannot finish active FTE query lifecycle: " +
+				                         teardown.lifecycle.owner_query_id);
+			}
+			if (!lifecycle->pending_registrations.empty()) {
+				throw std::runtime_error("cannot finish FTE query lifecycle with active registrations: " +
+				                         teardown.lifecycle.owner_query_id);
+			}
+			attempt->complete = true;
+			for (const auto &owned_query_id : lifecycle->query_ids) {
+				auto binding = query_bindings_.find(owned_query_id);
+				if (binding != query_bindings_.end() && SameLifecycle(binding->second, lifecycle->ref)) {
+					query_bindings_.erase(binding);
+				}
+			}
+			lifecycles_by_owner_.erase(lifecycle->ref.owner_query_id);
+		}
+	}
+	condition_.notify_all();
+}
+
+bool QueryLifecycleCoordinator::BeginShutdown() {
+	std::unique_lock<std::mutex> guard(mutex_);
+	while (shutdown_running_) {
+		condition_.wait(guard);
+	}
+	if (shutdown_finished_) {
+		return false;
+	}
+	shutdown_started_ = true;
+	shutdown_running_ = true;
+	for (auto &entry : lifecycles_by_owner_) {
+		if (entry.second->phase == Phase::OPEN) {
+			entry.second->phase = Phase::CLOSING;
+		}
+	}
+	condition_.wait(guard, [&]() {
+		return std::all_of(lifecycles_by_owner_.begin(), lifecycles_by_owner_.end(), [](const auto &entry) {
+			const auto &lifecycle = *entry.second;
+			return lifecycle.pending_registrations.empty() && !lifecycle.abort_attempt && !lifecycle.teardown_attempt;
+		});
+	});
+	return true;
+}
+
+void QueryLifecycleCoordinator::FinishShutdown(bool succeeded) {
+	{
+		std::lock_guard<std::mutex> guard(mutex_);
+		if (!shutdown_running_) {
+			throw std::runtime_error("cannot finish inactive query lifecycle shutdown");
+		}
+		if (succeeded) {
+			for (const auto &entry : lifecycles_by_owner_) {
+				const auto &lifecycle = *entry.second;
+				if (!lifecycle.pending_registrations.empty() || lifecycle.abort_attempt || lifecycle.teardown_attempt ||
+				    lifecycle.active_operations != 0) {
+					throw std::runtime_error("cannot finish query lifecycle shutdown with active transitions");
+				}
+			}
+			query_bindings_.clear();
+			lifecycles_by_owner_.clear();
+		}
+		shutdown_finished_ = succeeded;
+		shutdown_running_ = false;
+	}
+	condition_.notify_all();
+}
+
+} // namespace ray
+} // namespace python
+} // namespace distributed
+} // namespace duckdb

--- a/src/vane_py/ray/query_lifecycle_coordinator.hpp
+++ b/src/vane_py/ray/query_lifecycle_coordinator.hpp
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace duckdb {
+namespace distributed {
+namespace python {
+namespace ray {
+
+class QueryLifecycleCoordinator {
+public:
+	explicit QueryLifecycleCoordinator(std::string component_name);
+
+	struct LifecycleRef {
+		std::string owner_query_id;
+		uint64_t generation = 0;
+
+		explicit operator bool() const {
+			return !owner_query_id.empty() && generation != 0;
+		}
+	};
+
+	struct Registration {
+		LifecycleRef lifecycle;
+		std::string query_id;
+		uint64_t token = 0;
+		bool publish = false;
+	};
+
+	struct Operation {
+		LifecycleRef lifecycle;
+
+		explicit operator bool() const {
+			return static_cast<bool>(lifecycle);
+		}
+	};
+
+	struct Abort {
+		LifecycleRef lifecycle;
+		std::vector<std::string> execution_query_ids;
+		uint64_t token = 0;
+		bool had_active_operations = false;
+	};
+
+	struct Teardown {
+		LifecycleRef lifecycle;
+		std::vector<std::string> execution_query_ids;
+		uint64_t token = 0;
+	};
+
+	Registration BeginRegistration(const std::string &query_id, const std::string &owner_query_id);
+	void CompleteRegistration(const Registration &registration, bool succeeded);
+	void RegisterImmediate(const std::string &query_id, const std::string &owner_query_id);
+
+	std::optional<Operation> BeginOperation(const std::string &query_id,
+	                                        const std::string &requested_owner_query_id = {},
+	                                        bool create_if_missing = false);
+	void EndOperation(const Operation &operation) noexcept;
+	void Close(const LifecycleRef &lifecycle);
+	void WaitForOperations(const LifecycleRef &lifecycle);
+	void WaitForAllOperations();
+
+	std::string OwnerForQuery(const std::string &query_id) const;
+	bool IsClosing(const LifecycleRef &lifecycle) const;
+	bool IsQueryClosing(const std::string &query_id) const;
+	std::vector<std::string> QueryIds(const LifecycleRef &lifecycle) const;
+	std::vector<std::string> OwnerQueryIds() const;
+
+	std::optional<Abort> BeginAbort(const std::string &query_id);
+	std::optional<Abort> BeginAbort(const Teardown &teardown);
+	void CompleteAbort(const Abort &abort, const std::optional<std::string> &error);
+
+	std::optional<Teardown> BeginTeardown(const std::string &query_id);
+	void MarkDropping(const Teardown &teardown);
+	void CompleteTeardown(const Teardown &teardown, const std::optional<std::string> &error);
+
+	bool BeginShutdown();
+	void FinishShutdown(bool succeeded);
+
+private:
+	enum class Phase : uint8_t { OPEN, CLOSING, QUIESCING, QUIESCED, DROPPING };
+
+	struct Attempt {
+		uint64_t token = 0;
+		std::thread::id leader;
+		size_t waiters = 0;
+		bool complete = false;
+		std::optional<std::string> error;
+	};
+
+	struct LifecycleState {
+		LifecycleRef ref;
+		Phase phase = Phase::OPEN;
+		std::unordered_set<std::string> query_ids;
+		std::unordered_set<std::string> registered_query_ids;
+		std::unordered_map<std::string, uint64_t> pending_registrations;
+		uint64_t active_operations = 0;
+		std::shared_ptr<Attempt> abort_attempt;
+		std::shared_ptr<Attempt> teardown_attempt;
+	};
+
+	mutable std::mutex mutex_;
+	mutable std::condition_variable condition_;
+	const std::string component_name_;
+	std::unordered_map<std::string, LifecycleRef> query_bindings_;
+	std::unordered_map<std::string, std::shared_ptr<LifecycleState>> lifecycles_by_owner_;
+	uint64_t next_generation_ = 1;
+	uint64_t next_registration_token_ = 1;
+	uint64_t next_abort_token_ = 1;
+	uint64_t next_teardown_token_ = 1;
+	bool shutdown_started_ = false;
+	bool shutdown_running_ = false;
+	bool shutdown_finished_ = false;
+
+	static uint64_t NextToken(uint64_t &counter);
+	static std::vector<std::string> OrderedQueryIds(const LifecycleState &lifecycle);
+	static bool SameLifecycle(const LifecycleRef &lhs, const LifecycleRef &rhs);
+
+	std::shared_ptr<LifecycleState> FindLifecycleLocked(const LifecycleRef &lifecycle) const;
+	std::shared_ptr<LifecycleState> ResolveLocked(const std::string &query_id) const;
+	std::shared_ptr<LifecycleState> ResolveOwnerLocked(const std::string &owner_query_id) const;
+	std::shared_ptr<LifecycleState> CreateLifecycleLocked(const std::string &owner_query_id);
+	void BindQueryLocked(const std::shared_ptr<LifecycleState> &lifecycle, const std::string &query_id);
+	bool WaitForShutdownLocked(std::unique_lock<std::mutex> &guard, const std::string &query_id,
+	                           const char *operation) const;
+	static void EnsureAttemptLeader(const Attempt &attempt, const std::string &operation,
+	                                const std::string &owner_query_id);
+	void WaitForAttemptLocked(std::unique_lock<std::mutex> &guard, const std::shared_ptr<Attempt> &attempt,
+	                          const std::string &operation, const std::string &owner_query_id);
+	std::optional<Abort> BeginAbortLocked(std::unique_lock<std::mutex> &guard,
+	                                      const std::shared_ptr<LifecycleState> &lifecycle);
+};
+
+} // namespace ray
+} // namespace python
+} // namespace distributed
+} // namespace duckdb

--- a/src/vane_py/ray/query_lifecycle_coordinator.hpp
+++ b/src/vane_py/ray/query_lifecycle_coordinator.hpp
@@ -134,8 +134,7 @@ private:
 	std::shared_ptr<LifecycleState> ResolveOwnerLocked(const std::string &owner_query_id) const;
 	std::shared_ptr<LifecycleState> CreateLifecycleLocked(const std::string &owner_query_id);
 	void BindQueryLocked(const std::shared_ptr<LifecycleState> &lifecycle, const std::string &query_id);
-	bool WaitForShutdownLocked(std::unique_lock<std::mutex> &guard, const std::string &query_id,
-	                           const char *operation) const;
+	void EnsureTransitionAllowedLocked(const std::string &query_id, const char *operation) const;
 	static void EnsureAttemptLeader(const Attempt &attempt, const std::string &operation,
 	                                const std::string &owner_query_id);
 	void WaitForAttemptLocked(std::unique_lock<std::mutex> &guard, const std::shared_ptr<Attempt> &attempt,

--- a/src/vane_py/ray/worker_manager.cpp
+++ b/src/vane_py/ray/worker_manager.cpp
@@ -23,7 +23,7 @@ static constexpr auto REFRESH_INTERVAL = std::chrono::seconds(5);
 
 RayWorkerManager::RayWorkerManager(QueryCleanup query_cleanup)
     : manager_instance_id_(duckdb::UUID::ToString(duckdb::UUID::GenerateRandomUUID())),
-      query_cleanup_(std::move(query_cleanup)) {
+      query_cleanup_(std::move(query_cleanup)), query_lifecycles_("Ray worker manager") {
 }
 
 static std::vector<std::string> AbortWorkers(const std::vector<std::shared_ptr<RayWorkerRuntime>> &workers) {
@@ -56,6 +56,16 @@ static bool IsUnselectedFteHandle(const RayWorkerRuntime::TaskResultHandleType &
 	       finished_status->selected_attempt_task_ids.end();
 }
 
+static std::string ExceptionMessage(const std::exception_ptr &error) {
+	try {
+		std::rethrow_exception(error);
+	} catch (const std::exception &ex) {
+		return ex.what();
+	} catch (...) {
+		return "unknown exception";
+	}
+}
+
 bool RayWorkerManager::BeginOperation() const {
 	lock_guard<mutex> guard(mutex_);
 	if (state_.shutdown_started) {
@@ -74,60 +84,13 @@ void RayWorkerManager::EndOperation() const {
 	shutdown_cv_.notify_all();
 }
 
-std::optional<std::string> RayWorkerManager::BeginQueryOperation(const string &query_id,
-                                                                 const string &requested_owner_query_id) {
-	if (query_id.empty()) {
-		throw std::invalid_argument("FTE query operation requires non-empty query_id");
-	}
-	lock_guard<mutex> guard(mutex_);
-	if (state_.shutdown_started) {
-		return std::nullopt;
-	}
-	auto existing_owner = state_.query_owner_by_query.find(query_id);
-	if (existing_owner == state_.query_owner_by_query.end() && requested_owner_query_id.empty()) {
-		return std::nullopt;
-	}
-	const auto owner_query_id = requested_owner_query_id.empty() ? existing_owner->second : requested_owner_query_id;
-	if (owner_query_id.empty()) {
-		throw std::invalid_argument("FTE query operation requires non-empty resource_query_id");
-	}
-	if (existing_owner != state_.query_owner_by_query.end() && existing_owner->second != owner_query_id) {
-		throw std::runtime_error("FTE query owner changed while active: query=" + query_id +
-		                         " existing=" + existing_owner->second + " requested=" + owner_query_id);
-	}
-	auto owner_entry = state_.query_owner_by_query.find(owner_query_id);
-	if (owner_entry != state_.query_owner_by_query.end() && owner_entry->second != owner_query_id) {
-		throw std::runtime_error("FTE resource query is already owned by another query: " + owner_query_id);
-	}
-	if (state_.closed_query_owners.find(owner_query_id) != state_.closed_query_owners.end() ||
-	    state_.quiescing_query_owners.find(owner_query_id) != state_.quiescing_query_owners.end()) {
-		return std::nullopt;
-	}
-	state_.query_owner_by_query[owner_query_id] = owner_query_id;
-	state_.query_owner_by_query[query_id] = owner_query_id;
-	state_.active_query_operations_by_owner[owner_query_id]++;
-	return owner_query_id;
+std::optional<QueryLifecycleCoordinator::Operation>
+RayWorkerManager::BeginQueryOperation(const string &query_id, const string &requested_owner_query_id) {
+	return query_lifecycles_.BeginOperation(query_id, requested_owner_query_id, !requested_owner_query_id.empty());
 }
 
-void RayWorkerManager::EndQueryOperation(const string &owner_query_id) {
-	{
-		lock_guard<mutex> guard(mutex_);
-		auto active = state_.active_query_operations_by_owner.find(owner_query_id);
-		D_ASSERT(active != state_.active_query_operations_by_owner.end());
-		D_ASSERT(active->second > 0);
-		if (--active->second == 0) {
-			state_.active_query_operations_by_owner.erase(active);
-		}
-	}
-	shutdown_cv_.notify_all();
-}
-
-void RayWorkerManager::CloseQueryOwnerIngress(const string &owner_query_id) {
-	{
-		lock_guard<mutex> guard(mutex_);
-		state_.closed_query_owners.insert(owner_query_id);
-	}
-	shutdown_cv_.notify_all();
+void RayWorkerManager::EndQueryOperation(const QueryLifecycleCoordinator::Operation &operation) {
+	query_lifecycles_.EndOperation(operation);
 }
 
 void RayWorkerManager::register_query_owner(const string &query_id, const string &owner_query_id) {
@@ -135,27 +98,16 @@ void RayWorkerManager::register_query_owner(const string &query_id, const string
 	if (!operation) {
 		throw std::runtime_error("cannot register FTE query ownership after Ray worker manager shutdown");
 	}
-	QueryOperationGuard query_operation(*this, query_id, owner_query_id);
-	if (!query_operation) {
-		throw std::runtime_error("cannot register closing FTE query lifecycle: " + query_id);
-	}
+	query_lifecycles_.RegisterImmediate(query_id, owner_query_id);
 }
 
-void RayWorkerManager::WaitForQueryOperationsWithoutGIL(const string &owner_query_id) {
-	std::unique_lock<mutex> guard(mutex_);
-	shutdown_cv_.wait(guard, [&]() {
-		return state_.active_query_operations_by_owner.find(owner_query_id) ==
-		       state_.active_query_operations_by_owner.end();
-	});
-}
-
-void RayWorkerManager::WaitForQueryOperations(const string &owner_query_id) {
+void RayWorkerManager::WaitForQueryOperations(const QueryLifecycleCoordinator::LifecycleRef &lifecycle) {
 	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
 		py::gil_scoped_release release;
-		WaitForQueryOperationsWithoutGIL(owner_query_id);
+		query_lifecycles_.WaitForOperations(lifecycle);
 		return;
 	}
-	WaitForQueryOperationsWithoutGIL(owner_query_id);
+	query_lifecycles_.WaitForOperations(lifecycle);
 }
 
 void RayWorkerManager::RecordQueryWorkers(const string &owner_query_id,
@@ -169,66 +121,34 @@ void RayWorkerManager::RecordQueryWorkers(const string &owner_query_id,
 		owned_workers.push_back(worker);
 	}
 }
+std::optional<QueryLifecycleCoordinator::Abort> RayWorkerManager::BeginQueryAbort(const string &query_id) {
+	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
+		py::gil_scoped_release release;
+		return query_lifecycles_.BeginAbort(query_id);
+	}
+	return query_lifecycles_.BeginAbort(query_id);
+}
 
-std::optional<RayWorkerManager::QueryAbort> RayWorkerManager::BeginQueryAbortWithoutGIL(const string &query_id) {
-	std::unique_lock<mutex> guard(mutex_);
-	auto mapped_owner = state_.query_owner_by_query.find(query_id);
-	if (mapped_owner == state_.query_owner_by_query.end()) {
-		return std::nullopt;
+std::optional<QueryLifecycleCoordinator::Abort>
+RayWorkerManager::BeginQueryAbort(const QueryLifecycleCoordinator::Teardown &teardown) {
+	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
+		py::gil_scoped_release release;
+		return query_lifecycles_.BeginAbort(teardown);
 	}
-	const auto owner_query_id = mapped_owner->second;
-	while (true) {
-		auto active_abort = state_.quiescing_query_owners.find(owner_query_id);
-		if (active_abort == state_.quiescing_query_owners.end()) {
-			break;
-		}
-		const auto active_token = active_abort->second;
-		state_.quiesce_waiters_by_owner[owner_query_id]++;
-		shutdown_cv_.wait(guard, [&]() {
-			auto current = state_.quiescing_query_owners.find(owner_query_id);
-			return current == state_.quiescing_query_owners.end() || current->second != active_token;
-		});
-		auto waiter = state_.quiesce_waiters_by_owner.find(owner_query_id);
-		D_ASSERT(waiter != state_.quiesce_waiters_by_owner.end());
-		D_ASSERT(waiter->second > 0);
-		if (--waiter->second == 0) {
-			state_.quiesce_waiters_by_owner.erase(waiter);
-		}
-		shutdown_cv_.notify_all();
-		if (state_.quiesced_query_owners.find(owner_query_id) != state_.quiesced_query_owners.end()) {
-			return std::nullopt;
-		}
-	}
-	if (state_.quiesced_query_owners.find(owner_query_id) != state_.quiesced_query_owners.end()) {
-		return std::nullopt;
-	}
-	if (state_.shutdown_started) {
-		throw std::runtime_error("cannot abort FTE query while Ray worker manager is shutting down: " + query_id);
-	}
-	state_.closed_query_owners.insert(owner_query_id);
-	const auto token = state_.next_query_quiesce_token++;
-	if (state_.next_query_quiesce_token == 0) {
-		state_.next_query_quiesce_token = 1;
-	}
-	state_.quiescing_query_owners[owner_query_id] = token;
-	const bool had_active_operations =
-	    state_.active_query_operations_by_owner.find(owner_query_id) != state_.active_query_operations_by_owner.end();
+	return query_lifecycles_.BeginAbort(teardown);
+}
 
-	std::unordered_set<string> query_ids {owner_query_id};
-	for (const auto &entry : state_.query_owner_by_query) {
-		if (entry.second == owner_query_id) {
-			query_ids.insert(entry.first);
-		}
+std::optional<QueryLifecycleCoordinator::Teardown> RayWorkerManager::BeginQueryTeardown(const string &query_id) {
+	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
+		py::gil_scoped_release release;
+		return query_lifecycles_.BeginTeardown(query_id);
 	}
-	std::vector<string> ordered_query_ids(query_ids.begin(), query_ids.end());
-	std::sort(ordered_query_ids.begin(), ordered_query_ids.end(), [&](const string &lhs, const string &rhs) {
-		if ((lhs == owner_query_id) != (rhs == owner_query_id)) {
-			return lhs != owner_query_id;
-		}
-		return lhs < rhs;
-	});
+	return query_lifecycles_.BeginTeardown(query_id);
+}
 
+std::vector<std::shared_ptr<RayWorkerRuntime>> RayWorkerManager::QueryWorkers(const string &owner_query_id) const {
 	std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
+	lock_guard<mutex> guard(mutex_);
 	auto add_worker = [&](const std::shared_ptr<RayWorkerRuntime> &worker) {
 		if (worker && std::find(workers.begin(), workers.end(), worker) == workers.end()) {
 			workers.push_back(worker);
@@ -243,145 +163,7 @@ std::optional<RayWorkerManager::QueryAbort> RayWorkerManager::BeginQueryAbortWit
 	for (const auto &entry : state_.ray_workers) {
 		add_worker(entry.second);
 	}
-	return QueryAbort {owner_query_id, std::move(ordered_query_ids), std::move(workers), token, had_active_operations};
-}
-
-std::optional<RayWorkerManager::QueryAbort> RayWorkerManager::BeginQueryAbort(const string &query_id) {
-	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
-		py::gil_scoped_release release;
-		return BeginQueryAbortWithoutGIL(query_id);
-	}
-	return BeginQueryAbortWithoutGIL(query_id);
-}
-
-void RayWorkerManager::EndQueryAbort(const string &owner_query_id, uint64_t token, bool succeeded) {
-	{
-		lock_guard<mutex> guard(mutex_);
-		auto current = state_.quiescing_query_owners.find(owner_query_id);
-		if (current != state_.quiescing_query_owners.end() && current->second == token) {
-			state_.quiescing_query_owners.erase(current);
-			if (succeeded) {
-				state_.quiesced_query_owners.insert(owner_query_id);
-			}
-		}
-	}
-	shutdown_cv_.notify_all();
-}
-
-std::optional<RayWorkerManager::QueryAbort> RayWorkerManager::BeginQueryDropWithoutGIL(const string &query_id) {
-	std::unique_lock<mutex> guard(mutex_);
-	while (true) {
-		auto mapped_owner = state_.query_owner_by_query.find(query_id);
-		if (mapped_owner == state_.query_owner_by_query.end()) {
-			return std::nullopt;
-		}
-		const auto owner_query_id = mapped_owner->second;
-		shutdown_cv_.wait(guard, [&]() {
-			return state_.quiesce_waiters_by_owner.find(owner_query_id) == state_.quiesce_waiters_by_owner.end();
-		});
-		auto active_drop = state_.dropping_query_owners.find(owner_query_id);
-		if (active_drop != state_.dropping_query_owners.end()) {
-			const auto active_token = active_drop->second;
-			shutdown_cv_.wait(guard, [&]() {
-				auto current = state_.dropping_query_owners.find(owner_query_id);
-				return current == state_.dropping_query_owners.end() || current->second != active_token;
-			});
-			continue;
-		}
-		if (state_.shutdown_started) {
-			throw std::runtime_error("cannot drop FTE query while Ray worker manager is shutting down: " + query_id);
-		}
-		if (state_.quiesced_query_owners.find(owner_query_id) == state_.quiesced_query_owners.end()) {
-			throw std::runtime_error("cannot drop FTE query before its abort barrier: " + query_id);
-		}
-		const auto token = state_.next_query_drop_token++;
-		if (state_.next_query_drop_token == 0) {
-			state_.next_query_drop_token = 1;
-		}
-		state_.dropping_query_owners[owner_query_id] = token;
-
-		std::unordered_set<string> query_ids {owner_query_id};
-		for (const auto &entry : state_.query_owner_by_query) {
-			if (entry.second == owner_query_id) {
-				query_ids.insert(entry.first);
-			}
-		}
-		std::vector<string> ordered_query_ids(query_ids.begin(), query_ids.end());
-		std::sort(ordered_query_ids.begin(), ordered_query_ids.end(), [&](const string &lhs, const string &rhs) {
-			if ((lhs == owner_query_id) != (rhs == owner_query_id)) {
-				return lhs != owner_query_id;
-			}
-			return lhs < rhs;
-		});
-
-		std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
-		auto add_worker = [&](const std::shared_ptr<RayWorkerRuntime> &worker) {
-			if (worker && std::find(workers.begin(), workers.end(), worker) == workers.end()) {
-				workers.push_back(worker);
-			}
-		};
-		auto owned_workers = state_.workers_by_query_owner.find(owner_query_id);
-		if (owned_workers != state_.workers_by_query_owner.end()) {
-			for (const auto &worker : owned_workers->second) {
-				add_worker(worker);
-			}
-		}
-		for (const auto &entry : state_.ray_workers) {
-			add_worker(entry.second);
-		}
-		return QueryAbort {owner_query_id, std::move(ordered_query_ids), std::move(workers), token, false};
-	}
-}
-
-std::optional<RayWorkerManager::QueryAbort> RayWorkerManager::BeginQueryDrop(const string &query_id) {
-	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
-		py::gil_scoped_release release;
-		return BeginQueryDropWithoutGIL(query_id);
-	}
-	return BeginQueryDropWithoutGIL(query_id);
-}
-
-void RayWorkerManager::EndQueryDrop(const string &owner_query_id, uint64_t token) {
-	{
-		lock_guard<mutex> guard(mutex_);
-		auto current = state_.dropping_query_owners.find(owner_query_id);
-		if (current != state_.dropping_query_owners.end() && current->second == token) {
-			state_.dropping_query_owners.erase(current);
-		}
-	}
-	shutdown_cv_.notify_all();
-}
-
-void RayWorkerManager::FinishQueryLifecycle(const string &owner_query_id, uint64_t drop_token) {
-	{
-		lock_guard<mutex> guard(mutex_);
-		auto active_drop = state_.dropping_query_owners.find(owner_query_id);
-		if (active_drop == state_.dropping_query_owners.end() || active_drop->second != drop_token) {
-			throw std::runtime_error("cannot finish stale FTE query drop: " + owner_query_id);
-		}
-		if (state_.active_query_operations_by_owner.find(owner_query_id) !=
-		    state_.active_query_operations_by_owner.end()) {
-			throw std::runtime_error("cannot finish active FTE query lifecycle: " + owner_query_id);
-		}
-		if (state_.quiesced_query_owners.find(owner_query_id) == state_.quiesced_query_owners.end()) {
-			throw std::runtime_error("cannot finish FTE query lifecycle before quiescence: " + owner_query_id);
-		}
-		if (state_.quiesce_waiters_by_owner.find(owner_query_id) != state_.quiesce_waiters_by_owner.end()) {
-			throw std::runtime_error("cannot finish FTE query lifecycle with active abort waiters: " + owner_query_id);
-		}
-		for (auto entry = state_.query_owner_by_query.begin(); entry != state_.query_owner_by_query.end();) {
-			if (entry->second == owner_query_id) {
-				entry = state_.query_owner_by_query.erase(entry);
-			} else {
-				++entry;
-			}
-		}
-		state_.workers_by_query_owner.erase(owner_query_id);
-		state_.closed_query_owners.erase(owner_query_id);
-		state_.quiesced_query_owners.erase(owner_query_id);
-		state_.dropping_query_owners.erase(active_drop);
-	}
-	shutdown_cv_.notify_all();
+	return workers;
 }
 
 bool RayWorkerManager::ShutdownStarted() const {
@@ -792,7 +574,7 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 		}
 		try {
 			auto fail_submission = [&](const DuckDBError &error) {
-				CloseQueryOwnerIngress(query_operation.owner_query_id());
+				query_lifecycles_.Close(query_operation.lifecycle());
 				return DuckDBResult<void>::err(error);
 			};
 			auto collect_workers = [&]() {
@@ -837,12 +619,12 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 		} catch (const py::error_already_set &e) {
 			// Publish the Python exception before the query operation is allowed
 			// to quiesce or shutdown to discard its owner state.
-			CloseQueryOwnerIngress(query_operation.owner_query_id());
+			query_lifecycles_.Close(query_operation.lifecycle());
 			submission_errors_.Store(query_operation.owner_query_id(), e);
 			return DuckDBResult<void>::err(
 			    DuckDBError(string("Python error during submit_fte_task_events: ") + e.what()));
 		} catch (const std::exception &e) {
-			CloseQueryOwnerIngress(query_operation.owner_query_id());
+			query_lifecycles_.Close(query_operation.lifecycle());
 			return DuckDBResult<void>::err(DuckDBError(string("submit_fte_task_events failed: ") + e.what()));
 		}
 	} catch (const py::error_already_set &e) {
@@ -853,14 +635,7 @@ DuckDBResult<void> RayWorkerManager::submit_fte_task_events(std::vector<duckdb::
 }
 
 void RayWorkerManager::rethrow_submission_error(const string &query_id, const string &details) {
-	string owner_query_id = query_id;
-	{
-		lock_guard<mutex> guard(mutex_);
-		auto owner = state_.query_owner_by_query.find(query_id);
-		if (owner != state_.query_owner_by_query.end()) {
-			owner_query_id = owner->second;
-		}
-	}
+	const auto owner_query_id = query_lifecycles_.OwnerForQuery(query_id);
 	auto message = string("distributed worker task submission failed for query_id=") + query_id;
 	if (!details.empty()) {
 		message += "; execution error: " + details;
@@ -1131,6 +906,15 @@ DuckDBResult<void> RayWorkerManager::shutdown() {
 			return DuckDBResult<void>::ok();
 		}
 		state_.shutdown_started = true;
+	}
+	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
+		py::gil_scoped_release release;
+		query_lifecycles_.BeginShutdown();
+	} else {
+		query_lifecycles_.BeginShutdown();
+	}
+	{
+		lock_guard<mutex> guard(mutex_);
 		workers.reserve(state_.ray_workers.size());
 		for (auto &kv : state_.ray_workers) {
 			workers.push_back(kv.second);
@@ -1178,26 +962,22 @@ DuckDBResult<void> RayWorkerManager::shutdown() {
 	decltype(state_.fte_result_handles_by_query) result_handles;
 	decltype(state_.retained_fte_result_handles_by_query) retained_result_handles;
 	decltype(state_.workers_by_query_owner) query_workers;
-	std::unordered_set<string> owner_query_ids;
 	{
 		std::unique_lock<mutex> guard(mutex_);
 		shutdown_cv_.wait(guard, [&]() { return state_.active_operations == 0; });
-		for (const auto &entry : state_.query_owner_by_query) {
-			owner_query_ids.insert(entry.second);
-		}
 		state_.ray_workers.clear();
 		result_handles = std::move(state_.fte_result_handles_by_query);
 		retained_result_handles = std::move(state_.retained_fte_result_handles_by_query);
 		query_workers = std::move(state_.workers_by_query_owner);
-		state_.query_owner_by_query.clear();
-		state_.active_query_operations_by_owner.clear();
-		state_.closed_query_owners.clear();
-		state_.quiesced_query_owners.clear();
-		state_.quiescing_query_owners.clear();
-		state_.quiesce_waiters_by_owner.clear();
-		state_.dropping_query_owners.clear();
 		state_.last_refresh = {};
 	}
+	if (Py_IsInitialized() && !duckdb::PythonIsFinalizing() && PyGILState_Check()) {
+		py::gil_scoped_release release;
+		query_lifecycles_.WaitForAllOperations();
+	} else {
+		query_lifecycles_.WaitForAllOperations();
+	}
+	const auto owner_query_ids = query_lifecycles_.OwnerQueryIds();
 	result_handles.clear();
 	retained_result_handles.clear();
 	query_workers.clear();
@@ -1212,6 +992,27 @@ DuckDBResult<void> RayWorkerManager::shutdown() {
 			}
 		}
 		submission_errors_.Discard(owner_query_id);
+	}
+	try {
+		query_lifecycles_.FinishShutdown(true);
+	} catch (const std::exception &ex) {
+		errors.push_back(string("query lifecycle shutdown: ") + ex.what());
+		try {
+			query_lifecycles_.FinishShutdown(false);
+		} catch (const std::exception &finish_ex) {
+			errors.push_back(string("query lifecycle shutdown recovery: ") + finish_ex.what());
+		} catch (...) {
+			errors.push_back("query lifecycle shutdown recovery: unknown error");
+		}
+	} catch (...) {
+		errors.push_back("query lifecycle shutdown: unknown error");
+		try {
+			query_lifecycles_.FinishShutdown(false);
+		} catch (const std::exception &finish_ex) {
+			errors.push_back(string("query lifecycle shutdown recovery: ") + finish_ex.what());
+		} catch (...) {
+			errors.push_back("query lifecycle shutdown recovery: unknown error");
+		}
 	}
 	std::string error_message;
 	if (!errors.empty()) {
@@ -1269,6 +1070,68 @@ DuckDBResult<void> RayWorkerManager::close_session(const string &session_id) {
 	return DuckDBResult<void>::ok();
 }
 
+DuckDBResult<void> RayWorkerManager::ExecuteQueryAbort(std::optional<QueryLifecycleCoordinator::Abort> active_abort) {
+	if (!active_abort) {
+		return DuckDBResult<void>::ok();
+	}
+
+	std::optional<string> failure;
+	try {
+		std::vector<string> errors;
+		auto prepare_workers = [&]() {
+			const auto workers = QueryWorkers(active_abort->lifecycle.owner_query_id);
+			for (const auto &execution_query_id : active_abort->execution_query_ids) {
+				for (const auto &worker : workers) {
+					const auto worker_id = worker && worker->Id() ? *worker->Id() : string("<unknown>");
+					try {
+						worker->PrepareDropQuery(execution_query_id);
+					} catch (const std::exception &ex) {
+						errors.push_back(execution_query_id + "@" + worker_id + ": " + ex.what());
+					} catch (...) {
+						errors.push_back(execution_query_id + "@" + worker_id + ": unknown abort error");
+					}
+				}
+			}
+		};
+		prepare_workers();
+		if (errors.empty()) {
+			WaitForQueryOperations(active_abort->lifecycle);
+			if (active_abort->had_active_operations) {
+				prepare_workers();
+			}
+		}
+		if (!errors.empty()) {
+			failure = "resource query abort barrier failed with " + std::to_string(errors.size()) + " error(s)";
+			for (const auto &error : errors) {
+				*failure += "; " + error;
+			}
+		}
+	} catch (const std::exception &ex) {
+		failure = string("resource query abort orchestration failed: ") + ex.what();
+	} catch (...) {
+		failure = "resource query abort orchestration failed: unknown error";
+	}
+	try {
+		query_lifecycles_.CompleteAbort(*active_abort, failure);
+	} catch (const std::exception &ex) {
+		if (failure) {
+			*failure += "; lifecycle completion: " + string(ex.what());
+		} else {
+			failure = string("resource query abort lifecycle completion failed: ") + ex.what();
+		}
+	} catch (...) {
+		if (failure) {
+			*failure += "; lifecycle completion: unknown error";
+		} else {
+			failure = "resource query abort lifecycle completion failed: unknown error";
+		}
+	}
+	if (failure) {
+		return DuckDBResult<void>::err(DuckDBError::external_error(std::move(*failure)));
+	}
+	return DuckDBResult<void>::ok();
+}
+
 DuckDBResult<void> RayWorkerManager::abort_and_quiesce_query(const string &query_id) {
 	if (query_id.empty()) {
 		return DuckDBResult<void>::err(DuckDBError::value_error("FTE query abort requires non-empty query_id"));
@@ -1277,84 +1140,13 @@ DuckDBResult<void> RayWorkerManager::abort_and_quiesce_query(const string &query
 	if (!operation) {
 		return DuckDBResult<void>::err(DuckDBError::invalid_state_error("Ray worker manager is shut down"));
 	}
-	std::optional<QueryAbort> active_abort;
 	try {
-		active_abort = BeginQueryAbort(query_id);
+		return ExecuteQueryAbort(BeginQueryAbort(query_id));
 	} catch (const std::exception &ex) {
 		return DuckDBResult<void>::err(DuckDBError::external_error(ex.what()));
 	} catch (...) {
 		return DuckDBResult<void>::err(
 		    DuckDBError::external_error("unknown error while starting resource query abort"));
-	}
-	if (!active_abort) {
-		return DuckDBResult<void>::ok();
-	}
-
-	try {
-		std::vector<string> errors;
-		auto prepare_workers = [&]() {
-			try {
-				for (const auto &execution_query_id : active_abort->execution_query_ids) {
-					for (const auto &worker : active_abort->workers) {
-						const auto worker_id = worker && worker->Id() ? *worker->Id() : string("<unknown>");
-						try {
-							worker->PrepareDropQuery(execution_query_id);
-						} catch (const std::exception &ex) {
-							errors.push_back(execution_query_id + "@" + worker_id + ": " + ex.what());
-						} catch (...) {
-							errors.push_back(execution_query_id + "@" + worker_id + ": unknown abort error");
-						}
-					}
-				}
-			} catch (const std::exception &ex) {
-				errors.push_back(string("abort orchestration: ") + ex.what());
-			} catch (...) {
-				errors.push_back("abort orchestration: unknown error");
-			}
-		};
-		prepare_workers();
-		if (errors.empty()) {
-			WaitForQueryOperations(active_abort->owner_query_id);
-			if (active_abort->had_active_operations) {
-				{
-					lock_guard<mutex> guard(mutex_);
-					auto add_worker = [&](const std::shared_ptr<RayWorkerRuntime> &worker) {
-						if (worker && std::find(active_abort->workers.begin(), active_abort->workers.end(), worker) ==
-						                  active_abort->workers.end()) {
-							active_abort->workers.push_back(worker);
-						}
-					};
-					auto owned_workers = state_.workers_by_query_owner.find(active_abort->owner_query_id);
-					if (owned_workers != state_.workers_by_query_owner.end()) {
-						for (const auto &worker : owned_workers->second) {
-							add_worker(worker);
-						}
-					}
-					for (const auto &entry : state_.ray_workers) {
-						add_worker(entry.second);
-					}
-				}
-				prepare_workers();
-			}
-		}
-		const bool succeeded = errors.empty();
-		EndQueryAbort(active_abort->owner_query_id, active_abort->token, succeeded);
-		if (!succeeded) {
-			string message = "resource query abort barrier failed with " + std::to_string(errors.size()) + " error(s)";
-			for (const auto &error : errors) {
-				message += "; " + error;
-			}
-			return DuckDBResult<void>::err(DuckDBError::external_error(std::move(message)));
-		}
-		return DuckDBResult<void>::ok();
-	} catch (const std::exception &ex) {
-		EndQueryAbort(active_abort->owner_query_id, active_abort->token, false);
-		return DuckDBResult<void>::err(
-		    DuckDBError::external_error(string("resource query abort orchestration failed: ") + ex.what()));
-	} catch (...) {
-		EndQueryAbort(active_abort->owner_query_id, active_abort->token, false);
-		return DuckDBResult<void>::err(
-		    DuckDBError::external_error("resource query abort orchestration failed: unknown error"));
 	}
 }
 
@@ -1366,18 +1158,20 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 	if (!operation) {
 		throw std::runtime_error("Ray worker manager is shut down");
 	}
-	auto abort_res = abort_and_quiesce_query(query_id);
-	if (abort_res.is_err()) {
-		throw std::runtime_error(abort_res.error().what());
-	}
-	auto active_drop = BeginQueryDrop(query_id);
-	if (!active_drop) {
+	auto teardown = BeginQueryTeardown(query_id);
+	if (!teardown) {
 		return;
 	}
 	try {
+		auto abort_res = ExecuteQueryAbort(BeginQueryAbort(*teardown));
+		if (abort_res.is_err()) {
+			throw std::runtime_error(abort_res.error().what());
+		}
+		query_lifecycles_.MarkDropping(*teardown);
+		const auto workers = QueryWorkers(teardown->lifecycle.owner_query_id);
 		std::vector<string> errors;
-		for (const auto &execution_query_id : active_drop->execution_query_ids) {
-			for (const auto &worker : active_drop->workers) {
+		for (const auto &execution_query_id : teardown->execution_query_ids) {
+			for (const auto &worker : workers) {
 				const auto worker_id = worker && worker->Id() ? *worker->Id() : string("<unknown>");
 				try {
 					worker->CleanupQuery(execution_query_id);
@@ -1397,7 +1191,7 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 			throw std::runtime_error(std::move(message));
 		}
 
-		for (const auto &execution_query_id : active_drop->execution_query_ids) {
+		for (const auto &execution_query_id : teardown->execution_query_ids) {
 			try {
 				ClearFteResultHandles(execution_query_id);
 			} catch (const std::exception &ex) {
@@ -1414,13 +1208,24 @@ void RayWorkerManager::drop_query_fragments(const string &query_id) {
 			throw std::runtime_error(std::move(message));
 		}
 		if (query_cleanup_) {
-			query_cleanup_(active_drop->owner_query_id);
+			query_cleanup_(teardown->lifecycle.owner_query_id);
 		}
-		submission_errors_.Discard(active_drop->owner_query_id);
-		FinishQueryLifecycle(active_drop->owner_query_id, active_drop->token);
+		submission_errors_.Discard(teardown->lifecycle.owner_query_id);
+		{
+			lock_guard<mutex> guard(mutex_);
+			state_.workers_by_query_owner.erase(teardown->lifecycle.owner_query_id);
+		}
+		query_lifecycles_.CompleteTeardown(*teardown, std::nullopt);
 	} catch (...) {
-		EndQueryDrop(active_drop->owner_query_id, active_drop->token);
-		throw;
+		auto failure = ExceptionMessage(std::current_exception());
+		try {
+			query_lifecycles_.CompleteTeardown(*teardown, failure);
+		} catch (const std::exception &ex) {
+			failure += "; lifecycle completion: " + string(ex.what());
+		} catch (...) {
+			failure += "; lifecycle completion: unknown error";
+		}
+		throw std::runtime_error(std::move(failure));
 	}
 }
 

--- a/src/vane_py/ray/worker_manager.hpp
+++ b/src/vane_py/ray/worker_manager.hpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "safe_pyobject.hpp"
+#include "query_lifecycle_coordinator.hpp"
 #include "worker.hpp"
 #include "task.hpp"
 #include "duckdb/execution/distributed/utils/channel.hpp"
@@ -82,27 +83,10 @@ private:
 		    fte_result_handles_by_query;
 		std::unordered_map<string, std::vector<std::unique_ptr<RayWorkerRuntime::TaskResultHandleType>>>
 		    retained_fte_result_handles_by_query;
-		std::unordered_map<string, string> query_owner_by_query;
-		std::unordered_map<string, idx_t> active_query_operations_by_owner;
 		std::unordered_map<string, std::vector<std::shared_ptr<RayWorkerRuntime>>> workers_by_query_owner;
-		std::unordered_set<string> closed_query_owners;
-		std::unordered_set<string> quiesced_query_owners;
-		std::unordered_map<string, uint64_t> quiescing_query_owners;
-		std::unordered_map<string, idx_t> quiesce_waiters_by_owner;
-		std::unordered_map<string, uint64_t> dropping_query_owners;
-		uint64_t next_query_quiesce_token = 1;
-		uint64_t next_query_drop_token = 1;
 		idx_t active_operations = 0;
 		bool shutdown_started = false;
 		bool shutdown_finished = false;
-	};
-
-	struct QueryAbort {
-		string owner_query_id;
-		std::vector<string> execution_query_ids;
-		std::vector<std::shared_ptr<RayWorkerRuntime>> workers;
-		uint64_t token;
-		bool had_active_operations;
 	};
 
 	class OperationGuard {
@@ -130,25 +114,28 @@ private:
 	public:
 		QueryOperationGuard(RayWorkerManager &manager, const string &query_id,
 		                    const string &requested_owner_query_id = string())
-		    : manager_(manager), owner_query_id_(manager_.BeginQueryOperation(query_id, requested_owner_query_id)) {
+		    : manager_(manager), operation_(manager_.BeginQueryOperation(query_id, requested_owner_query_id)) {
 		}
 		QueryOperationGuard(const QueryOperationGuard &) = delete;
 		QueryOperationGuard &operator=(const QueryOperationGuard &) = delete;
 		~QueryOperationGuard() {
-			if (owner_query_id_) {
-				manager_.EndQueryOperation(*owner_query_id_);
+			if (operation_) {
+				manager_.EndQueryOperation(*operation_);
 			}
 		}
 		explicit operator bool() const {
-			return owner_query_id_.has_value();
+			return operation_.has_value();
 		}
 		const string &owner_query_id() const {
-			return *owner_query_id_;
+			return operation_->lifecycle.owner_query_id;
+		}
+		const QueryLifecycleCoordinator::LifecycleRef &lifecycle() const {
+			return operation_->lifecycle;
 		}
 
 	private:
 		RayWorkerManager &manager_;
-		std::optional<string> owner_query_id_;
+		std::optional<QueryLifecycleCoordinator::Operation> operation_;
 	};
 
 	const string manager_instance_id_;
@@ -156,24 +143,23 @@ private:
 	mutable mutex mutex_;
 	mutable std::condition_variable shutdown_cv_;
 	mutable State state_;
+	QueryLifecycleCoordinator query_lifecycles_;
 	PythonExceptionStore submission_errors_;
 
 	bool BeginOperation() const;
 	void EndOperation() const;
-	std::optional<string> BeginQueryOperation(const string &query_id, const string &requested_owner_query_id);
-	void EndQueryOperation(const string &owner_query_id);
-	void CloseQueryOwnerIngress(const string &owner_query_id);
-	void WaitForQueryOperationsWithoutGIL(const string &owner_query_id);
-	void WaitForQueryOperations(const string &owner_query_id);
+	std::optional<QueryLifecycleCoordinator::Operation> BeginQueryOperation(const string &query_id,
+	                                                                        const string &requested_owner_query_id);
+	void EndQueryOperation(const QueryLifecycleCoordinator::Operation &operation);
+	void WaitForQueryOperations(const QueryLifecycleCoordinator::LifecycleRef &lifecycle);
 	void RecordQueryWorkers(const string &owner_query_id,
 	                        const std::vector<std::shared_ptr<RayWorkerRuntime>> &workers);
-	std::optional<QueryAbort> BeginQueryAbortWithoutGIL(const string &query_id);
-	std::optional<QueryAbort> BeginQueryAbort(const string &query_id);
-	void EndQueryAbort(const string &owner_query_id, uint64_t token, bool succeeded);
-	std::optional<QueryAbort> BeginQueryDropWithoutGIL(const string &query_id);
-	std::optional<QueryAbort> BeginQueryDrop(const string &query_id);
-	void EndQueryDrop(const string &owner_query_id, uint64_t token);
-	void FinishQueryLifecycle(const string &owner_query_id, uint64_t drop_token);
+	std::optional<QueryLifecycleCoordinator::Abort> BeginQueryAbort(const string &query_id);
+	std::optional<QueryLifecycleCoordinator::Abort>
+	BeginQueryAbort(const QueryLifecycleCoordinator::Teardown &teardown);
+	std::optional<QueryLifecycleCoordinator::Teardown> BeginQueryTeardown(const string &query_id);
+	std::vector<std::shared_ptr<RayWorkerRuntime>> QueryWorkers(const string &owner_query_id) const;
+	DuckDBResult<void> ExecuteQueryAbort(std::optional<QueryLifecycleCoordinator::Abort> active_abort);
 	bool ShutdownStarted() const;
 	bool RetireWorkerForFailure(const string &worker_id, const std::shared_ptr<RayWorkerRuntime> &worker,
 	                            const std::shared_ptr<std::atomic<bool>> &retired) const;

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -2993,6 +2993,60 @@ def test_cxx_backend_serializes_overlapping_drop_and_reuses_query_id():
     assert backend.drop_calls == [query_id, query_id]
 
 
+def test_cxx_backend_overlapping_drop_joins_failure_and_retry_generation():
+    thread_count = 6
+    caller_barrier = threading.Barrier(thread_count)
+    drop_condition = threading.Condition()
+
+    class Backend(_QueryLifecycleBackend):
+        def __init__(self):
+            self.drop_calls = []
+
+        def drop_query(self, query_id):
+            with drop_condition:
+                self.drop_calls.append(str(query_id))
+                call_number = len(self.drop_calls)
+                drop_condition.notify_all()
+                if call_number == 1:
+                    # A correct single-flight implementation admits only this
+                    # leader. Keep it open long enough for the other callers to
+                    # join; the predicate only completes early for the broken
+                    # implementation that calls every backend drop.
+                    drop_condition.wait_for(lambda: len(self.drop_calls) == thread_count, timeout=0.5)
+            if call_number == 1:
+                raise RuntimeError("planned shared teardown failure")
+
+    query_id = f"backend-overlapping-drop-failure-{uuid.uuid4()}"
+    backend = Backend()
+    runner = vane.ray_cxx.DistributedPhysicalPlanRunner(backend)
+    runner._register_query_owner_for_test(query_id, query_id)
+    errors: list[BaseException] = []
+
+    def drop() -> None:
+        try:
+            caller_barrier.wait(timeout=5.0)
+            runner.drop_query_fragments(query_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=drop) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5.0)
+
+    assert [thread for thread in threads if thread.is_alive()] == []
+    assert len(errors) == thread_count
+    assert len({str(error) for error in errors}) == 1
+    assert "planned shared teardown failure" in str(errors[0])
+    assert backend.drop_calls == [query_id]
+
+    runner.drop_query_fragments(query_id)
+    runner._register_query_owner_for_test(query_id, query_id)
+    runner.drop_query_fragments(query_id)
+    assert backend.drop_calls == [query_id, query_id, query_id]
+
+
 def test_cxx_backend_routes_nested_execution_drop_to_registered_resource_owner():
     class Backend(_QueryLifecycleBackend):
         def __init__(self):

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -3481,8 +3481,8 @@ def test_cxx_backend_drop_failure_preserves_replay_state_for_active_submit_until
         con.close()
 
 
-def test_cxx_backend_drop_waits_for_shutdown_before_owner_state_cleanup():
-    """A drop joining shutdown must not report success before shutdown quiesces work."""
+def test_cxx_backend_drop_rejects_running_shutdown_without_waiting():
+    """A teardown must not wait on shutdown while its caller can block shutdown."""
     submit_started = threading.Event()
     allow_submit_return = threading.Event()
     shutdown_started = threading.Event()
@@ -3571,9 +3571,11 @@ def test_cxx_backend_drop_waits_for_shutdown_before_owner_state_cleanup():
 
         drop_thread.start()
         assert drop_invoked.wait(timeout=5.0)
-        drop_thread.join(timeout=0.05)
-        assert drop_thread.is_alive()
+        drop_thread.join(timeout=5.0)
+        assert not drop_thread.is_alive()
         assert shutdown_thread.is_alive()
+        assert len(drop_errors) == 1
+        assert "cannot tear down FTE query while Python backend is shutting down" in str(drop_errors[0])
         assert vane.ray_cxx._lookup_query_connection_snapshot(query_id) is not None
 
         allow_submit_return.set()
@@ -3585,7 +3587,7 @@ def test_cxx_backend_drop_waits_for_shutdown_before_owner_state_cleanup():
         assert not shutdown_thread.is_alive()
         assert not drop_thread.is_alive()
         assert shutdown_errors == []
-        assert drop_errors == []
+        assert len(drop_errors) == 1
         assert len(run_errors) == 1
         assert "query is closing" in str(run_errors[0])
         assert backend.drop_calls == []

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -4117,6 +4117,95 @@ def test_ray_worker_manager_snapshot_refresh_shutdown_has_no_deadlock(monkeypatc
     assert aborted == ["worker-racing-shutdown"]
 
 
+def test_ray_worker_manager_overlapping_drop_joins_failure_and_retry_generation(monkeypatch):
+    query_id = "query-overlapping-drop-failure"
+    thread_count = 6
+    caller_barrier = threading.Barrier(thread_count)
+    drop_condition = threading.Condition()
+    prepare_calls = []
+    cleanup_calls = []
+
+    class DummyRayWorkerHandle:
+        def fte_prepare_drop_query(self, actual_query_id):
+            with drop_condition:
+                prepare_calls.append(str(actual_query_id))
+                call_number = len(prepare_calls)
+                drop_condition.notify_all()
+                if call_number == 1:
+                    # A correct single-flight implementation admits only this
+                    # leader. Keep it open long enough for the other callers to
+                    # join; the predicate only completes early for the broken
+                    # implementation that calls every worker abort.
+                    drop_condition.wait_for(lambda: len(prepare_calls) == thread_count, timeout=0.5)
+            if call_number == 1:
+                raise RuntimeError("planned shared Ray teardown failure")
+            return {
+                "tasks_removed": 0,
+                "tasks_canceled": 0,
+                "fragments_removed": 0,
+            }
+
+        def fte_cleanup_query(self, actual_query_id):
+            cleanup_calls.append(str(actual_query_id))
+            return {}
+
+        def prepare_shutdown(self):
+            pass
+
+        def finish_shutdown(self):
+            pass
+
+        def abort_shutdown(self):
+            raise AssertionError("successful shutdown must not abort the worker")
+
+    def start_ray_workers(_existing_ids, _manager_instance_id):
+        return [
+            vane.ray_cxx.RayWorkerRuntime(
+                "worker-overlapping-drop",
+                DummyRayWorkerHandle(),
+                1.0,
+                0.0,
+                1024,
+            )
+        ]
+
+    import vane.runners.ray.worker_handle as ray_worker_handle
+
+    monkeypatch.setattr(ray_worker_handle, "start_ray_workers", start_ray_workers)
+    monkeypatch.setattr(ray_worker_handle, "try_autoscale", lambda _bundles: None)
+    manager = vane.ray_cxx.RayWorkerManager()
+    assert len(manager.worker_snapshots()) == 1
+    manager.register_query_owner(query_id, query_id)
+    errors: list[BaseException] = []
+
+    def drop() -> None:
+        try:
+            caller_barrier.wait(timeout=5.0)
+            manager.drop_query_fragments(query_id)
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=drop) for _ in range(thread_count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5.0)
+
+    assert [thread for thread in threads if thread.is_alive()] == []
+    assert len(errors) == thread_count
+    assert len({str(error) for error in errors}) == 1
+    assert "planned shared Ray teardown failure" in str(errors[0])
+    assert prepare_calls == [query_id]
+    assert cleanup_calls == []
+
+    manager.drop_query_fragments(query_id)
+    manager.register_query_owner(query_id, query_id)
+    manager.drop_query_fragments(query_id)
+    assert prepare_calls == [query_id, query_id, query_id]
+    assert cleanup_calls == [query_id, query_id]
+    manager.shutdown()
+
+
 def test_ray_worker_manager_drop_is_best_effort_across_worker_failures(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Summary

- Add a shared, generation-scoped `QueryLifecycleCoordinator` for the Python backend and `RayWorkerManager`, replacing their duplicated lifecycle maps and concurrency state.
- Make abort and full teardown single-flight operations. Duplicate drops join the same leader and receive the same final result; failures preserve the generation for an explicit retry, while success removes every binding atomically.
- Coordinate two-phase registration, active-operation draining, shutdown, callback reentry, and generation reuse so stale waiters cannot act on a later lifecycle.
- Add concurrent failure/join/retry tests for both backends, including successful reuse of the same query ID in a new generation.

## Related issue

close: #609

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This changes internal FTE lifecycle coordination and does not add a public API.

## Validation

- Reproduced #609 on exact `upstream/main` before the change: 6 failures in 100 runs of the overlapping-drop regression.
- `CMAKE_BUILD_PARALLEL_LEVEL=12 uv pip install . --no-build-isolation --no-deps --reinstall`
- `scripts/format root --from-ref upstream/main --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- `scripts/run_installed_pytest.sh tests/fast/test_fte_native_backend.py tests/fast/test_ray_cpp_bindings.py`: 256 passed, 4 deselected
- `scripts/run_release_tests.sh`: 555 non-Ray passed; 11 real-Ray passed
- `scripts/run_fast_tests.sh shared-ray`: 106 passed, 6 skipped
- `scripts/run_fast_tests.sh owner-ray`: 7 passed, 1 optional vLLM test skipped
- A complete fast run before the final clang-format-only amend passed all phases (6368 non-Ray, 106 shared-Ray, and 7 owner-Ray tests). The final rebuilt artifact reran the gates above.
- On the final artifact, two complete non-Ray phases each passed 6367 tests and hit the same pre-existing flaky `test_run_plan_cancellation_after_startup_claim_tears_down_once`. The test and driver implementation are unchanged from `upstream/main`; it passed alone, while a 100-run isolation reproduced its existing cancellation/startup race (80 passed, 20 failed).

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
