### PR TITLE
[feat](distributed) Replay trusted dynamic extensions on Ray workers

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,8 +65,49 @@ VANE_TEST_LOADABLE_EXTENSION_PATH=\
 Loadable artifacts require `EXTENSION_STATIC_BUILD=ON`. This keeps each
 artifact self-contained and preserves Vane's private `_native` symbol boundary.
 The staging directory is configurable with
-`VANE_LOADABLE_EXTENSION_OUTPUT_DIRECTORY`; packaging and trusted artifact
-metadata are intentionally handled separately.
+`VANE_LOADABLE_EXTENSION_OUTPUT_DIRECTORY`.
+
+## Building an optional extension wheel
+
+The base `vane-ai` wheel must stay free of optional `.duckdb_extension`
+artifacts. Package one already-staged, release-approved artifact into a
+separate platform wheel instead:
+
+```bash
+python scripts/build_extension_wheel.py \
+  --artifact "$SKBUILD_BUILD_DIR/vane_extensions/<extension>.duckdb_extension" \
+  --extension-name <extension> \
+  --platform-tag linux_x86_64 \
+  --trust-identity astrovela/vane \
+  --license-expression "Apache-2.0 AND MIT" \
+  --license-file LICENSE \
+  --license-file LICENSES/DuckDB-MIT.txt \
+  --output-directory dist/extensions
+```
+
+The generated wheel has an exact `vane-ai` dependency, embeds a versioned
+descriptor, and publishes a `vane.dynamic_extension_providers` entry point.
+The build command uses the installed Vane runtime to create that descriptor, so
+run it after installing Vane with the development build procedure above.
+Supply every license required by the selected artifact explicitly; the builder
+does not infer licenses or reuse the base wheel's metadata. Supply a valid,
+corresponding SPDX expression with `--license-expression` as well.
+Its platform tag must match the platform embedded in the extension artifact;
+the builder rejects a mismatched OS, architecture, or Linux libc-family tag.
+Pass that provider explicitly to `DynamicExtensionResolver`; neither installing
+a wheel nor using the resolver performs a network lookup. Validate a base and
+extension wheel together in a clean environment with:
+
+```bash
+python scripts/verify_extension_wheel.py \
+  --base-wheel dist/vane_ai-*.whl \
+  --extension-wheel dist/extensions/vane_extension_<extension>-*.whl \
+  --extension-name <extension> \
+  --trust-identity astrovela/vane
+```
+
+`tpch` remains an in-tree build/test artifact only: its source has additional
+redistribution terms and it must not be published as an extension wheel.
 
 ## Native C++ tests
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,8 +95,14 @@ corresponding SPDX expression with `--license-expression` as well.
 Its platform tag must match the platform embedded in the extension artifact;
 the builder rejects a mismatched OS, architecture, or Linux libc-family tag.
 Pass that provider explicitly to `DynamicExtensionResolver`; neither installing
-a wheel nor using the resolver performs a network lookup. Validate a base and
-extension wheel together in a clean environment with:
+a wheel nor using the resolver performs a network lookup. For Ray execution,
+the resolver records the exact loaded descriptor, artifact digest, and
+dependency order in the connection snapshot. A worker resolves only the named,
+preinstalled `vane.dynamic_extension_providers` entry points before it
+deserializes the plan. It never receives a coordinator-local artifact path,
+scans a directory, or downloads an extension; it also keeps unsigned loading,
+autoloading, and autoinstalling disabled. Validate a base and extension wheel
+together in a clean environment with:
 
 ```bash
 python scripts/verify_extension_wheel.py \

--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -105,12 +105,23 @@ method, matching DuckDB's `OperatorExtension`, `ParserExtension`,
 ## Build and loading
 
 The connection snapshot records the content-derived DuckDB `SourceID`, every
-loaded static extension name and exact extension version, and a sorted list of
-canonical distributed contract identities. A worker first validates its
-`SourceID`, invokes DuckDB's generated static loader, compares the loaded
-extension identities, and then compares the registered contracts before
-deserializing a plan. Dynamically
-installed extension binaries are not accepted by distributed execution.
+loaded static extension name and exact extension version, an ordered dynamic
+artifact list, and a sorted list of canonical distributed contract identities.
+Each dynamic entry contains the immutable descriptor, SHA-256 artifact digest,
+and declared dependency order. The coordinator records an entry only after
+`DynamicExtensionResolver` has verified and loaded it; a non-static extension
+loaded by another route is rejected while the snapshot is captured.
+
+A worker first validates its `SourceID`, resolves each dynamic entry from the
+matching preinstalled `vane.dynamic_extension_providers` entry point, verifies
+the descriptor and bytes, loads the dependency order, invokes DuckDB's
+generated static loader, compares loaded extension identities, and then
+compares registered contracts before deserializing a plan. The worker never
+receives a coordinator-local artifact path, scans a directory, or downloads an
+extension. It keeps unsigned loading, autoloading, and autoinstalling disabled;
+missing, altered, unsigned, platform-incompatible, or provider-disagreed
+artifacts fail deterministically. The exact dynamic descriptors and order are
+part of the worker DatabaseInstance cache identity.
 
 The snapshot schema is strict. Legacy name-only extension lists, absent
 contract data, extra worker contracts, and any protocol mismatch are rejected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ build-backend = "build_backend"
 backend-path = ["."]
 requires = [
     "scikit-build-core>=0.11.4",
+	"packaging>=24.2",
 	"pybind11[global]>=3.0.0",
     "setuptools-scm>=9.2.0",
 ]
@@ -208,6 +209,7 @@ include = [
     "/scripts/bootstrap_vcpkg.sh",
     "cmake/**",
     "/scripts/check_release_artifacts.py",
+    "/scripts/build_extension_wheel.py",
     "/scripts/run_installed_pytest.sh",
     "/scripts/run_release_tests.sh",
     "/scripts/resolve_duckdb_fork_version.py",
@@ -215,6 +217,7 @@ include = [
     "/scripts/sync_vcpkg_licenses.py",
     "/scripts/verify_base_install.py",
     "/scripts/verify_duckdb_coexistence.py",
+    "/scripts/verify_extension_wheel.py",
 
     # Curated base-installation release gate. The larger inherited test tree
     # stays in the repository and is intentionally not part of the PyPI sdist.

--- a/scripts/build_extension_wheel.py
+++ b/scripts/build_extension_wheel.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Package one staged Vane extension artifact as an independent platform wheel."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from vane_packaging.extension_wheel import build_extension_wheel
+
+sys.path[:] = [import_path for import_path in sys.path if Path(import_path or ".").resolve() != REPOSITORY_ROOT]
+
+
+def main() -> int:
+    """Build an extension wheel from one explicit self-contained artifact."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact", required=True, type=Path, help="Path to <extension>.duckdb_extension")
+    parser.add_argument("--extension-name", required=True, help="Lowercase DuckDB extension name")
+    parser.add_argument("--output-directory", required=True, type=Path, help="Directory for the generated wheel")
+    parser.add_argument(
+        "--platform-tag",
+        required=True,
+        help="Exact wheel platform tag, such as linux_x86_64 or manylinux_2_28_x86_64",
+    )
+    parser.add_argument("--trust-identity", required=True, help="Descriptor trust identity")
+    parser.add_argument(
+        "--license-expression",
+        required=True,
+        help="SPDX license expression covering the extension wheel",
+    )
+    parser.add_argument(
+        "--license-file",
+        action="append",
+        required=True,
+        type=Path,
+        help="License file required by the artifact; pass once for each file",
+    )
+    arguments = parser.parse_args()
+
+    built = build_extension_wheel(
+        artifact=arguments.artifact,
+        extension_name=arguments.extension_name,
+        output_directory=arguments.output_directory,
+        platform_tag=arguments.platform_tag,
+        trust_identity=arguments.trust_identity,
+        license_expression=arguments.license_expression,
+        license_files=arguments.license_file,
+    )
+    print(built.path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -466,12 +466,15 @@ def _check_sdist(artifact: SdistArtifact, layout: DistributionLayout) -> None:
         "external/duckdb/LICENSE",
         "build_backend.py",
         "vane_packaging/__init__.py",
+        "vane_packaging/extension_wheel.py",
         "vane_packaging/setuptools_scm_version.py",
+        "scripts/build_extension_wheel.py",
         "scripts/resolve_duckdb_fork_version.py",
         "scripts/run_installed_pytest.sh",
         "scripts/run_release_tests.sh",
         "scripts/sync_duckdb_source_id.py",
         "scripts/verify_duckdb_coexistence.py",
+        "scripts/verify_extension_wheel.py",
         "tests/ray_test_profile.py",
         "tests/fast/test_package_metadata.py",
         "tests/fast/test_ray_test_profile.py",
@@ -565,6 +568,12 @@ def _check_wheel(artifact: WheelArtifact, layout: DistributionLayout) -> None:
         if root in {"vane", layout.dist_info_root, EXPECTED_LIBRARY_ROOT}:
             continue
         raise ValueError(f"{artifact.path}: Vane wheel contains conflicting Python package path {name!r}")
+
+    optional_artifacts = [name for name in names if name.endswith(".duckdb_extension")]
+    if optional_artifacts:
+        raise ValueError(
+            f"{artifact.path}: base Vane wheel must not contain optional extension artifacts: {optional_artifacts}"
+        )
 
     native_extensions = [
         name

--- a/scripts/verify_extension_wheel.py
+++ b/scripts/verify_extension_wheel.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Install a base Vane wheel and extension wheel in a clean environment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import venv
+import zipfile
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from vane_packaging.extension_wheel import ENTRY_POINT_GROUP
+
+sys.path[:] = [import_path for import_path in sys.path if Path(import_path or ".").resolve() != REPOSITORY_ROOT]
+
+
+def _run(command: list[str], *, cwd: Path, environment: dict[str, str] | None = None) -> None:
+    subprocess.run(command, cwd=cwd, env=environment, check=True)
+
+
+def _python_path(environment_directory: Path) -> Path:
+    executable_name = "python.exe" if os.name == "nt" else "python"
+    return environment_directory / ("Scripts" if os.name == "nt" else "bin") / executable_name
+
+
+def _assert_base_wheel_is_artifact_free(base_wheel: Path) -> None:
+    with zipfile.ZipFile(base_wheel) as wheel:
+        artifacts = [name for name in wheel.namelist() if name.endswith(".duckdb_extension")]
+    if artifacts:
+        raise RuntimeError(f"base Vane wheel must not contain dynamic extension artifacts: {artifacts}")
+
+
+def verify_extension_wheel(
+    *,
+    base_wheel: str | Path,
+    extension_wheel: str | Path,
+    extension_name: str,
+    trust_identity: str,
+) -> None:
+    """Verify clean installation, metadata discovery, and local artifact loading."""
+    resolved_base_wheel = Path(base_wheel).expanduser().resolve(strict=True)
+    resolved_extension_wheel = Path(extension_wheel).expanduser().resolve(strict=True)
+    _assert_base_wheel_is_artifact_free(resolved_base_wheel)
+
+    with tempfile.TemporaryDirectory(prefix="vane-extension-wheel-") as temporary_directory:
+        workspace = Path(temporary_directory)
+        environment_directory = workspace / "venv"
+        venv.EnvBuilder(with_pip=True, clear=True).create(environment_directory)
+        python = _python_path(environment_directory)
+        environment = os.environ.copy()
+        environment.pop("PYTHONPATH", None)
+        environment.pop("PYTHONOPTIMIZE", None)
+        environment.pop("VIRTUAL_ENV", None)
+        environment["PYTHONSAFEPATH"] = "1"
+        _run(
+            [
+                str(python),
+                "-m",
+                "pip",
+                "--disable-pip-version-check",
+                "install",
+                str(resolved_base_wheel),
+                str(resolved_extension_wheel),
+            ],
+            cwd=workspace,
+            environment=environment,
+        )
+
+        validation = textwrap.dedent(
+            f"""
+            from importlib import import_module
+            from importlib.metadata import entry_points
+
+            import vane
+            from vane.extensions import DynamicExtensionResolver
+
+            providers = [
+                entry_point
+                for entry_point in entry_points(group={ENTRY_POINT_GROUP!r})
+                if entry_point.name == {extension_name!r}
+            ]
+            assert len(providers) == 1, providers
+            provider_entry_point = providers[0]
+            provider = provider_entry_point.load()()
+            descriptor = import_module(provider_entry_point.module).descriptor()
+            assert descriptor.name == {extension_name!r}
+            artifact = provider.find(descriptor.identity)
+            assert artifact is not None
+            assert artifact.path.name == {extension_name + ".duckdb_extension"!r}
+
+            connection = vane.connect(config={{"allow_unsigned_extensions": "true"}})
+            try:
+                resolved = DynamicExtensionResolver(
+                    trusted_identities={{{trust_identity!r}}},
+                    providers=(provider,),
+                ).load(connection, descriptor)
+                assert resolved.identity == descriptor.identity
+                assert connection.execute(
+                    "SELECT loaded FROM duckdb_extensions() WHERE extension_name = ?", [descriptor.name]
+                ).fetchone() == (True,)
+            finally:
+                connection.close()
+            """
+        )
+        program = f"exec(compile({validation!r}, '<extension-wheel-validation>', 'exec', optimize=0))"
+        _run([str(python), "-I", "-c", program], cwd=workspace, environment=environment)
+
+
+def main() -> int:
+    """Run clean-install verification for one extension wheel."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-wheel", required=True, type=Path)
+    parser.add_argument("--extension-wheel", required=True, type=Path)
+    parser.add_argument("--extension-name", required=True)
+    parser.add_argument("--trust-identity", required=True)
+    arguments = parser.parse_args()
+    verify_extension_wheel(
+        base_wheel=arguments.base_wheel,
+        extension_wheel=arguments.extension_wheel,
+        extension_name=arguments.extension_name,
+        trust_identity=arguments.trust_identity,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
+++ b/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
@@ -160,6 +160,7 @@ struct VaneSessionContext {
 
 	string id;
 	py::dict config;
+	vector<string> dynamic_extension_snapshot_entries;
 	mutex lock;
 	idx_t connection_count = 1;
 	bool ray_session_opened = false;
@@ -382,6 +383,8 @@ public:
 	const string &GetVaneSessionId() const;
 	py::dict ExportVaneSessionConfig() const;
 	void MarkVaneRaySessionOpened();
+	void RecordDynamicExtensionSnapshotEntry(const string &entry);
+	vector<string> ExportDynamicExtensionSnapshotEntries() const;
 	void ReleaseVaneSession();
 
 	static vector<Value> TransformPythonParamList(const py::handle &params);

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -807,6 +807,9 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	      py::arg("extension"), py::kw_only(), py::arg("force_install") = false, py::arg("repository") = py::none(),
 	      py::arg("repository_url") = py::none(), py::arg("version") = py::none());
 	m.def("load_extension", &DuckDBPyConnection::LoadExtension, "Load an installed extension", py::arg("extension"));
+	m.def("_record_dynamic_extension_snapshot_entry", &DuckDBPyConnection::RecordDynamicExtensionSnapshotEntry,
+	      py::arg("entry"));
+	m.def("_export_dynamic_extension_snapshot_entries", &DuckDBPyConnection::ExportDynamicExtensionSnapshotEntries);
 	m.def("get_profiling_information", &DuckDBPyConnection::GetProfilingInformation,
 	      "Get profiling information for a query", py::arg("format") = "json");
 	m.def("enable_profiling", &DuckDBPyConnection::EnableProfiling, "Enable profiling for subsequent queries");
@@ -2980,6 +2983,36 @@ void DuckDBPyConnection::MarkVaneRaySessionOpened() {
 	vane_session->ray_session_opened = true;
 }
 
+void DuckDBPyConnection::RecordDynamicExtensionSnapshotEntry(const string &entry) {
+	if (entry.empty()) {
+		throw InvalidInputException("Dynamic extension snapshot entry must not be empty");
+	}
+	if (!vane_session) {
+		throw InternalException("DuckDB connection is missing its Vane session identity");
+	}
+	lock_guard<mutex> guard(vane_session->lock);
+	if (!vane_session_attached || vane_session->connection_count == 0) {
+		throw InternalException("DuckDB connection Vane session is closed");
+	}
+	for (const auto &existing : vane_session->dynamic_extension_snapshot_entries) {
+		if (existing == entry) {
+			return;
+		}
+	}
+	vane_session->dynamic_extension_snapshot_entries.push_back(entry);
+}
+
+vector<string> DuckDBPyConnection::ExportDynamicExtensionSnapshotEntries() const {
+	if (!vane_session) {
+		throw InternalException("DuckDB connection is missing its Vane session identity");
+	}
+	lock_guard<mutex> guard(vane_session->lock);
+	if (!vane_session_attached || vane_session->connection_count == 0) {
+		throw InternalException("DuckDB connection Vane session is closed");
+	}
+	return vane_session->dynamic_extension_snapshot_entries;
+}
+
 void DuckDBPyConnection::ReleaseVaneSession() {
 	if (!vane_session_attached) {
 		return;
@@ -3002,6 +3035,7 @@ void DuckDBPyConnection::ReleaseVaneSession() {
 	}
 	vane_session->connection_count = 0;
 	vane_session->config = py::dict();
+	vane_session->dynamic_extension_snapshot_entries.clear();
 	vane_session_attached = false;
 }
 

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -786,26 +786,134 @@ static void ApplyEffectiveVaneSessionConfig(DuckDBPyConnection &conn_wrapper, co
 	ApplyVaneSessionConfigValues(conn_wrapper.con.GetConnection(), config_obj.cast<py::dict>());
 }
 
-static std::vector<string> QueryLoadedNonStaticExtensionNames(DuckDBPyConnection &conn_wrapper) {
-	std::vector<string> extensions;
-	auto result =
-	    ExecuteSnapshotQuery(conn_wrapper.con.GetConnection(), "SELECT extension_name "
-	                                                           "FROM duckdb_extensions() "
-	                                                           "WHERE loaded AND install_mode <> 'STATICALLY_LINKED' "
-	                                                           "ORDER BY extension_name");
-	auto &collection = result->Collection();
-	extensions.reserve(collection.Count());
-	for (auto &row : collection.Rows()) {
-		auto value = row.GetValue(0);
-		if (value.IsNull()) {
+static vector<string> LoadedNonStaticExtensionNames(DuckDBPyConnection &conn_wrapper) {
+	vector<string> extensions;
+	auto &database = DatabaseInstance::GetDatabase(*conn_wrapper.con.GetConnection().context);
+	auto &manager = ExtensionManager::Get(database);
+	for (const auto &extension_name : manager.GetExtensions()) {
+		auto info = manager.GetExtensionInfo(extension_name);
+		if (!info) {
 			continue;
 		}
-		auto extension_name = value.ToString();
-		if (!extension_name.empty()) {
-			extensions.push_back(std::move(extension_name));
+		lock_guard<mutex> guard(info->lock);
+		if (!info->is_loaded || !info->install_info ||
+		    info->install_info->mode == ExtensionInstallMode::STATICALLY_LINKED) {
+			continue;
 		}
+		extensions.push_back(extension_name);
 	}
+	std::sort(extensions.begin(), extensions.end());
 	return extensions;
+}
+
+static py::list NormalizeDynamicExtensionSnapshot(const py::object &snapshot_obj) {
+	try {
+		auto extensions_module = py::module_::import("vane.extensions");
+		auto normalized = extensions_module.attr("_normalize_dynamic_extension_snapshot")(snapshot_obj);
+		if (!py::isinstance<py::list>(normalized)) {
+			throw duckdb::InternalException("Dynamic extension snapshot normalizer did not return a list");
+		}
+		return normalized.cast<py::list>();
+	} catch (const py::error_already_set &exception) {
+		throw duckdb::InvalidInputException("Failed to validate dynamic extension snapshot: %s", exception.what());
+	}
+}
+
+static py::list CaptureDynamicExtensionSnapshot(const py::object &conn_obj) {
+	try {
+		auto extensions_module = py::module_::import("vane.extensions");
+		auto snapshot = extensions_module.attr("_capture_dynamic_extension_snapshot")(conn_obj);
+		if (!py::isinstance<py::list>(snapshot)) {
+			throw duckdb::InternalException("Dynamic extension snapshot capture did not return a list");
+		}
+		return snapshot.cast<py::list>();
+	} catch (const py::error_already_set &exception) {
+		throw duckdb::InvalidInputException("Failed to capture dynamic extension snapshot: %s", exception.what());
+	}
+}
+
+static vector<string> DynamicExtensionNamesFromSnapshot(const py::list &dynamic_extensions,
+                                                        const string &snapshot_description) {
+	vector<string> names;
+	set<string> unique_names;
+	for (auto item : dynamic_extensions) {
+		if (!py::isinstance<py::dict>(item)) {
+			throw duckdb::InvalidInputException("%s dynamic extension entry must be a dict", snapshot_description);
+		}
+		auto entry = py::reinterpret_borrow<py::dict>(item);
+		auto descriptor_key = py::str("descriptor");
+		if (!entry.contains(descriptor_key) || !py::isinstance<py::dict>(entry[descriptor_key])) {
+			throw duckdb::InvalidInputException("%s dynamic extension entry is missing a descriptor",
+			                                    snapshot_description);
+		}
+		auto descriptor = py::reinterpret_borrow<py::dict>(entry[descriptor_key]);
+		auto name_key = py::str("name");
+		if (!descriptor.contains(name_key) || !py::isinstance<py::str>(descriptor[name_key])) {
+			throw duckdb::InvalidInputException("%s dynamic extension descriptor is missing a string name",
+			                                    snapshot_description);
+		}
+		auto name = descriptor[name_key].cast<string>();
+		if (name.empty() || !unique_names.insert(name).second) {
+			throw duckdb::InvalidInputException("%s has an empty or duplicate dynamic extension name",
+			                                    snapshot_description);
+		}
+		names.push_back(std::move(name));
+	}
+	std::sort(names.begin(), names.end());
+	return names;
+}
+
+static string DynamicExtensionListIdentity(const vector<string> &extensions) {
+	return "[" + StringUtil::Join(extensions, ",") + "]";
+}
+
+static void ValidateCapturedDynamicExtensionNames(const vector<string> &loaded_extensions,
+                                                  const vector<string> &snapshot_extensions) {
+	if (loaded_extensions == snapshot_extensions) {
+		return;
+	}
+	if (snapshot_extensions.empty() && !loaded_extensions.empty()) {
+		throw duckdb::InvalidInputException(
+		    "Ray distributed execution rejects dynamic extensions that were not loaded through "
+		    "vane.DynamicExtensionResolver: %s",
+		    StringUtil::Join(loaded_extensions, ", "));
+	}
+	throw duckdb::InvalidInputException(
+	    "Dynamic extension identities changed while capturing the connection snapshot: loaded %s, snapshot has %s",
+	    DynamicExtensionListIdentity(loaded_extensions), DynamicExtensionListIdentity(snapshot_extensions));
+}
+
+static void ValidateWorkerDynamicExtensionNames(DuckDBPyConnection &conn_wrapper,
+                                                const vector<string> &expected_extensions) {
+	auto loaded_extensions = LoadedNonStaticExtensionNames(conn_wrapper);
+	if (loaded_extensions == expected_extensions) {
+		return;
+	}
+	throw duckdb::InvalidInputException(
+	    "Dynamic extension identities differ between coordinator and worker: expected %s, worker loaded %s",
+	    DynamicExtensionListIdentity(expected_extensions), DynamicExtensionListIdentity(loaded_extensions));
+}
+
+static void ValidateWorkerRecordedDynamicExtensionNames(DuckDBPyConnection &conn_wrapper, const py::object &conn_obj) {
+	auto recorded_extensions = CaptureDynamicExtensionSnapshot(conn_obj);
+	auto recorded_extension_names =
+	    DynamicExtensionNamesFromSnapshot(recorded_extensions, "Worker connection dynamic extension state");
+	auto loaded_extensions = LoadedNonStaticExtensionNames(conn_wrapper);
+	if (loaded_extensions == recorded_extension_names) {
+		return;
+	}
+	throw duckdb::InvalidInputException("Worker dynamic extension state is not resolver-owned: loaded %s, recorded %s",
+	                                    DynamicExtensionListIdentity(loaded_extensions),
+	                                    DynamicExtensionListIdentity(recorded_extension_names));
+}
+
+static void ReplayDynamicExtensionSnapshot(py::object conn_obj, const py::list &dynamic_extensions) {
+	try {
+		auto extensions_module = py::module_::import("vane.extensions");
+		extensions_module.attr("_replay_dynamic_extension_snapshot")(conn_obj, dynamic_extensions, py::bool_(false));
+	} catch (const py::error_already_set &exception) {
+		throw duckdb::InvalidInputException("Failed to replay dynamic extension snapshot: %s", exception.what());
+	}
 }
 
 struct StaticExtensionSnapshotEntry {
@@ -868,20 +976,6 @@ static std::vector<ConnectionSettingRecord> QueryConnectionSettings(DuckDBPyConn
 		settings.push_back(std::move(record));
 	}
 	return settings;
-}
-
-static void RejectNonStaticRayExtensions(const std::vector<string> &extension_names) {
-	if (extension_names.empty()) {
-		return;
-	}
-	auto joined_names = extension_names.front();
-	for (idx_t index = 1; index < extension_names.size(); index++) {
-		joined_names += ", " + extension_names[index];
-	}
-	throw duckdb::InvalidInputException("Ray distributed execution supports only statically linked extensions; "
-	                                    "non-static extensions are not supported: "
-	                                    "%s",
-	                                    joined_names);
 }
 
 static bool IsSafeStaticExtensionName(const string &name) {
@@ -1056,10 +1150,13 @@ static bool VaneRaySessionLifecycleEnabled() {
 	return runner == "ray";
 }
 
-static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
+static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper, const py::object &conn_obj) {
 	auto bootstrap_obj = conn_wrapper.ExportConnectionBootstrapConfig();
-	auto non_static_extensions = QueryLoadedNonStaticExtensionNames(conn_wrapper);
-	RejectNonStaticRayExtensions(non_static_extensions);
+	auto non_static_extensions = LoadedNonStaticExtensionNames(conn_wrapper);
+	auto dynamic_extensions = CaptureDynamicExtensionSnapshot(conn_obj);
+	auto dynamic_extension_names =
+	    DynamicExtensionNamesFromSnapshot(dynamic_extensions, "Captured connection snapshot");
+	ValidateCapturedDynamicExtensionNames(non_static_extensions, dynamic_extension_names);
 	auto static_extensions = QueryLoadedStaticExtensions(conn_wrapper);
 	auto source_settings = QueryConnectionSettings(conn_wrapper);
 
@@ -1110,6 +1207,7 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper) {
 		extensions_obj.append(std::move(extension_obj));
 	}
 	snapshot_obj[py::str("extensions")] = std::move(extensions_obj);
+	snapshot_obj[py::str("dynamic_extensions")] = std::move(dynamic_extensions);
 	auto &source_database = DatabaseInstance::GetDatabase(*conn_wrapper.con.GetConnection().context);
 	snapshot_obj[py::str("distributed_extension_contracts")] = CaptureDistributedExtensionContracts(source_database);
 	snapshot_obj[py::str("settings")] = std::move(settings_obj);
@@ -1162,7 +1260,7 @@ static PyLogicalPlan LogicalPlanFromDuckDBRelation(py::object relation_obj, py::
 		if (py::len(registrations) > 0) {
 			plan.udf_registrations_ = std::move(registrations);
 		}
-		plan.connection_snapshot_ = CaptureConnectionSnapshot(conn_wrapper);
+		plan.connection_snapshot_ = CaptureConnectionSnapshot(conn_wrapper, connection_owner);
 	}
 	return plan;
 }
@@ -1257,6 +1355,12 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 		extensions.push_back(std::move(extension));
 	}
 	std::sort(extensions.begin(), extensions.end());
+	if (!snapshot.contains(py::str("dynamic_extensions")) ||
+	    !py::isinstance<py::list>(snapshot[py::str("dynamic_extensions")])) {
+		throw InvalidInputException("Connection snapshot dynamic_extensions must be a list");
+	}
+	auto dynamic_extensions = NormalizeDynamicExtensionSnapshot(snapshot[py::str("dynamic_extensions")]);
+	auto dynamic_extension_names = DynamicExtensionNamesFromSnapshot(dynamic_extensions, "Connection snapshot");
 	auto distributed_extension_contracts = ParseDistributedExtensionContracts(snapshot);
 	auto &conn_wrapper = ExtractPyConnectionWrapper(conn_obj);
 	// Snapshot replay starts a new unit of work on this Python cursor. Close a
@@ -1268,6 +1372,9 @@ static void ApplyConnectionSnapshot(py::object conn_obj, const py::object &snaps
 		// runtime downloads or unsigned extension binaries.
 		EnforceExtensionSecuritySettings(conn);
 	}
+	ValidateWorkerRecordedDynamicExtensionNames(conn_wrapper, conn_obj);
+	ReplayDynamicExtensionSnapshot(conn_obj, dynamic_extensions);
+	ValidateWorkerDynamicExtensionNames(conn_wrapper, dynamic_extension_names);
 	LoadStaticRayExtensions(conn, extensions);
 	DistributedExtensionManager::Get(DatabaseInstance::GetDatabase(*conn.context))
 	    .ValidateExact(distributed_extension_contracts);

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -1015,7 +1015,7 @@ void register_ray_bindings(py::module_ &mod) {
 				    conn_obj = conn_obj.attr("c");
 			    }
 			    auto &py_conn = conn_obj.cast<DuckDBPyConnection &>();
-			    result.connection_snapshot_ = CaptureConnectionSnapshot(py_conn);
+			    result.connection_snapshot_ = CaptureConnectionSnapshot(py_conn, conn_obj);
 		    }
 		    return result;
 	    },

--- a/tests/fast/test_dynamic_extension_resolver.py
+++ b/tests/fast/test_dynamic_extension_resolver.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 import vane
+import vane.extensions as extension_module
 from vane.extensions import (
     DynamicExtensionDependency,
     DynamicExtensionDescriptor,
@@ -15,6 +16,7 @@ from vane.extensions import (
     DynamicExtensionResolver,
     LocalExtensionArtifact,
     LocalExtensionProvider,
+    ResolvedDynamicExtension,
     create_dynamic_extension_descriptor,
 )
 
@@ -66,6 +68,15 @@ def _descriptor(path, *, name, trust_identity="local-tests"):
 def _resolver(*artifacts, trust_identity="local-tests"):
     provider = LocalExtensionProvider(trust_identity, artifacts)
     return DynamicExtensionResolver(trusted_identities={trust_identity}, providers=[provider])
+
+
+class _InstalledProviderEntryPoint:
+    def __init__(self, name, provider):
+        self.name = name
+        self._provider = provider
+
+    def load(self):
+        return lambda: self._provider
 
 
 def test_descriptor_round_trip_preserves_ordered_dependency_identity(tmp_path):
@@ -138,6 +149,180 @@ def test_resolver_loads_dependencies_before_root_and_caches_digest(tmp_path):
     assert resolver.loaded_identities(connection) == (dependency.identity, root.identity)
 
 
+def test_resolver_captures_ordered_immutable_snapshot_without_local_paths(tmp_path):
+    platform = _runtime_platform()
+    dependency_path = _write_extension_artifact(
+        tmp_path / "dependency.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    root_path = _write_extension_artifact(
+        tmp_path / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+        extension_version="root-version",
+    )
+    dependency = _descriptor(dependency_path, name="dependency")
+    root = replace(
+        _descriptor(root_path, name="root"),
+        dependencies=(
+            DynamicExtensionDependency(
+                name=dependency.name,
+                extension_version=dependency.extension_version,
+                sha256=dependency.sha256,
+            ),
+        ),
+    )
+    resolver = _resolver(
+        LocalExtensionArtifact(dependency, dependency_path),
+        LocalExtensionArtifact(root, root_path),
+    )
+    connection = RecordingConnection(platform)
+
+    resolver.load(connection, root)
+
+    assert extension_module._capture_dynamic_extension_snapshot(connection) == [
+        {
+            "descriptor": dependency.to_dict(),
+            "dependency_order": [],
+        },
+        {
+            "descriptor": root.to_dict(),
+            "dependency_order": [dependency.identity],
+        },
+    ]
+    snapshot_json = str(extension_module._capture_dynamic_extension_snapshot(connection))
+    assert str(dependency_path) not in snapshot_json
+    assert str(root_path) not in snapshot_json
+
+
+def test_vane_connection_cursors_share_dynamic_snapshot_state():
+    connection = vane.connect()
+    cursor = connection.cursor()
+    try:
+        platform = connection.execute("SELECT platform FROM pragma_platform()").fetchone()[0]
+        descriptor = DynamicExtensionDescriptor(
+            name="dynamic_test",
+            extension_version="test-version",
+            abi_type="CPP",
+            duckdb_source_id=vane.__git_revision__,
+            vane_version=vane.__version__,
+            platform=platform,
+            sha256="1" * 64,
+            trust_identity="local-tests",
+        )
+        extension_module._record_dynamic_extension_snapshot_entry(
+            cursor,
+            ResolvedDynamicExtension(descriptor, Path("/not-a-worker-artifact-path")),
+        )
+
+        assert extension_module._capture_dynamic_extension_snapshot(connection) == [
+            {
+                "descriptor": descriptor.to_dict(),
+                "dependency_order": [],
+            }
+        ]
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def test_worker_replay_uses_preinstalled_providers_in_snapshot_dependency_order(tmp_path, monkeypatch):
+    platform = _runtime_platform()
+    dependency_path = _write_extension_artifact(
+        tmp_path / "dependency.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    root_path = _write_extension_artifact(
+        tmp_path / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+        extension_version="root-version",
+    )
+    dependency = _descriptor(dependency_path, name="dependency")
+    root = replace(
+        _descriptor(root_path, name="root"),
+        dependencies=(
+            DynamicExtensionDependency(
+                name=dependency.name,
+                extension_version=dependency.extension_version,
+                sha256=dependency.sha256,
+            ),
+        ),
+    )
+    coordinator = RecordingConnection(platform)
+    _resolver(
+        LocalExtensionArtifact(dependency, dependency_path),
+        LocalExtensionArtifact(root, root_path),
+    ).load(coordinator, root)
+    snapshot = extension_module._capture_dynamic_extension_snapshot(coordinator)
+    dependency_provider = LocalExtensionProvider(
+        "local-tests",
+        (LocalExtensionArtifact(dependency, dependency_path),),
+    )
+    root_provider = LocalExtensionProvider(
+        "local-tests",
+        (LocalExtensionArtifact(root, root_path),),
+    )
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: (
+            (
+                _InstalledProviderEntryPoint("dependency", dependency_provider),
+                _InstalledProviderEntryPoint("root", root_provider),
+            )
+            if group == "vane.dynamic_extension_providers"
+            else ()
+        ),
+    )
+    worker = RecordingConnection(platform)
+
+    extension_module._replay_dynamic_extension_snapshot(worker, snapshot)
+    extension_module._replay_dynamic_extension_snapshot(worker, snapshot)
+
+    assert worker.loaded_paths == [dependency_path, root_path]
+    assert extension_module._capture_dynamic_extension_snapshot(worker) == snapshot
+
+
+def test_worker_replay_rejects_missing_or_mismatched_installed_provider_before_loading(tmp_path, monkeypatch):
+    platform = _runtime_platform()
+    artifact_path = _write_extension_artifact(
+        tmp_path / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    descriptor = _descriptor(artifact_path, name="root")
+    snapshot = [
+        {
+            "descriptor": descriptor.to_dict(),
+            "dependency_order": [],
+        }
+    ]
+    worker = RecordingConnection(platform)
+    monkeypatch.setattr(extension_module, "entry_points", lambda *, group: ())
+
+    with pytest.raises(DynamicExtensionError, match="PROVIDER_NOT_FOUND"):
+        extension_module._replay_dynamic_extension_snapshot(worker, snapshot)
+
+    mismatched_descriptor = replace(descriptor, trust_identity="different-local-tests")
+    mismatched_provider = LocalExtensionProvider(
+        "different-local-tests",
+        (LocalExtensionArtifact(mismatched_descriptor, artifact_path),),
+    )
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: (_InstalledProviderEntryPoint("root", mismatched_provider),),
+    )
+
+    with pytest.raises(DynamicExtensionError, match="PROVIDER_DESCRIPTOR_MISMATCH"):
+        extension_module._replay_dynamic_extension_snapshot(worker, snapshot)
+
+    assert worker.loaded_paths == []
+
+
 def test_resolver_cache_is_scoped_to_the_connection(tmp_path):
     platform = _runtime_platform()
     artifact_path = _write_extension_artifact(
@@ -155,6 +340,23 @@ def test_resolver_cache_is_scoped_to_the_connection(tmp_path):
 
     assert first_connection.loaded_paths == [artifact_path]
     assert second_connection.loaded_paths == [artifact_path]
+
+
+def test_resolver_reuses_the_connection_snapshot_across_resolver_instances(tmp_path):
+    platform = _runtime_platform()
+    artifact_path = _write_extension_artifact(
+        tmp_path / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    descriptor = _descriptor(artifact_path, name="root")
+    artifact = LocalExtensionArtifact(descriptor, artifact_path)
+    connection = RecordingConnection(platform)
+
+    _resolver(artifact).load(connection, descriptor)
+    _resolver(artifact).load(connection, descriptor)
+
+    assert connection.loaded_paths == [artifact_path]
 
 
 def test_resolver_rejects_a_different_digest_for_an_already_loaded_extension_name(tmp_path):

--- a/tests/fast/test_extension_wheel.py
+++ b/tests/fast/test_extension_wheel.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import hashlib
+import io
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import vane
+from scripts.verify_extension_wheel import verify_extension_wheel
+from vane.extensions import DynamicExtensionDescriptor
+from vane_packaging.extension_wheel import ENTRY_POINT_GROUP, build_extension_wheel
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _runtime_platform() -> str:
+    connection = vane.connect()
+    try:
+        return connection.execute("SELECT platform FROM pragma_platform()").fetchone()[0]
+    finally:
+        connection.close()
+
+
+def _wheel_platform_tag() -> str:
+    return {
+        "linux_amd64": "linux_x86_64",
+        "linux_amd64_musl": "musllinux_1_2_x86_64",
+        "linux_arm64": "linux_aarch64",
+        "linux_arm64_musl": "musllinux_1_2_aarch64",
+        "osx_amd64": "macosx_10_9_x86_64",
+        "osx_arm64": "macosx_11_0_arm64",
+        "windows_amd64": "win_amd64",
+        "windows_arm64": "win_arm64",
+    }[_runtime_platform()]
+
+
+def _write_extension_artifact(
+    path: Path,
+    payload: bytes = b"Vane extension wheel test payload",
+    source_id: str | None = None,
+) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    footer = bytearray(512)
+    fields = ["", "", "", "CPP", "test-version", source_id or vane.__git_revision__, _runtime_platform(), "4"]
+    for index, value in enumerate(fields):
+        start = index * 32
+        footer[start : start + len(value)] = value.encode("ascii")
+    path.write_bytes(payload + footer)
+    return path
+
+
+def test_platform_wheel_contains_one_verified_artifact_and_provider_entry_point(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    platform_tag = _wheel_platform_tag()
+
+    built = build_extension_wheel(
+        artifact=artifact_path,
+        extension_name="sample",
+        output_directory=tmp_path / "dist",
+        platform_tag=platform_tag,
+        trust_identity="vane-tests",
+        license_expression="Apache-2.0 AND MIT",
+        license_files=[REPOSITORY_ROOT / "LICENSE", REPOSITORY_ROOT / "LICENSES" / "DuckDB-MIT.txt"],
+    )
+
+    assert built.distribution_name == "vane-extension-sample"
+    assert built.wheel_tag == f"py3-none-{platform_tag}"
+    assert built.path.name == f"vane_extension_sample-{vane.__version__}-py3-none-{platform_tag}.whl"
+
+    package_root = "vane_extensions/sample"
+    dist_info_root = f"vane_extension_sample-{vane.__version__}.dist-info"
+    with zipfile.ZipFile(built.path) as wheel:
+        names = set(wheel.namelist())
+        assert names == {
+            f"{package_root}/__init__.py",
+            f"{package_root}/sample.duckdb_extension",
+            f"{package_root}/sample.dynamic-extension.json",
+            f"{dist_info_root}/METADATA",
+            f"{dist_info_root}/WHEEL",
+            f"{dist_info_root}/entry_points.txt",
+            f"{dist_info_root}/RECORD",
+            f"{dist_info_root}/licenses/LICENSE",
+            f"{dist_info_root}/licenses/LICENSES/DuckDB-MIT.txt",
+        }
+        assert not any(name.startswith("vane/") for name in names)
+        assert wheel.read(f"{package_root}/sample.duckdb_extension") == artifact_path.read_bytes()
+        descriptor = DynamicExtensionDescriptor.from_json(wheel.read(f"{package_root}/sample.dynamic-extension.json"))
+        assert descriptor == built.descriptor
+        assert descriptor.sha256 == hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+
+        metadata = wheel.read(f"{dist_info_root}/METADATA").decode("utf-8")
+        assert metadata.startswith("Metadata-Version: 2.4\n")
+        assert f"Name: {built.distribution_name}" in metadata
+        assert "License-Expression: Apache-2.0 AND MIT" in metadata
+        assert f"Requires-Dist: vane-ai (=={vane.__version__})" in metadata
+        assert "License-File: LICENSE" in metadata
+        assert "License-File: LICENSES/DuckDB-MIT.txt" in metadata
+        assert wheel.read(f"{dist_info_root}/WHEEL").decode("utf-8").endswith(f"Tag: py3-none-{platform_tag}\n")
+        assert wheel.read(f"{dist_info_root}/entry_points.txt").decode("utf-8") == (
+            f"[{ENTRY_POINT_GROUP}]\nsample = vane_extensions.sample:provider\n"
+        )
+        assert "LocalExtensionProvider" in wheel.read(f"{package_root}/__init__.py").decode("utf-8")
+
+        record_rows = list(csv.reader(io.StringIO(wheel.read(f"{dist_info_root}/RECORD").decode("utf-8"))))
+        assert {row[0] for row in record_rows} == names
+        assert next(row for row in record_rows if row[0].endswith("/RECORD")) == [
+            f"{dist_info_root}/RECORD",
+            "",
+            "",
+        ]
+
+
+def test_platform_wheel_requires_one_explicit_platform_tag(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+
+    with pytest.raises(ValueError, match="platform_tag"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag="linux-x86_64",
+            trust_identity="vane-tests",
+            license_expression="Apache-2.0 AND MIT",
+            license_files=[REPOSITORY_ROOT / "LICENSE"],
+        )
+
+
+def test_platform_wheel_rejects_an_invalid_license_expression(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+
+    with pytest.raises(ValueError, match="license_expression"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag=_wheel_platform_tag(),
+            trust_identity="vane-tests",
+            license_expression="not-an-spdx-expression",
+            license_files=[REPOSITORY_ROOT / "LICENSE"],
+        )
+
+
+def test_platform_wheel_rejects_an_unsafe_license_file_path(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    license_path = tmp_path / "license\ninjected.txt"
+    license_path.write_text("license", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="safe ASCII relative path"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag=_wheel_platform_tag(),
+            trust_identity="vane-tests",
+            license_expression="Apache-2.0 AND MIT",
+            license_files=[license_path],
+        )
+
+
+def test_extension_wheel_cli_scripts_import_from_outside_the_repository(tmp_path):
+    for script_name in ("build_extension_wheel.py", "verify_extension_wheel.py"):
+        completed = subprocess.run(
+            [sys.executable, "-I", str(REPOSITORY_ROOT / "scripts" / script_name), "--help"],
+            check=True,
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+
+        assert "usage:" in completed.stdout
+
+
+def test_extension_wheel_build_cli_uses_the_installed_vane_runtime(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            str(REPOSITORY_ROOT / "scripts" / "build_extension_wheel.py"),
+            "--artifact",
+            str(artifact_path),
+            "--extension-name",
+            "sample",
+            "--output-directory",
+            str(tmp_path / "dist"),
+            "--platform-tag",
+            _wheel_platform_tag(),
+            "--trust-identity",
+            "vane-tests",
+            "--license-expression",
+            "Apache-2.0",
+            "--license-file",
+            str(REPOSITORY_ROOT / "LICENSE"),
+        ],
+        check=True,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    assert Path(completed.stdout.strip()).is_file()
+
+
+def test_platform_wheel_is_deterministic_regardless_of_license_argument_order(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    license_files = [REPOSITORY_ROOT / "LICENSE", REPOSITORY_ROOT / "LICENSES" / "DuckDB-MIT.txt"]
+    first = build_extension_wheel(
+        artifact=artifact_path,
+        extension_name="sample",
+        output_directory=tmp_path / "first",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity="vane-tests",
+        license_expression="Apache-2.0 AND MIT",
+        license_files=license_files,
+    )
+    second = build_extension_wheel(
+        artifact=artifact_path,
+        extension_name="sample",
+        output_directory=tmp_path / "second",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity="vane-tests",
+        license_expression="Apache-2.0 AND MIT",
+        license_files=list(reversed(license_files)),
+    )
+
+    assert first.path.read_bytes() == second.path.read_bytes()
+
+
+def test_platform_wheel_escapes_license_paths_in_record_csv(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    license_path = tmp_path / 'license,"quoted".txt'
+    license_path.write_text("license", encoding="utf-8")
+    built = build_extension_wheel(
+        artifact=artifact_path,
+        extension_name="sample",
+        output_directory=tmp_path / "dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity="vane-tests",
+        license_expression="Apache-2.0",
+        license_files=[license_path],
+    )
+
+    with zipfile.ZipFile(built.path) as wheel:
+        record_name = f"vane_extension_sample-{vane.__version__}.dist-info/RECORD"
+        record_rows = list(csv.reader(io.StringIO(wheel.read(record_name).decode("utf-8"))))
+
+    assert any(row[0].endswith('licenses/license,"quoted".txt') for row in record_rows)
+    assert all(len(row) == 3 for row in record_rows)
+
+
+def test_platform_wheel_rejects_a_tag_for_a_different_artifact_platform(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    wrong_platform_tag = "win_amd64" if _runtime_platform() != "windows_amd64" else "linux_x86_64"
+
+    with pytest.raises(ValueError, match="does not match extension artifact platform"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag=wrong_platform_tag,
+            trust_identity="vane-tests",
+            license_expression="Apache-2.0 AND MIT",
+            license_files=[REPOSITORY_ROOT / "LICENSE"],
+        )
+
+
+def test_platform_wheel_rejects_an_artifact_from_a_different_duckdb_source(tmp_path):
+    source_id = "a" * 40 if vane.__git_revision__ != "a" * 40 else "b" * 40
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension", source_id=source_id)
+
+    with pytest.raises(RuntimeError, match="does not match installed Vane runtime SourceID"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag=_wheel_platform_tag(),
+            trust_identity="vane-tests",
+            license_expression="Apache-2.0 AND MIT",
+            license_files=[REPOSITORY_ROOT / "LICENSE"],
+        )
+
+
+def test_platform_wheel_rejects_an_artifact_named_for_another_extension(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "another.duckdb_extension")
+
+    with pytest.raises(ValueError, match="artifact must be named"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag=_wheel_platform_tag(),
+            trust_identity="vane-tests",
+            license_expression="Apache-2.0 AND MIT",
+            license_files=[REPOSITORY_ROOT / "LICENSE"],
+        )
+
+
+def test_platform_wheel_does_not_replace_a_different_existing_artifact(tmp_path):
+    artifact_path = _write_extension_artifact(tmp_path / "sample.duckdb_extension")
+    build_extension_wheel(
+        artifact=artifact_path,
+        extension_name="sample",
+        output_directory=tmp_path / "dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity="vane-tests",
+        license_expression="Apache-2.0 AND MIT",
+        license_files=[REPOSITORY_ROOT / "LICENSE"],
+    )
+    existing_wheel = next((tmp_path / "dist").glob("*.whl"))
+    existing_contents = existing_wheel.read_bytes()
+    _write_extension_artifact(artifact_path, b"changed extension wheel test payload")
+
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        build_extension_wheel(
+            artifact=artifact_path,
+            extension_name="sample",
+            output_directory=tmp_path / "dist",
+            platform_tag=_wheel_platform_tag(),
+            trust_identity="vane-tests",
+            license_expression="Apache-2.0 AND MIT",
+            license_files=[REPOSITORY_ROOT / "LICENSE"],
+        )
+
+    assert existing_wheel.read_bytes() == existing_contents
+
+
+def test_installed_platform_wheel_resolves_a_staged_artifact_in_a_clean_environment(tmp_path):
+    staged_artifact = os.environ.get("VANE_TEST_LOADABLE_EXTENSION_PATH")
+    base_wheel = os.environ.get("VANE_TEST_BASE_WHEEL")
+    if staged_artifact is None or base_wheel is None:
+        pytest.skip("set VANE_TEST_LOADABLE_EXTENSION_PATH and VANE_TEST_BASE_WHEEL for clean wheel validation")
+
+    built = build_extension_wheel(
+        artifact=Path(staged_artifact),
+        extension_name="tpch",
+        output_directory=tmp_path / "dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity="vane-tests",
+        license_expression="Apache-2.0 AND MIT",
+        license_files=[REPOSITORY_ROOT / "LICENSE", REPOSITORY_ROOT / "LICENSES" / "DuckDB-MIT.txt"],
+    )
+
+    verify_extension_wheel(
+        base_wheel=Path(base_wheel),
+        extension_wheel=built.path,
+        extension_name="tpch",
+        trust_identity="vane-tests",
+    )

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -8,6 +8,7 @@ import threading
 import pytest
 
 import vane
+import vane.extensions as extension_module
 
 
 def _require_ray_cxx():
@@ -25,6 +26,29 @@ def _table_from_native_result(result):
     if len(payloads) == 1:
         return payloads[0]
     return pa.concat_tables(payloads)
+
+
+def _dynamic_snapshot_entry(*, sha256="1" * 64, dependencies=(), dependency_order=()):
+    connection = vane.connect()
+    try:
+        platform = connection.execute("SELECT platform FROM pragma_platform()").fetchone()[0]
+    finally:
+        connection.close()
+    return {
+        "descriptor": {
+            "format_version": 1,
+            "name": "dynamic_test",
+            "extension_version": "test-version",
+            "abi_type": "CPP",
+            "duckdb_source_id": vane.__git_revision__,
+            "vane_version": vane.__version__,
+            "platform": platform,
+            "sha256": sha256,
+            "trust_identity": "test-provider",
+            "dependencies": list(dependencies),
+        },
+        "dependency_order": list(dependency_order),
+    }
 
 
 def test_logical_plan_captures_connection_scoped_vane_session(monkeypatch):
@@ -786,6 +810,7 @@ def test_connection_snapshot_captures_exact_extension_contract():
     assert snapshot["duckdb_source_id"]
     assert isinstance(snapshot["extensions"], list)
     assert all(set(extension) >= {"name", "version"} for extension in snapshot["extensions"])
+    assert snapshot["dynamic_extensions"] == []
     assert snapshot["distributed_extension_contracts"] == [
         "vane_core{table_function:datasource_scan@1}",
     ]
@@ -901,6 +926,7 @@ def test_logical_snapshot_validates_manifest_before_applying_effective_s3_config
     [
         ("duckdb_source_id", "missing duckdb_source_id"),
         ("extensions", "extensions must be a list"),
+        ("dynamic_extensions", "dynamic_extensions must be a list"),
         ("distributed_extension_contracts", "distributed_extension_contracts must be a list"),
     ],
 )
@@ -1002,6 +1028,88 @@ def test_snapshot_replay_rejects_non_static_extensions_without_installing(tmp_pa
     assert "sqlite_scanner" in message
     assert "Failed to download extension" not in message
     assert not extension_directory.exists()
+
+
+def test_snapshot_replay_rejects_missing_dynamic_provider_without_downloading(tmp_path, monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    monkeypatch.setattr(extension_module, "entry_points", lambda *, group: ())
+
+    source_conn = vane.connect()
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-missing-dynamic-provider",
+    )
+    physical_plan = logical_plan.to_physical_plan(vane.connect())
+    state = list(physical_plan.__getstate__())
+    snapshot = dict(state[6])
+    snapshot["dynamic_extensions"] = [_dynamic_snapshot_entry()]
+    state[6] = snapshot
+    replay_plan = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+    replay_plan.__setstate__(tuple(state))
+
+    extension_directory = tmp_path / "extensions"
+    worker_connection = vane.connect(
+        config={
+            "allow_unsigned_extensions": "true",
+            "autoinstall_known_extensions": "true",
+            "autoload_known_extensions": "true",
+            "extension_directory": str(extension_directory),
+        }
+    )
+    worker_connection.execute("SET custom_extension_repository = 'http://127.0.0.1:9'")
+
+    with pytest.raises(Exception, match="VANE_DYNAMIC_EXTENSION_PROVIDER_NOT_FOUND"):
+        ray_cxx.DistributedPhysicalPlanRunner().execute_native(worker_connection.cursor(), replay_plan)
+
+    settings = dict(
+        worker_connection.execute(
+            """
+            SELECT name, value
+            FROM duckdb_settings()
+            WHERE name IN ('allow_unsigned_extensions', 'autoinstall_known_extensions', 'autoload_known_extensions')
+            """
+        ).fetchall()
+    )
+    assert settings == {
+        "allow_unsigned_extensions": "false",
+        "autoinstall_known_extensions": "false",
+        "autoload_known_extensions": "false",
+    }
+    assert not extension_directory.exists()
+
+
+def test_snapshot_replay_rejects_dynamic_dependency_order_before_provider_lookup(monkeypatch):
+    ray_cxx = _require_ray_cxx()
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: pytest.fail("invalid dynamic snapshot must not discover providers"),
+    )
+    dependency = {
+        "name": "dependency",
+        "extension_version": "test-version",
+        "sha256": "2" * 64,
+    }
+    source_conn = vane.connect()
+    logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        source_conn.sql("SELECT 1"),
+        "snapshot-invalid-dynamic-dependency-order",
+    )
+    physical_plan = logical_plan.to_physical_plan(vane.connect())
+    state = list(physical_plan.__getstate__())
+    snapshot = dict(state[6])
+    snapshot["dynamic_extensions"] = [
+        _dynamic_snapshot_entry(
+            dependencies=(dependency,),
+            dependency_order=("dependency@test-version#sha256:" + "2" * 64,),
+        )
+    ]
+    state[6] = snapshot
+    replay_plan = ray_cxx.DistributedPhysicalPlan.__new__(ray_cxx.DistributedPhysicalPlan)
+    replay_plan.__setstate__(tuple(state))
+
+    with pytest.raises(Exception, match="VANE_DYNAMIC_EXTENSION_SNAPSHOT_DEPENDENCY_ORDER"):
+        ray_cxx.DistributedPhysicalPlanRunner().execute_native(vane.connect().cursor(), replay_plan)
 
 
 def test_snapshot_bootstrap_is_sanitized_before_connect(tmp_path):

--- a/tests/fast/test_ray_worker_connection_snapshot.py
+++ b/tests/fast/test_ray_worker_connection_snapshot.py
@@ -38,7 +38,7 @@ def _snapshot_database_identity(
     session_id="test-session",
 ):
     return worker_module._worker_snapshot_database_identity(
-        snapshot,
+        {"dynamic_extensions": [], **snapshot},
         session_id=session_id,
         effective_s3_config=effective_s3_config or {},
         use_session_credentials=use_session_credentials,
@@ -383,6 +383,48 @@ def test_worker_snapshot_execution_cursor_isolates_exact_extension_identities(mo
     assert actor._active_snapshot_execution_cursors == 0
 
 
+def test_worker_snapshot_database_identity_includes_dynamic_artifact_identity():
+    base_snapshot = {
+        "duckdb_source_id": "test-source-id",
+        "extensions": [],
+        "dynamic_extensions": [],
+        "distributed_extension_contracts": [],
+        "settings": [],
+    }
+
+    def dynamic_snapshot(digest):
+        return {
+            **base_snapshot,
+            "dynamic_extensions": [
+                {
+                    "descriptor": {
+                        "format_version": 1,
+                        "name": "dynamic_test",
+                        "extension_version": "test-version",
+                        "abi_type": "CPP",
+                        "duckdb_source_id": "a" * 40,
+                        "vane_version": "test-vane-version",
+                        "platform": "linux_amd64",
+                        "sha256": digest,
+                        "trust_identity": "test-provider",
+                        "dependencies": [],
+                    },
+                    "dependency_order": [],
+                }
+            ],
+        }
+
+    no_dynamic_identity = _snapshot_database_identity(base_snapshot)
+    first_dynamic_identity = _snapshot_database_identity(dynamic_snapshot("1" * 64))
+    same_dynamic_identity = _snapshot_database_identity(dynamic_snapshot("1" * 64))
+    altered_dynamic_identity = _snapshot_database_identity(dynamic_snapshot("2" * 64))
+
+    assert first_dynamic_identity == same_dynamic_identity
+    assert no_dynamic_identity != first_dynamic_identity
+    assert first_dynamic_identity != altered_dynamic_identity
+    assert first_dynamic_identity.dynamic_extensions
+
+
 def test_worker_snapshot_execution_cursor_isolates_replayed_settings(monkeypatch):
     actor_class, actor = _worker_actor()
     base_snapshot = {
@@ -611,6 +653,21 @@ def test_worker_snapshot_database_identity_omits_s3_state_without_httpfs():
 def test_worker_snapshot_database_identity_rejects_ambiguous_contract(snapshot, message):
     with pytest.raises((TypeError, ValueError), match=message):
         _snapshot_database_identity(snapshot)
+
+
+def test_worker_snapshot_database_identity_requires_dynamic_extension_snapshot():
+    with pytest.raises(TypeError, match="dynamic_extensions must be a list"):
+        worker_module._worker_snapshot_database_identity(
+            {
+                "duckdb_source_id": "test-source-id",
+                "extensions": [],
+                "distributed_extension_contracts": [],
+                "settings": [],
+            },
+            session_id="test-session",
+            effective_s3_config={},
+            use_session_credentials=True,
+        )
 
 
 def test_worker_snapshot_cursor_reserves_shutdown_fence_before_cursor_creation(monkeypatch):

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -255,6 +255,13 @@ def test_wheel_rejects_every_import_or_distribution_root_not_owned_by_vane(membe
         check_release_artifacts._check_wheel(artifact, TEST_LAYOUT)
 
 
+def test_base_wheel_rejects_a_dynamic_extension_artifact():
+    artifact = _NamesOnlyArtifact(["vane/extensions/tpch.duckdb_extension"])
+
+    with pytest.raises(ValueError, match="must not contain optional extension artifacts"):
+        check_release_artifacts._check_wheel(artifact, TEST_LAYOUT)
+
+
 @pytest.mark.parametrize("required_path", REQUIRED_WHEEL_PATHS)
 def test_wheel_required_files_must_use_their_exact_install_paths(required_path):
     decoy = (

--- a/vane/extensions.py
+++ b/vane/extensions.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import threading
+import weakref
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Any, NoReturn, Protocol
 
@@ -27,6 +30,8 @@ _HEX_RE = re.compile(r"^[0-9a-f]{7,64}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _PLATFORM_RE = re.compile(r"^[a-z0-9_]+$")
 _TRUST_IDENTITY_RE = re.compile(r"^[A-Za-z0-9._:/-]+$")
+_DYNAMIC_EXTENSION_PROVIDER_ENTRY_POINT_GROUP = "vane.dynamic_extension_providers"
+_DYNAMIC_EXTENSION_SNAPSHOT_ENTRY_KEYS = frozenset({"descriptor", "dependency_order"})
 
 
 class DynamicExtensionError(RuntimeError):
@@ -357,6 +362,355 @@ class _ExtensionConnection(Protocol):
     def load_extension(self, extension: str) -> None: ...
 
 
+@dataclass(frozen=True)
+class _DynamicExtensionSnapshotEntry:
+    """One ordered dynamic artifact entry retained for distributed replay."""
+
+    descriptor: DynamicExtensionDescriptor
+    dependency_order: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "descriptor": self.descriptor.to_dict(),
+            "dependency_order": list(self.dependency_order),
+        }
+
+
+# Vane's native connections retain these entries in their Vane session so
+# cursors share the exact same state. Protocol-only connections use weak state
+# solely so resolver unit doubles can exercise the same invariant without
+# retaining a closed connection.
+_protocol_snapshot_entries_lock = threading.Lock()
+_protocol_snapshot_entries_by_connection: dict[
+    int,
+    tuple[weakref.ReferenceType[object], list[str]],
+] = {}
+
+
+def _discard_protocol_snapshot_entries(connection_id: int, reference: weakref.ReferenceType[object]) -> None:
+    with _protocol_snapshot_entries_lock:
+        cached = _protocol_snapshot_entries_by_connection.get(connection_id)
+        if cached is not None and cached[0] is reference:
+            _protocol_snapshot_entries_by_connection.pop(connection_id, None)
+
+
+def _protocol_snapshot_entries(connection: _ExtensionConnection, *, create: bool) -> list[str]:
+    connection_id = id(connection)
+    with _protocol_snapshot_entries_lock:
+        cached = _protocol_snapshot_entries_by_connection.get(connection_id)
+        if cached is not None and cached[0]() is connection:
+            return cached[1]
+        if not create:
+            return []
+        try:
+            reference = weakref.ref(
+                connection,
+                lambda reference: _discard_protocol_snapshot_entries(connection_id, reference),
+            )
+        except TypeError as exception:
+            raise DynamicExtensionError(
+                "SNAPSHOT_UNAVAILABLE",
+                "dynamic extension snapshots require a weak-referenceable protocol connection",
+            ) from exception
+        entries: list[str] = []
+        _protocol_snapshot_entries_by_connection[connection_id] = (reference, entries)
+        return entries
+
+
+def _dynamic_extension_snapshot_entry(candidate: ResolvedDynamicExtension) -> _DynamicExtensionSnapshotEntry:
+    return _DynamicExtensionSnapshotEntry(
+        descriptor=candidate.descriptor,
+        dependency_order=tuple(dependency.identity for dependency in candidate.descriptor.dependencies),
+    )
+
+
+def _canonical_snapshot_entry(entry: _DynamicExtensionSnapshotEntry) -> str:
+    return json.dumps(entry.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _parse_dynamic_extension_snapshot(snapshot: object) -> tuple[_DynamicExtensionSnapshotEntry, ...]:
+    """Validate an ordered dynamic-extension snapshot without loading anything."""
+    if not isinstance(snapshot, list):
+        _fail("SNAPSHOT_INVALID", "dynamic_extensions must be a list")
+
+    parsed: list[_DynamicExtensionSnapshotEntry] = []
+    seen_identities: set[str] = set()
+    seen_names: set[str] = set()
+    available_dependencies: set[str] = set()
+    for entry_index, raw_entry in enumerate(snapshot):
+        if not isinstance(raw_entry, Mapping):
+            _fail("SNAPSHOT_INVALID", f"dynamic_extensions[{entry_index}] must be an object")
+        if set(raw_entry) != _DYNAMIC_EXTENSION_SNAPSHOT_ENTRY_KEYS:
+            _fail(
+                "SNAPSHOT_INVALID",
+                f"dynamic_extensions[{entry_index}] must contain only descriptor and dependency_order",
+            )
+        raw_descriptor = raw_entry["descriptor"]
+        if not isinstance(raw_descriptor, Mapping):
+            _fail("SNAPSHOT_INVALID", f"dynamic_extensions[{entry_index}].descriptor must be an object")
+        descriptor = DynamicExtensionDescriptor.from_dict(raw_descriptor)
+
+        raw_dependency_order = raw_entry["dependency_order"]
+        if not isinstance(raw_dependency_order, list) or any(
+            not isinstance(identity, str) for identity in raw_dependency_order
+        ):
+            _fail(
+                "SNAPSHOT_INVALID",
+                f"dynamic_extensions[{entry_index}].dependency_order must be a list of strings",
+            )
+        dependency_order = tuple(raw_dependency_order)
+        expected_dependency_order = tuple(dependency.identity for dependency in descriptor.dependencies)
+        if dependency_order != expected_dependency_order:
+            _fail(
+                "SNAPSHOT_DEPENDENCY_ORDER",
+                f"dynamic_extensions[{entry_index}] dependency_order does not match its descriptor",
+            )
+        missing_dependencies = [identity for identity in dependency_order if identity not in available_dependencies]
+        if missing_dependencies:
+            _fail(
+                "SNAPSHOT_DEPENDENCY_ORDER",
+                f"dynamic_extensions[{entry_index}] declares dependencies before they are loaded: "
+                f"{', '.join(missing_dependencies)}",
+            )
+        if descriptor.identity in seen_identities:
+            _fail("SNAPSHOT_INVALID", f"dynamic_extensions contains duplicate {descriptor.identity}")
+        if descriptor.name in seen_names:
+            _fail("SNAPSHOT_INVALID", f"dynamic_extensions contains conflicting name {descriptor.name}")
+
+        parsed_entry = _DynamicExtensionSnapshotEntry(descriptor, dependency_order)
+        parsed.append(parsed_entry)
+        seen_identities.add(descriptor.identity)
+        seen_names.add(descriptor.name)
+        available_dependencies.add(descriptor.identity)
+    return tuple(parsed)
+
+
+def _normalize_dynamic_extension_snapshot(snapshot: object) -> list[dict[str, object]]:
+    """Return the canonical dynamic snapshot after strict structural validation."""
+    return [entry.to_dict() for entry in _parse_dynamic_extension_snapshot(snapshot)]
+
+
+def _dynamic_extension_snapshot_cache_identity(snapshot: object) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    """Return an exact, hashable artifact identity for a worker DB cache key."""
+    return tuple(
+        (entry.descriptor.to_json(), entry.dependency_order) for entry in _parse_dynamic_extension_snapshot(snapshot)
+    )
+
+
+def _native_dynamic_extension_snapshot_entries(connection: _ExtensionConnection) -> list[object] | None:
+    export_entries = getattr(connection, "_export_dynamic_extension_snapshot_entries", None)
+    if not callable(export_entries):
+        return None
+    try:
+        serialized_entries = export_entries()
+    except Exception as exception:
+        raise DynamicExtensionError(
+            "SNAPSHOT_UNAVAILABLE", "could not read the connection's dynamic extension snapshot"
+        ) from exception
+    if not isinstance(serialized_entries, list) or any(not isinstance(entry, str) for entry in serialized_entries):
+        _fail("SNAPSHOT_INVALID", "connection dynamic extension snapshot entries must be a list of JSON strings")
+    parsed_entries: list[object] = []
+    for entry_index, serialized_entry in enumerate(serialized_entries):
+        try:
+            parsed_entries.append(json.loads(serialized_entry))
+        except ValueError as exception:
+            raise DynamicExtensionError(
+                "SNAPSHOT_INVALID",
+                f"connection dynamic extension snapshot entry {entry_index} is not valid JSON",
+            ) from exception
+    return parsed_entries
+
+
+def _capture_dynamic_extension_snapshot(connection: _ExtensionConnection) -> list[dict[str, object]]:
+    """Capture resolver-owned dynamic artifacts without serializing local paths."""
+    native_entries = _native_dynamic_extension_snapshot_entries(connection)
+    if native_entries is not None:
+        return _normalize_dynamic_extension_snapshot(native_entries)
+
+    serialized_entries = list(_protocol_snapshot_entries(connection, create=False))
+    parsed_entries: list[object] = []
+    for entry_index, serialized_entry in enumerate(serialized_entries):
+        try:
+            parsed_entries.append(json.loads(serialized_entry))
+        except ValueError as exception:  # pragma: no cover - entries are produced locally below.
+            raise DynamicExtensionError(
+                "SNAPSHOT_INVALID",
+                f"connection dynamic extension snapshot entry {entry_index} is not valid JSON",
+            ) from exception
+    return _normalize_dynamic_extension_snapshot(parsed_entries)
+
+
+def _assert_native_loaded_extensions_match_snapshot(connection: _ExtensionConnection) -> None:
+    """Ensure a Vane connection has no dynamic binary outside resolver state."""
+    if _native_dynamic_extension_snapshot_entries(connection) is None:
+        return
+    expected_names = sorted(
+        entry.descriptor.name
+        for entry in _parse_dynamic_extension_snapshot(_capture_dynamic_extension_snapshot(connection))
+    )
+    try:
+        rows = connection.execute(
+            """
+            SELECT extension_name
+            FROM duckdb_extensions()
+            WHERE loaded AND install_mode <> 'STATICALLY_LINKED'
+            ORDER BY extension_name
+            """
+        ).fetchall()
+    except Exception as exception:
+        raise DynamicExtensionError(
+            "RUNTIME_IDENTITY_UNAVAILABLE", "could not query loaded dynamic extensions"
+        ) from exception
+    loaded_names: list[str] = []
+    for row in rows:
+        if not isinstance(row, tuple) or len(row) != 1 or not isinstance(row[0], str) or not row[0]:
+            _fail("RUNTIME_IDENTITY_UNAVAILABLE", "duckdb_extensions() returned an invalid extension name")
+        loaded_names.append(row[0])
+    if loaded_names != expected_names:
+        _fail(
+            "LOADED_STATE_MISMATCH",
+            "loaded dynamic extensions do not exactly match resolver-owned snapshot state: "
+            f"loaded={loaded_names}, recorded={expected_names}",
+        )
+
+
+def _assert_dynamic_extension_snapshot_can_record(
+    connection: _ExtensionConnection,
+    candidate: ResolvedDynamicExtension,
+) -> bool:
+    """Reject cross-resolver identity conflicts before DuckDB loads another binary."""
+    for existing in _parse_dynamic_extension_snapshot(_capture_dynamic_extension_snapshot(connection)):
+        if existing.descriptor.identity == candidate.identity:
+            if existing.descriptor != candidate.descriptor:
+                _fail(
+                    "LOADED_IDENTITY_CONFLICT",
+                    f"{candidate.identity} has conflicting immutable descriptors on this connection",
+                )
+            return True
+        if existing.descriptor.name == candidate.descriptor.name:
+            _fail(
+                "LOADED_NAME_CONFLICT",
+                f"{candidate.descriptor.name} is already loaded as {existing.descriptor.identity}",
+            )
+    return False
+
+
+def _record_dynamic_extension_snapshot_entry(
+    connection: _ExtensionConnection, candidate: ResolvedDynamicExtension
+) -> None:
+    """Persist a verified loaded artifact for later distributed snapshot capture."""
+    entry = _dynamic_extension_snapshot_entry(candidate)
+    serialized_entry = _canonical_snapshot_entry(entry)
+    record_entry = getattr(connection, "_record_dynamic_extension_snapshot_entry", None)
+    if callable(record_entry):
+        try:
+            record_entry(serialized_entry)
+        except Exception as exception:
+            raise DynamicExtensionError(
+                "SNAPSHOT_UNAVAILABLE", "could not record the connection's dynamic extension snapshot"
+            ) from exception
+        return
+
+    cached_entries = _protocol_snapshot_entries(connection, create=True)
+    with _protocol_snapshot_entries_lock:
+        if serialized_entry not in cached_entries:
+            cached_entries.append(serialized_entry)
+
+
+def _load_installed_dynamic_extension_providers(
+    extension_names: Iterable[str],
+) -> tuple[LocalExtensionProvider, ...]:
+    """Load only the entry points for artifacts explicitly named by a snapshot."""
+    names = tuple(sorted({_validate_extension_name(name) for name in extension_names}))
+    if not names:
+        return ()
+    try:
+        available_entry_points = tuple(entry_points(group=_DYNAMIC_EXTENSION_PROVIDER_ENTRY_POINT_GROUP))
+    except Exception as exception:
+        raise DynamicExtensionError(
+            "PROVIDER_DISCOVERY_FAILED", "could not enumerate installed dynamic extension providers"
+        ) from exception
+
+    providers: list[LocalExtensionProvider] = []
+    for name in names:
+        matches = [entry_point for entry_point in available_entry_points if entry_point.name == name]
+        if not matches:
+            _fail(
+                "PROVIDER_NOT_FOUND",
+                f"no installed local provider entry point exists for {name}",
+            )
+        if len(matches) != 1:
+            _fail(
+                "PROVIDER_AMBIGUOUS",
+                f"multiple installed local provider entry points exist for {name}",
+            )
+        try:
+            provider_factory = matches[0].load()
+            provider = provider_factory()
+        except DynamicExtensionError:
+            raise
+        except Exception as exception:
+            raise DynamicExtensionError(
+                "PROVIDER_INVALID", f"could not initialize installed local provider for {name}"
+            ) from exception
+        if not isinstance(provider, LocalExtensionProvider):
+            _fail("PROVIDER_INVALID", f"installed local provider for {name} did not return LocalExtensionProvider")
+        if all(existing is not provider for existing in providers):
+            providers.append(provider)
+    return tuple(providers)
+
+
+def _replay_dynamic_extension_snapshot(
+    connection: _ExtensionConnection,
+    snapshot: object,
+    verify_native_loaded_state: bool = True,
+) -> None:
+    """Verify and load an immutable dynamic-extension snapshot from local wheels only."""
+    expected_entries = _parse_dynamic_extension_snapshot(snapshot)
+    if verify_native_loaded_state:
+        _assert_native_loaded_extensions_match_snapshot(connection)
+    if not expected_entries:
+        return
+
+    existing_entries = _parse_dynamic_extension_snapshot(_capture_dynamic_extension_snapshot(connection))
+    expected_prefix = expected_entries[: len(existing_entries)]
+    if existing_entries != expected_prefix:
+        _fail(
+            "WORKER_DISAGREEMENT",
+            "worker dynamic extension snapshot differs from the coordinator snapshot",
+        )
+
+    providers = _load_installed_dynamic_extension_providers(entry.descriptor.name for entry in expected_entries)
+    resolver = DynamicExtensionResolver(
+        trusted_identities={entry.descriptor.trust_identity for entry in expected_entries},
+        providers=providers,
+    )
+
+    # Verify every byte and every dependency before modifying the worker's
+    # DuckDB instance. The resolver is then primed with an interrupted replay's
+    # verified prefix so a retry is deterministic and does not reload it.
+    resolved_by_identity: dict[str, ResolvedDynamicExtension] = {}
+    for entry in expected_entries:
+        for candidate in resolver.resolve(connection, entry.descriptor):
+            resolved_by_identity[candidate.identity] = candidate
+    loaded = resolver._loaded_for_connection(connection)
+    for entry in existing_entries:
+        candidate = resolved_by_identity.get(entry.descriptor.identity)
+        if candidate is None:  # pragma: no cover - resolve above is exhaustive.
+            _fail("WORKER_DISAGREEMENT", f"worker cannot resolve {entry.descriptor.identity}")
+        loaded[candidate.descriptor.sha256] = candidate
+
+    for entry in expected_entries[len(existing_entries) :]:
+        resolver.load(connection, entry.descriptor)
+
+    replayed_entries = _parse_dynamic_extension_snapshot(_capture_dynamic_extension_snapshot(connection))
+    if replayed_entries != expected_entries:
+        _fail(
+            "WORKER_DISAGREEMENT",
+            "worker dynamic extension identities differ after local replay",
+        )
+
+
 class DynamicExtensionResolver:
     """Resolve and load only explicitly trusted local extension artifacts."""
 
@@ -397,7 +751,10 @@ class DynamicExtensionResolver:
             visiting.add(candidate.identity)
             try:
                 if candidate_path is None:
-                    candidate_path = self._provider_artifact(candidate.identity).path
+                    candidate_path = self._provider_artifact(
+                        candidate.identity,
+                        expected_descriptor=candidate,
+                    ).path
                 self._verify_artifact(
                     candidate,
                     candidate_path,
@@ -427,6 +784,7 @@ class DynamicExtensionResolver:
         artifact: str | Path | None = None,
     ) -> ResolvedDynamicExtension:
         """Resolve and load dependencies before the requested extension."""
+        _assert_native_loaded_extensions_match_snapshot(connection)
         resolved = self.resolve(connection, descriptor, artifact=artifact)
         loaded = self._loaded_for_connection(connection)
         for candidate in resolved:
@@ -444,6 +802,9 @@ class DynamicExtensionResolver:
                         "LOADED_NAME_CONFLICT",
                         f"{candidate.descriptor.name} is already loaded as {loaded_candidate.identity}",
                     )
+            if _assert_dynamic_extension_snapshot_can_record(connection, candidate):
+                loaded[candidate.descriptor.sha256] = candidate
+                continue
             try:
                 connection.load_extension(str(candidate.path))
             except Exception as exception:
@@ -452,6 +813,7 @@ class DynamicExtensionResolver:
                     f"failed to load {candidate.identity} from {candidate.path.name}: {exception}",
                 ) from exception
             loaded[candidate.descriptor.sha256] = candidate
+            _record_dynamic_extension_snapshot_entry(connection, candidate)
         return resolved[-1]
 
     def loaded_identities(self, connection: _ExtensionConnection) -> tuple[str, ...]:
@@ -470,13 +832,24 @@ class DynamicExtensionResolver:
         self._loaded_by_connection[connection_id] = (connection, loaded)
         return loaded
 
-    def _provider_artifact(self, identity: str) -> LocalExtensionArtifact:
+    def _provider_artifact(
+        self,
+        identity: str,
+        *,
+        expected_descriptor: DynamicExtensionDescriptor | None = None,
+    ) -> LocalExtensionArtifact:
         candidates = [artifact for provider in self._providers if (artifact := provider.find(identity)) is not None]
         if not candidates:
             _fail("DEPENDENCY_NOT_FOUND", f"no trusted local provider contains {identity}")
         if len(candidates) != 1:
             _fail("ARTIFACT_AMBIGUOUS", f"multiple local providers contain {identity}")
-        return candidates[0]
+        artifact = candidates[0]
+        if expected_descriptor is not None and artifact.descriptor != expected_descriptor:
+            _fail(
+                "PROVIDER_DESCRIPTOR_MISMATCH",
+                f"local provider descriptor does not exactly match {expected_descriptor.identity}",
+            )
+        return artifact
 
     def _verify_artifact(
         self,

--- a/vane/runners/ray/worker.py
+++ b/vane/runners/ray/worker.py
@@ -19,6 +19,7 @@ from typing import Any, NamedTuple, cast
 import ray
 
 from vane._ray_cxx import require_ray_cxx_attr
+from vane.extensions import _dynamic_extension_snapshot_cache_identity
 
 # Avoid importing C++ bindings at module import time (may not be registered yet).
 # Resolve `vane.ray_cxx` attributes lazily at use-time instead.
@@ -263,6 +264,7 @@ class WorkerSnapshotDatabaseIdentity(NamedTuple):
     s3_session_id: str
     effective_s3_config_identity: str
     use_session_credentials: bool
+    dynamic_extensions: tuple[tuple[str, tuple[str, ...]], ...] = ()
 
     def has_static_extension(self, extension_name: str) -> bool:
         normalized_name = str(extension_name).lower()
@@ -370,6 +372,11 @@ def _worker_snapshot_database_identity(
         extensions.append((name, version))
     extensions.sort()
 
+    raw_dynamic_extensions = snapshot.get("dynamic_extensions")
+    if not isinstance(raw_dynamic_extensions, list):
+        raise TypeError("query connection snapshot dynamic_extensions must be a list")
+    dynamic_extensions = _dynamic_extension_snapshot_cache_identity(raw_dynamic_extensions)
+
     raw_distributed_contracts = snapshot.get("distributed_extension_contracts")
     if not isinstance(raw_distributed_contracts, list):
         raise TypeError("query connection snapshot distributed_extension_contracts must be a list")
@@ -418,6 +425,7 @@ def _worker_snapshot_database_identity(
         s3_session_id,
         s3_config_identity,
         identity_uses_session_credentials,
+        dynamic_extensions,
     )
 
 

--- a/vane_packaging/extension_wheel.py
+++ b/vane_packaging/extension_wheel.py
@@ -1,0 +1,350 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a platform-specific wheel for one verified Vane extension artifact.
+
+The base ``vane-ai`` wheel deliberately does not contain optional DuckDB
+extension binaries. This module packages one already-built artifact and its
+immutable descriptor into an independent wheel with an installed-provider
+entry point.
+"""
+
+from __future__ import annotations
+
+import base64
+import csv
+import hashlib
+import io
+import os
+import re
+import stat
+import tempfile
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from packaging.licenses import InvalidLicenseExpression, canonicalize_license_expression
+
+if TYPE_CHECKING:
+    from vane.extensions import DynamicExtensionDescriptor
+
+ENTRY_POINT_GROUP = "vane.dynamic_extension_providers"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_EXTENSION_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_WHEEL_PLATFORM_TAG_RE = re.compile(r"^[a-z0-9_]+$")
+_WHEEL_VERSION_RE = re.compile(r"^[A-Za-z0-9.]+$")
+_ARTIFACT_PLATFORM_TAGS = {
+    "linux_amd64": re.compile(r"^(?:linux_x86_64|manylinux_[0-9]+_[0-9]+_x86_64)$"),
+    "linux_amd64_musl": re.compile(r"^musllinux_[0-9]+_[0-9]+_x86_64$"),
+    "linux_arm64": re.compile(r"^(?:linux_aarch64|manylinux_[0-9]+_[0-9]+_aarch64)$"),
+    "linux_arm64_musl": re.compile(r"^musllinux_[0-9]+_[0-9]+_aarch64$"),
+    "osx_amd64": re.compile(r"^macosx_[0-9]+_[0-9]+_x86_64$"),
+    "osx_arm64": re.compile(r"^macosx_[0-9]+_[0-9]+_arm64$"),
+    "windows_amd64": re.compile(r"^win_amd64$"),
+    "windows_arm64": re.compile(r"^win_arm64$"),
+}
+
+
+@dataclass(frozen=True)
+class BuiltExtensionWheel:
+    """The generated wheel and the descriptor embedded in it."""
+
+    path: Path
+    descriptor: DynamicExtensionDescriptor
+    distribution_name: str
+    wheel_tag: str
+
+
+def build_extension_wheel(
+    *,
+    artifact: str | Path,
+    extension_name: str,
+    output_directory: str | Path,
+    platform_tag: str,
+    trust_identity: str,
+    license_expression: str,
+    license_files: Iterable[str | Path],
+) -> BuiltExtensionWheel:
+    """Build one platform-specific wheel from an already-built local artifact.
+
+    ``artifact`` must be the exact, self-contained
+    ``<extension_name>.duckdb_extension`` emitted by the Vane build.
+    ``license_files`` must explicitly cover that artifact's redistributed
+    source and binary dependencies, and ``license_expression`` must be the
+    corresponding SPDX expression. The descriptor is generated from the
+    artifact using the currently installed Vane runtime, which pins the wheel
+    to its Vane and DuckDB identities.
+    """
+    name = _validate_extension_name(extension_name)
+    normalized_platform_tag = _validate_platform_tag(platform_tag)
+    normalized_license_expression = _validate_license_expression(license_expression)
+    artifact_path = Path(artifact).expanduser().resolve()
+    expected_artifact_name = f"{name}.duckdb_extension"
+    if artifact_path.name != expected_artifact_name:
+        raise ValueError(f"artifact must be named {expected_artifact_name!r}: {artifact_path}")
+    import vane
+    from vane.extensions import create_dynamic_extension_descriptor
+
+    descriptor = create_dynamic_extension_descriptor(
+        artifact_path,
+        name=name,
+        trust_identity=trust_identity,
+    )
+    if descriptor.duckdb_source_id != vane.__git_revision__:
+        raise RuntimeError(
+            f"artifact SourceID {descriptor.duckdb_source_id} does not match installed Vane runtime "
+            f"SourceID {vane.__git_revision__}"
+        )
+    _validate_artifact_platform_tag(descriptor.platform, normalized_platform_tag)
+    artifact_contents = artifact_path.read_bytes()
+    if hashlib.sha256(artifact_contents).hexdigest() != descriptor.sha256:
+        raise RuntimeError(f"artifact changed while creating its extension wheel: {artifact_path}")
+
+    vane_version = _validate_wheel_version(vane.__version__)
+    distribution_name = f"vane-extension-{name}"
+    distribution_root = f"vane_extension_{name}-{vane_version}"
+    wheel_tag = f"py3-none-{normalized_platform_tag}"
+    output_path = Path(output_directory).expanduser().resolve() / f"{distribution_root}-{wheel_tag}.whl"
+    package_root = f"vane_extensions/{name}"
+    descriptor_name = f"{package_root}/{name}.dynamic-extension.json"
+    artifact_name = f"{package_root}/{name}.duckdb_extension"
+    dist_info_root = f"{distribution_root}.dist-info"
+    license_entries = _license_entries(license_files, dist_info_root)
+
+    entries = {
+        f"{package_root}/__init__.py": _provider_module_source(name).encode("utf-8"),
+        descriptor_name: (descriptor.to_json() + "\n").encode("utf-8"),
+        artifact_name: artifact_contents,
+        f"{dist_info_root}/METADATA": _metadata(
+            distribution_name,
+            vane_version,
+            normalized_license_expression,
+            tuple(sorted(license_entries)),
+            dist_info_root,
+        ).encode("utf-8"),
+        f"{dist_info_root}/WHEEL": _wheel_metadata(wheel_tag).encode("utf-8"),
+        f"{dist_info_root}/entry_points.txt": _entry_points(name).encode("utf-8"),
+    }
+    entries.update(license_entries)
+    record_name = f"{dist_info_root}/RECORD"
+    entries[record_name] = _record(entries, record_name).encode("utf-8")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor_handle, temporary_name = tempfile.mkstemp(
+        prefix=f".{output_path.name}.",
+        suffix=".tmp",
+        dir=output_path.parent,
+    )
+    os.close(descriptor_handle)
+    temporary_path = Path(temporary_name)
+    try:
+        with zipfile.ZipFile(temporary_path, mode="w", compression=zipfile.ZIP_DEFLATED) as wheel:
+            for member_name, contents in sorted(entries.items()):
+                wheel.writestr(_zip_info(member_name), contents)
+        try:
+            os.link(temporary_path, output_path)
+        except FileExistsError:
+            if output_path.read_bytes() != temporary_path.read_bytes():
+                raise FileExistsError(
+                    f"refusing to replace a different extension wheel at {output_path}; "
+                    "choose a new output directory or version"
+                ) from None
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+    return BuiltExtensionWheel(
+        path=output_path,
+        descriptor=descriptor,
+        distribution_name=distribution_name,
+        wheel_tag=wheel_tag,
+    )
+
+
+def _validate_extension_name(value: str) -> str:
+    if _EXTENSION_NAME_RE.fullmatch(value) is None:
+        raise ValueError("extension_name must contain lowercase ASCII letters, digits, and underscores")
+    return value
+
+
+def _validate_platform_tag(value: str) -> str:
+    if _WHEEL_PLATFORM_TAG_RE.fullmatch(value) is None:
+        raise ValueError("platform_tag must contain lowercase ASCII letters, digits, and underscores")
+    return value
+
+
+def _validate_artifact_platform_tag(artifact_platform: str, wheel_platform_tag: str) -> None:
+    allowed_tags = _ARTIFACT_PLATFORM_TAGS.get(artifact_platform)
+    if allowed_tags is None:
+        raise ValueError(
+            f"extension artifact platform {artifact_platform!r} has no supported wheel platform tag policy"
+        )
+    if allowed_tags.fullmatch(wheel_platform_tag) is None:
+        raise ValueError(
+            f"wheel platform tag {wheel_platform_tag!r} does not match extension artifact platform "
+            f"{artifact_platform!r}"
+        )
+
+
+def _validate_license_expression(value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError("license_expression must be a non-empty SPDX expression")
+    expression = value.strip()
+    if not expression:
+        raise ValueError("license_expression must be a non-empty SPDX expression")
+    if any(ord(character) < 32 or ord(character) > 126 for character in expression):
+        raise ValueError("license_expression must contain printable ASCII SPDX syntax only")
+    try:
+        return canonicalize_license_expression(expression)
+    except InvalidLicenseExpression as exception:
+        raise ValueError(f"license_expression must be a valid SPDX expression: {expression!r}") from exception
+
+
+def _validate_wheel_version(value: str) -> str:
+    if _WHEEL_VERSION_RE.fullmatch(value) is None:
+        raise RuntimeError(f"installed Vane version cannot be used in a wheel filename: {value!r}")
+    return value
+
+
+def _provider_module_source(name: str) -> str:
+    return f'''# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Installed provider for the {name} Vane dynamic extension."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from vane.extensions import (
+    DynamicExtensionDescriptor,
+    LocalExtensionArtifact,
+    LocalExtensionProvider,
+)
+
+_PACKAGE_DIRECTORY = Path(__file__).resolve().parent
+
+
+def descriptor() -> DynamicExtensionDescriptor:
+    """Return the immutable descriptor shipped with this extension wheel."""
+    return DynamicExtensionDescriptor.from_json(
+        (_PACKAGE_DIRECTORY / "{name}.dynamic-extension.json").read_bytes()
+    )
+
+
+def provider() -> LocalExtensionProvider:
+    """Return the explicit provider advertised through package metadata."""
+    extension_descriptor = descriptor()
+    return LocalExtensionProvider(
+        extension_descriptor.trust_identity,
+        (
+            LocalExtensionArtifact(
+                extension_descriptor,
+                _PACKAGE_DIRECTORY / "{name}.duckdb_extension",
+            ),
+        ),
+    )
+
+
+__all__ = ["descriptor", "provider"]
+'''
+
+
+def _metadata(
+    distribution_name: str,
+    vane_version: str,
+    license_expression: str,
+    license_members: tuple[str, ...],
+    dist_info_root: str,
+) -> str:
+    lines = [
+        "Metadata-Version: 2.4",
+        f"Name: {distribution_name}",
+        f"Version: {vane_version}",
+        "Summary: Platform-specific Vane dynamic extension artifact",
+        f"License-Expression: {license_expression}",
+        "Requires-Python: >=3.10",
+        f"Requires-Dist: vane-ai (=={vane_version})",
+    ]
+    for member_name in license_members:
+        lines.append(f"License-File: {member_name.removeprefix(dist_info_root + '/licenses/')}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _wheel_metadata(wheel_tag: str) -> str:
+    return "\n".join(
+        (
+            "Wheel-Version: 1.0",
+            "Generator: vane-extension-wheel",
+            "Root-Is-Purelib: false",
+            f"Tag: {wheel_tag}",
+            "",
+        )
+    )
+
+
+def _entry_points(name: str) -> str:
+    return "\n".join(
+        (
+            f"[{ENTRY_POINT_GROUP}]",
+            f"{name} = vane_extensions.{name}:provider",
+            "",
+        )
+    )
+
+
+def _record(entries: dict[str, bytes], record_name: str) -> str:
+    record_buffer = io.StringIO()
+    writer = csv.writer(record_buffer, lineterminator="\n")
+    for member_name, member_contents in sorted(entries.items()):
+        digest = base64.urlsafe_b64encode(hashlib.sha256(member_contents).digest()).rstrip(b"=").decode("ascii")
+        writer.writerow((member_name, f"sha256={digest}", len(member_contents)))
+    writer.writerow((record_name, "", ""))
+    return record_buffer.getvalue()
+
+
+def _license_entries(license_files: Iterable[str | Path], dist_info_root: str) -> dict[str, bytes]:
+    entries: dict[str, bytes] = {}
+    for license_file in license_files:
+        path = Path(license_file).expanduser().resolve(strict=True)
+        if not path.is_file():
+            raise ValueError(f"license file is not a regular file: {path}")
+        relative_path = _license_member_path(path)
+        member_name = f"{dist_info_root}/licenses/{relative_path}"
+        if member_name in entries:
+            raise ValueError(f"license files must have unique wheel paths: {relative_path}")
+        entries[member_name] = path.read_bytes()
+    if not entries:
+        raise ValueError("license_files must contain every license required by the extension artifact")
+    return entries
+
+
+def _license_member_path(path: Path) -> str:
+    try:
+        relative_path = path.relative_to(REPOSITORY_ROOT)
+    except ValueError:
+        relative_path = Path(path.name)
+    member_path = relative_path.as_posix()
+    if (
+        not member_path
+        or "\\" in member_path
+        or any(part in {"", ".", ".."} for part in relative_path.parts)
+        or any(ord(character) < 32 or ord(character) > 126 for character in member_path)
+    ):
+        raise ValueError(f"license file must have a safe ASCII relative path: {path}")
+    return member_path
+
+
+def _zip_info(member_name: str) -> zipfile.ZipInfo:
+    source_date_epoch = int(os.environ.get("SOURCE_DATE_EPOCH", "315532800"))
+    timestamp = datetime.fromtimestamp(max(source_date_epoch, 315532800), tz=timezone.utc)
+    info = zipfile.ZipInfo(member_name, date_time=timestamp.timetuple()[:6])
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.create_system = 3
+    info.external_attr = (stat.S_IFREG | 0o644) << 16
+    return info
+
+
+__all__ = ["ENTRY_POINT_GROUP", "BuiltExtensionWheel", "build_extension_wheel"]


### PR DESCRIPTION
## Summary

- Stack this PR on #620; once #620 merges into this base, the diff narrows to the Ray replay commit below.
- Capture resolver-owned dynamic-extension descriptors, digests, and dependency order in shared Vane connection state and Ray physical-plan snapshots.
- Replay required artifacts from explicitly named, trusted local platform-wheel providers before worker rebind, static extension handling, or distributed contract validation.
- Include dynamic artifact identity in worker database-cache identity; reject missing, altered, untrusted, unordered, or untracked extension state deterministically.
- Keep worker extension security settings disabled and avoid introducing internal queries into the user connection result collector.

## Related issue

close: #615

Depends on #620.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`DEVELOPMENT.md` and `DISTRIBUTED_EXTENSIONS.md` document immutable dynamic snapshots, local provider replay, and worker security behavior.

## Validation

- `scripts/format root --changed`
- Incremental native rebuild and installation: `CMAKE_BUILD_PARALLEL_LEVEL=16 VANE_NATIVE_BUILD_JOBS=16 uv pip install . --no-build-isolation`
- `scripts/run_installed_pytest.sh tests/fast/test_dynamic_extension_resolver.py tests/fast/test_ray_connection_snapshot.py tests/fast/test_ray_worker_connection_snapshot.py` — 84 passed, 1 optional staged-artifact test skipped
- `scripts/run_installed_pytest.sh tests/fast/test_ray_cpp_bindings.py::test_execute_native_keeps_result_collector_query_local` — 1 passed
- `scripts/run_release_tests.sh` — completed successfully across non-Ray and real-Ray shards

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.