### PR TITLE
[fix](ray) Execute empty-result plans

### DIFF
--- a/external/duckdb/src/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/src/execution/distributed/CMakeLists.txt
@@ -40,6 +40,7 @@ set(DISTRIBUTED_SOURCES_COMMON
 
 set(DISTRIBUTED_SOURCES_PIPELINE_NODE
     pipeline_node/aggregate.cpp
+    pipeline_node/empty_result_source.cpp
     pipeline_node/expression_scan.cpp
     pipeline_node/extension_write_sink.cpp
     pipeline_node/grouping_set_expand.cpp

--- a/external/duckdb/src/execution/distributed/pipeline_node/empty_result_source.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/empty_result_source.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/empty_result_source.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+EmptyResultSourceNode::EmptyResultSourceNode(PipelineNodeContext context, DuckPhysicalPlanRef empty_plan,
+                                             SchemaRef schema, DuckDBExecutionConfigRef execution_config)
+    : context_(std::move(context)),
+      config_(std::move(schema), std::move(execution_config), ClusteringSpec::unknown_with_num_partitions(1)),
+      empty_plan_(std::move(empty_plan)) {
+}
+
+SubmittableTaskStream<WorkerTask> EmptyResultSourceNode::produce_tasks(PlanExecutionContext &plan_context) {
+	if (!empty_plan_ || !empty_plan_->HasRoot()) {
+		throw InternalException("EmptyResultSourceNode requires an empty-result physical plan");
+	}
+
+	auto channel = create_channel<SubmittableTask<WorkerTask>>(1);
+	TaskContext task_context =
+	    TaskContext::from_node_context(context_.query_idx(), node_id(), plan_context.task_id_counter().next());
+	WorkerTask task(task_context, empty_plan_, config_.execution_config(), context_.to_hashmap());
+	auto send_result = channel.first.send(SubmittableTask<WorkerTask>(std::move(task)));
+	channel.first.close();
+	if (send_result.is_err()) {
+		throw InternalException("EmptyResultSourceNode failed to create its logical empty-input task");
+	}
+	return SubmittableTaskStream<WorkerTask>::from_receiver(std::move(channel.second));
+}
+
+std::vector<std::string> EmptyResultSourceNode::multiline_display(bool /*verbose*/) const {
+	return {"EmptyResultSource"};
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -32,6 +32,7 @@
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
 #include "duckdb/execution/operator/projection/physical_unnest.hpp"
 #include "duckdb/execution/operator/projection/physical_pivot.hpp"
@@ -332,6 +333,11 @@ void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOpera
 	case PhysicalOperatorType::DUMMY_SCAN: {
 		auto &dummy_scan = static_cast<PhysicalDummyScan &>(op);
 		node_stack_.push_back(TranslateDummyScanSource(dummy_scan));
+		return;
+	}
+	case PhysicalOperatorType::EMPTY_RESULT: {
+		auto &empty_result = static_cast<PhysicalEmptyResult &>(op);
+		node_stack_.push_back(TranslateEmptyResultSource(empty_result));
 		return;
 	}
 	case PhysicalOperatorType::COLUMN_DATA_SCAN:

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_source.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_source.cpp
@@ -6,10 +6,12 @@
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/execution/distributed/pipeline_node/empty_result_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/translator_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 
 namespace duckdb {
@@ -30,6 +32,14 @@ DuckPhysicalPlanRef MakeDummyScanPlan(const duckdb::PhysicalDummyScan &scan) {
 	auto plan = std::make_shared<duckdb::PhysicalPlan>(alloc);
 	auto &dummy = plan->Make<duckdb::PhysicalDummyScan>(scan.GetTypes(), scan.estimated_cardinality);
 	plan->SetRoot(dummy);
+	return plan;
+}
+
+DuckPhysicalPlanRef MakeEmptyResultPlan(const duckdb::PhysicalEmptyResult &empty_result) {
+	Allocator &alloc = Allocator::DefaultAllocator();
+	auto plan = std::make_shared<duckdb::PhysicalPlan>(alloc);
+	auto &empty = plan->Make<duckdb::PhysicalEmptyResult>(empty_result.GetTypes(), empty_result.estimated_cardinality);
+	plan->SetRoot(empty);
 	return plan;
 }
 
@@ -108,6 +118,18 @@ PhysicalPlanToPipelineNodeTranslator::TranslateDummyScanSource(const PhysicalDum
 	return MakeScanSourceNode(MakePipelineNodeContext(plan_config_.query_idx, plan_config_.query_id,
 	                                                  get_next_pipeline_node_id(), "ScanSource"),
 	                          std::move(scan_plan), std::move(scan_splits), schema, exec_cfg, false);
+}
+
+std::shared_ptr<DistributedPipelineNode>
+PhysicalPlanToPipelineNodeTranslator::TranslateEmptyResultSource(const PhysicalEmptyResult &op) {
+	auto empty_plan = MakeEmptyResultPlan(op);
+	auto schema = MakeSchemaFromTypes(op.GetTypes());
+	auto exec_cfg = ResolveExecutionConfig(plan_config_);
+	auto empty_result = std::make_shared<EmptyResultSourceNode>(
+	    MakePipelineNodeContext(plan_config_.query_idx, plan_config_.query_id, get_next_pipeline_node_id(),
+	                            "EmptyResultSource"),
+	    std::move(empty_plan), std::move(schema), std::move(exec_cfg));
+	return std::make_shared<DistributedPipelineNode>(std::move(empty_result));
 }
 
 std::shared_ptr<DistributedPipelineNode>

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -48,6 +48,7 @@
 #include "duckdb/execution/operator/persistent/physical_distributed_extension_write.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
@@ -888,6 +889,9 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 	}
 	case PhysicalOperatorType::DUMMY_SCAN: {
 		return make_uniq<PhysicalDummyScan>(physical_plan, std::move(types), estimated_cardinality);
+	}
+	case PhysicalOperatorType::EMPTY_RESULT: {
+		return make_uniq<PhysicalEmptyResult>(physical_plan, std::move(types), estimated_cardinality);
 	}
 	case PhysicalOperatorType::EXPRESSION_SCAN: {
 		auto expressions = deserializer.ReadProperty<vector<vector<unique_ptr<Expression>>>>(103, "expressions");

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/empty_result_source.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/empty_result_source.hpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class EmptyResultSourceNode : public PipelineNodeImpl {
+public:
+	EmptyResultSourceNode(PipelineNodeContext context, DuckPhysicalPlanRef empty_plan, SchemaRef schema,
+	                      DuckDBExecutionConfigRef execution_config);
+
+	std::string name() const override {
+		return "EmptyResultSource";
+	}
+	NodeID node_id() const override {
+		return context_.node_id();
+	}
+	const PipelineNodeContext &context() const override {
+		return context_;
+	}
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override {
+		return {};
+	}
+	bool is_statically_empty_result() const override {
+		return true;
+	}
+
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
+	std::vector<std::string> multiline_display(bool verbose) const override;
+
+private:
+	PipelineNodeContext context_;
+	PipelineNodeConfig config_;
+	DuckPhysicalPlanRef empty_plan_;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/pipeline_node.hpp
@@ -434,6 +434,12 @@ public:
 	virtual bool is_materialization_barrier() const {
 		return false;
 	}
+	/// True when the node itself is a complete, statically empty query result.
+	/// A parent may still need to execute over that empty input (for example,
+	/// an ungrouped aggregate), so this property is intentionally not inherited.
+	virtual bool is_statically_empty_result() const {
+		return false;
+	}
 	/// Physical child nodes whose complete distributed output must be
 	/// materialized before this barrier is released. Barrier nodes must
 	/// explicitly identify at least one input; non-barrier nodes return none.
@@ -508,6 +514,10 @@ public:
 
 	bool is_materialization_barrier() const override {
 		return op_->is_materialization_barrier();
+	}
+
+	bool is_statically_empty_result() const override {
+		return op_->is_statically_empty_result();
 	}
 
 	std::vector<NodeID> materialized_input_node_ids() const override {

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -23,6 +23,7 @@ class PhysicalNestedLoopJoin;
 class PhysicalHashAggregate;
 class PhysicalColumnDataScan;
 class PhysicalDummyScan;
+class PhysicalEmptyResult;
 class PhysicalExpressionScan;
 class PhysicalFilter;
 class PhysicalLimit;
@@ -155,6 +156,8 @@ private:
 	std::shared_ptr<DistributedPipelineNode> TranslateCTESource(PhysicalOperator &op);
 
 	std::shared_ptr<DistributedPipelineNode> TranslateDummyScanSource(const PhysicalDummyScan &op);
+
+	std::shared_ptr<DistributedPipelineNode> TranslateEmptyResultSource(const PhysicalEmptyResult &op);
 
 	std::shared_ptr<DistributedPipelineNode> TranslateColumnDataScanSource(const PhysicalColumnDataScan &op);
 

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -295,6 +295,9 @@ public:
 	DuckDBResult<void> execute_plan(std::shared_ptr<DistributedPipelineNode> pipeline_node,
 	                                std::shared_ptr<PlanTaskExecutor> task_executor,
 	                                UnboundedSender<MaterializedOutput> output_sender, TaskInputs initial_inputs = {}) {
+		if (pipeline_node->is_statically_empty_result()) {
+			return DuckDBResult<void>::ok();
+		}
 		auto fte_task_submitter = std::make_shared<WorkerManagerFteTaskSubmitter>(worker_manager_);
 		PlanExecutionContext ctx(task_executor, client_context_, std::move(initial_inputs), fte_task_submitter);
 		auto tasks_stream = pipeline_node->produce_tasks(ctx);

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -28,6 +28,7 @@
 #include "duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp"
 #include "duckdb/execution/operator/exchange/physical_remote_exchange_source.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
@@ -350,6 +351,30 @@ TEST_CASE("PhysicalProjection serialization roundtrip", "[serialization][physica
 	REQUIRE(proj_ptr->select_list.size() == 2);
 
 	std::cerr << "[test] PhysicalProjection serialization roundtrip PASSED" << std::endl;
+}
+
+TEST_CASE("PhysicalEmptyResult serialization roundtrip", "[serialization][physical_plan]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	vector<LogicalType> types = {LogicalType::BIGINT, LogicalType::VARCHAR};
+	PhysicalEmptyResult empty_result(plan, types, 0);
+
+	MemoryStream stream(allocator);
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	empty_result.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	auto deserialized_op = PhysicalOperator::Deserialize(deserializer, plan);
+	deserializer.End();
+
+	REQUIRE(deserialized_op != nullptr);
+	REQUIRE(deserialized_op->type == PhysicalOperatorType::EMPTY_RESULT);
+	REQUIRE(deserialized_op->GetTypes() == types);
+	REQUIRE(deserialized_op->estimated_cardinality == 0);
 }
 
 TEST_CASE("PhysicalFilter serialization roundtrip", "[serialization][physical_plan]") {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/execution/operator/order/physical_top_n.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/multi_file/multi_file_states.hpp"
@@ -62,6 +63,7 @@
 #include "duckdb/execution/distributed/pipeline_node/aggregate.hpp"
 #include "duckdb/execution/distributed/pipeline_node/grouping_set_expand.hpp"
 #include "duckdb/execution/distributed/pipeline_node/limit.hpp"
+#include "duckdb/execution/distributed/pipeline_node/empty_result_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/projection.hpp"
 #include "duckdb/execution/distributed/pipeline_node/sample.hpp"
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
@@ -1221,6 +1223,58 @@ TEST_CASE("PhysicalPlanTranslator: dummy scan -> ScanSourceNode", "[distributed]
 	REQUIRE(res.value() != nullptr);
 	auto inner = res.value()->inner();
 	REQUIRE(std::dynamic_pointer_cast<duckdb::distributed::ScanSourceNode>(inner) != nullptr);
+}
+
+TEST_CASE("PhysicalPlanTranslator: empty result -> EmptyResultSourceNode", "[distributed]") {
+	Allocator allocator;
+	auto plan_ptr = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> types = {LogicalType::BIGINT, LogicalType::VARCHAR};
+
+	auto &empty_result = plan_ptr->Make<PhysicalEmptyResult>(types, 0);
+	plan_ptr->SetRoot(empty_result);
+
+	auto res = duckdb::distributed::physical_plan_to_pipeline_node(duckdb::distributed::PlanConfig {}, plan_ptr);
+	REQUIRE(res.ok);
+	REQUIRE(res.value() != nullptr);
+	auto empty_source = std::dynamic_pointer_cast<duckdb::distributed::EmptyResultSourceNode>(res.value()->inner());
+	REQUIRE(empty_source != nullptr);
+	REQUIRE(GetSchemaTypes(empty_source->config().schema()) == types);
+	REQUIRE(empty_source->config().clustering_spec()->num_partitions() == 1);
+
+	PlanExecutionContext execution_context(nullptr);
+	auto task_stream = res.value()->produce_tasks(execution_context);
+	auto task = task_stream.poll_next();
+	REQUIRE(task.first);
+	REQUIRE(task.second.task()->plan()->Root().type == PhysicalOperatorType::EMPTY_RESULT);
+	REQUIRE_FALSE(task_stream.poll_next().first);
+}
+
+TEST_CASE("PhysicalPlanTranslator: ungrouped aggregate executes over an empty-result input", "[distributed]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	auto logical_plan =
+	    conn.ExtractPlan("SELECT count(*) FROM (SELECT * FROM (VALUES (1), (2)) AS input(x) WHERE FALSE)");
+	REQUIRE(logical_plan != nullptr);
+
+	PhysicalPlanGenerator generator(*conn.context);
+	auto generated_plan = generator.Plan(std::move(logical_plan));
+	REQUIRE(generated_plan != nullptr);
+	REQUIRE(generated_plan->Root().type == PhysicalOperatorType::UNGROUPED_AGGREGATE);
+	REQUIRE(generated_plan->Root().children.size() == 1);
+	REQUIRE(generated_plan->Root().children[0].get().type == PhysicalOperatorType::EMPTY_RESULT);
+	auto physical_plan = DuckPhysicalPlanRef(generated_plan.release());
+
+	auto res = duckdb::distributed::physical_plan_to_pipeline_node(duckdb::distributed::PlanConfig {}, physical_plan,
+	                                                               conn.context.get());
+	REQUIRE(res.is_ok());
+	PlanExecutionContext execution_context(nullptr, conn.context);
+	auto task_stream = res.value()->produce_tasks(execution_context);
+	auto task = task_stream.poll_next();
+	REQUIRE(task.first);
+	REQUIRE(task.second.task()->plan()->Root().type == PhysicalOperatorType::UNGROUPED_AGGREGATE);
+	REQUIRE(task.second.task()->plan()->Root().children.size() == 1);
+	REQUIRE(task.second.task()->plan()->Root().children[0].get().type == PhysicalOperatorType::EMPTY_RESULT);
+	REQUIRE_FALSE(task_stream.poll_next().first);
 }
 
 TEST_CASE("PhysicalPlanTranslator: column data scan -> ScanSourceNode", "[distributed]") {

--- a/external/duckdb/test/execution/distributed/test_planrunner_local.cpp
+++ b/external/duckdb/test/execution/distributed/test_planrunner_local.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/distributed/copy_finalize.hpp"
 #include "duckdb/execution/distributed/extension_write_task_provider.hpp"
 #include "duckdb/execution/distributed/pipeline_node/copy_finish.hpp"
@@ -392,6 +393,31 @@ TEST_CASE("PlanRunner instantiation", "[distributed][plan][local]") {
 	auto runner = std::make_shared<PlanRunner>(worker_mgr, con.context);
 
 	REQUIRE(runner != nullptr);
+}
+
+TEST_CASE("PlanRunner finishes an empty-result plan without submitting worker tasks", "[distributed][plan][local]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	auto logical_plan = con.ExtractPlan("SELECT * FROM (VALUES (1), (2)) AS input(x) WHERE FALSE");
+	REQUIRE(logical_plan != nullptr);
+
+	PhysicalPlanGenerator generator(*con.context);
+	auto generated_plan = generator.Plan(std::move(logical_plan));
+	REQUIRE(generated_plan != nullptr);
+	REQUIRE(generated_plan->Root().type == PhysicalOperatorType::EMPTY_RESULT);
+	auto physical_plan = DuckPhysicalPlanRef(generated_plan.release());
+
+	auto workers = setup_workers({{make_worker_id("empty-result-w1"), 1}});
+	auto worker_manager = std::make_shared<MockWorkerManager>(std::move(workers));
+	auto runner = std::make_shared<PlanRunner>(worker_manager, con.context);
+	auto execution_config = std::make_shared<DuckDBExecutionConfig>(DuckDBExecutionConfig::from_env());
+	auto distributed_plan = std::make_shared<DistributedPhysicalPlan>(17, "planrunner-empty-result", physical_plan,
+	                                                                  std::move(execution_config));
+
+	auto result = runner->run_plan(std::move(distributed_plan));
+	REQUIRE(result.is_ok());
+	REQUIRE(result.value().tag == PlanRunner::PlanResult::STREAMING);
+	REQUIRE_FALSE(result.value().stream.next().first);
 }
 
 TEST_CASE("PlanRunner rejects an unregistered extension write capability",

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -443,6 +443,28 @@ def test_ray_scan_filter_projection(ray_runner, duckdb_conn, parquet_path):
     )
 
 
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM (VALUES (1), (2)) AS input(x) WHERE FALSE",
+        "SELECT * FROM (VALUES (1), (2)) AS input(x) LIMIT 0",
+    ],
+)
+def test_ray_empty_result_plan_returns_no_partitions(ray_runner, duckdb_conn, sql):
+    label = "test_ray_e2e: empty result"
+    explain_text = _explain_text(duckdb_conn, sql)
+    _assert_explain_contains(explain_text, require_all=["EMPTY_RESULT"], label=label)
+
+    relation = duckdb_conn.sql(sql)
+    assert relation.columns == ["x"]
+    parts = _run_iter_tables(ray_runner, relation, label)
+    assert parts == []
+
+    arrow_result = duckdb_conn.sql(sql).to_arrow_table()
+    assert arrow_result.schema.names == ["x"]
+    assert arrow_result.num_rows == 0
+
+
 def test_ray_range_and_generate_series_distributed(ray_runner, duckdb_conn, monkeypatch):
     monkeypatch.setenv("VANE_RAY_SCAN_SPLIT_MIN_COUNT", "4")
     label = "test_ray_e2e: distributed range source"


### PR DESCRIPTION
## Summary

- Add a first-class distributed source for DuckDB `EMPTY_RESULT` plans, including physical-plan serialization.
- Finish a root empty-result plan without submitting Ray worker tasks, while preserving executable empty input when a parent operator such as an ungrouped aggregate still needs to run.
- Cover translation, serialization, local runner behavior, parent-operator semantics, and real Ray end-to-end schema preservation.

## Related issue

close: #629

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change fixes distributed execution semantics without adding a user-facing API or configuration.

## Validation

- `scripts/format workspace --from-ref upstream/main --check`
- `CMAKE_BUILD_PARALLEL_LEVEL=16 VANE_NATIVE_BUILD_JOBS=16 SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `scripts/run_native_tests.sh "PhysicalEmptyResult serialization roundtrip,PhysicalPlanTranslator: empty result -> EmptyResultSourceNode,PhysicalPlanTranslator: ungrouped aggregate executes over an empty-result input,PlanRunner finishes an empty-result plan without submitting worker tasks" -s` — 4 test cases, 29 assertions passed
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e.py::test_ray_empty_result_plan_returns_no_partitions` — 2 passed
- `scripts/run_release_tests.sh` — 554 passed / 15 deselected in the non-Ray shard; 11 passed / 558 deselected in the real-Ray shard

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

No compatibility layer or fallback path is included, and no new dependencies, copied code, model assets, or datasets are introduced.