### PR TITLE
[fix](macos) Compile distributed sources with libc++

### DIFF
--- a/cmake/duckdb_loader.cmake
+++ b/cmake/duckdb_loader.cmake
@@ -576,11 +576,8 @@ function(_duckdb_create_interface_target target_name)
                 /utf-8 # treat source files as UTF-8 encoded
     )
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    target_compile_options(
-      ${target_name}
-      INTERFACE -stdlib=libc++ # for libc++ in favor of older libstdc++
-                -mmacosx-version-min=10.7 # minimum osx version compatibility
-    )
+    # Use libc++ on macOS; the deployment target is supplied by the toolchain.
+    target_compile_options(${target_name} INTERFACE -stdlib=libc++)
   endif()
 
   # Link to the DuckDB static library

--- a/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/shuffle_cache.cpp
@@ -33,6 +33,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <unistd.h>
 
 namespace duckdb {
 namespace distributed {

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -88,7 +88,7 @@ void ExchangeSourceTaskDescriptor::Serialize(Serializer &serializer) const {
 				files.WriteObject([&](Serializer &file_obj) {
 					const auto &file = handle.files[file_idx];
 					file_obj.WriteProperty(1, "path", file.path);
-					file_obj.WriteProperty(2, "file_size", file.file_size);
+					file_obj.WriteProperty<uint64_t>(2, "file_size", static_cast<uint64_t>(file.file_size));
 					file_obj.WriteProperty(3, "rows", file.rows);
 				});
 			});
@@ -119,7 +119,7 @@ ExchangeSourceTaskDescriptor ExchangeSourceTaskDescriptor::Deserialize(Deseriali
 				ExchangeSourceFile file;
 				files.ReadObject([&](Deserializer &file_obj) {
 					file.path = file_obj.ReadProperty<string>(1, "path");
-					file.file_size = file_obj.ReadProperty<size_t>(2, "file_size");
+					file.file_size = static_cast<size_t>(file_obj.ReadProperty<uint64_t>(2, "file_size"));
 					file_obj.ReadPropertyWithDefault<idx_t>(3, "rows", file.rows);
 				});
 				handle.files.push_back(std::move(file));

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -244,7 +244,7 @@ string SerializeSourceDescriptorWithoutFlightHost() {
 			obj.WriteList(4, "files", 1, [&](Serializer::List &files, idx_t) {
 				files.WriteObject([&](Serializer &file_obj) {
 					file_obj.WriteProperty(1, "path", string("pre-strict-source"));
-					file_obj.WriteProperty<size_t>(2, "file_size", 0);
+					file_obj.WriteProperty<uint64_t>(2, "file_size", 0);
 					file_obj.WriteProperty<idx_t>(3, "rows", 0);
 				});
 			});
@@ -2169,7 +2169,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	handle0.flight_host = "flight-node-1.internal";
 	handle0.flight_port = 5010;
 	handle0.flight_server_epoch = "epoch-1";
-	handle0.files.push_back(ExchangeSourceFile("exchange__sink_0__attempt_7", 0, 11));
+	handle0.files.push_back(ExchangeSourceFile("exchange__sink_0__attempt_7", 0, (uint64_t(1) << 40) + 123));
 	descriptor.source_handles.push_back(handle0);
 
 	distributed::ExchangeSourceHandle handle1;
@@ -2201,7 +2201,7 @@ TEST_CASE("ExchangeSourceTaskDescriptor serialization preserves source handle at
 	REQUIRE(roundtrip.source_handles[0].flight_server_epoch == "epoch-1");
 	REQUIRE(roundtrip.source_handles[0].files.size() == 1);
 	REQUIRE(roundtrip.source_handles[0].files[0].path == "exchange__sink_0__attempt_7");
-	REQUIRE(roundtrip.source_handles[0].files[0].file_size == 11);
+	REQUIRE(roundtrip.source_handles[0].files[0].file_size == (uint64_t(1) << 40) + 123);
 	REQUIRE(roundtrip.source_handles[1].partition_id == 1);
 	REQUIRE(roundtrip.source_handles[1].source_task_partition_id == 22);
 	REQUIRE(roundtrip.source_handles[1].attempt_id == 2);

--- a/src/vane_py/ray/task.cpp
+++ b/src/vane_py/ray/task.cpp
@@ -381,7 +381,7 @@ duckdb::distributed::DuckDBResult<size_t> RayBackedResultPartition::size_bytes()
 		return duckdb::distributed::DuckDBResult<size_t>::ok(size_bytes_);
 	}
 
-	auto collection = materialized_collection_.load();
+	auto collection = std::atomic_load(&materialized_collection_);
 	return duckdb::distributed::DuckDBResult<size_t>::ok(collection ? collection->SizeInBytes() : 0);
 }
 
@@ -390,7 +390,7 @@ duckdb::distributed::DuckDBResult<size_t> RayBackedResultPartition::num_rows() c
 		return duckdb::distributed::DuckDBResult<size_t>::ok(num_rows_);
 	}
 
-	auto collection = materialized_collection_.load();
+	auto collection = std::atomic_load(&materialized_collection_);
 	return duckdb::distributed::DuckDBResult<size_t>::ok(collection ? collection->Count() : 0);
 }
 
@@ -412,7 +412,7 @@ std::shared_ptr<duckdb::ColumnDataCollection> RayBackedResultPartition::to_colum
 			duckdb::PythonGILWrapper gil;
 			try {
 				auto object_ref = object_ref_.get();
-				materialized_collection_.store(MaterializePyPayloadToCollection(object_ref, nullptr));
+				std::atomic_store(&materialized_collection_, MaterializePyPayloadToCollection(object_ref, nullptr));
 			} catch (const py::error_already_set &ex) {
 				throw duckdb::InvalidInputException("Failed to materialize Ray result partition: %s", ex.what());
 			}
@@ -424,7 +424,7 @@ std::shared_ptr<duckdb::ColumnDataCollection> RayBackedResultPartition::to_colum
 	if (materialize_error_) {
 		std::rethrow_exception(materialize_error_);
 	}
-	return materialized_collection_.load();
+	return std::atomic_load(&materialized_collection_);
 }
 
 py::object duckdb::distributed::python::ray::ResultPartitionToPyObject(

--- a/src/vane_py/ray/task.hpp
+++ b/src/vane_py/ray/task.hpp
@@ -159,7 +159,7 @@ private:
 	size_t num_rows_;
 	size_t size_bytes_;
 	mutable std::once_flag materialize_once_;
-	mutable std::atomic<std::shared_ptr<duckdb::ColumnDataCollection>> materialized_collection_;
+	mutable std::shared_ptr<duckdb::ColumnDataCollection> materialized_collection_;
 	mutable std::exception_ptr materialize_error_;
 };
 


### PR DESCRIPTION
## Summary

- Let the active macOS toolchain supply the deployment target instead of forcing macOS 10.7, so libc++ APIs used by the C++20 build remain available.
- Serialize exchange file sizes with a fixed `uint64_t` wire type and explicitly include the POSIX declaration for `getpid()`.
- Preserve thread-safe Ray result materialization with the libc++-supported `std::atomic_load` / `std::atomic_store` shared-pointer API.
- Add a native regression assertion that round-trips a file size larger than 32 bits.

This PR is intentionally limited to source compatibility. macOS wheel/release automation, dependency provisioning, and installation acceptance scripts remain follow-up work under #610.

## Related issue

Refs #610

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The changes only make existing distributed functionality compile on macOS; they do not add or change a public API.

## Validation

- `scripts/format root --changed --check`
- `scripts/format duckdb --changed --check`
- `scripts/run_native_tests.sh "[serialization][physical_plan][exchange]"` — 183 assertions in 12 test cases passed.
- `uv build --wheel --out-dir /tmp/vane-issue-610-dist --python 3.12 .` — full CPython 3.12 native wheel built successfully on Linux x86_64, including `task.cpp` and `ray_module.cpp`.
- Installed the wheel into an isolated virtual environment and verified `import vane`, engine/version metadata, and `SELECT 42` with `VANE_RUNNER=local-fast`.
- Ran `tests/fast/test_ray_cpp_bindings.py::test_ray_backed_result_partition_concurrent_materialization` against the installed wheel — 2 parameterized cases passed (success and cached failure across eight concurrent callers).
- The equivalent source compatibility changes were previously validated on arm64 macOS 26 with CPython 3.12, including a two-node local Ray plan with Arrow Flight shuffle; this branch was independently compiled and regression-tested in the Linux environment above.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
