### PR TITLE
[fix](ray) Distribute range and generate_series scans

### DIFF
--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -66,12 +66,15 @@ void IcebergExtension::Load(ExtensionLoader &loader) {
 }
 ```
 
-Each concrete capability owns a protocol version so scan and write contracts
-can evolve independently. Names and versions are stable wire identities, not
-display labels. The current registry accepts only implemented hook kinds:
-distributed table scans and distributed write operators. It has no public
-placeholder API for hypothetical aggregate, COPY, storage, or context
-protocols.
+Each table-function overload with callbacks owns a capability and protocol
+version, identified by its canonical catalog signature (for example,
+`range(BIGINT, BIGINT)`). Different overloads of one function may evolve
+independently, and distributed and native-only overloads may coexist. Write
+contracts remain identified by operator name. These signatures, names, and
+versions are stable wire identities, not display labels. The current registry
+accepts only implemented hook kinds: distributed table scans and distributed
+write operators. It has no public placeholder API for hypothetical aggregate,
+COPY, storage, or context protocols.
 
 Ordinary DuckDB registrations remain available on every statically linked
 worker:
@@ -88,12 +91,12 @@ worker:
 
 `ExtensionLoader` automatically stages a table-function capability when the
 normally registered `TableFunction` carries distributed scan callbacks. The
-extension name, function name, and capability kind are derived rather than
-repeated by the extension author. A write hook similarly receives its extension
-identity from the loader. The loader stages every concrete contract and
-publishes the manifest and write implementations atomically only when loading
-finalizes successfully. Duplicate identities, zero protocol versions, mixed
-distributed/native-only overloads, incomplete callbacks, and non-canonical
+extension name, canonical overload signature, and capability kind are derived
+rather than repeated by the extension author. A write hook similarly receives
+its extension identity from the loader. The loader stages every concrete
+overload contract and publishes the manifest and write implementations
+atomically only when loading finalizes successfully. Duplicate overload
+identities, zero protocol versions, incomplete callbacks, and non-canonical
 names are rejected.
 
 `DistributedWriteOperatorExtension` is a hook type, not another loadable
@@ -189,8 +192,9 @@ version, a split codec identity, and three operations:
 
 The ordinary `loader.RegisterFunction(...)` call binds the complete
 `DistributedExtensionCapabilityReference` from the loader's extension identity
-and the table function's catalog name. No second table-function registration is
-required, and native DuckDB continues to execute the original bind/init/scan
+and the table function overload's canonical catalog signature. No second
+table-function registration is required, native-only overloads remain
+unaffected, and native DuckDB continues to execute the original bind/init/scan
 callbacks.
 
 Each envelope contains a stable `split_id`, one opaque payload, and optional

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
@@ -84,7 +84,7 @@ vector<ScanSplit> MakeExtensionScanSplits(const PhysicalTableScan &scan, const D
 		                             scan.function.name);
 	}
 	const auto &callbacks = scan.function.GetDistributedScanCallbacks();
-	callbacks.Validate(scan.function.name);
+	callbacks.Validate(scan.function);
 	const auto &capability = callbacks.GetCapability();
 	if (!db) {
 		throw InvalidInputException("Distributed extension scan '%s' requires a DatabaseInstance for capability "
@@ -134,7 +134,7 @@ DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
 			                             scan.function.name);
 		}
 		const auto &callbacks = scan.function.GetDistributedScanCallbacks();
-		callbacks.Validate(scan.function.name);
+		callbacks.Validate(scan.function);
 		bind_data = callbacks.create_worker_bind(MakeDistributedScanInput(scan));
 		if (!bind_data) {
 			throw InvalidInputException("Distributed table function '%s' returned null from create_worker_bind",

--- a/external/duckdb/src/execution/distributed/plan/scan_split.cpp
+++ b/external/duckdb/src/execution/distributed/plan/scan_split.cpp
@@ -365,7 +365,7 @@ static bool ApplyExtensionScanSplits(PhysicalTableScan &scan, const ScanSplitBat
 		return false;
 	}
 	const auto &callbacks = scan.function.GetDistributedScanCallbacks();
-	callbacks.Validate(scan.function.name);
+	callbacks.Validate(scan.function);
 	const auto &capability = callbacks.GetCapability();
 	const auto &first_split = batch.splits[0];
 	if (first_split.extension_capability != capability) {

--- a/external/duckdb/src/function/table/range.cpp
+++ b/external/duckdb/src/function/table/range.cpp
@@ -5,130 +5,374 @@
 // Modified by Vane contributors.
 
 #include "duckdb/function/table/range.hpp"
+
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/limits.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/set.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/function/table/distributed_sequence.hpp"
 #include "duckdb/function/table/summary.hpp"
 #include "duckdb/function/table_function.hpp"
-#include "duckdb/function/function_set.hpp"
-#include "duckdb/common/operator/add.hpp"
-#include "duckdb/common/operator/subtract.hpp"
-#include "duckdb/common/types/timestamp.hpp"
+
+#include <algorithm>
 
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
+// Distributed sequence split protocol
+//===--------------------------------------------------------------------===//
+static string EncodeDistributedSequenceSplitPayload(const DistributedSequenceSplit &sequence_split) {
+	MemoryStream stream(Allocator::DefaultAllocator());
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	serializer.WriteProperty(1, "ordinal", sequence_split.ordinal);
+	serializer.WriteProperty(2, "row_offset", sequence_split.row_offset);
+	serializer.WriteProperty(3, "row_count", sequence_split.row_count);
+	serializer.WriteProperty(4, "exact_count", sequence_split.exact_count);
+	serializer.End();
+	return string(reinterpret_cast<const char *>(stream.GetData()), stream.GetPosition());
+}
+
+static DistributedSequenceSplit DecodeDistributedSequenceSplitPayload(const string &payload) {
+	if (payload.empty()) {
+		throw InvalidInputException("distributed sequence split payload is empty");
+	}
+	auto data = reinterpret_cast<data_ptr_t>(const_cast<char *>(payload.data()));
+	MemoryStream stream(data, payload.size());
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	DistributedSequenceSplit result;
+	result.ordinal = deserializer.ReadProperty<idx_t>(1, "ordinal");
+	result.row_offset = deserializer.ReadProperty<idx_t>(2, "row_offset");
+	result.row_count = deserializer.ReadProperty<idx_t>(3, "row_count");
+	result.exact_count = deserializer.ReadProperty<bool>(4, "exact_count");
+	deserializer.End();
+	if (stream.GetPosition() != payload.size()) {
+		throw InvalidInputException("distributed sequence split payload has trailing bytes");
+	}
+	return result;
+}
+
+static idx_t ParseDistributedSequenceSplitId(const string &split_id) {
+	if (split_id.empty() || (split_id.size() > 1 && split_id[0] == '0')) {
+		throw InvalidInputException("distributed sequence split has non-canonical id '%s'", split_id);
+	}
+	idx_t result = 0;
+	for (auto character : split_id) {
+		if (character < '0' || character > '9') {
+			throw InvalidInputException("distributed sequence split has non-canonical id '%s'", split_id);
+		}
+		const auto digit = NumericCast<idx_t>(character - '0');
+		if (result > (NumericLimits<idx_t>::Maximum() - digit) / 10) {
+			throw InvalidInputException("distributed sequence split id '%s' overflows idx_t", split_id);
+		}
+		result = result * 10 + digit;
+	}
+	if (result == NumericLimits<idx_t>::Maximum()) {
+		throw InvalidInputException("distributed sequence split id '%s' is reserved", split_id);
+	}
+	return result;
+}
+
+static idx_t SaturatingSequenceByteEstimate(idx_t row_count) {
+	constexpr idx_t MAX_VALID_OPTIONAL_INDEX = NumericLimits<idx_t>::Maximum() - 1;
+	if (row_count > MAX_VALID_OPTIONAL_INDEX / sizeof(int64_t)) {
+		return MAX_VALID_OPTIONAL_INDEX;
+	}
+	return row_count * sizeof(int64_t);
+}
+
+vector<DistributedScanSplit> PlanDistributedSequenceSplits(idx_t cardinality, bool exact_count,
+                                                           idx_t target_split_count) {
+	vector<DistributedScanSplit> result;
+	if (!exact_count) {
+		DistributedSequenceSplit sequence_split;
+		sequence_split.exact_count = false;
+		DistributedScanSplit split;
+		split.split_id = "0";
+		split.payload = EncodeDistributedSequenceSplitPayload(sequence_split);
+		split.Validate();
+		result.push_back(std::move(split));
+		return result;
+	}
+	if (cardinality == 0) {
+		return result;
+	}
+	if (cardinality == NumericLimits<idx_t>::Maximum()) {
+		throw OutOfRangeException("distributed sequence cardinality exceeds the supported index range");
+	}
+
+	const auto partition_count = MinValue<idx_t>(cardinality, MaxValue<idx_t>(target_split_count, 1));
+	const auto rows_per_partition = cardinality / partition_count;
+	const auto remainder = cardinality % partition_count;
+	result.reserve(partition_count);
+	idx_t row_offset = 0;
+	for (idx_t ordinal = 0; ordinal < partition_count; ordinal++) {
+		DistributedSequenceSplit sequence_split;
+		sequence_split.ordinal = ordinal;
+		sequence_split.row_offset = row_offset;
+		sequence_split.row_count = rows_per_partition + (ordinal < remainder ? 1 : 0);
+		sequence_split.exact_count = true;
+
+		DistributedScanSplit split;
+		split.split_id = std::to_string(ordinal);
+		split.payload = EncodeDistributedSequenceSplitPayload(sequence_split);
+		split.estimated_cardinality = optional_idx(sequence_split.row_count);
+		split.estimated_bytes = optional_idx(SaturatingSequenceByteEstimate(sequence_split.row_count));
+		split.Validate();
+		result.push_back(std::move(split));
+		row_offset += sequence_split.row_count;
+	}
+	D_ASSERT(row_offset == cardinality);
+	return result;
+}
+
+vector<DistributedSequenceSplit> DecodeDistributedSequenceSplits(const vector<DistributedScanSplit> &splits,
+                                                                 idx_t cardinality, bool exact_count) {
+	vector<DistributedSequenceSplit> result;
+	result.reserve(splits.size());
+	set<idx_t> ordinals;
+	for (const auto &split : splits) {
+		split.Validate();
+		auto sequence_split = DecodeDistributedSequenceSplitPayload(split.payload);
+		if (ParseDistributedSequenceSplitId(split.split_id) != sequence_split.ordinal) {
+			throw InvalidInputException("distributed sequence split id '%s' does not match payload ordinal %llu",
+			                            split.split_id, static_cast<unsigned long long>(sequence_split.ordinal));
+		}
+		if (!ordinals.insert(sequence_split.ordinal).second) {
+			throw InvalidInputException("distributed sequence split ordinal %llu is assigned more than once",
+			                            static_cast<unsigned long long>(sequence_split.ordinal));
+		}
+		if (sequence_split.exact_count != exact_count) {
+			throw InvalidInputException("distributed sequence split '%s' count mode does not match its worker bind",
+			                            split.split_id);
+		}
+		if (exact_count) {
+			if (sequence_split.row_count == 0 || sequence_split.row_offset >= cardinality ||
+			    sequence_split.row_count > cardinality - sequence_split.row_offset) {
+				throw InvalidInputException("distributed sequence split '%s' is outside cardinality %llu",
+				                            split.split_id, static_cast<unsigned long long>(cardinality));
+			}
+		} else if (sequence_split.ordinal != 0 || sequence_split.row_offset != 0 || sequence_split.row_count != 0 ||
+		           splits.size() != 1) {
+			throw InvalidInputException("calendar-sensitive distributed sequence requires exactly split '0'");
+		}
+		result.push_back(std::move(sequence_split));
+	}
+	std::sort(result.begin(), result.end(),
+	          [](const DistributedSequenceSplit &left, const DistributedSequenceSplit &right) {
+		          if (left.row_offset != right.row_offset) {
+			          return left.row_offset < right.row_offset;
+		          }
+		          return left.ordinal < right.ordinal;
+	          });
+	if (exact_count) {
+		for (idx_t sequence_split_index = 1; sequence_split_index < result.size(); sequence_split_index++) {
+			const auto &previous = result[sequence_split_index - 1];
+			const auto &current = result[sequence_split_index];
+			if (current.row_offset < previous.row_offset + previous.row_count) {
+				throw InvalidInputException("distributed sequence split assignments overlap");
+			}
+		}
+	}
+	return result;
+}
+
+static bool DistributedSequenceSplitsEqual(const vector<DistributedSequenceSplit> &left,
+                                           const vector<DistributedSequenceSplit> &right) {
+	if (left.size() != right.size()) {
+		return false;
+	}
+	for (idx_t sequence_split_index = 0; sequence_split_index < left.size(); sequence_split_index++) {
+		if (left[sequence_split_index].ordinal != right[sequence_split_index].ordinal ||
+		    left[sequence_split_index].row_offset != right[sequence_split_index].row_offset ||
+		    left[sequence_split_index].row_count != right[sequence_split_index].row_count ||
+		    left[sequence_split_index].exact_count != right[sequence_split_index].exact_count) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static idx_t CastSequenceCardinality(hugeint_t cardinality) {
+	idx_t result;
+	if (cardinality < 0 || !Hugeint::TryCast<idx_t>(cardinality, result)) {
+		throw OutOfRangeException("range cardinality exceeds the supported index range");
+	}
+	return result;
+}
+
+static idx_t ComputeSequenceCardinalityHuge(hugeint_t start, hugeint_t end, hugeint_t increment, bool inclusive) {
+	if (increment == 0) {
+		throw BinderException("interval cannot be 0!");
+	}
+	if (increment > 0) {
+		if (inclusive ? start > end : start >= end) {
+			return 0;
+		}
+		const auto distance = end - start;
+		if (inclusive) {
+			return CastSequenceCardinality(distance / increment + 1);
+		}
+		return CastSequenceCardinality((distance + increment - 1) / increment);
+	}
+	if (inclusive ? start < end : start <= end) {
+		return 0;
+	}
+	const auto distance = start - end;
+	const auto magnitude = -increment;
+	if (inclusive) {
+		return CastSequenceCardinality(distance / magnitude + 1);
+	}
+	return CastSequenceCardinality((distance + magnitude - 1) / magnitude);
+}
+
+idx_t ComputeDistributedSequenceCardinality(int64_t start, int64_t end, int64_t increment, bool inclusive) {
+	return ComputeSequenceCardinalityHuge(hugeint_t(start), hugeint_t(end), hugeint_t(increment), inclusive);
+}
+
+int64_t GetDistributedSequenceValue(int64_t start, int64_t increment, idx_t row_offset) {
+	const auto value = hugeint_t(start) + hugeint_t(increment) * hugeint_t(NumericCast<uint64_t>(row_offset));
+	int64_t result;
+	if (!Hugeint::TryCast<int64_t>(value, result)) {
+		throw InvalidInputException("distributed sequence split starts outside the value domain");
+	}
+	return result;
+}
+
+//===--------------------------------------------------------------------===//
 // Range (integers)
 //===--------------------------------------------------------------------===//
-static void GetParameters(int64_t values[], idx_t value_count, hugeint_t &start, hugeint_t &end, hugeint_t &increment) {
+static void GetParameters(const int64_t values[], idx_t value_count, int64_t &start, int64_t &end, int64_t &increment) {
 	if (value_count < 2) {
-		// single argument: only the end is specified
 		start = 0;
 		end = values[0];
 	} else {
-		// two arguments: first two arguments are start and end
 		start = values[0];
 		end = values[1];
 	}
-	if (value_count < 3) {
-		increment = 1;
-	} else {
-		increment = values[2];
-	}
+	increment = value_count < 3 ? 1 : values[2];
 }
 
 struct RangeFunctionBindData : public TableFunctionData {
-	RangeFunctionBindData() : cardinality(0) {
+	RangeFunctionBindData() = default;
+
+	RangeFunctionBindData(const RangeFunctionBindData &other)
+	    : TableFunctionData(other), has_parameters(other.has_parameters), is_null(other.is_null),
+	      generate_series(other.generate_series), distributed(other.distributed), start(other.start), end(other.end),
+	      increment(other.increment), cardinality(other.cardinality), sequence_splits(other.sequence_splits) {
 	}
 
-	explicit RangeFunctionBindData(const vector<Value> &inputs, bool generate_series) : cardinality(0) {
+	RangeFunctionBindData(const vector<Value> &inputs, bool generate_series_p) : generate_series(generate_series_p) {
+		if (inputs.empty()) {
+			return;
+		}
+		has_parameters = true;
 		int64_t values[3];
-		for (idx_t i = 0; i < inputs.size(); i++) {
-			if (inputs[i].IsNull()) {
+		for (idx_t input_index = 0; input_index < inputs.size(); input_index++) {
+			if (inputs[input_index].IsNull()) {
+				is_null = true;
 				return;
 			}
-			values[i] = inputs[i].GetValue<int64_t>();
+			values[input_index] = inputs[input_index].GetValue<int64_t>();
 		}
-		hugeint_t start;
-		hugeint_t end;
-		hugeint_t increment;
 		GetParameters(values, inputs.size(), start, end, increment);
-		if (generate_series) {
-			// generate_series has inclusive bounds on the RHS
-			end += 1;
-		}
-
-		cardinality = Hugeint::Cast<idx_t>((end - start) / increment);
-		if ((end - start) % increment != 0) {
-			cardinality += 1;
-		}
+		cardinality = ComputeDistributedSequenceCardinality(start, end, increment, generate_series);
 	}
 
-	idx_t cardinality;
+	bool has_parameters = false;
+	bool is_null = false;
+	bool generate_series = false;
+	bool distributed = false;
+	int64_t start = 0;
+	int64_t end = 0;
+	int64_t increment = 1;
+	idx_t cardinality = 0;
+	vector<DistributedSequenceSplit> sequence_splits;
 
 	unique_ptr<FunctionData> Copy() const override {
-		auto result = make_uniq<RangeFunctionBindData>();
-		result->cardinality = cardinality;
-		return std::move(result);
+		return make_uniq<RangeFunctionBindData>(*this);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto other = dynamic_cast<const RangeFunctionBindData *>(&other_p);
+		return other && column_ids == other->column_ids && has_parameters == other->has_parameters &&
+		       is_null == other->is_null && generate_series == other->generate_series &&
+		       distributed == other->distributed && start == other->start && end == other->end &&
+		       increment == other->increment && cardinality == other->cardinality &&
+		       DistributedSequenceSplitsEqual(sequence_splits, other->sequence_splits);
 	}
 };
 
 template <bool GENERATE_SERIES>
-static unique_ptr<FunctionData> RangeFunctionBind(ClientContext &context, TableFunctionBindInput &input,
+static unique_ptr<FunctionData> RangeFunctionBind(ClientContext &, TableFunctionBindInput &input,
                                                   vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.emplace_back(LogicalType::BIGINT);
-	if (GENERATE_SERIES) {
-		names.emplace_back("generate_series");
-	} else {
-		names.emplace_back("range");
-	}
-	if (input.inputs.empty() || input.inputs.size() > 3) {
+	names.emplace_back(GENERATE_SERIES ? "generate_series" : "range");
+	if (input.inputs.size() > 3) {
 		return nullptr;
 	}
 	return make_uniq<RangeFunctionBindData>(input.inputs, GENERATE_SERIES);
 }
 
 struct RangeFunctionLocalState : public LocalTableFunctionState {
-	RangeFunctionLocalState() {
-	}
-
 	bool initialized_row = false;
 	idx_t current_input_row = 0;
-	idx_t current_idx = 0;
+	hugeint_t current_idx = 0;
 
 	hugeint_t start;
 	hugeint_t end;
 	hugeint_t increment;
-
 	bool empty_range = false;
+
+	idx_t sequence_split_index = 0;
+	idx_t sequence_split_row = 0;
 };
 
-static unique_ptr<LocalTableFunctionState> RangeFunctionLocalInit(ExecutionContext &context,
-                                                                  TableFunctionInitInput &input,
-                                                                  GlobalTableFunctionState *global_state) {
+static unique_ptr<LocalTableFunctionState> RangeFunctionLocalInit(ExecutionContext &, TableFunctionInitInput &,
+                                                                  GlobalTableFunctionState *) {
 	return make_uniq<RangeFunctionLocalState>();
 }
 
 template <bool GENERATE_SERIES>
 static void GenerateRangeParameters(DataChunk &input, idx_t row_id, RangeFunctionLocalState &result) {
 	input.Flatten();
-	for (idx_t c = 0; c < input.ColumnCount(); c++) {
-		if (FlatVector::IsNull(input.data[c], row_id)) {
-			result.start = GENERATE_SERIES ? 1 : 0;
+	result.empty_range = false;
+	for (idx_t column_index = 0; column_index < input.ColumnCount(); column_index++) {
+		if (FlatVector::IsNull(input.data[column_index], row_id)) {
+			result.start = 0;
 			result.end = 0;
 			result.increment = 1;
+			result.empty_range = true;
 			return;
 		}
 	}
 	int64_t values[3];
-	for (idx_t c = 0; c < input.ColumnCount(); c++) {
-		if (c >= 3) {
+	for (idx_t column_index = 0; column_index < input.ColumnCount(); column_index++) {
+		if (column_index >= 3) {
 			throw InternalException("Unsupported parameter count for range function");
 		}
-		values[c] = FlatVector::GetValue<int64_t>(input.data[c], row_id);
+		values[column_index] = FlatVector::GetValue<int64_t>(input.data[column_index], row_id);
 	}
-	GetParameters(values, input.ColumnCount(), result.start, result.end, result.increment);
+	int64_t start;
+	int64_t end;
+	int64_t increment;
+	GetParameters(values, input.ColumnCount(), start, end, increment);
+	result.start = start;
+	result.end = end;
+	result.increment = increment;
 	if (result.increment == 0) {
 		throw BinderException("interval cannot be 0!");
 	}
-	result.empty_range = false;
 	if (result.start > result.end && result.increment > 0) {
 		result.empty_range = true;
 	}
@@ -136,24 +380,43 @@ static void GenerateRangeParameters(DataChunk &input, idx_t row_id, RangeFunctio
 		result.empty_range = true;
 	}
 	if (GENERATE_SERIES) {
-		// generate_series has inclusive bounds on the RHS
-		if (result.increment < 0) {
-			result.end = result.end - 1;
-		} else {
-			result.end = result.end + 1;
-		}
+		result.end += result.increment < 0 ? -1 : 1;
 	}
 }
 
+static OperatorResultType DistributedIntegerRangeFunction(const RangeFunctionBindData &bind_data,
+                                                          RangeFunctionLocalState &state, DataChunk &output) {
+	while (state.sequence_split_index < bind_data.sequence_splits.size()) {
+		const auto &sequence_split = bind_data.sequence_splits[state.sequence_split_index];
+		if (state.sequence_split_row == sequence_split.row_count) {
+			state.sequence_split_index++;
+			state.sequence_split_row = 0;
+			continue;
+		}
+		const auto output_count =
+		    MinValue<idx_t>(STANDARD_VECTOR_SIZE, sequence_split.row_count - state.sequence_split_row);
+		const auto row_offset = sequence_split.row_offset + state.sequence_split_row;
+		const auto current_value = GetDistributedSequenceValue(bind_data.start, bind_data.increment, row_offset);
+		output.data[0].Sequence(current_value, bind_data.increment, output_count);
+		state.sequence_split_row += output_count;
+		output.SetCardinality(output_count);
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	}
+	output.SetCardinality(0);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
 template <bool GENERATE_SERIES>
-static OperatorResultType RangeFunction(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+static OperatorResultType RangeFunction(ExecutionContext &, TableFunctionInput &data_p, DataChunk &input,
                                         DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<RangeFunctionBindData>();
 	auto &state = data_p.local_state->Cast<RangeFunctionLocalState>();
+	if (bind_data.distributed) {
+		return DistributedIntegerRangeFunction(bind_data, state, output);
+	}
 	while (true) {
 		if (!state.initialized_row) {
-			// initialize for the current input row
 			if (state.current_input_row >= input.size()) {
-				// ran out of rows
 				state.current_input_row = 0;
 				state.initialized_row = false;
 				return OperatorResultType::NEED_MORE_INPUT;
@@ -163,32 +426,28 @@ static OperatorResultType RangeFunction(ExecutionContext &context, TableFunction
 			state.current_idx = 0;
 		}
 		if (state.empty_range) {
-			// empty range
 			output.SetCardinality(0);
 			state.current_input_row++;
 			state.initialized_row = false;
 			return OperatorResultType::HAVE_MORE_OUTPUT;
 		}
-		auto increment = state.increment;
-		auto end = state.end;
-		hugeint_t current_value = state.start + increment * UnsafeNumericCast<int64_t>(state.current_idx);
+		const auto current_value = state.start + state.increment * state.current_idx;
 		int64_t current_value_i64;
 		if (!Hugeint::TryCast<int64_t>(current_value, current_value_i64)) {
-			// move to next row
 			state.current_input_row++;
 			state.initialized_row = false;
 			continue;
 		}
-		int64_t offset = increment < 0 ? 1 : -1;
-		idx_t remaining = MinValue<idx_t>(
-		    Hugeint::Cast<idx_t>((end - current_value + (increment + offset)) / increment), STANDARD_VECTOR_SIZE);
-		// set the result vector as a sequence vector
-		output.data[0].Sequence(current_value_i64, Hugeint::Cast<int64_t>(increment), remaining);
-		// increment the index pointer by the remaining count
-		state.current_idx += remaining;
+		const hugeint_t bound_offset = state.increment < 0 ? 1 : -1;
+		const auto remaining_huge = (state.end - current_value + (state.increment + bound_offset)) / state.increment;
+		idx_t remaining = STANDARD_VECTOR_SIZE;
+		if (remaining_huge < hugeint_t(STANDARD_VECTOR_SIZE)) {
+			remaining = CastSequenceCardinality(remaining_huge);
+		}
+		output.data[0].Sequence(current_value_i64, Hugeint::Cast<int64_t>(state.increment), remaining);
+		state.current_idx += hugeint_t(NumericCast<uint64_t>(remaining));
 		output.SetCardinality(remaining);
 		if (remaining == 0) {
-			// move to next row
 			state.current_input_row++;
 			state.initialized_row = false;
 			continue;
@@ -197,131 +456,252 @@ static OperatorResultType RangeFunction(ExecutionContext &context, TableFunction
 	}
 }
 
-unique_ptr<NodeStatistics> RangeCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+static unique_ptr<NodeStatistics> RangeCardinality(ClientContext &, const FunctionData *bind_data_p) {
 	if (!bind_data_p) {
 		return nullptr;
 	}
 	auto &bind_data = bind_data_p->Cast<RangeFunctionBindData>();
+	if (!bind_data.has_parameters) {
+		return nullptr;
+	}
 	return make_uniq<NodeStatistics>(bind_data.cardinality, bind_data.cardinality);
+}
+
+static void RangeFunctionSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                                   const TableFunction &) {
+	if (!bind_data_p) {
+		throw SerializationException("integer sequence function requires bind data");
+	}
+	auto &bind_data = bind_data_p->Cast<RangeFunctionBindData>();
+	serializer.WriteProperty(101, "has_parameters", bind_data.has_parameters);
+	serializer.WriteProperty(102, "is_null", bind_data.is_null);
+	serializer.WriteProperty(103, "generate_series", bind_data.generate_series);
+	serializer.WriteProperty(104, "distributed", bind_data.distributed);
+	serializer.WriteProperty(105, "start", bind_data.start);
+	serializer.WriteProperty(106, "end", bind_data.end);
+	serializer.WriteProperty(107, "increment", bind_data.increment);
+}
+
+static bool IsGenerateSeriesFunction(const TableFunction &function) {
+	if (function.name == "generate_series") {
+		return true;
+	}
+	if (function.name == "range") {
+		return false;
+	}
+	throw SerializationException("unexpected sequence table function '%s'", function.name);
+}
+
+static unique_ptr<FunctionData> RangeFunctionDeserialize(Deserializer &deserializer, TableFunction &function) {
+	auto result = make_uniq<RangeFunctionBindData>();
+	result->has_parameters = deserializer.ReadProperty<bool>(101, "has_parameters");
+	result->is_null = deserializer.ReadProperty<bool>(102, "is_null");
+	result->generate_series = deserializer.ReadProperty<bool>(103, "generate_series");
+	result->distributed = deserializer.ReadProperty<bool>(104, "distributed");
+	result->start = deserializer.ReadProperty<int64_t>(105, "start");
+	result->end = deserializer.ReadProperty<int64_t>(106, "end");
+	result->increment = deserializer.ReadProperty<int64_t>(107, "increment");
+	if (result->generate_series != IsGenerateSeriesFunction(function)) {
+		throw SerializationException("serialized integer sequence bind does not match function '%s'", function.name);
+	}
+	if (result->is_null && !result->has_parameters) {
+		throw SerializationException("serialized integer sequence has null state without bound parameters");
+	}
+	if (result->distributed && !result->has_parameters) {
+		throw SerializationException("serialized distributed integer sequence has no bound parameters");
+	}
+	if (result->has_parameters && !result->is_null) {
+		result->cardinality = ComputeDistributedSequenceCardinality(result->start, result->end, result->increment,
+		                                                            result->generate_series);
+	}
+	return std::move(result);
+}
+
+static vector<DistributedScanSplit>
+PlanDistributedIntegerRange(const TableFunctionDistributedScanPlanningInput &input) {
+	auto &bind_data = input.bind_data.Cast<RangeFunctionBindData>();
+	if (!bind_data.has_parameters) {
+		throw InvalidInputException("distributed integer range requires scalar bound parameters");
+	}
+	return PlanDistributedSequenceSplits(bind_data.cardinality, true, input.target_split_count);
+}
+
+static unique_ptr<FunctionData>
+CreateDistributedIntegerRangeWorkerBind(const TableFunctionDistributedScanInput &input) {
+	auto &source_bind = input.bind_data.Cast<RangeFunctionBindData>();
+	if (!source_bind.has_parameters) {
+		throw InvalidInputException("distributed integer range requires scalar bound parameters");
+	}
+	auto result = make_uniq<RangeFunctionBindData>(source_bind);
+	result->distributed = true;
+	result->sequence_splits.clear();
+	return std::move(result);
+}
+
+static void ApplyDistributedIntegerRangeSplits(FunctionData &worker_bind_data,
+                                               const vector<DistributedScanSplit> &splits) {
+	auto &bind_data = worker_bind_data.Cast<RangeFunctionBindData>();
+	if (!bind_data.distributed || !bind_data.has_parameters) {
+		throw InvalidInputException("distributed integer range splits require a worker bind");
+	}
+	bind_data.sequence_splits = DecodeDistributedSequenceSplits(splits, bind_data.cardinality, true);
 }
 
 //===--------------------------------------------------------------------===//
 // Range (timestamp)
 //===--------------------------------------------------------------------===//
+static hugeint_t TimestampIntervalMicros(const interval_t &increment) {
+	return hugeint_t(static_cast<int64_t>(increment.days)) * hugeint_t(Interval::MICROS_PER_DAY) +
+	       hugeint_t(increment.micros);
+}
+
 struct RangeDateTimeBindData : public TableFunctionData {
-	RangeDateTimeBindData() : cardinality(0) {
+	RangeDateTimeBindData() = default;
+
+	RangeDateTimeBindData(const RangeDateTimeBindData &other)
+	    : TableFunctionData(other), has_parameters(other.has_parameters), is_null(other.is_null),
+	      generate_series(other.generate_series), distributed(other.distributed), exact_count(other.exact_count),
+	      increasing(other.increasing), empty_range(other.empty_range), start(other.start), end(other.end),
+	      increment(other.increment), cardinality(other.cardinality), sequence_splits(other.sequence_splits) {
 	}
 
-	explicit RangeDateTimeBindData(const vector<Value> &inputs) : cardinality(0) {
-		timestamp_t bounds[2];
-		interval_t step;
-		for (idx_t i = 0; i < inputs.size(); i++) {
-			if (inputs[i].IsNull()) {
+	RangeDateTimeBindData(const vector<Value> &inputs, bool generate_series_p) : generate_series(generate_series_p) {
+		if (inputs.empty()) {
+			return;
+		}
+		has_parameters = true;
+		for (const auto &value : inputs) {
+			if (value.IsNull()) {
+				is_null = true;
+				exact_count = true;
+				empty_range = true;
 				return;
 			}
-			if (i >= 2) {
-				step = inputs[i].GetValue<interval_t>();
-			} else {
-				bounds[i] = inputs[i].GetValue<timestamp_t>();
-			}
 		}
-		// Estimate cardinality using micros.
-		int64_t increment = 0;
-		if (!Interval::TryGetMicro(step, increment) || !increment) {
-			return;
-		}
-		int64_t delta = 0;
-		if (!TrySubtractOperator::Operation(bounds[1].value, bounds[0].value, delta)) {
-			return;
-		}
-
-		cardinality = idx_t(delta / increment);
+		start = inputs[0].GetValue<timestamp_t>();
+		end = inputs[1].GetValue<timestamp_t>();
+		increment = inputs[2].GetValue<interval_t>();
+		Initialize();
 	}
 
-	idx_t cardinality;
+	void Initialize() {
+		if (!Timestamp::IsFinite(start) || !Timestamp::IsFinite(end)) {
+			throw BinderException("RANGE with infinite bounds is not supported");
+		}
+		const bool has_positive = increment.months > 0 || increment.days > 0 || increment.micros > 0;
+		const bool has_negative = increment.months < 0 || increment.days < 0 || increment.micros < 0;
+		if (!has_positive && !has_negative) {
+			throw BinderException("interval cannot be 0!");
+		}
+		if (has_positive && has_negative) {
+			throw BinderException("RANGE with composite interval that has mixed signs is not supported");
+		}
+		increasing = has_positive;
+		empty_range = increasing ? start > end : start < end;
+		if (empty_range) {
+			exact_count = true;
+			cardinality = 0;
+			return;
+		}
+		if (start == end) {
+			exact_count = true;
+			cardinality = generate_series ? 1 : 0;
+			empty_range = !generate_series;
+			return;
+		}
+		if (increment.months == 0) {
+			exact_count = true;
+			cardinality = ComputeSequenceCardinalityHuge(hugeint_t(start.value), hugeint_t(end.value),
+			                                             TimestampIntervalMicros(increment), generate_series);
+			empty_range = cardinality == 0;
+		}
+	}
+
+	bool has_parameters = false;
+	bool is_null = false;
+	bool generate_series = false;
+	bool distributed = false;
+	bool exact_count = false;
+	bool increasing = true;
+	bool empty_range = false;
+	timestamp_t start = timestamp_t(0);
+	timestamp_t end = timestamp_t(0);
+	interval_t increment {0, 0, 0};
+	idx_t cardinality = 0;
+	vector<DistributedSequenceSplit> sequence_splits;
 
 	unique_ptr<FunctionData> Copy() const override {
-		auto result = make_uniq<RangeDateTimeBindData>();
-		result->cardinality = cardinality;
-		return std::move(result);
+		return make_uniq<RangeDateTimeBindData>(*this);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto other = dynamic_cast<const RangeDateTimeBindData *>(&other_p);
+		return other && column_ids == other->column_ids && has_parameters == other->has_parameters &&
+		       is_null == other->is_null && generate_series == other->generate_series &&
+		       distributed == other->distributed && exact_count == other->exact_count &&
+		       increasing == other->increasing && empty_range == other->empty_range && start == other->start &&
+		       end == other->end && increment == other->increment && cardinality == other->cardinality &&
+		       DistributedSequenceSplitsEqual(sequence_splits, other->sequence_splits);
 	}
 };
 
 template <bool GENERATE_SERIES>
-static unique_ptr<FunctionData> RangeDateTimeBind(ClientContext &context, TableFunctionBindInput &input,
+static unique_ptr<FunctionData> RangeDateTimeBind(ClientContext &, TableFunctionBindInput &input,
                                                   vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.push_back(LogicalType::TIMESTAMP);
-	if (GENERATE_SERIES) {
-		names.emplace_back("generate_series");
-	} else {
-		names.emplace_back("range");
-	}
-	if (input.inputs.size() != 3) {
+	names.emplace_back(GENERATE_SERIES ? "generate_series" : "range");
+	if (!input.inputs.empty() && input.inputs.size() != 3) {
 		return nullptr;
 	}
-	return make_uniq<RangeDateTimeBindData>(input.inputs);
+	return make_uniq<RangeDateTimeBindData>(input.inputs, GENERATE_SERIES);
 }
 
-unique_ptr<NodeStatistics> RangeDateTimeCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+static unique_ptr<NodeStatistics> RangeDateTimeCardinality(ClientContext &, const FunctionData *bind_data_p) {
 	if (!bind_data_p) {
 		return nullptr;
 	}
 	auto &bind_data = bind_data_p->Cast<RangeDateTimeBindData>();
+	if (!bind_data.has_parameters || !bind_data.exact_count) {
+		return nullptr;
+	}
 	return make_uniq<NodeStatistics>(bind_data.cardinality, bind_data.cardinality);
 }
 
 struct RangeDateTimeLocalState : public LocalTableFunctionState {
-	RangeDateTimeLocalState() {
-	}
-
 	bool initialized_row = false;
 	idx_t current_input_row = 0;
 	timestamp_t current_state;
 
 	timestamp_t start;
 	timestamp_t end;
-	interval_t increment;
-	bool inclusive_bound;
-	bool greater_than_check;
-
+	interval_t increment {0, 0, 0};
+	bool inclusive_bound = false;
+	bool greater_than_check = true;
 	bool empty_range = false;
+
+	idx_t sequence_split_index = 0;
+	idx_t sequence_split_row = 0;
 
 	bool Finished(timestamp_t current_value) const {
 		if (greater_than_check) {
-			if (inclusive_bound) {
-				return current_value > end;
-			} else {
-				return current_value >= end;
-			}
-		} else {
-			if (inclusive_bound) {
-				return current_value < end;
-			} else {
-				return current_value <= end;
-			}
+			return inclusive_bound ? current_value > end : current_value >= end;
 		}
+		return inclusive_bound ? current_value < end : current_value <= end;
 	}
 };
 
 template <bool GENERATE_SERIES>
 static void GenerateRangeDateTimeParameters(DataChunk &input, idx_t row_id, RangeDateTimeLocalState &result) {
 	input.Flatten();
-
-	// The local state is reused for every input row, so empty_range must be reset
-	// here. Without this it is only ever set to true and never back to false, so
-	// once ONE row produces an empty range every subsequent row is treated as
-	// empty and silently emits nothing. The integer overload
-	// (GenerateRangeParameters) already resets it, which is why only the
-	// timestamp overload was affected.
 	result.empty_range = false;
-
-	for (idx_t c = 0; c < input.ColumnCount(); c++) {
-		if (FlatVector::IsNull(input.data[c], row_id)) {
+	for (idx_t column_index = 0; column_index < input.ColumnCount(); column_index++) {
+		if (FlatVector::IsNull(input.data[column_index], row_id)) {
 			result.start = timestamp_t(0);
 			result.end = timestamp_t(0);
-			result.increment = interval_t();
+			result.increment = interval_t {0, 0, 0};
 			result.greater_than_check = true;
 			result.inclusive_bound = false;
+			result.empty_range = true;
 			return;
 		}
 	}
@@ -329,48 +709,97 @@ static void GenerateRangeDateTimeParameters(DataChunk &input, idx_t row_id, Rang
 	result.start = FlatVector::GetValue<timestamp_t>(input.data[0], row_id);
 	result.end = FlatVector::GetValue<timestamp_t>(input.data[1], row_id);
 	result.increment = FlatVector::GetValue<interval_t>(input.data[2], row_id);
-
-	// Infinities either cause errors or infinite loops, so just ban them
 	if (!Timestamp::IsFinite(result.start) || !Timestamp::IsFinite(result.end)) {
 		throw BinderException("RANGE with infinite bounds is not supported");
 	}
-
-	if (result.increment.months == 0 && result.increment.days == 0 && result.increment.micros == 0) {
+	const bool has_positive = result.increment.months > 0 || result.increment.days > 0 || result.increment.micros > 0;
+	const bool has_negative = result.increment.months < 0 || result.increment.days < 0 || result.increment.micros < 0;
+	if (!has_positive && !has_negative) {
 		throw BinderException("interval cannot be 0!");
 	}
-	// all elements should point in the same direction
-	if (result.increment.months > 0 || result.increment.days > 0 || result.increment.micros > 0) {
-		if (result.increment.months < 0 || result.increment.days < 0 || result.increment.micros < 0) {
-			throw BinderException("RANGE with composite interval that has mixed signs is not supported");
-		}
-		result.greater_than_check = true;
-		if (result.start > result.end) {
-			result.empty_range = true;
-		}
-	} else {
-		result.greater_than_check = false;
-		if (result.start < result.end) {
-			result.empty_range = true;
-		}
+	if (has_positive && has_negative) {
+		throw BinderException("RANGE with composite interval that has mixed signs is not supported");
+	}
+	result.greater_than_check = has_positive;
+	if ((has_positive && result.start > result.end) || (has_negative && result.start < result.end)) {
+		result.empty_range = true;
 	}
 	result.inclusive_bound = GENERATE_SERIES;
 }
 
-static unique_ptr<LocalTableFunctionState> RangeDateTimeLocalInit(ExecutionContext &context,
-                                                                  TableFunctionInitInput &input,
-                                                                  GlobalTableFunctionState *global_state) {
+static unique_ptr<LocalTableFunctionState> RangeDateTimeLocalInit(ExecutionContext &, TableFunctionInitInput &,
+                                                                  GlobalTableFunctionState *) {
 	return make_uniq<RangeDateTimeLocalState>();
 }
 
+static timestamp_t DistributedTimestampValueAt(const RangeDateTimeBindData &bind_data, idx_t row_offset) {
+	const auto value = hugeint_t(bind_data.start.value) +
+	                   TimestampIntervalMicros(bind_data.increment) * hugeint_t(NumericCast<uint64_t>(row_offset));
+	int64_t result;
+	if (!Hugeint::TryCast<int64_t>(value, result)) {
+		throw InvalidInputException("distributed timestamp sequence value is outside the timestamp domain");
+	}
+	return timestamp_t(result);
+}
+
+static OperatorResultType DistributedDateTimeRangeFunction(const RangeDateTimeBindData &bind_data,
+                                                           RangeDateTimeLocalState &state, DataChunk &output) {
+	while (state.sequence_split_index < bind_data.sequence_splits.size()) {
+		const auto &sequence_split = bind_data.sequence_splits[state.sequence_split_index];
+		if (!state.initialized_row) {
+			state.current_state = sequence_split.exact_count
+			                          ? DistributedTimestampValueAt(bind_data, sequence_split.row_offset)
+			                          : bind_data.start;
+			state.end = bind_data.end;
+			state.increment = bind_data.increment;
+			state.greater_than_check = bind_data.increasing;
+			state.inclusive_bound = bind_data.generate_series;
+			state.sequence_split_row = 0;
+			state.initialized_row = true;
+		}
+
+		idx_t size = 0;
+		auto output_data = FlatVector::GetData<timestamp_t>(output.data[0]);
+		if (sequence_split.exact_count) {
+			while (state.sequence_split_row < sequence_split.row_count && size < STANDARD_VECTOR_SIZE) {
+				output_data[size++] =
+				    DistributedTimestampValueAt(bind_data, sequence_split.row_offset + state.sequence_split_row);
+				state.sequence_split_row++;
+			}
+		} else {
+			while (!state.Finished(state.current_state) && size < STANDARD_VECTOR_SIZE) {
+				output_data[size++] = state.current_state;
+				state.current_state =
+				    AddOperator::Operation<timestamp_t, interval_t, timestamp_t>(state.current_state, state.increment);
+			}
+		}
+
+		const bool finished = sequence_split.exact_count ? state.sequence_split_row == sequence_split.row_count
+		                                                 : state.Finished(state.current_state);
+		if (finished) {
+			state.sequence_split_index++;
+			state.initialized_row = false;
+		}
+		if (size > 0) {
+			output.SetCardinality(size);
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+	}
+	output.SetCardinality(0);
+	return OperatorResultType::NEED_MORE_INPUT;
+}
+
 template <bool GENERATE_SERIES>
-static OperatorResultType RangeDateTimeFunction(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+static OperatorResultType RangeDateTimeFunction(ExecutionContext &, TableFunctionInput &data_p, DataChunk &input,
                                                 DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<RangeDateTimeBindData>();
 	auto &state = data_p.local_state->Cast<RangeDateTimeLocalState>();
+	if (bind_data.distributed) {
+		return DistributedDateTimeRangeFunction(bind_data, state, output);
+	}
 	while (true) {
 		if (!state.initialized_row) {
-			// initialize for the current input row
 			if (state.current_input_row >= input.size()) {
-				// ran out of rows
 				state.current_input_row = 0;
 				state.initialized_row = false;
 				return OperatorResultType::NEED_MORE_INPUT;
@@ -380,27 +809,19 @@ static OperatorResultType RangeDateTimeFunction(ExecutionContext &context, Table
 			state.current_state = state.start;
 		}
 		if (state.empty_range) {
-			// empty range
 			output.SetCardinality(0);
 			state.current_input_row++;
 			state.initialized_row = false;
 			return OperatorResultType::HAVE_MORE_OUTPUT;
 		}
 		idx_t size = 0;
-		auto data = FlatVector::GetData<timestamp_t>(output.data[0]);
-		while (true) {
-			if (state.Finished(state.current_state)) {
-				break;
-			}
-			if (size >= STANDARD_VECTOR_SIZE) {
-				break;
-			}
-			data[size++] = state.current_state;
+		auto output_data = FlatVector::GetData<timestamp_t>(output.data[0]);
+		while (!state.Finished(state.current_state) && size < STANDARD_VECTOR_SIZE) {
+			output_data[size++] = state.current_state;
 			state.current_state =
 			    AddOperator::Operation<timestamp_t, interval_t, timestamp_t>(state.current_state, state.increment);
 		}
 		if (size == 0) {
-			// move to next row
 			state.current_input_row++;
 			state.initialized_row = false;
 			continue;
@@ -410,42 +831,157 @@ static OperatorResultType RangeDateTimeFunction(ExecutionContext &context, Table
 	}
 }
 
+static void RangeDateTimeSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                                   const TableFunction &) {
+	if (!bind_data_p) {
+		throw SerializationException("timestamp sequence function requires bind data");
+	}
+	auto &bind_data = bind_data_p->Cast<RangeDateTimeBindData>();
+	serializer.WriteProperty(101, "has_parameters", bind_data.has_parameters);
+	serializer.WriteProperty(102, "is_null", bind_data.is_null);
+	serializer.WriteProperty(103, "generate_series", bind_data.generate_series);
+	serializer.WriteProperty(104, "distributed", bind_data.distributed);
+	serializer.WriteProperty(105, "start", bind_data.start.value);
+	serializer.WriteProperty(106, "end", bind_data.end.value);
+	serializer.WriteProperty(107, "increment_months", bind_data.increment.months);
+	serializer.WriteProperty(108, "increment_days", bind_data.increment.days);
+	serializer.WriteProperty(109, "increment_micros", bind_data.increment.micros);
+}
+
+static unique_ptr<FunctionData> RangeDateTimeDeserialize(Deserializer &deserializer, TableFunction &function) {
+	auto result = make_uniq<RangeDateTimeBindData>();
+	result->has_parameters = deserializer.ReadProperty<bool>(101, "has_parameters");
+	result->is_null = deserializer.ReadProperty<bool>(102, "is_null");
+	result->generate_series = deserializer.ReadProperty<bool>(103, "generate_series");
+	result->distributed = deserializer.ReadProperty<bool>(104, "distributed");
+	result->start = timestamp_t(deserializer.ReadProperty<int64_t>(105, "start"));
+	result->end = timestamp_t(deserializer.ReadProperty<int64_t>(106, "end"));
+	result->increment.months = deserializer.ReadProperty<int32_t>(107, "increment_months");
+	result->increment.days = deserializer.ReadProperty<int32_t>(108, "increment_days");
+	result->increment.micros = deserializer.ReadProperty<int64_t>(109, "increment_micros");
+	if (result->generate_series != IsGenerateSeriesFunction(function)) {
+		throw SerializationException("serialized timestamp sequence bind does not match function '%s'", function.name);
+	}
+	if (result->is_null && !result->has_parameters) {
+		throw SerializationException("serialized timestamp sequence has null state without bound parameters");
+	}
+	if (result->distributed && !result->has_parameters) {
+		throw SerializationException("serialized distributed timestamp sequence has no bound parameters");
+	}
+	if (result->has_parameters) {
+		if (result->is_null) {
+			result->exact_count = true;
+			result->empty_range = true;
+		} else {
+			result->Initialize();
+		}
+	}
+	return std::move(result);
+}
+
+static vector<DistributedScanSplit>
+PlanDistributedDateTimeRange(const TableFunctionDistributedScanPlanningInput &input) {
+	auto &bind_data = input.bind_data.Cast<RangeDateTimeBindData>();
+	if (!bind_data.has_parameters) {
+		throw InvalidInputException("distributed timestamp range requires scalar bound parameters");
+	}
+	return PlanDistributedSequenceSplits(bind_data.cardinality, bind_data.exact_count, input.target_split_count);
+}
+
+static unique_ptr<FunctionData>
+CreateDistributedDateTimeRangeWorkerBind(const TableFunctionDistributedScanInput &input) {
+	auto &source_bind = input.bind_data.Cast<RangeDateTimeBindData>();
+	if (!source_bind.has_parameters) {
+		throw InvalidInputException("distributed timestamp range requires scalar bound parameters");
+	}
+	auto result = make_uniq<RangeDateTimeBindData>(source_bind);
+	result->distributed = true;
+	result->sequence_splits.clear();
+	return std::move(result);
+}
+
+static void ApplyDistributedDateTimeRangeSplits(FunctionData &worker_bind_data,
+                                                const vector<DistributedScanSplit> &splits) {
+	auto &bind_data = worker_bind_data.Cast<RangeDateTimeBindData>();
+	if (!bind_data.distributed || !bind_data.has_parameters) {
+		throw InvalidInputException("distributed timestamp range splits require a worker bind");
+	}
+	bind_data.sequence_splits = DecodeDistributedSequenceSplits(splits, bind_data.cardinality, bind_data.exact_count);
+}
+
+static TableFunctionDistributedScanCallbacks IntegerRangeDistributedCallbacks() {
+	TableFunctionDistributedScanCallbacks callbacks;
+	callbacks.protocol_version = DISTRIBUTED_SEQUENCE_PROTOCOL_VERSION;
+	callbacks.split_codec = {DISTRIBUTED_SEQUENCE_SPLIT_CODEC, DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION};
+	callbacks.plan_splits = PlanDistributedIntegerRange;
+	callbacks.create_worker_bind = CreateDistributedIntegerRangeWorkerBind;
+	callbacks.apply_splits = ApplyDistributedIntegerRangeSplits;
+	return callbacks;
+}
+
+static TableFunctionDistributedScanCallbacks DateTimeRangeDistributedCallbacks() {
+	TableFunctionDistributedScanCallbacks callbacks;
+	callbacks.protocol_version = DISTRIBUTED_SEQUENCE_PROTOCOL_VERSION;
+	callbacks.split_codec = {DISTRIBUTED_SEQUENCE_SPLIT_CODEC, DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION};
+	callbacks.plan_splits = PlanDistributedDateTimeRange;
+	callbacks.create_worker_bind = CreateDistributedDateTimeRangeWorkerBind;
+	callbacks.apply_splits = ApplyDistributedDateTimeRangeSplits;
+	return callbacks;
+}
+
+template <bool GENERATE_SERIES>
+static TableFunction CreateIntegerRangeFunction(vector<LogicalType> arguments) {
+	const string name = GENERATE_SERIES ? "generate_series" : "range";
+	TableFunction result(name, arguments, nullptr, RangeFunctionBind<GENERATE_SERIES>, nullptr, RangeFunctionLocalInit);
+	result.in_out_function = RangeFunction<GENERATE_SERIES>;
+	result.cardinality = RangeCardinality;
+	result.serialize = RangeFunctionSerialize;
+	result.deserialize = RangeFunctionDeserialize;
+	result.SetDistributedScanCallbacks(IntegerRangeDistributedCallbacks());
+	result.BindDistributedScanCapability("vane_core");
+	return result;
+}
+
+template <bool GENERATE_SERIES>
+static TableFunction CreateDateTimeRangeFunction() {
+	const string name = GENERATE_SERIES ? "generate_series" : "range";
+	TableFunction result(name, {LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL}, nullptr,
+	                     RangeDateTimeBind<GENERATE_SERIES>, nullptr, RangeDateTimeLocalInit);
+	result.in_out_function = RangeDateTimeFunction<GENERATE_SERIES>;
+	result.cardinality = RangeDateTimeCardinality;
+	result.serialize = RangeDateTimeSerialize;
+	result.deserialize = RangeDateTimeDeserialize;
+	result.SetDistributedScanCallbacks(DateTimeRangeDistributedCallbacks());
+	result.BindDistributedScanCapability("vane_core");
+	return result;
+}
+
+vector<TableFunction> RangeTableFunction::GetFunctions() {
+	vector<TableFunction> result;
+	result.push_back(CreateIntegerRangeFunction<false>({LogicalType::BIGINT}));
+	result.push_back(CreateIntegerRangeFunction<false>({LogicalType::BIGINT, LogicalType::BIGINT}));
+	result.push_back(
+	    CreateIntegerRangeFunction<false>({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT}));
+	result.push_back(CreateDateTimeRangeFunction<false>());
+	result.push_back(CreateIntegerRangeFunction<true>({LogicalType::BIGINT}));
+	result.push_back(CreateIntegerRangeFunction<true>({LogicalType::BIGINT, LogicalType::BIGINT}));
+	result.push_back(CreateIntegerRangeFunction<true>({LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT}));
+	result.push_back(CreateDateTimeRangeFunction<true>());
+	return result;
+}
+
 void RangeTableFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunctionSet range("range");
-
-	TableFunction range_function({LogicalType::BIGINT}, nullptr, RangeFunctionBind<false>, nullptr,
-	                             RangeFunctionLocalInit);
-	range_function.in_out_function = RangeFunction<false>;
-	range_function.cardinality = RangeCardinality;
-
-	// single argument range: (end) - implicit start = 0 and increment = 1
-	range.AddFunction(range_function);
-	// two arguments range: (start, end) - implicit increment = 1
-	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT};
-	range.AddFunction(range_function);
-	// three arguments range: (start, end, increment)
-	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
-	range.AddFunction(range_function);
-	TableFunction range_in_out({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL}, nullptr,
-	                           RangeDateTimeBind<false>, nullptr, RangeDateTimeLocalInit);
-	range_in_out.in_out_function = RangeDateTimeFunction<false>;
-	range_in_out.cardinality = RangeDateTimeCardinality;
-	range.AddFunction(range_in_out);
-	set.AddFunction(range);
-	// generate_series: similar to range, but inclusive instead of exclusive bounds on the RHS
 	TableFunctionSet generate_series("generate_series");
-	range_function.bind = RangeFunctionBind<true>;
-	range_function.in_out_function = RangeFunction<true>;
-	range_function.arguments = {LogicalType::BIGINT};
-	generate_series.AddFunction(range_function);
-	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT};
-	generate_series.AddFunction(range_function);
-	range_function.arguments = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
-	generate_series.AddFunction(range_function);
-	TableFunction generate_series_in_out({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP, LogicalType::INTERVAL},
-	                                     nullptr, RangeDateTimeBind<true>, nullptr, RangeDateTimeLocalInit);
-	generate_series_in_out.in_out_function = RangeDateTimeFunction<true>;
-	generate_series.AddFunction(generate_series_in_out);
+	for (auto &function : GetFunctions()) {
+		if (function.name == "range") {
+			range.AddFunction(std::move(function));
+		} else {
+			D_ASSERT(function.name == "generate_series");
+			generate_series.AddFunction(std::move(function));
+		}
+	}
+	set.AddFunction(range);
 	set.AddFunction(generate_series);
 }
 

--- a/external/duckdb/src/function/table_function.cpp
+++ b/external/duckdb/src/function/table_function.cpp
@@ -117,6 +117,11 @@ bool TableFunction::operator==(const TableFunction &rhs) const {
 	       global_initialization == rhs.global_initialization;
 }
 
+string GetDistributedTableFunctionSignature(const string &function_name, const vector<LogicalType> &arguments,
+                                            const LogicalType &varargs) {
+	return Function::CallToString(string(), string(), function_name, arguments, varargs);
+}
+
 void TableFunctionDistributedScanCallbacks::ValidateDefinition(const string &function_name) const {
 	if (!plan_splits || !create_worker_bind || !apply_splits) {
 		throw InvalidInputException("Distributed scan callbacks for table function '%s' must define plan_splits, "
@@ -130,36 +135,42 @@ void TableFunctionDistributedScanCallbacks::ValidateDefinition(const string &fun
 	split_codec.Validate("Distributed scan split codec for table function '" + function_name + "'");
 }
 
-void TableFunctionDistributedScanCallbacks::Validate(const string &function_name) const {
-	ValidateDefinition(function_name);
+void TableFunctionDistributedScanCallbacks::Validate(const TableFunction &function) const {
+	ValidateDefinition(function.name);
 	if (capability.extension_name.empty()) {
 		throw InvalidInputException("Distributed scan capability for table function '%s' was not bound by its loader",
-		                            function_name);
+		                            function.name);
 	}
 	if (capability.capability.kind != DistributedExtensionCapabilityKind::TABLE_FUNCTION) {
 		throw InvalidInputException("Distributed scan capability for table function '%s' must have kind table_function",
-		                            function_name);
+		                            function.name);
 	}
-	if (capability.capability.name != function_name) {
+	if (capability.capability.name != function.name) {
 		throw InvalidInputException("Distributed scan capability name '%s' does not match table function '%s'",
-		                            capability.capability.name, function_name);
+		                            capability.capability.name, function.name);
 	}
+	// BindCapability freezes the declared catalog overload. Bind callbacks may
+	// subsequently specialize or erase arguments, so the runtime function shape
+	// must not be used to recompute this wire identity.
 	capability.Validate();
 }
 
-void TableFunctionDistributedScanCallbacks::BindCapability(const string &extension_name, const string &function_name) {
-	ValidateDefinition(function_name);
+void TableFunctionDistributedScanCallbacks::BindCapability(const string &extension_name,
+                                                           const TableFunction &function) {
+	ValidateDefinition(function.name);
 	DistributedExtensionCapabilityReference bound_capability;
 	bound_capability.extension_name = extension_name;
 	bound_capability.capability.kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
-	bound_capability.capability.name = function_name;
+	bound_capability.capability.name = function.name;
 	bound_capability.capability.protocol_version = protocol_version;
+	bound_capability.capability.function_signature =
+	    GetDistributedTableFunctionSignature(function.name, function.arguments, function.varargs);
 	if (!capability.extension_name.empty() && capability != bound_capability) {
 		throw InvalidInputException("Distributed scan capability for table function '%s' is already bound to '%s'",
-		                            function_name, capability.CanonicalIdentity());
+		                            function.name, capability.CanonicalIdentity());
 	}
 	capability = std::move(bound_capability);
-	Validate(function_name);
+	Validate(function);
 }
 
 const DistributedExtensionCapabilityReference &TableFunctionDistributedScanCallbacks::GetCapability() const {
@@ -185,7 +196,7 @@ void TableFunction::BindDistributedScanCapability(const string &extension_name) 
 		throw InternalException("Table function '%s' has no distributed scan callbacks", name);
 	}
 	auto callbacks = *distributed_scan;
-	callbacks.BindCapability(extension_name, name);
+	callbacks.BindCapability(extension_name, *this);
 	distributed_scan = make_shared_ptr<const TableFunctionDistributedScanCallbacks>(std::move(callbacks));
 }
 

--- a/external/duckdb/src/include/duckdb/function/distributed_table_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/distributed_table_function.hpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/column_index.hpp"
 #include "duckdb/common/optional_idx.hpp"
 #include "duckdb/common/optional_ptr.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/main/distributed_extension_manager.hpp"
@@ -21,6 +22,13 @@ namespace duckdb {
 
 class FunctionData;
 class TableFilterSet;
+class TableFunction;
+
+//! Stable catalog identity for one table-function overload. This uses the
+//! declared argument and varargs types rather than bind-time concrete types.
+DUCKDB_API string GetDistributedTableFunctionSignature(const string &function_name,
+                                                       const vector<LogicalType> &arguments,
+                                                       const LogicalType &varargs = LogicalType::INVALID);
 
 //! One stable, independently assignable unit of scan work produced by an
 //! extension on the coordinator. Vane never interprets the payload bytes.
@@ -94,8 +102,8 @@ struct TableFunctionDistributedScanCallbacks {
 	table_function_apply_distributed_scan_splits_t apply_splits = nullptr;
 
 	DUCKDB_API void ValidateDefinition(const string &function_name) const;
-	DUCKDB_API void Validate(const string &function_name) const;
-	DUCKDB_API void BindCapability(const string &extension_name, const string &function_name);
+	DUCKDB_API void Validate(const TableFunction &function) const;
+	DUCKDB_API void BindCapability(const string &extension_name, const TableFunction &function);
 	DUCKDB_API const DistributedExtensionCapabilityReference &GetCapability() const;
 	DUCKDB_API bool operator==(const TableFunctionDistributedScanCallbacks &other) const;
 

--- a/external/duckdb/src/include/duckdb/function/table/distributed_sequence.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/distributed_sequence.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/table/distributed_sequence.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/distributed_table_function.hpp"
+
+namespace duckdb {
+
+static constexpr idx_t DISTRIBUTED_SEQUENCE_PROTOCOL_VERSION = 1;
+static constexpr idx_t DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION = 1;
+static constexpr const char *DISTRIBUTED_SEQUENCE_SPLIT_CODEC = "vane.sequence-split";
+
+//! A half-open slice of a deterministic sequence. The sequence definition
+//! itself stays in the serialized worker bind; splits carry only row offsets.
+struct DistributedSequenceSplit {
+	idx_t ordinal = 0;
+	idx_t row_offset = 0;
+	idx_t row_count = 0;
+	bool exact_count = false;
+};
+
+//! Split an exactly counted sequence across the scheduler-selected target, or
+//! emit one explicit split for a calendar-sensitive sequence whose count cannot
+//! be indexed without walking it.
+DUCKDB_API vector<DistributedScanSplit> PlanDistributedSequenceSplits(idx_t cardinality, bool exact_count,
+                                                                      idx_t target_split_count);
+
+//! Decode and validate the complete assignment for one worker. Empty
+//! assignments are valid. Exact assignments may be non-contiguous because the
+//! scheduler is free to group elementary splits.
+DUCKDB_API vector<DistributedSequenceSplit> DecodeDistributedSequenceSplits(const vector<DistributedScanSplit> &splits,
+                                                                            idx_t cardinality, bool exact_count);
+
+//! Exact arithmetic shared by indexable BIGINT and TIMESTAMP sequences.
+DUCKDB_API idx_t ComputeDistributedSequenceCardinality(int64_t start, int64_t end, int64_t increment, bool inclusive);
+DUCKDB_API int64_t GetDistributedSequenceValue(int64_t start, int64_t increment, idx_t row_offset);
+
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/function/table/range.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/range.hpp
@@ -22,6 +22,10 @@ struct GlobTableFunction {
 };
 
 struct RangeTableFunction {
+	//! Construct the complete overload set. The core distributed manifest uses
+	//! these same function objects so protocol identities cannot drift from
+	//! catalog registration.
+	static vector<TableFunction> GetFunctions();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/external/duckdb/src/include/duckdb/main/distributed_extension_manager.hpp
+++ b/external/duckdb/src/include/duckdb/main/distributed_extension_manager.hpp
@@ -24,6 +24,9 @@ struct DistributedExtensionCapability {
 	DistributedExtensionCapabilityKind kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
 	string name;
 	idx_t protocol_version = 0;
+	//! Canonical catalog overload signature. Required for table-function
+	//! capabilities and empty for capability kinds that are not overloaded.
+	string function_signature;
 
 	DUCKDB_API string CanonicalIdentity() const;
 	DUCKDB_API bool operator==(const DistributedExtensionCapability &other) const;

--- a/external/duckdb/src/main/database.cpp
+++ b/external/duckdb/src/main/database.cpp
@@ -38,6 +38,9 @@
 #include "duckdb/main/result_set_manager.hpp"
 #include "duckdb/main/extension_callback_manager.hpp"
 #include "duckdb/main/distributed_extension_manager.hpp"
+#include "duckdb/function/distributed_table_function.hpp"
+#include "duckdb/function/table/datasource_scan.hpp"
+#include "duckdb/function/table/range.hpp"
 
 #ifndef DUCKDB_NO_THREADS
 #include "duckdb/common/thread.hpp"
@@ -344,7 +347,20 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	distributed_extension_manager = make_uniq<DistributedExtensionManager>(*this);
 	DistributedExtensionManifest core_manifest;
 	core_manifest.extension_name = "vane_core";
-	core_manifest.capabilities.push_back({DistributedExtensionCapabilityKind::TABLE_FUNCTION, "datasource_scan", 1});
+	auto add_core_table_function = [&](const TableFunction &function) {
+		const auto &callbacks = function.GetDistributedScanCallbacks();
+		callbacks.Validate(function);
+		const auto &capability = callbacks.GetCapability();
+		if (capability.extension_name != core_manifest.extension_name) {
+			throw InternalException("Core table function '%s' bound distributed capability to '%s'", function.name,
+			                        capability.extension_name);
+		}
+		core_manifest.capabilities.push_back(capability.capability);
+	};
+	add_core_table_function(DataSourceScanFunction::GetFunction());
+	for (const auto &function : RangeTableFunction::GetFunctions()) {
+		add_core_table_function(function);
+	}
 	distributed_extension_manager->RegisterExtension(core_manifest);
 
 	// initialize the secret manager

--- a/external/duckdb/src/main/distributed_extension_manager.cpp
+++ b/external/duckdb/src/main/distributed_extension_manager.cpp
@@ -62,18 +62,34 @@ static void ValidateExtensionRegistration(const string &extension_name) {
 	}
 }
 
-static void ValidateCapabilityRegistration(const string &extension_name, const string &capability_name,
-                                           idx_t protocol_version) {
+static void ValidateCapabilityRegistration(const string &extension_name,
+                                           const DistributedExtensionCapability &capability) {
 	ValidateExtensionRegistration(extension_name);
-	if (!IsValidCapabilityName(capability_name)) {
+	if (!IsValidCapabilityName(capability.name)) {
 		throw InvalidInputException("Distributed extension capability name must contain only lowercase ASCII letters, "
 		                            "digits, underscores, dots, and hyphens: '%s'",
-		                            capability_name);
+		                            capability.name);
 	}
-	if (protocol_version == 0) {
+	if (capability.protocol_version == 0) {
 		throw InvalidInputException(
 		    "Distributed extension capability '%s.%s' protocol version must be greater than zero", extension_name,
-		    capability_name);
+		    capability.name);
+	}
+	if (capability.kind == DistributedExtensionCapabilityKind::TABLE_FUNCTION) {
+		if (capability.function_signature.empty()) {
+			throw InvalidInputException("Distributed table-function capability '%s.%s' requires an overload signature",
+			                            extension_name, capability.name);
+		}
+		if (!StringUtil::StartsWith(capability.function_signature, capability.name + "(") ||
+		    capability.function_signature.back() != ')') {
+			throw InvalidInputException(
+			    "Distributed table-function capability '%s.%s' has a non-canonical overload signature '%s'",
+			    extension_name, capability.name, capability.function_signature);
+		}
+	} else if (!capability.function_signature.empty()) {
+		throw InvalidInputException(
+		    "Distributed capability '%s.%s' must not define a table-function overload signature", extension_name,
+		    capability.name);
 	}
 }
 
@@ -95,12 +111,14 @@ static string DistributedExtensionCapabilityKindToString(DistributedExtensionCap
 }
 
 string DistributedExtensionCapability::CanonicalIdentity() const {
-	return StringUtil::Format("%s:%s@%llu", DistributedExtensionCapabilityKindToString(kind), name,
+	const auto &subject = kind == DistributedExtensionCapabilityKind::TABLE_FUNCTION ? function_signature : name;
+	return StringUtil::Format("%s:%s@%llu", DistributedExtensionCapabilityKindToString(kind), subject,
 	                          static_cast<unsigned long long>(protocol_version));
 }
 
 bool DistributedExtensionCapability::operator==(const DistributedExtensionCapability &other) const {
-	return kind == other.kind && name == other.name && protocol_version == other.protocol_version;
+	return kind == other.kind && name == other.name && protocol_version == other.protocol_version &&
+	       function_signature == other.function_signature;
 }
 
 bool DistributedExtensionCapability::operator<(const DistributedExtensionCapability &other) const {
@@ -110,12 +128,15 @@ bool DistributedExtensionCapability::operator<(const DistributedExtensionCapabil
 	if (name != other.name) {
 		return name < other.name;
 	}
+	if (function_signature != other.function_signature) {
+		return function_signature < other.function_signature;
+	}
 	return protocol_version < other.protocol_version;
 }
 
 void DistributedExtensionCapabilityReference::Validate() const {
 	ValidateCapabilityKind(capability.kind);
-	ValidateCapabilityRegistration(extension_name, capability.name, capability.protocol_version);
+	ValidateCapabilityRegistration(extension_name, capability);
 }
 
 void DistributedExtensionCapabilityReference::Serialize(Serializer &serializer) const {
@@ -124,6 +145,7 @@ void DistributedExtensionCapabilityReference::Serialize(Serializer &serializer) 
 	serializer.WriteProperty(2, "capability_kind", static_cast<uint8_t>(capability.kind));
 	serializer.WriteProperty(3, "capability_name", capability.name);
 	serializer.WriteProperty(4, "capability_protocol_version", capability.protocol_version);
+	serializer.WriteProperty(5, "table_function_signature", capability.function_signature);
 }
 
 DistributedExtensionCapabilityReference
@@ -134,6 +156,7 @@ DistributedExtensionCapabilityReference::Deserialize(Deserializer &deserializer)
 	    static_cast<DistributedExtensionCapabilityKind>(deserializer.ReadProperty<uint8_t>(2, "capability_kind"));
 	result.capability.name = deserializer.ReadProperty<string>(3, "capability_name");
 	result.capability.protocol_version = deserializer.ReadProperty<idx_t>(4, "capability_protocol_version");
+	result.capability.function_signature = deserializer.ReadProperty<string>(5, "table_function_signature");
 	result.Validate();
 	return result;
 }
@@ -202,14 +225,16 @@ void DistributedExtensionManager::ValidateManifest(const DistributedExtensionMan
 		throw InvalidInputException("Distributed extension '%s' must contain a concrete capability",
 		                            manifest.extension_name);
 	}
-	set<pair<DistributedExtensionCapabilityKind, string>> capability_identities;
+	set<string> capability_identities;
 	for (const auto &capability : manifest.capabilities) {
 		ValidateCapabilityKind(capability.kind);
-		ValidateCapabilityRegistration(manifest.extension_name, capability.name, capability.protocol_version);
-		auto identity = make_pair(capability.kind, capability.name);
+		ValidateCapabilityRegistration(manifest.extension_name, capability);
+		auto identity = StringUtil::Format("%u:%s:%s", static_cast<unsigned int>(capability.kind), capability.name,
+		                                   capability.function_signature);
 		if (!capability_identities.insert(identity).second) {
-			throw InvalidInputException("Distributed extension capability '%s.%s' is declared more than once",
-			                            manifest.extension_name, capability.name);
+			throw InvalidInputException("Distributed extension capability '%s.%s' with signature '%s' is declared more "
+			                            "than once",
+			                            manifest.extension_name, capability.name, capability.function_signature);
 		}
 	}
 }
@@ -287,7 +312,8 @@ void DistributedExtensionManager::RequireCapability(const DistributedExtensionCa
 		throw InvalidInputException("Distributed extension '%s' is not registered", capability.extension_name);
 	}
 	for (const auto &registered : extension->second.capabilities) {
-		if (registered.kind == capability.capability.kind && registered.name == capability.capability.name) {
+		if (registered.kind == capability.capability.kind && registered.name == capability.capability.name &&
+		    registered.function_signature == capability.capability.function_signature) {
 			if (registered.protocol_version != capability.capability.protocol_version) {
 				throw InvalidInputException(
 				    "Distributed extension capability '%s.%s' protocol mismatch: required %llu, registered %llu",
@@ -320,7 +346,8 @@ DistributedExtensionManager::GetWriteOperator(const DistributedExtensionCapabili
 
 shared_ptr<const DistributedWriteOperatorExtension>
 DistributedExtensionManager::GetWriteOperator(const string &extension_name, const string &operator_name) const {
-	ValidateCapabilityRegistration(extension_name, operator_name, 1);
+	DistributedExtensionCapability requested {DistributedExtensionCapabilityKind::WRITE_OPERATOR, operator_name, 1};
+	ValidateCapabilityRegistration(extension_name, requested);
 	lock_guard<mutex> guard(lock);
 	auto extension = extensions.find(extension_name);
 	if (extension == extensions.end()) {

--- a/external/duckdb/src/main/extension/extension_loader.cpp
+++ b/external/duckdb/src/main/extension/extension_loader.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/parser/parsed_data/create_collation_info.hpp"
 #include "duckdb/main/extension_install_info.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/set.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/main/database.hpp"
@@ -137,96 +138,41 @@ void ExtensionLoader::RegisterFunction(TableFunctionSet function) {
 }
 
 unique_ptr<DistributedExtensionManifest> ExtensionLoader::BindDistributedTableFunctions(TableFunctionSet &functions) {
-	idx_t callback_count = 0;
-	idx_t protocol_version = 0;
+	set<string> overload_signatures;
 	for (const auto &function : functions.functions) {
+		auto signature = GetDistributedTableFunctionSignature(functions.name, function.arguments, function.varargs);
+		if (!overload_signatures.insert(signature).second) {
+			throw InvalidInputException("Table-function overload '%s' is declared more than once in one registration",
+			                            signature);
+		}
+	}
+
+	unique_ptr<DistributedExtensionManifest> candidate_manifest;
+	for (auto &function : functions.functions) {
 		if (!function.HasDistributedScanCallbacks()) {
 			continue;
 		}
-		callback_count++;
 		const auto &callbacks = function.GetDistributedScanCallbacks();
 		callbacks.ValidateDefinition(functions.name);
 		if (!function.HasSerializationCallbacks()) {
 			throw InvalidInputException(
-			    "Distributed table function '%s' must define serialize and deserialize callbacks before registration",
-			    functions.name);
+			    "Distributed table-function overload '%s' must define serialize and deserialize callbacks before "
+			    "registration",
+			    GetDistributedTableFunctionSignature(functions.name, function.arguments, function.varargs));
 		}
-		if (protocol_version == 0) {
-			protocol_version = callbacks.protocol_version;
-		} else if (protocol_version != callbacks.protocol_version) {
-			throw InvalidInputException(
-			    "Distributed table function '%s' overloads must use one capability protocol version", functions.name);
-		}
-	}
-	if (callback_count != 0 && callback_count != functions.functions.size()) {
-		throw InvalidInputException("Distributed table function '%s' must define callbacks for every overload",
-		                            functions.name);
-	}
-
-	auto existing_entry = TryGetTableFunction(functions.name);
-	idx_t existing_callback_count = 0;
-	if (existing_entry) {
-		for (const auto &function : existing_entry->Cast<TableFunctionCatalogEntry>().functions.functions) {
-			if (function.HasDistributedScanCallbacks()) {
-				existing_callback_count++;
-			}
-		}
-	}
-	if (existing_entry && existing_callback_count != 0 &&
-	    existing_callback_count != existing_entry->Cast<TableFunctionCatalogEntry>().functions.functions.size()) {
-		throw InternalException("Distributed table function '%s' has a mixed callback registration", functions.name);
-	}
-	if (callback_count == 0) {
-		if (existing_callback_count != 0) {
-			throw InvalidInputException("Distributed table function '%s' must define callbacks for every overload",
-			                            functions.name);
-		}
-		return nullptr;
-	}
-	if (existing_entry && existing_callback_count == 0) {
-		throw InvalidInputException("Distributed table function '%s' cannot add callbacks to native-only overloads",
-		                            functions.name);
-	}
-	auto &manifest = GetOrCreateDistributedManifest();
-
-	DistributedExtensionCapability capability;
-	capability.kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
-	capability.name = functions.name;
-	capability.protocol_version = protocol_version;
-	auto candidate_manifest = make_uniq<DistributedExtensionManifest>(manifest);
-	bool capability_exists = false;
-	for (const auto &registered : candidate_manifest->capabilities) {
-		if (registered.kind != capability.kind || registered.name != capability.name) {
-			continue;
-		}
-		if (registered.protocol_version != capability.protocol_version) {
-			throw InvalidInputException(
-			    "Distributed table function '%s' protocol mismatch: callbacks use %llu, manifest uses %llu",
-			    functions.name, static_cast<unsigned long long>(capability.protocol_version),
-			    static_cast<unsigned long long>(registered.protocol_version));
-		}
-		capability_exists = true;
-	}
-	if (!capability_exists) {
-		candidate_manifest->capabilities.push_back(capability);
-	}
-	DistributedExtensionManager::ValidateManifest(*candidate_manifest);
-
-	DistributedExtensionCapabilityReference reference;
-	reference.extension_name = extension_name;
-	reference.capability = capability;
-	if (existing_entry) {
-		for (const auto &function : existing_entry->Cast<TableFunctionCatalogEntry>().functions.functions) {
-			const auto &callbacks = function.GetDistributedScanCallbacks();
-			callbacks.Validate(function.name);
-			if (callbacks.GetCapability() != reference) {
-				throw InvalidInputException("Distributed table function '%s' is already owned by '%s'", functions.name,
-				                            callbacks.GetCapability().CanonicalIdentity());
-			}
-		}
-	}
-	for (auto &function : functions.functions) {
 		function.BindDistributedScanCapability(extension_name);
+		if (!candidate_manifest) {
+			if (distributed_manifest) {
+				candidate_manifest = make_uniq<DistributedExtensionManifest>(*distributed_manifest);
+			} else {
+				candidate_manifest = make_uniq<DistributedExtensionManifest>();
+				candidate_manifest->extension_name = extension_name;
+			}
+		}
+		candidate_manifest->capabilities.push_back(function.GetDistributedScanCallbacks().GetCapability().capability);
+	}
+	if (candidate_manifest) {
+		DistributedExtensionManager::ValidateManifest(*candidate_manifest);
 	}
 	return candidate_manifest;
 }
@@ -308,8 +254,18 @@ void ExtensionLoader::AddFunctionOverload(TableFunctionSet functions) { // NOLIN
 	for (auto &function : functions.functions) {
 		function.name = functions.name;
 	}
-	auto candidate_manifest = BindDistributedTableFunctions(functions);
 	auto &table_function = GetTableFunction(functions.name);
+	for (const auto &function : functions.functions) {
+		for (const auto &existing_function : table_function.functions.functions) {
+			if (!function.Equal(existing_function)) {
+				continue;
+			}
+			throw InvalidInputException(
+			    "Table-function overload '%s' is already registered",
+			    GetDistributedTableFunctionSignature(functions.name, function.arguments, function.varargs));
+		}
+	}
+	auto candidate_manifest = BindDistributedTableFunctions(functions);
 	for (auto &function : functions.functions) {
 		table_function.functions.AddFunction(std::move(function));
 	}

--- a/external/duckdb/test/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/test/execution/distributed/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_EXECUTION_DISTRIBUTED_SOURCES
     test_clustering_spec.cpp
     test_copy_finalize.cpp
     test_distributed_extension_manager.cpp
+    test_distributed_range.cpp
     test_distributed_test_extension.cpp
     test_execute_plan.cpp
     test_physical_operator_visitor.cpp

--- a/external/duckdb/test/execution/distributed/test_distributed_extension_manager.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_extension_manager.cpp
@@ -137,18 +137,32 @@ static unique_ptr<FunctionData> DistributedOverloadDeserialize(Deserializer &des
 	return make_uniq<DistributedOverloadBindData>();
 }
 
-static TableFunction DistributedOverloadFunction(const LogicalType &argument) {
+static TableFunction DistributedOverloadFunction(const LogicalType &argument, idx_t protocol_version = 1) {
 	TableFunction function({argument}, DistributedOverloadScan, DistributedOverloadBind);
 	function.serialize = DistributedOverloadSerialize;
 	function.deserialize = DistributedOverloadDeserialize;
 	TableFunctionDistributedScanCallbacks callbacks;
-	callbacks.protocol_version = 1;
-	callbacks.split_codec = {"distributed-overload.split", 1};
+	callbacks.protocol_version = protocol_version;
+	callbacks.split_codec = {"distributed-overload.split", protocol_version};
 	callbacks.plan_splits = DistributedOverloadPlan;
 	callbacks.create_worker_bind = DistributedOverloadCreateWorkerBind;
 	callbacks.apply_splits = DistributedOverloadApply;
 	function.SetDistributedScanCallbacks(std::move(callbacks));
 	return function;
+}
+
+static TableFunction NativeOverloadFunction(const LogicalType &argument) {
+	return TableFunction({argument}, DistributedOverloadScan, DistributedOverloadBind);
+}
+
+static DistributedExtensionCapability TableFunctionCapability(string name, vector<LogicalType> arguments,
+                                                              idx_t protocol_version = 1) {
+	DistributedExtensionCapability result;
+	result.kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
+	result.name = std::move(name);
+	result.protocol_version = protocol_version;
+	result.function_signature = GetDistributedTableFunctionSignature(result.name, arguments, LogicalType::INVALID);
+	return result;
 }
 
 static bool ManagerHasContractIdentity(DistributedExtensionManager &manager, const string &identity) {
@@ -163,11 +177,22 @@ static bool ManagerHasContractIdentity(DistributedExtensionManager &manager, con
 class DistributedOverloadExtension : public Extension {
 public:
 	void Load(ExtensionLoader &loader) override {
+		TableFunctionSet ambiguous("ambiguous_overload_scan");
+		ambiguous.AddFunction(DistributedOverloadFunction(LogicalType::INTEGER));
+		ambiguous.AddFunction(NativeOverloadFunction(LogicalType::INTEGER));
+		REQUIRE_THROWS_WITH(loader.RegisterFunction(std::move(ambiguous)),
+		                    Catch::Matchers::Contains("declared more than once"));
+
 		TableFunctionSet initial("distributed_overload_scan");
 		initial.AddFunction(DistributedOverloadFunction(LogicalType::INTEGER));
+		initial.AddFunction(NativeOverloadFunction(LogicalType::VARCHAR));
 		loader.RegisterFunction(std::move(initial));
+		TableFunctionSet duplicate("distributed_overload_scan");
+		duplicate.AddFunction(NativeOverloadFunction(LogicalType::INTEGER));
+		REQUIRE_THROWS_WITH(loader.AddFunctionOverload(std::move(duplicate)),
+		                    Catch::Matchers::Contains("already registered"));
 		TableFunctionSet overloads("distributed_overload_scan");
-		overloads.AddFunction(DistributedOverloadFunction(LogicalType::BIGINT));
+		overloads.AddFunction(DistributedOverloadFunction(LogicalType::BIGINT, 2));
 		loader.AddFunctionOverload(std::move(overloads));
 	}
 
@@ -184,23 +209,23 @@ TEST_CASE("Distributed extension manifests are deterministic and exact", "[distr
 
 	DistributedExtensionManifest registered_manifest;
 	registered_manifest.extension_name = "test_manifest";
-	registered_manifest.capabilities.push_back({DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 1});
+	registered_manifest.capabilities.push_back(TableFunctionCapability("scan", {LogicalType::BIGINT}));
 	registered_manifest.capabilities.push_back({DistributedExtensionCapabilityKind::WRITE_OPERATOR, "write", 2});
 	manager.RegisterExtension(
 	    registered_manifest, {make_shared_ptr<const DistributedWriteOperatorExtension>(FileWriteOperator("write", 2))});
 
-	REQUIRE(ManagerHasContractIdentity(manager, "test_manifest{table_function:scan@1,write_operator:write@2}"));
+	REQUIRE(ManagerHasContractIdentity(manager, "test_manifest{table_function:scan(BIGINT)@1,write_operator:write@2}"));
 	auto identities = manager.GetContractIdentities();
 	REQUIRE_NOTHROW(manager.ValidateExact(identities));
 	DistributedExtensionCapabilityReference reference;
 	reference.extension_name = "test_manifest";
-	reference.capability = {DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 1};
+	reference.capability = TableFunctionCapability("scan", {LogicalType::BIGINT});
 	REQUIRE_NOTHROW(manager.RequireCapability(reference));
 
 	auto mismatched = identities;
 	for (auto &identity : mismatched) {
 		if (StringUtil::StartsWith(identity, "test_manifest{")) {
-			identity = "test_manifest{table_function:scan@7,write_operator:write@2}";
+			identity = "test_manifest{table_function:scan(BIGINT)@7,write_operator:write@2}";
 		}
 	}
 	REQUIRE_THROWS_WITH(manager.ValidateExact(mismatched), Catch::Matchers::Contains("coordinator and worker"));
@@ -217,16 +242,24 @@ TEST_CASE("Distributed extension registration rejects ambiguous declarations", "
 	DistributedExtensionManifest empty_contract {"empty_contract", {}};
 	REQUIRE_THROWS_WITH(manager.RegisterExtension(empty_contract), Catch::Matchers::Contains("concrete capability"));
 	DistributedExtensionManifest zero_version {"zero_version",
-	                                           {{DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 0}}};
+	                                           {TableFunctionCapability("scan", {LogicalType::BIGINT}, 0)}};
 	REQUIRE_THROWS_WITH(manager.RegisterExtension(zero_version), Catch::Matchers::Contains("greater than zero"));
+	DistributedExtensionManifest missing_signature {"missing_signature",
+	                                                {{DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 1}}};
+	REQUIRE_THROWS_WITH(manager.RegisterExtension(missing_signature), Catch::Matchers::Contains("overload signature"));
+	auto non_canonical_capability = TableFunctionCapability("scan", {LogicalType::BIGINT});
+	non_canonical_capability.function_signature = "other(BIGINT)";
+	DistributedExtensionManifest non_canonical_signature {"non_canonical_signature", {non_canonical_capability}};
+	REQUIRE_THROWS_WITH(manager.RegisterExtension(non_canonical_signature),
+	                    Catch::Matchers::Contains("non-canonical overload signature"));
 
 	DistributedExtensionManifest strict;
 	strict.extension_name = "strict";
-	strict.capabilities.push_back({DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 1});
+	strict.capabilities.push_back(TableFunctionCapability("scan", {LogicalType::BIGINT}));
 	manager.RegisterExtension(strict);
 	REQUIRE_THROWS_WITH(manager.RegisterExtension(strict), Catch::Matchers::Contains("already registered"));
 	strict.extension_name = "duplicate_capability";
-	strict.capabilities.push_back({DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 2});
+	strict.capabilities.push_back(TableFunctionCapability("scan", {LogicalType::BIGINT}, 2));
 	REQUIRE_THROWS_WITH(manager.RegisterExtension(strict), Catch::Matchers::Contains("declared more than once"));
 
 	DistributedExtensionManifest missing_write {"missing_write",
@@ -267,7 +300,7 @@ TEST_CASE("Distributed write operators require an exact concrete capability", "[
 	auto &manager = DistributedExtensionManager::Get(*db.instance);
 	DistributedExtensionManifest manifest;
 	manifest.extension_name = "write_contract";
-	manifest.capabilities.push_back({DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 1});
+	manifest.capabilities.push_back(TableFunctionCapability("scan", {LogicalType::BIGINT}));
 	manifest.capabilities.push_back({DistributedExtensionCapabilityKind::WRITE_OPERATOR, "write", 3});
 	manager.RegisterExtension(
 	    manifest, {make_shared_ptr<const DistributedWriteOperatorExtension>(FileWriteOperator("write", 3))});
@@ -280,7 +313,7 @@ TEST_CASE("Distributed write operators require an exact concrete capability", "[
 	REQUIRE(write_operator->mode == DistributedWriteMode::FILE_ARTIFACT);
 
 	auto scan = write;
-	scan.capability = {DistributedExtensionCapabilityKind::TABLE_FUNCTION, "scan", 1};
+	scan.capability = TableFunctionCapability("scan", {LogicalType::BIGINT});
 	REQUIRE_THROWS_WITH(manager.GetWriteOperator(scan), Catch::Matchers::Contains("write-operator capability"));
 }
 
@@ -293,17 +326,19 @@ TEST_CASE("ExtensionLoader distributed declaration validation has strong excepti
 	                                   "loader_retry{write_operator:scan@1}"));
 }
 
-TEST_CASE("ExtensionLoader derives one capability across separately registered table overloads",
-          "[distributed][extension]") {
+TEST_CASE("ExtensionLoader derives capabilities per distributed table overload", "[distributed][extension]") {
 	DuckDB db(nullptr);
 	REQUIRE_NOTHROW(db.LoadStaticExtension<DistributedOverloadExtension>());
 
 	REQUIRE(ManagerHasContractIdentity(DistributedExtensionManager::Get(*db.instance),
-	                                   "distributed_overload{table_function:distributed_overload_scan@1}"));
+	                                   "distributed_overload{table_function:distributed_overload_scan(BIGINT)@2,"
+	                                   "table_function:distributed_overload_scan(INTEGER)@1}"));
 
 	Connection connection(db);
 	auto integer_result = connection.Query("SELECT * FROM distributed_overload_scan(1::INTEGER)");
 	REQUIRE_NO_FAIL(*integer_result);
 	auto bigint_result = connection.Query("SELECT * FROM distributed_overload_scan(1::BIGINT)");
 	REQUIRE_NO_FAIL(*bigint_result);
+	auto native_result = connection.Query("SELECT * FROM distributed_overload_scan('native')");
+	REQUIRE_NO_FAIL(*native_result);
 }

--- a/external/duckdb/test/execution/distributed/test_distributed_range.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_range.cpp
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "catch.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/pipeline_node/translator_scan.hpp"
+#include "duckdb/execution/distributed/plan/scan_split.hpp"
+#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
+#include "duckdb/execution/physical_plan.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/function/table/distributed_sequence.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+
+#include <algorithm>
+
+using namespace duckdb;
+
+namespace {
+
+struct PlannedRangeScan {
+	distributed::DuckPhysicalPlanRef worker_plan;
+	vector<distributed::ScanSplit> splits;
+};
+
+static distributed::ScanSplitBatch MakeSplitBatch(vector<distributed::ScanSplit> splits) {
+	distributed::ScanSplitBatch result;
+	result.splits = std::move(splits);
+	result.Validate();
+	return result;
+}
+
+static distributed::ScanSplitBatch MakeSplitBatch(const distributed::ScanSplit &split) {
+	return MakeSplitBatch(vector<distributed::ScanSplit> {split});
+}
+
+static PlannedRangeScan PlanRangeScan(DuckDB &db, Connection &connection, const string &query, idx_t worker_slots) {
+	auto logical_plan = connection.ExtractPlan(query);
+	REQUIRE(logical_plan != nullptr);
+	PhysicalPlanGenerator generator(*connection.context);
+	auto generated_plan = generator.Plan(std::move(logical_plan));
+	REQUIRE(generated_plan != nullptr);
+	REQUIRE(generated_plan->Root().type == PhysicalOperatorType::TABLE_SCAN);
+	auto &coordinator_scan = generated_plan->Root().Cast<PhysicalTableScan>();
+	REQUIRE(coordinator_scan.function.HasDistributedScanCallbacks());
+
+	distributed::DuckDBExecutionConfig config;
+	config.set_distributed_worker_slots(worker_slots);
+	PlannedRangeScan result;
+	result.worker_plan = distributed::MakeTableScanPlan(coordinator_scan);
+	result.splits = distributed::MakeTableScanSplits(coordinator_scan, config, db.instance);
+	return result;
+}
+
+static vector<Value> ExecuteRangeAssignment(Connection &connection, const distributed::DuckPhysicalPlanRef &worker_plan,
+                                            const distributed::ScanSplitBatch &batch, idx_t scan_node_id) {
+	auto execution_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	auto &scan = distributed::ClonePhysicalPlanRootIntoPlanOrThrow(worker_plan, *execution_plan, "distributed_range",
+	                                                               connection.context.get())
+	                 .Cast<PhysicalTableScan>();
+	scan.extra_info.scan_node_id = optional_idx(scan_node_id);
+	scan.extra_info.scan_group_id = optional_idx(scan_node_id);
+	execution_plan->SetRoot(scan);
+
+	unordered_map<idx_t, distributed::ScanSplitBatch> assignments;
+	assignments.emplace(scan_node_id, batch);
+	string apply_error;
+	REQUIRE(distributed::ApplyScanSplitBatchesToPlan(*execution_plan, assignments, &apply_error));
+	REQUIRE(apply_error.empty());
+	REQUIRE(distributed::ValidateDistributedScanSplitsApplied(*execution_plan));
+
+	auto prepared = make_shared_ptr<PreparedStatementData>(StatementType::SELECT_STATEMENT);
+	prepared->names = scan.names;
+	prepared->types = scan.GetTypes();
+	prepared->properties.return_type = StatementReturnType::QUERY_RESULT;
+	prepared->output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	prepared->memory_type = QueryResultMemoryType::IN_MEMORY;
+	prepared->physical_plan = std::move(execution_plan);
+	PendingQueryParameters parameters;
+	auto pending =
+	    connection.context->PendingQueryPreparedStatementNoRebind("test:distributed_range", prepared, parameters);
+	REQUIRE(pending != nullptr);
+	REQUIRE_FALSE(pending->HasError());
+	auto query_result = pending->Execute();
+	REQUIRE(query_result != nullptr);
+	REQUIRE_NO_FAIL(*query_result);
+	auto materialized = dynamic_cast<MaterializedQueryResult *>(query_result.get());
+	REQUIRE(materialized != nullptr);
+	vector<Value> result;
+	result.reserve(materialized->RowCount());
+	for (idx_t row_index = 0; row_index < materialized->RowCount(); row_index++) {
+		result.push_back(materialized->GetValue(0, row_index));
+	}
+	return result;
+}
+
+static vector<Value> ExecuteRangeAssignment(Connection &connection, const distributed::DuckPhysicalPlanRef &worker_plan,
+                                            const distributed::ScanSplit &split, idx_t scan_node_id) {
+	return ExecuteRangeAssignment(connection, worker_plan, MakeSplitBatch(split), scan_node_id);
+}
+
+static vector<int64_t> ExecuteIntegerAssignments(Connection &connection, const PlannedRangeScan &planned) {
+	vector<int64_t> result;
+	for (idx_t split_index = 0; split_index < planned.splits.size(); split_index++) {
+		auto values =
+		    ExecuteRangeAssignment(connection, planned.worker_plan, planned.splits[split_index], 100 + split_index);
+		for (const auto &value : values) {
+			result.push_back(value.GetValue<int64_t>());
+		}
+	}
+	std::sort(result.begin(), result.end());
+	return result;
+}
+
+} // namespace
+
+TEST_CASE("Distributed integer range plans exact index splits", "[distributed][range]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanRangeScan(db, connection, "SELECT * FROM range(0, 10)", 4);
+	REQUIRE(planned.splits.size() == 4);
+	idx_t planned_cardinality = 0;
+	for (idx_t split_index = 0; split_index < planned.splits.size(); split_index++) {
+		const auto &split = planned.splits[split_index];
+		REQUIRE(split.kind == distributed::ScanSplitKind::EXTENSION);
+		REQUIRE_FALSE(split.empty);
+		REQUIRE(split.split_id == std::to_string(split_index));
+		REQUIRE(split.split_codec.name == DISTRIBUTED_SEQUENCE_SPLIT_CODEC);
+		REQUIRE(split.split_codec.version == DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION);
+		REQUIRE(split.estimated_cardinality.IsValid());
+		planned_cardinality += split.estimated_cardinality.GetIndex();
+	}
+	REQUIRE(planned_cardinality == 10);
+	REQUIRE(ExecuteIntegerAssignments(connection, planned) == vector<int64_t> {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+	auto non_contiguous = MakeSplitBatch(planned.splits[0]);
+	non_contiguous.Merge(MakeSplitBatch(planned.splits[2]));
+	auto non_contiguous_values = ExecuteRangeAssignment(connection, planned.worker_plan, non_contiguous, 200);
+	vector<int64_t> actual;
+	for (const auto &value : non_contiguous_values) {
+		actual.push_back(value.GetValue<int64_t>());
+	}
+	REQUIRE(actual == vector<int64_t> {0, 1, 2, 6, 7});
+}
+
+TEST_CASE("Distributed generate_series preserves inclusive negative steps", "[distributed][range]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanRangeScan(db, connection, "SELECT * FROM generate_series(5, -1, -2)", 3);
+	REQUIRE(planned.splits.size() == 3);
+	REQUIRE(ExecuteIntegerAssignments(connection, planned) == vector<int64_t> {-1, 1, 3, 5});
+}
+
+TEST_CASE("Distributed range installs an explicit empty split", "[distributed][range]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanRangeScan(db, connection, "SELECT * FROM range(0)", 8);
+	REQUIRE(planned.splits.size() == 1);
+	REQUIRE(planned.splits[0].empty);
+	REQUIRE(ExecuteRangeAssignment(connection, planned.worker_plan, planned.splits[0], 300).empty());
+}
+
+TEST_CASE("Distributed timestamp range splits only indexable intervals", "[distributed][range]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto fixed = PlanRangeScan(
+	    db, connection, "SELECT * FROM range(TIMESTAMP '2026-01-01', TIMESTAMP '2026-01-06', INTERVAL 1 DAY)", 3);
+	REQUIRE(fixed.splits.size() == 3);
+	vector<string> fixed_values;
+	for (idx_t split_index = 0; split_index < fixed.splits.size(); split_index++) {
+		for (const auto &value :
+		     ExecuteRangeAssignment(connection, fixed.worker_plan, fixed.splits[split_index], 400 + split_index)) {
+			fixed_values.push_back(value.ToString());
+		}
+	}
+	std::sort(fixed_values.begin(), fixed_values.end());
+	auto fixed_native =
+	    connection.Query("SELECT * FROM range(TIMESTAMP '2026-01-01', TIMESTAMP '2026-01-06', INTERVAL 1 DAY)");
+	REQUIRE_NO_FAIL(*fixed_native);
+	vector<string> fixed_expected;
+	for (idx_t row_index = 0; row_index < fixed_native->RowCount(); row_index++) {
+		fixed_expected.push_back(fixed_native->GetValue(0, row_index).ToString());
+	}
+	std::sort(fixed_expected.begin(), fixed_expected.end());
+	REQUIRE(fixed_values == fixed_expected);
+
+	auto calendar = PlanRangeScan(
+	    db, connection,
+	    "SELECT * FROM generate_series(TIMESTAMP '2026-01-31', TIMESTAMP '2026-05-31', INTERVAL 1 MONTH)", 8);
+	REQUIRE(calendar.splits.size() == 1);
+	REQUIRE_FALSE(calendar.splits[0].empty);
+	REQUIRE_FALSE(calendar.splits[0].estimated_cardinality.IsValid());
+	auto distributed_values = ExecuteRangeAssignment(connection, calendar.worker_plan, calendar.splits[0], 500);
+	auto native = connection.Query(
+	    "SELECT * FROM generate_series(TIMESTAMP '2026-01-31', TIMESTAMP '2026-05-31', INTERVAL 1 MONTH)");
+	REQUIRE_NO_FAIL(*native);
+	auto native_materialized = dynamic_cast<MaterializedQueryResult *>(native.get());
+	REQUIRE(native_materialized != nullptr);
+	REQUIRE(distributed_values.size() == native_materialized->RowCount());
+	for (idx_t row_index = 0; row_index < distributed_values.size(); row_index++) {
+		REQUIRE(distributed_values[row_index] == native_materialized->GetValue(0, row_index));
+	}
+}
+
+TEST_CASE("Distributed range rejects malformed split payloads", "[distributed][range]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanRangeScan(db, connection, "SELECT * FROM range(10)", 2);
+	auto malformed = planned.splits[0];
+	malformed.extension_payload.push_back('\0');
+
+	auto execution_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	auto &scan = distributed::ClonePhysicalPlanRootIntoPlanOrThrow(
+	                 planned.worker_plan, *execution_plan, "distributed_range_malformed", connection.context.get())
+	                 .Cast<PhysicalTableScan>();
+	scan.extra_info.scan_node_id = optional_idx(600);
+	scan.extra_info.scan_group_id = optional_idx(600);
+	execution_plan->SetRoot(scan);
+	unordered_map<idx_t, distributed::ScanSplitBatch> assignments;
+	assignments.emplace(600, MakeSplitBatch(malformed));
+	string apply_error;
+	REQUIRE_THROWS_WITH(distributed::ApplyScanSplitBatchesToPlan(*execution_plan, assignments, &apply_error),
+	                    Catch::Matchers::Contains("trailing bytes"));
+}

--- a/external/duckdb/test/execution/distributed/test_distributed_test_extension.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_test_extension.cpp
@@ -153,6 +153,8 @@ static DistributedExtensionCapabilityReference DistributedTestCapability() {
 	reference.capability.kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
 	reference.capability.name = "distributed_test_scan";
 	reference.capability.protocol_version = DISTRIBUTED_TEST_SCAN_PROTOCOL;
+	reference.capability.function_signature =
+	    GetDistributedTableFunctionSignature("distributed_test_scan", {LogicalType::BIGINT}, LogicalType::INVALID);
 	return reference;
 }
 
@@ -539,9 +541,9 @@ TEST_CASE("Distributed synthetic extension transports file splits with an explic
 	                    Catch::Matchers::Contains("planned duplicate split_id 'file-0'"));
 
 	auto &coordinator_manager = DistributedExtensionManager::Get(*coordinator_db.instance);
-	REQUIRE(SyntheticExtensionHasContractIdentity(
-	    coordinator_manager,
-	    "distributed_test{table_function:distributed_test_scan@1,write_operator:distributed_test_opaque_write@1}"));
+	REQUIRE(SyntheticExtensionHasContractIdentity(coordinator_manager,
+	                                              "distributed_test{table_function:distributed_test_scan(BIGINT)@1,"
+	                                              "write_operator:distributed_test_opaque_write@1}"));
 
 	auto planned = PlanDistributedTestScan(coordinator_db, coordinator, "SELECT * FROM distributed_test_scan(1)", 3);
 	REQUIRE(planned.splits.size() == 1);
@@ -848,6 +850,8 @@ TEST_CASE("Distributed extension file writes use the fixed artifact adapter",
 	                       distributed::DISTRIBUTED_FILE_WRITE_FRAGMENT_CODEC_VERSION};
 	auto invalid_info = info;
 	invalid_info.capability.capability.kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
+	invalid_info.capability.capability.function_signature =
+	    GetDistributedTableFunctionSignature("distributed_test_file_write", {});
 	REQUIRE_THROWS_WITH(invalid_info.Validate(), Catch::Matchers::Contains("must be a write operator"));
 
 	distributed::DistributedCopyFileInfo file;
@@ -875,6 +879,8 @@ TEST_CASE("Distributed extension file writes use the fixed artifact adapter",
 	auto roundtrip = DistributedWriteTaskResult::DeserializeFromBytes(encoded[0].SerializeToBytes());
 	auto invalid_result = roundtrip;
 	invalid_result.capability.capability.kind = DistributedExtensionCapabilityKind::TABLE_FUNCTION;
+	invalid_result.capability.capability.function_signature =
+	    GetDistributedTableFunctionSignature("distributed_test_file_write", {});
 	REQUIRE_THROWS_WITH(invalid_result.Validate(), Catch::Matchers::Contains("not a write operator"));
 	auto decoded = distributed::DecodeDistributedFileWriteResults(info, {roundtrip});
 	REQUIRE(decoded.size() == 1);

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -787,7 +787,15 @@ def test_connection_snapshot_captures_exact_extension_contract():
     assert isinstance(snapshot["extensions"], list)
     assert all(set(extension) >= {"name", "version"} for extension in snapshot["extensions"])
     assert snapshot["distributed_extension_contracts"] == [
-        "vane_core{table_function:datasource_scan@1}",
+        "vane_core{table_function:datasource_scan(POINTER, POINTER, BLOB, BLOB[])@1,"
+        "table_function:generate_series(BIGINT)@1,"
+        "table_function:generate_series(BIGINT, BIGINT)@1,"
+        "table_function:generate_series(BIGINT, BIGINT, BIGINT)@1,"
+        "table_function:generate_series(TIMESTAMP, TIMESTAMP, INTERVAL)@1,"
+        "table_function:range(BIGINT)@1,"
+        "table_function:range(BIGINT, BIGINT)@1,"
+        "table_function:range(BIGINT, BIGINT, BIGINT)@1,"
+        "table_function:range(TIMESTAMP, TIMESTAMP, INTERVAL)@1}",
     ]
 
 
@@ -847,7 +855,7 @@ def test_snapshot_replay_rejects_different_distributed_extension_contract():
     snapshot = dict(state[6])
     snapshot["distributed_extension_contracts"] = [
         *snapshot["distributed_extension_contracts"],
-        "missing_test_extension{table_function:scan@1}",
+        "missing_test_extension{table_function:scan(BIGINT)@1}",
     ]
     state[6] = snapshot
 

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -443,6 +443,37 @@ def test_ray_scan_filter_projection(ray_runner, duckdb_conn, parquet_path):
     )
 
 
+def test_ray_range_and_generate_series_distributed(ray_runner, duckdb_conn, monkeypatch):
+    monkeypatch.setenv("VANE_RAY_SCAN_SPLIT_MIN_COUNT", "4")
+    label = "test_ray_e2e: distributed range source"
+    sql = "SELECT i FROM range(0, 8193) AS t(i)"
+    relation = duckdb_conn.sql(sql)
+    _, num_parts = _get_distributed_plan_info(relation, label)
+    assert num_parts is not None and num_parts >= 4
+    parts = _run_iter_tables(ray_runner, relation, label, timeout_s=30.0)
+    _assert_results_match(duckdb_conn, sql, parts, label)
+
+    cases = [
+        (
+            "SELECT i FROM generate_series(5, -5, -2) AS t(i)",
+            "test_ray_e2e: distributed negative generate_series",
+        ),
+        (
+            "SELECT ts FROM range(TIMESTAMP '2026-01-01', TIMESTAMP '2026-01-08', INTERVAL 1 DAY) AS t(ts)",
+            "test_ray_e2e: distributed fixed timestamp range",
+        ),
+        (
+            "SELECT ts FROM generate_series(TIMESTAMP '2026-01-31', TIMESTAMP '2026-05-31', INTERVAL 1 MONTH) AS t(ts)",
+            "test_ray_e2e: distributed calendar timestamp generate_series",
+        ),
+    ]
+    for case_sql, case_label in cases:
+        try:
+            _run_query_case(duckdb_conn, ray_runner, case_sql, case_label, timeout_s=30.0)
+        except Exception as exc:
+            raise AssertionError(f"{case_label}: distributed execution failed") from exc
+
+
 @pytest.mark.gpu
 def test_ray_vllm_distributed(ray_runner, duckdb_conn):
     from vane.ai.providers.vllm import _build_native_vllm_options_argument


### PR DESCRIPTION
## Summary

- make distributed table-function capabilities identify a concrete overload by its canonical function signature, so native-only and distributed overloads can coexist without fallback behavior
- implement deterministic, independently schedulable sequence splits for the core BIGINT and TIMESTAMP overloads of `range` and `generate_series` under the scan-split contract introduced by #636
- add strict split/bind-data serialization validation, native coverage, Ray end-to-end coverage, manifest snapshots, and distributed-extension documentation

This replaces #634 with an implementation based on the independently schedulable scan-split model. ICU TIMESTAMPTZ overloads and lateral/delim execution are intentionally outside this PR.

## Related issue

close: #624

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`DISTRIBUTED_EXTENSIONS.md` documents overload-scoped capability identity and mixed native/distributed overload registration.

## Validation

- `scripts/format workspace --changed --check`
- release native/Python install with `CMAKE_BUILD_PARALLEL_LEVEL=16`, `SKBUILD_BUILD_DIR=$PWD/build/python-release`, and `SKBUILD_CMAKE_BUILD_TYPE=Release`
- `VANE_NATIVE_BUILD_JOBS=16 scripts/run_native_tests.sh "[distributed]"` (225 test cases, 8,999 assertions)
- `scripts/run_installed_pytest.sh tests/fast/test_ray_connection_snapshot.py -q` (49 passed)
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e.py::test_ray_range_and_generate_series_distributed -q` (1 passed)
- `scripts/run_release_tests.sh` (passed, including the isolated real-Ray shard: 11 passed)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
