### PR TITLE
[feat](file) Add DuckDB FILE alias type

### DIFF
--- a/external/duckdb/extension/core_functions/aggregate/distributive/approx_count.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/distributive/approx_count.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/types/hyperloglog.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "core_functions/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_set.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -94,10 +95,21 @@ AggregateFunction GetApproxCountDistinctFunction(const LogicalType &input_type) 
 	return fun;
 }
 
+unique_ptr<FunctionData> BindApproxCountDistinct(ClientContext &, AggregateFunction &,
+                                                 vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() == 1);
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("approx_count_distinct does not support FILE values");
+	}
+	return nullptr;
+}
+
 } // namespace
 
 AggregateFunction ApproxCountDistinctFun::GetFunction() {
-	return GetApproxCountDistinctFunction(LogicalType::ANY);
+	auto function = GetApproxCountDistinctFunction(LogicalType::ANY);
+	function.SetBindCallback(BindApproxCountDistinct);
+	return function;
 }
 
 } // namespace duckdb

--- a/external/duckdb/extension/core_functions/aggregate/distributive/arg_min_max.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/distributive/arg_min_max.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "core_functions/aggregate/distributive_functions.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
@@ -13,6 +14,13 @@
 namespace duckdb {
 
 namespace {
+
+static void RejectFileOrderingArgument(const vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() >= 2);
+	if (TypeVisitor::Contains(arguments[1]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("arg_min/arg_max ordering arguments do not support FILE values");
+	}
+}
 
 struct ArgMinMaxStateBase {
 	ArgMinMaxStateBase() : is_initialized(false), arg_null(false), val_null(false) {
@@ -187,6 +195,7 @@ struct ArgMinMaxBase {
 	template <ArgMinMaxNullHandling NULL_HANDLING>
 	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
 	                                     vector<unique_ptr<Expression>> &arguments) {
+		RejectFileOrderingArgument(arguments);
 		if (arguments[1]->return_type.InternalType() == PhysicalType::VARCHAR) {
 			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->return_type);
 		}
@@ -350,6 +359,7 @@ struct VectorArgMinMaxBase : ArgMinMaxBase<COMPARATOR> {
 	template <ArgMinMaxNullHandling NULL_HANDLING>
 	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
 	                                     vector<unique_ptr<Expression>> &arguments) {
+		RejectFileOrderingArgument(arguments);
 		if (arguments[1]->return_type.InternalType() == PhysicalType::VARCHAR) {
 			ExpressionBinder::PushCollation(context, arguments[1], arguments[1]->return_type);
 		}
@@ -520,6 +530,7 @@ AggregateFunction GetDecimalArgMinMaxFunction(const LogicalType &by_type, const 
 template <class OP, ArgMinMaxNullHandling NULL_HANDLING>
 unique_ptr<FunctionData> BindDecimalArgMinMax(ClientContext &context, AggregateFunction &function,
                                               vector<unique_ptr<Expression>> &arguments) {
+	RejectFileOrderingArgument(arguments);
 	auto decimal_type = arguments[0]->return_type;
 	auto by_type = arguments[1]->return_type;
 
@@ -850,6 +861,7 @@ void SpecializeArgMinMaxNullNFunction(PhysicalType val_type, PhysicalType arg_ty
 template <ArgMinMaxNullHandling NULL_HANDLING, bool NULLS_LAST, class COMPARATOR>
 unique_ptr<FunctionData> ArgMinMaxNBind(ClientContext &context, AggregateFunction &function,
                                         vector<unique_ptr<Expression>> &arguments) {
+	RejectFileOrderingArgument(arguments);
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/external/duckdb/extension/core_functions/aggregate/holistic/approx_top_k.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/holistic/approx_top_k.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/function/aggregate/sort_key_helpers.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/common/string_map_set.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/printer.hpp"
 
 namespace duckdb {
@@ -393,6 +394,9 @@ unique_ptr<FunctionData> ApproxTopKBind(ClientContext &context, AggregateFunctio
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
 		}
+	}
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("approx_top_k does not support FILE values");
 	}
 	if (arguments[0]->return_type.id() == LogicalTypeId::VARCHAR) {
 		function.SetStateUpdateCallback(ApproxTopKUpdate<string_t, HistogramStringFunctor>);

--- a/external/duckdb/extension/core_functions/aggregate/holistic/mode.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/holistic/mode.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "core_functions/aggregate/distributive_functions.hpp"
 #include "core_functions/aggregate/holistic_functions.hpp"
 #include "duckdb/common/owning_string_map.hpp"
@@ -502,6 +503,9 @@ AggregateFunction GetModeAggregate(const LogicalType &type) {
 
 unique_ptr<FunctionData> BindModeAggregate(ClientContext &context, AggregateFunction &function,
                                            vector<unique_ptr<Expression>> &arguments) {
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("mode does not support FILE values");
+	}
 	function = GetModeAggregate(arguments[0]->return_type);
 	function.name = "mode";
 	return nullptr;
@@ -603,6 +607,9 @@ AggregateFunction GetEntropyFunction(const LogicalType &type) {
 
 unique_ptr<FunctionData> BindEntropyAggregate(ClientContext &context, AggregateFunction &function,
                                               vector<unique_ptr<Expression>> &arguments) {
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("entropy does not support FILE values");
+	}
 	function = GetEntropyFunction(arguments[0]->return_type);
 	function.name = "entropy";
 	return nullptr;

--- a/external/duckdb/extension/core_functions/aggregate/holistic/quantile.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/holistic/quantile.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/operator/abs.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "core_functions/aggregate/quantile_state.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
@@ -565,6 +566,9 @@ static Value CheckQuantile(const Value &quantile_val) {
 
 unique_ptr<FunctionData> BindQuantile(ClientContext &context, AggregateFunction &function,
                                       vector<unique_ptr<Expression>> &arguments) {
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("quantile_disc does not support FILE values");
+	}
 	if (arguments.size() < 2) {
 		throw BinderException("QUANTILE requires a range argument between [0, 1]");
 	}
@@ -654,6 +658,9 @@ struct MedianFunction {
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, AggregateFunction &function,
 	                                     vector<unique_ptr<Expression>> &arguments) {
+		if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("median does not support FILE values");
+		}
 		function = GetAggregate(arguments[0]->return_type);
 		return make_uniq<QuantileBindData>(Value::DECIMAL(int16_t(5), 2, 1));
 	}

--- a/external/duckdb/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "core_functions/aggregate/nested_functions.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "core_functions/aggregate/histogram_helpers.hpp"
@@ -398,6 +399,9 @@ unique_ptr<FunctionData> HistogramBinBindFunction(ClientContext &context, Aggreg
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();
+		}
+		if (TypeVisitor::Contains(arg->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("%s does not support FILE values", function.name);
 		}
 	}
 

--- a/external/duckdb/extension/core_functions/aggregate/nested/binned_histogram.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/nested/binned_histogram.cpp
@@ -282,6 +282,15 @@ void IsHistogramOtherBinFunction(DataChunk &args, ExpressionState &state, Vector
 	}
 }
 
+static unique_ptr<FunctionData> IsHistogramOtherBinBind(ClientContext &, ScalarFunction &,
+                                                        vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() == 1);
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("is_histogram_other_bin does not support FILE values");
+	}
+	return nullptr;
+}
+
 template <class OP, class T>
 void HistogramBinFinalizeFunction(Vector &state_vector, AggregateInputData &, Vector &result, idx_t count,
                                   idx_t offset) {
@@ -425,7 +434,7 @@ AggregateFunction HistogramExactFun::GetFunction() {
 
 ScalarFunction IsHistogramOtherBinFun::GetFunction() {
 	return ScalarFunction("is_histogram_other_bin", {LogicalType::ANY}, LogicalType::BOOLEAN,
-	                      IsHistogramOtherBinFunction);
+	                      IsHistogramOtherBinFunction, IsHistogramOtherBinBind);
 }
 
 } // namespace duckdb

--- a/external/duckdb/extension/core_functions/aggregate/nested/histogram.cpp
+++ b/external/duckdb/extension/core_functions/aggregate/nested/histogram.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "core_functions/aggregate/nested_functions.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/string_map_set.hpp"
 #include "core_functions/aggregate/histogram_helpers.hpp"
@@ -212,6 +213,9 @@ unique_ptr<FunctionData> HistogramBindFunction(ClientContext &context, Aggregate
 
 	if (arguments[0]->return_type.id() == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
+	}
+	if (IS_ORDERED && TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("%s does not support FILE values", function.name);
 	}
 	function = GetHistogramFunction<IS_ORDERED>(arguments[0]->return_type);
 	return make_uniq<VariableReturnBindData>(function.GetReturnType());

--- a/external/duckdb/extension/core_functions/function_list.cpp
+++ b/external/duckdb/extension/core_functions/function_list.cpp
@@ -359,7 +359,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(StructInsertFun),
 	DUCKDB_SCALAR_FUNCTION(StructKeysFun),
 	DUCKDB_SCALAR_FUNCTION(StructUpdateFun),
-	DUCKDB_SCALAR_FUNCTION_SET(StructValuesFun),
+	DUCKDB_SCALAR_FUNCTION(StructValuesFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(SumFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(SumNoOverflowFun),
 	DUCKDB_AGGREGATE_FUNCTION_ALIAS(SumkahanFun),

--- a/external/duckdb/extension/core_functions/function_list.cpp
+++ b/external/duckdb/extension/core_functions/function_list.cpp
@@ -359,7 +359,7 @@ static const StaticFunctionDefinition core_functions[] = {
 	DUCKDB_SCALAR_FUNCTION(StructInsertFun),
 	DUCKDB_SCALAR_FUNCTION(StructKeysFun),
 	DUCKDB_SCALAR_FUNCTION(StructUpdateFun),
-	DUCKDB_SCALAR_FUNCTION(StructValuesFun),
+	DUCKDB_SCALAR_FUNCTION_SET(StructValuesFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(SumFun),
 	DUCKDB_AGGREGATE_FUNCTION_SET(SumNoOverflowFun),
 	DUCKDB_AGGREGATE_FUNCTION_ALIAS(SumkahanFun),

--- a/external/duckdb/extension/core_functions/include/core_functions/scalar/struct_functions.hpp
+++ b/external/duckdb/extension/core_functions/include/core_functions/scalar/struct_functions.hpp
@@ -52,7 +52,7 @@ struct StructValuesFun {
 	static constexpr const char *Example = "struct_values({'a': 1, 'b': 'world'})";
 	static constexpr const char *Categories = "";
 
-	static ScalarFunctionSet GetFunctions();
+	static ScalarFunction GetFunction();
 };
 
 } // namespace duckdb

--- a/external/duckdb/extension/core_functions/include/core_functions/scalar/struct_functions.hpp
+++ b/external/duckdb/extension/core_functions/include/core_functions/scalar/struct_functions.hpp
@@ -52,7 +52,7 @@ struct StructValuesFun {
 	static constexpr const char *Example = "struct_values({'a': 1, 'b': 'world'})";
 	static constexpr const char *Categories = "";
 
-	static ScalarFunction GetFunction();
+	static ScalarFunctionSet GetFunctions();
 };
 
 } // namespace duckdb

--- a/external/duckdb/extension/core_functions/scalar/generic/hash.cpp
+++ b/external/duckdb/extension/core_functions/scalar/generic/hash.cpp
@@ -1,4 +1,6 @@
 #include "core_functions/scalar/generic_functions.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 namespace duckdb {
 
@@ -9,8 +11,17 @@ static void HashFunction(DataChunk &args, ExpressionState &state, Vector &result
 	}
 }
 
+static unique_ptr<FunctionData> HashBind(ClientContext &, ScalarFunction &, vector<unique_ptr<Expression>> &arguments) {
+	for (auto &argument : arguments) {
+		if (TypeVisitor::Contains(argument->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("hash does not support FILE values");
+		}
+	}
+	return nullptr;
+}
+
 ScalarFunction HashFun::GetFunction() {
-	auto hash_fun = ScalarFunction({LogicalType::ANY}, LogicalType::HASH, HashFunction);
+	auto hash_fun = ScalarFunction({LogicalType::ANY}, LogicalType::HASH, HashFunction, HashBind);
 	hash_fun.varargs = LogicalType::ANY;
 	hash_fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return hash_fun;

--- a/external/duckdb/extension/core_functions/scalar/generic/least.cpp
+++ b/external/duckdb/extension/core_functions/scalar/generic/least.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "core_functions/scalar/generic_functions.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -197,6 +198,9 @@ unique_ptr<FunctionData> BindLeastGreatest(ClientContext &context, ScalarFunctio
 		break;
 	default:
 		break;
+	}
+	if (TypeVisitor::Contains(child_type, FileLogicalType::IsFile)) {
+		throw BinderException("%s does not support FILE values", bound_function.name);
 	}
 	using OP = typename LEAST_GREATER_OP::OP;
 	switch (child_type.InternalType()) {

--- a/external/duckdb/extension/core_functions/scalar/list/list_aggregates.cpp
+++ b/external/duckdb/extension/core_functions/scalar/list/list_aggregates.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 #include "duckdb/common/owning_string_map.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 namespace duckdb {
 
@@ -436,6 +437,9 @@ unique_ptr<FunctionData> ListAggregatesBind(ClientContext &context, ScalarFuncti
 	} else {
 		// Unreachable
 		throw InvalidInputException("First argument of list aggregate must be a list, map or array");
+	}
+	if (!IS_AGGR && TypeVisitor::Contains(child_type, FileLogicalType::IsFile)) {
+		throw BinderException("%s does not support FILE values", bound_function.name);
 	}
 
 	string function_name = "histogram";

--- a/external/duckdb/extension/core_functions/scalar/list/list_has_any_or_all.cpp
+++ b/external/duckdb/extension/core_functions/scalar/list/list_has_any_or_all.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/function/lambda_functions.hpp"
 #include "core_functions/scalar/list_functions.hpp"
 #include "duckdb/function/create_sort_key.hpp"
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/common/string_map_set.hpp"
 
@@ -165,13 +166,13 @@ static void ListHasAllFunction(DataChunk &args, ExpressionState &state, Vector &
 
 ScalarFunction ListHasAnyFun::GetFunction() {
 	ScalarFunction fun({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::LIST(LogicalType::TEMPLATE("T"))},
-	                   LogicalType::BOOLEAN, ListHasAnyFunction);
+	                   LogicalType::BOOLEAN, ListHasAnyFunction, BindFileCollectionSearch);
 	return fun;
 }
 
 ScalarFunction ListHasAllFun::GetFunction() {
 	ScalarFunction fun({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::LIST(LogicalType::TEMPLATE("T"))},
-	                   LogicalType::BOOLEAN, ListHasAllFunction);
+	                   LogicalType::BOOLEAN, ListHasAllFunction, BindFileCollectionSearch);
 	return fun;
 }
 

--- a/external/duckdb/extension/core_functions/scalar/list/list_sort.cpp
+++ b/external/duckdb/extension/core_functions/scalar/list/list_sort.cpp
@@ -1,6 +1,7 @@
 #include "core_functions/scalar/list_functions.hpp"
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -251,6 +252,12 @@ static void ListSortFunction(DataChunk &args, ExpressionState &state, Vector &re
 	}
 }
 
+static void RejectFileListOrdering(const LogicalType &list_type) {
+	if (TypeVisitor::Contains(ListType::GetChildType(list_type), FileLogicalType::IsFile)) {
+		throw BinderException("List ordering functions do not support FILE values");
+	}
+}
+
 static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunction &bound_function,
                                              vector<unique_ptr<Expression>> &arguments, OrderType &order,
                                              OrderByNullType &null_order) {
@@ -264,6 +271,7 @@ static unique_ptr<FunctionData> ListSortBind(ClientContext &context, ScalarFunct
 	}
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
+	RejectFileListOrdering(arguments[0]->return_type);
 	child_type = ListType::GetChildType(arguments[0]->return_type);
 
 	bound_function.arguments[0] = arguments[0]->return_type;
@@ -301,6 +309,7 @@ static unique_ptr<FunctionData> ListGradeUpBind(ClientContext &context, ScalarFu
 	null_order = config.ResolveNullOrder(context, order, null_order);
 
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
+	RejectFileListOrdering(arguments[0]->return_type);
 
 	bound_function.arguments[0] = arguments[0]->return_type;
 	bound_function.SetReturnType(LogicalType::LIST(LogicalTypeId::BIGINT));

--- a/external/duckdb/extension/core_functions/scalar/map/map.cpp
+++ b/external/duckdb/extension/core_functions/scalar/map/map.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/types/value_map.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 
 namespace duckdb {
@@ -169,6 +170,13 @@ static void MapFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	result.Verify(row_count);
 }
 
+static unique_ptr<FunctionData> MapBind(ClientContext &, ScalarFunction &, vector<unique_ptr<Expression>> &arguments) {
+	if (!arguments.empty() && TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("map does not support FILE keys");
+	}
+	return nullptr;
+}
+
 ScalarFunctionSet MapFun::GetFunctions() {
 	ScalarFunction empty_func({}, LogicalType::MAP(LogicalType::SQLNULL, LogicalType::SQLNULL), MapFunction);
 	empty_func.SetFallible();
@@ -176,7 +184,7 @@ ScalarFunctionSet MapFun::GetFunctions() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 	ScalarFunction value_func({LogicalType::LIST(key_type), LogicalType::LIST(val_type)},
-	                          LogicalType::MAP(key_type, val_type), MapFunction);
+	                          LogicalType::MAP(key_type, val_type), MapFunction, MapBind);
 	value_func.SetFallible();
 	value_func.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 

--- a/external/duckdb/extension/core_functions/scalar/map/map_concat.cpp
+++ b/external/duckdb/extension/core_functions/scalar/map/map_concat.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/unordered_map.hpp"
@@ -163,6 +164,9 @@ unique_ptr<FunctionData> MapConcatBind(ClientContext &context, ScalarFunction &b
 		}
 		if (map.id() != LogicalTypeId::MAP) {
 			throw InvalidInputException("MAP_CONCAT only takes map arguments");
+		}
+		if (TypeVisitor::Contains(MapType::KeyType(map), FileLogicalType::IsFile)) {
+			throw BinderException("MAP_CONCAT does not support FILE map keys");
 		}
 		is_null = false;
 		if (IsEmptyMap(map)) {

--- a/external/duckdb/extension/core_functions/scalar/map/map_extract.cpp
+++ b/external/duckdb/extension/core_functions/scalar/map/map_extract.cpp
@@ -1,5 +1,6 @@
 #include "core_functions/scalar/map_functions.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -117,7 +118,8 @@ ScalarFunction MapExtractValueFun::GetFunction() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 
-	ScalarFunction fun({LogicalType::MAP(key_type, val_type), key_type}, val_type, MapExtractValueFunc);
+	ScalarFunction fun({LogicalType::MAP(key_type, val_type), key_type}, val_type, MapExtractValueFunc,
+	                   BindFileMapSearch);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }
@@ -127,7 +129,7 @@ ScalarFunction MapExtractFun::GetFunction() {
 	auto val_type = LogicalType::TEMPLATE("V");
 
 	ScalarFunction fun({LogicalType::MAP(key_type, val_type), key_type}, LogicalType::LIST(val_type),
-	                   MapExtractListFunc);
+	                   MapExtractListFunc, BindFileMapSearch);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/external/duckdb/extension/core_functions/scalar/map/map_from_entries.cpp
+++ b/external/duckdb/extension/core_functions/scalar/map/map_from_entries.cpp
@@ -1,8 +1,10 @@
 #include "core_functions/scalar/map_functions.hpp"
+#include "duckdb/common/exception.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 
 namespace duckdb {
@@ -19,13 +21,28 @@ static void MapFromEntriesFunction(DataChunk &args, ExpressionState &state, Vect
 	}
 }
 
+static unique_ptr<FunctionData> MapFromEntriesBind(ClientContext &, ScalarFunction &,
+                                                   vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() == 1);
+	auto &entries_type = arguments[0]->return_type;
+	if (entries_type.id() == LogicalTypeId::LIST || entries_type.id() == LogicalTypeId::ARRAY) {
+		auto &entry_type = entries_type.id() == LogicalTypeId::LIST ? ListType::GetChildType(entries_type)
+		                                                            : ArrayType::GetChildType(entries_type);
+		if (entry_type.id() == LogicalTypeId::STRUCT && StructType::GetChildCount(entry_type) == 2 &&
+		    TypeVisitor::Contains(StructType::GetChildType(entry_type, 0), FileLogicalType::IsFile)) {
+			throw BinderException("map_from_entries does not support FILE keys");
+		}
+	}
+	return nullptr;
+}
+
 ScalarFunction MapFromEntriesFun::GetFunction() {
 	auto key_type = LogicalType::TEMPLATE("K");
 	auto val_type = LogicalType::TEMPLATE("V");
 	auto map_type = LogicalType::MAP(key_type, val_type);
 	auto row_type = LogicalType::STRUCT({{"", key_type}, {"", val_type}});
 
-	ScalarFunction fun({LogicalType::LIST(row_type)}, map_type, MapFromEntriesFunction);
+	ScalarFunction fun({LogicalType::LIST(row_type)}, map_type, MapFromEntriesFunction, MapFromEntriesBind);
 	fun.SetNullHandling(FunctionNullHandling::DEFAULT_NULL_HANDLING);
 
 	fun.SetFallible();

--- a/external/duckdb/extension/core_functions/scalar/map/switch.cpp
+++ b/external/duckdb/extension/core_functions/scalar/map/switch.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 namespace duckdb {
 namespace {
@@ -48,6 +49,9 @@ unique_ptr<FunctionData> SwitchBindReturnType(ClientContext &context, ScalarFunc
 		throw BinderException("Switch: No map argument found");
 	}
 	auto &cases = arguments[map_index];
+	if (TypeVisitor::Contains(MapType::KeyType(cases->return_type), FileLogicalType::IsFile)) {
+		throw BinderException("SWITCH does not support FILE map keys");
+	}
 	if (cases->GetExpressionClass() != ExpressionClass::BOUND_FUNCTION) {
 		throw BinderException("SWITCH expected a constant map for the cases");
 	}

--- a/external/duckdb/extension/core_functions/scalar/struct/functions.json
+++ b/external/duckdb/extension/core_functions/scalar/struct/functions.json
@@ -25,6 +25,6 @@
       "parameters": "struct",
       "description": "Returns the field values of a STRUCT as an UnnamedStruct",
       "example": "struct_values({'a': 1, 'b': 'world'})",
-      "type": "scalar_function"
+      "type": "scalar_function_set"
     }
 ]

--- a/external/duckdb/extension/core_functions/scalar/struct/functions.json
+++ b/external/duckdb/extension/core_functions/scalar/struct/functions.json
@@ -25,6 +25,6 @@
       "parameters": "struct",
       "description": "Returns the field values of a STRUCT as an UnnamedStruct",
       "example": "struct_values({'a': 1, 'b': 'world'})",
-      "type": "scalar_function_set"
+      "type": "scalar_function"
     }
 ]

--- a/external/duckdb/extension/core_functions/scalar/struct/struct_insert.cpp
+++ b/external/duckdb/extension/core_functions/scalar/struct/struct_insert.cpp
@@ -41,6 +41,9 @@ static unique_ptr<FunctionData> StructInsertBind(ClientContext &context, ScalarF
 	if (LogicalTypeId::STRUCT != arguments[0]->return_type.id()) {
 		throw InvalidInputException("The first argument to struct_insert must be a STRUCT");
 	}
+	if (FileLogicalType::IsFile(arguments[0]->return_type)) {
+		throw BinderException("struct_insert does not support FILE values");
+	}
 	if (arguments.size() < 2) {
 		throw InvalidInputException("Can't insert nothing into a STRUCT");
 	}

--- a/external/duckdb/extension/core_functions/scalar/struct/struct_update.cpp
+++ b/external/duckdb/extension/core_functions/scalar/struct/struct_update.cpp
@@ -64,6 +64,9 @@ static unique_ptr<FunctionData> StructUpdateBind(ClientContext &context, ScalarF
 	if (LogicalTypeId::STRUCT != arguments[0]->return_type.id()) {
 		throw InvalidInputException("The first argument to struct_update must be a STRUCT");
 	}
+	if (FileLogicalType::IsFile(arguments[0]->return_type)) {
+		throw BinderException("struct_update does not support FILE values");
+	}
 	if (arguments.size() < 2) {
 		throw InvalidInputException("Can't update nothing into a STRUCT");
 	}

--- a/external/duckdb/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/external/duckdb/extension/core_functions/scalar/struct/struct_values.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/execution/expression_executor_state.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp" // VariableReturnBindData
@@ -57,6 +58,9 @@ static unique_ptr<FunctionData> StructValuesBind(ClientContext &context, ScalarF
 	if (arg_type == LogicalTypeId::UNKNOWN) {
 		throw ParameterNotResolvedException();
 	}
+	if (FileLogicalType::IsFile(arg_type)) {
+		throw BinderException("struct_values does not support FILE values");
+	}
 
 	// Since the type of the argument we declared of in `GetFunction` doesn't contain the inner STRUCT type,
 	// we should take it from the arguments
@@ -73,9 +77,18 @@ static unique_ptr<FunctionData> StructValuesBind(ClientContext &context, ScalarF
 	return nullptr;
 }
 
-ScalarFunction StructValuesFun::GetFunction() {
+static ScalarFunction GetStructValuesFunction() {
 	ScalarFunction func({LogicalTypeId::STRUCT}, LogicalTypeId::STRUCT, StructValuesFunction, StructValuesBind);
 	return func;
+}
+
+ScalarFunctionSet StructValuesFun::GetFunctions() {
+	ScalarFunctionSet struct_values_set("struct_values");
+	struct_values_set.AddFunction(GetStructValuesFunction());
+	auto file_values = GetStructValuesFunction();
+	file_values.arguments[0] = FileLogicalType::Create();
+	struct_values_set.AddFunction(std::move(file_values));
+	return struct_values_set;
 }
 
 } // namespace duckdb

--- a/external/duckdb/extension/core_functions/scalar/struct/struct_values.cpp
+++ b/external/duckdb/extension/core_functions/scalar/struct/struct_values.cpp
@@ -77,18 +77,9 @@ static unique_ptr<FunctionData> StructValuesBind(ClientContext &context, ScalarF
 	return nullptr;
 }
 
-static ScalarFunction GetStructValuesFunction() {
+ScalarFunction StructValuesFun::GetFunction() {
 	ScalarFunction func({LogicalTypeId::STRUCT}, LogicalTypeId::STRUCT, StructValuesFunction, StructValuesBind);
 	return func;
-}
-
-ScalarFunctionSet StructValuesFun::GetFunctions() {
-	ScalarFunctionSet struct_values_set("struct_values");
-	struct_values_set.AddFunction(GetStructValuesFunction());
-	auto file_values = GetStructValuesFunction();
-	file_values.arguments[0] = FileLogicalType::Create();
-	struct_values_set.AddFunction(std::move(file_values));
-	return struct_values_set;
 }
 
 } // namespace duckdb

--- a/external/duckdb/extension/json/json_functions/json_transform.cpp
+++ b/external/duckdb/extension/json/json_functions/json_transform.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
@@ -87,6 +88,9 @@ static unique_ptr<FunctionData> JSONTransformBind(ClientContext &context, Scalar
 		JSONAllocator json_allocator(Allocator::DefaultAllocator());
 		auto doc = JSONCommon::ReadDocument(structure_string, JSONCommon::READ_FLAG, json_allocator.GetYYAlc());
 		bound_function.return_type = StructureStringToType(doc->root, context);
+		if (TypeVisitor::Contains(bound_function.return_type, FileLogicalType::IsFile)) {
+			throw BinderException("json_transform does not support FILE output types");
+		}
 	}
 	return make_uniq<VariableReturnBindData>(bound_function.return_type);
 }

--- a/external/duckdb/extension/json/json_multi_file_info.cpp
+++ b/external/duckdb/extension/json/json_multi_file_info.cpp
@@ -1,5 +1,6 @@
 #include "json_multi_file_info.hpp"
 #include "json_scan.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/parallel/async_result.hpp"
 
@@ -90,7 +91,11 @@ bool JSONMultiFileInfo::ParseOption(ClientContext &context, const string &key, c
 			if (val.type().id() != LogicalTypeId::VARCHAR) {
 				throw BinderException("read_json \"columns\" parameter type specification must be VARCHAR.");
 			}
-			options.sql_type_list.emplace_back(TransformStringToLogicalType(StringValue::Get(val), context));
+			auto sql_type = TransformStringToLogicalType(StringValue::Get(val), context);
+			if (TypeVisitor::Contains(sql_type, FileLogicalType::IsFile)) {
+				throw BinderException("read_json does not support FILE column types");
+			}
+			options.sql_type_list.emplace_back(std::move(sql_type));
 		}
 		D_ASSERT(options.name_list.size() == options.sql_type_list.size());
 		if (options.name_list.empty()) {
@@ -362,6 +367,11 @@ void JSONMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
 void JSONMultiFileInfo::FinalizeCopyBind(ClientContext &context, BaseFileReaderOptions &options_p,
                                          const vector<string> &expected_names,
                                          const vector<LogicalType> &expected_types) {
+	for (const auto &expected_type : expected_types) {
+		if (TypeVisitor::Contains(expected_type, FileLogicalType::IsFile)) {
+			throw BinderException("COPY FROM JSON does not support FILE column types");
+		}
+	}
 	auto &reader_options = options_p.Cast<JSONFileReaderOptions>();
 	auto &options = reader_options.options;
 	options.name_list = expected_names;

--- a/external/duckdb/extension/parquet/include/parquet_column_schema.hpp
+++ b/external/duckdb/extension/parquet/include/parquet_column_schema.hpp
@@ -20,6 +20,23 @@ using duckdb_parquet::SchemaElement;
 
 using duckdb_parquet::FileMetaData;
 struct ParquetOptions;
+struct ParquetColumnSchema;
+
+enum class ParquetFileTypeMetadataKind : uint8_t { FILE, UNION };
+
+struct ParquetFileTypeMetadataEntry {
+	ParquetFileTypeMetadataKind kind;
+	vector<idx_t> path;
+};
+
+struct ParquetFileTypeMetadata {
+	static constexpr const char *KEY = "vane.file.paths";
+
+	static string Serialize(const vector<ParquetFileTypeMetadataEntry> &entries);
+	static vector<ParquetFileTypeMetadataEntry> Deserialize(const string &metadata, const string &file_path);
+	static void Apply(ParquetColumnSchema &root, const vector<ParquetFileTypeMetadataEntry> &entries,
+	                  const string &file_path);
+};
 
 enum class ParquetColumnSchemaType { COLUMN, FILE_ROW_NUMBER, EXPRESSION, VARIANT, GEOMETRY };
 

--- a/external/duckdb/extension/parquet/parquet_column_schema.cpp
+++ b/external/duckdb/extension/parquet/parquet_column_schema.cpp
@@ -1,7 +1,205 @@
 #include "parquet_column_schema.hpp"
 #include "parquet_reader.hpp"
+#include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/unordered_set.hpp"
 
 namespace duckdb {
+
+constexpr const char *ParquetFileTypeMetadata::KEY;
+
+static char ParquetFileTypeMetadataKindToChar(ParquetFileTypeMetadataKind kind) {
+	switch (kind) {
+	case ParquetFileTypeMetadataKind::FILE:
+		return 'F';
+	case ParquetFileTypeMetadataKind::UNION:
+		return 'U';
+	default:
+		throw InternalException("Unknown Parquet FILE metadata kind");
+	}
+}
+
+string ParquetFileTypeMetadata::Serialize(const vector<ParquetFileTypeMetadataEntry> &entries) {
+	string result = "1";
+	for (auto &entry : entries) {
+		result += ';';
+		result += ParquetFileTypeMetadataKindToChar(entry.kind);
+		result += ':';
+		for (idx_t path_index = 0; path_index < entry.path.size(); path_index++) {
+			if (path_index > 0) {
+				result += '.';
+			}
+			result += to_string(entry.path[path_index]);
+		}
+	}
+	return result;
+}
+
+[[noreturn]] static void ThrowInvalidParquetFileTypeMetadata(const string &file_path, const string &message) {
+	throw InvalidInputException("Failed to read Parquet file \"%s\": invalid %s metadata: %s", file_path,
+	                            ParquetFileTypeMetadata::KEY, message);
+}
+
+vector<ParquetFileTypeMetadataEntry> ParquetFileTypeMetadata::Deserialize(const string &metadata,
+                                                                          const string &file_path) {
+	auto parts = StringUtil::Split(metadata, ';');
+	if (parts.empty() || parts[0] != "1") {
+		ThrowInvalidParquetFileTypeMetadata(file_path, "unsupported format version");
+	}
+
+	vector<ParquetFileTypeMetadataEntry> result;
+	unordered_set<string> seen_entries;
+	for (idx_t part_index = 1; part_index < parts.size(); part_index++) {
+		auto &part = parts[part_index];
+		if (part.size() < 3 || part[1] != ':') {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "malformed path entry");
+		}
+
+		ParquetFileTypeMetadataEntry entry;
+		switch (part[0]) {
+		case 'F':
+			entry.kind = ParquetFileTypeMetadataKind::FILE;
+			break;
+		case 'U':
+			entry.kind = ParquetFileTypeMetadataKind::UNION;
+			break;
+		default:
+			ThrowInvalidParquetFileTypeMetadata(file_path, "unknown path kind");
+		}
+
+		for (auto &path_part : StringUtil::Split(part.substr(2), '.')) {
+			idx_t child_index;
+			if (!TryCast::Operation<string_t, idx_t>(string_t(path_part), child_index, true)) {
+				ThrowInvalidParquetFileTypeMetadata(file_path, "invalid child index");
+			}
+			entry.path.push_back(child_index);
+		}
+		if (entry.path.empty()) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "empty path");
+		}
+		if (!seen_entries.insert(part).second) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "duplicate path");
+		}
+		result.push_back(std::move(entry));
+	}
+	if (result.empty() || Serialize(result) != metadata) {
+		ThrowInvalidParquetFileTypeMetadata(file_path, "non-canonical encoding");
+	}
+	return result;
+}
+
+static ParquetColumnSchema &ResolveParquetFileTypePath(ParquetColumnSchema &root, const vector<idx_t> &path,
+                                                       const string &file_path) {
+	auto node = &root;
+	for (auto child_index : path) {
+		if (child_index >= node->children.size()) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "path is outside the Parquet schema");
+		}
+		node = &node->children[child_index];
+	}
+	return *node;
+}
+
+static LogicalType ParquetFileStorageType() {
+	auto result = FileLogicalType::Create();
+	result.SetAlias(string());
+	return result;
+}
+
+static bool RefreshParquetFileTypes(ParquetColumnSchema &schema, const string &file_path) {
+	if (FileLogicalType::IsFile(schema.type)) {
+		return true;
+	}
+
+	bool contains_file = false;
+	for (auto &child : schema.children) {
+		contains_file = RefreshParquetFileTypes(child, file_path) || contains_file;
+	}
+	if (!contains_file) {
+		return false;
+	}
+
+	switch (schema.type.id()) {
+	case LogicalTypeId::STRUCT: {
+		child_list_t<LogicalType> children;
+		for (auto &child : schema.children) {
+			children.emplace_back(child.name, child.type);
+		}
+		schema.type = LogicalType::STRUCT(std::move(children));
+		break;
+	}
+	case LogicalTypeId::UNION: {
+		if (schema.children.size() < 2 || !schema.children[0].name.empty() ||
+		    schema.children[0].type != LogicalType::UTINYINT) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "UNION path has incompatible storage");
+		}
+		child_list_t<LogicalType> members;
+		for (idx_t child_index = 1; child_index < schema.children.size(); child_index++) {
+			auto &child = schema.children[child_index];
+			members.emplace_back(child.name, child.type);
+		}
+		schema.type = LogicalType::UNION(std::move(members));
+		break;
+	}
+	case LogicalTypeId::LIST:
+		if (schema.children.size() != 1) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "LIST path has incompatible storage");
+		}
+		schema.type = LogicalType::LIST(schema.children[0].type);
+		break;
+	case LogicalTypeId::MAP: {
+		if (schema.children.size() != 1 || schema.children[0].type.id() != LogicalTypeId::STRUCT ||
+		    StructType::GetChildCount(schema.children[0].type) != 2) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "MAP path has incompatible storage");
+		}
+		auto &entry_type = schema.children[0].type;
+		schema.type =
+		    LogicalType::MAP(StructType::GetChildType(entry_type, 0), StructType::GetChildType(entry_type, 1));
+		break;
+	}
+	default:
+		ThrowInvalidParquetFileTypeMetadata(file_path, "FILE path has an unsupported parent type");
+	}
+	return true;
+}
+
+void ParquetFileTypeMetadata::Apply(ParquetColumnSchema &root, const vector<ParquetFileTypeMetadataEntry> &entries,
+                                    const string &file_path) {
+	for (auto &entry : entries) {
+		if (entry.kind != ParquetFileTypeMetadataKind::FILE) {
+			continue;
+		}
+		auto &node = ResolveParquetFileTypePath(root, entry.path, file_path);
+		if (node.type != ParquetFileStorageType() || node.children.size() != FileLogicalType::FIELD_COUNT) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "FILE path has incompatible storage");
+		}
+		node.type = FileLogicalType::Create();
+	}
+	RefreshParquetFileTypes(root, file_path);
+
+	for (idx_t entry_index = entries.size(); entry_index > 0; entry_index--) {
+		auto &entry = entries[entry_index - 1];
+		if (entry.kind != ParquetFileTypeMetadataKind::UNION) {
+			continue;
+		}
+		auto &node = ResolveParquetFileTypePath(root, entry.path, file_path);
+		if (node.type.id() != LogicalTypeId::STRUCT || node.children.size() < 2 || !node.children[0].name.empty() ||
+		    node.children[0].type != LogicalType::UTINYINT) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "UNION path has incompatible storage");
+		}
+		child_list_t<LogicalType> members;
+		for (idx_t child_index = 1; child_index < node.children.size(); child_index++) {
+			auto &child = node.children[child_index];
+			members.emplace_back(child.name, child.type);
+		}
+		node.type = LogicalType::UNION(std::move(members));
+		if (!TypeVisitor::Contains(node.type, FileLogicalType::IsFile)) {
+			ThrowInvalidParquetFileTypeMetadata(file_path, "UNION path does not contain FILE");
+		}
+	}
+	RefreshParquetFileTypes(root, file_path);
+}
 
 void ParquetColumnSchema::SetSchemaIndex(idx_t schema_idx) {
 	D_ASSERT(!schema_index.IsValid());

--- a/external/duckdb/extension/parquet/parquet_extension.cpp
+++ b/external/duckdb/extension/parquet/parquet_extension.cpp
@@ -403,6 +403,11 @@ static void ParquetWriteSink(ExecutionContext &context, FunctionData &bind_data_
 	auto &bind_data = bind_data_p.Cast<ParquetWriteBindData>();
 	auto &global_state = gstate.Cast<ParquetWriteGlobalState>();
 	auto &local_state = lstate.Cast<ParquetWriteLocalState>();
+	for (idx_t column_index = 0; column_index < input.ColumnCount(); column_index++) {
+		if (TypeVisitor::Contains(input.data[column_index].GetType(), FileLogicalType::IsFile)) {
+			FileLogicalType::Validate(input.data[column_index], input.size(), "Parquet FILE");
+		}
+	}
 
 	// append data to the local (buffered) chunk collection
 	local_state.buffer.Append(local_state.append_state, input);

--- a/external/duckdb/extension/parquet/parquet_reader.cpp
+++ b/external/duckdb/extension/parquet/parquet_reader.cpp
@@ -20,6 +20,7 @@
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/storage/object_cache.hpp"
 #include "duckdb/optimizer/statistics_propagator.hpp"
@@ -444,6 +445,7 @@ unique_ptr<ColumnReader> ParquetReader::CreateReaderRecursive(ClientContext &con
 			D_ASSERT(children.size() == 1);
 			return make_uniq<ListColumnReader>(*this, schema, std::move(children[0]));
 		case LogicalTypeId::STRUCT:
+		case LogicalTypeId::UNION:
 			return make_uniq<StructColumnReader>(*this, schema, std::move(children));
 		default:
 			throw InternalException("Unsupported schema type for schema with children");
@@ -762,6 +764,25 @@ unique_ptr<ParquetColumnSchema> ParquetReader::ParseSchema(ClientContext &contex
 	if (!file_meta_data->row_groups.empty() && next_file_idx != file_meta_data->row_groups[0].columns.size()) {
 		throw InvalidInputException("Failed to read Parquet file \"%s\": row group does not have enough columns",
 		                            file.path);
+	}
+	const string *file_type_metadata = nullptr;
+	for (auto &kv : file_meta_data->key_value_metadata) {
+		if (kv.key != ParquetFileTypeMetadata::KEY) {
+			continue;
+		}
+		if (file_type_metadata) {
+			throw InvalidInputException("Failed to read Parquet file \"%s\": duplicate %s metadata", file.path,
+			                            ParquetFileTypeMetadata::KEY);
+		}
+		if (!kv.__isset.value) {
+			throw InvalidInputException("Failed to read Parquet file \"%s\": %s metadata has no value", file.path,
+			                            ParquetFileTypeMetadata::KEY);
+		}
+		file_type_metadata = &kv.value;
+	}
+	if (file_type_metadata) {
+		auto entries = ParquetFileTypeMetadata::Deserialize(*file_type_metadata, file.path);
+		ParquetFileTypeMetadata::Apply(root, entries, file.path);
 	}
 	if (parquet_options.file_row_number) {
 		for (auto &column : root.children) {
@@ -1606,6 +1627,11 @@ AsyncResult ParquetReader::Scan(ClientContext &context, ParquetReaderScanState &
 
 	rows_read += scan_count;
 	state.offset_in_group += scan_count;
+	for (idx_t column_index = 0; column_index < result.ColumnCount(); column_index++) {
+		if (TypeVisitor::Contains(result.data[column_index].GetType(), FileLogicalType::IsFile)) {
+			FileLogicalType::Validate(result.data[column_index], result.size(), "Parquet FILE");
+		}
+	}
 	return SourceResultType::HAVE_MORE_OUTPUT;
 }
 

--- a/external/duckdb/extension/parquet/parquet_statistics.cpp
+++ b/external/duckdb/extension/parquet/parquet_statistics.cpp
@@ -418,8 +418,8 @@ unique_ptr<BaseStatistics> ParquetStatisticsUtils::TransformColumnStatistics(con
 		row_group_stats = list_stats.ToUnique();
 		return row_group_stats;
 	}
-	// Structs are handled differently (they dont have stats)
-	if (type.id() == LogicalTypeId::STRUCT) {
+	// Structs and unions are handled differently (they dont have stats)
+	if (type.id() == LogicalTypeId::STRUCT || type.id() == LogicalTypeId::UNION) {
 		auto struct_stats = StructStats::CreateUnknown(type);
 		// Recurse into child readers
 		for (idx_t i = 0; i < schema.children.size(); i++) {

--- a/external/duckdb/extension/parquet/parquet_writer.cpp
+++ b/external/duckdb/extension/parquet/parquet_writer.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/write_stream.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -377,6 +378,25 @@ ColumnDataCollection &ParquetWriteTransformData::ApplyTransform(ColumnDataCollec
 	return buffer;
 }
 
+static void CollectParquetFileTypeMetadata(const ColumnWriter &writer, vector<idx_t> &path,
+                                           vector<ParquetFileTypeMetadataEntry> &entries) {
+	auto &type = writer.Type();
+	if (type.id() == LogicalTypeId::UNION && TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+		entries.push_back({ParquetFileTypeMetadataKind::UNION, path});
+	}
+	if (FileLogicalType::IsFile(type)) {
+		entries.push_back({ParquetFileTypeMetadataKind::FILE, path});
+		return;
+	}
+
+	auto &children = writer.ChildWriters();
+	for (idx_t child_index = 0; child_index < children.size(); child_index++) {
+		path.push_back(child_index);
+		CollectParquetFileTypeMetadata(*children[child_index], path, entries);
+		path.pop_back();
+	}
+}
+
 ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file_name_p, vector<LogicalType> types_p,
                              vector<string> names_p, CompressionCodec::type codec, ChildFieldIDs field_ids_p,
                              ShreddingType shredding_types_p, const vector<pair<string, string>> &kv_metadata,
@@ -393,6 +413,12 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
       enable_bloom_filters(enable_bloom_filters_p),
       bloom_filter_false_positive_ratio(bloom_filter_false_positive_ratio_p), compression_level(compression_level_p),
       parquet_version(parquet_version), geoparquet_version(geoparquet_version), total_written(0), num_row_groups(0) {
+	for (auto &kv_pair : kv_metadata) {
+		if (kv_pair.first == ParquetFileTypeMetadata::KEY) {
+			throw InvalidInputException("Parquet metadata key \"%s\" is reserved", ParquetFileTypeMetadata::KEY);
+		}
+	}
+
 	// initialize the file writer
 	writer = make_uniq<BufferedFileWriter>(fs, file_name.c_str(),
 	                                       FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW);
@@ -440,6 +466,19 @@ ParquetWriter::ParquetWriter(ClientContext &context, FileSystem &fs, string file
 		column_writers.push_back(ColumnWriter::CreateWriterRecursive(context, *this, path_in_schema, sql_types[i],
 		                                                             unique_names[i], allow_geometry, &field_ids,
 		                                                             &shredding_types));
+	}
+
+	vector<ParquetFileTypeMetadataEntry> file_type_entries;
+	for (idx_t column_index = 0; column_index < column_writers.size(); column_index++) {
+		vector<idx_t> path {column_index};
+		CollectParquetFileTypeMetadata(*column_writers[column_index], path, file_type_entries);
+	}
+	if (!file_type_entries.empty()) {
+		duckdb_parquet::KeyValue kv;
+		kv.__set_key(ParquetFileTypeMetadata::KEY);
+		kv.__set_value(ParquetFileTypeMetadata::Serialize(file_type_entries));
+		file_meta_data.key_value_metadata.push_back(std::move(kv));
+		file_meta_data.__isset.key_value_metadata = true;
 	}
 }
 

--- a/external/duckdb/src/common/arrow/arrow_converter.cpp
+++ b/external/duckdb/src/common/arrow/arrow_converter.cpp
@@ -25,6 +25,9 @@ namespace duckdb {
 void ArrowConverter::ToArrowArray(
     DataChunk &input, ArrowArray *out_array, ClientProperties options,
     const unordered_map<idx_t, const shared_ptr<ArrowTypeExtensionData>> &extension_type_cast) {
+	for (idx_t column_index = 0; column_index < input.ColumnCount(); column_index++) {
+		FileLogicalType::Validate(input.data[column_index], input.size(), "Arrow FILE");
+	}
 	ArrowAppender appender(input.GetTypes(), input.size(), std::move(options), extension_type_cast);
 	appender.Append(input, 0, input.size(), input.size());
 	*out_array = appender.Finalize();

--- a/external/duckdb/src/common/arrow/arrow_converter.cpp
+++ b/external/duckdb/src/common/arrow/arrow_converter.cpp
@@ -93,6 +93,17 @@ void SetArrowStructFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &chi
 	}
 }
 
+void PopulateArrowFileSchema(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
+                             ClientContext &context, const ArrowTypeExtension &extension) {
+	D_ASSERT(FileLogicalType::IsFile(type));
+	auto options = context.GetClientProperties();
+	SetArrowStructFormat(root_holder, child, type, options, context);
+
+	const auto schema_metadata = ArrowSchemaMetadata::ArrowCanonicalType(extension.GetInfo().GetExtensionName());
+	root_holder.metadata_info.emplace_back(schema_metadata.SerializeMetadata());
+	child.metadata = root_holder.metadata_info.back().get();
+}
+
 void SetArrowMapFormat(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child, const LogicalType &type,
                        ClientProperties &options, ClientContext &context) {
 	child.format = "+m";

--- a/external/duckdb/src/common/arrow/arrow_type_extension.cpp
+++ b/external/duckdb/src/common/arrow/arrow_type_extension.cpp
@@ -335,7 +335,6 @@ struct ArrowFile {
 		for (auto &child : StructVector::GetEntries(source)) {
 			FlatVector::Validity(*child).Combine(result_validity, count);
 		}
-		FileLogicalType::Validate(source, count, "Arrow FILE");
 		result.Reference(source);
 		FlatVector::Validity(result) = std::move(result_validity);
 	}

--- a/external/duckdb/src/common/arrow/arrow_type_extension.cpp
+++ b/external/duckdb/src/common/arrow/arrow_type_extension.cpp
@@ -323,8 +323,12 @@ struct ArrowFile {
 	}
 
 	static void ArrowToDuck(ClientContext &, Vector &source, Vector &result, idx_t count) {
+		source.Flatten(count);
 		auto result_validity = FlatVector::Validity(result);
 		FlatVector::Validity(source) = result_validity;
+		for (auto &child : StructVector::GetEntries(source)) {
+			FlatVector::Validity(*child).Combine(result_validity, count);
+		}
 		FileLogicalType::Validate(source, count, "Arrow FILE");
 		result.Reference(source);
 		FlatVector::Validity(result) = std::move(result_validity);

--- a/external/duckdb/src/common/arrow/arrow_type_extension.cpp
+++ b/external/duckdb/src/common/arrow/arrow_type_extension.cpp
@@ -294,6 +294,43 @@ struct ArrowJson {
 	}
 };
 
+struct ArrowFile {
+	static unique_ptr<ArrowType> GetType(ClientContext &context, const ArrowSchema &schema,
+	                                     const ArrowSchemaMetadata &) {
+		if (!schema.format || string(schema.format) != "+s" ||
+		    schema.n_children != static_cast<int64_t>(FileLogicalType::FIELD_COUNT) || !schema.children) {
+			throw InvalidInputException("Arrow extension type \"vane.file\" requires the canonical FILE struct");
+		}
+
+		auto file_type = FileLogicalType::Create();
+		auto &fields = StructType::GetChildTypes(file_type);
+		vector<shared_ptr<ArrowType>> children;
+		children.reserve(FileLogicalType::FIELD_COUNT);
+		for (idx_t field_index = 0; field_index < FileLogicalType::FIELD_COUNT; field_index++) {
+			auto child_schema = schema.children[field_index];
+			if (!child_schema || !child_schema->name || string(child_schema->name) != fields[field_index].first) {
+				throw InvalidInputException("Arrow extension type \"vane.file\" has an invalid field at index %d",
+				                            field_index);
+			}
+			auto child = ArrowType::GetArrowLogicalType(context, *child_schema);
+			if (child->GetDuckType(true) != fields[field_index].second) {
+				throw InvalidInputException("Arrow extension type \"vane.file\" has an invalid type for field \"%s\"",
+				                            fields[field_index].first);
+			}
+			children.emplace_back(std::move(child));
+		}
+		return make_uniq<ArrowType>(std::move(file_type), make_uniq<ArrowStructInfo>(std::move(children)));
+	}
+
+	static void ArrowToDuck(ClientContext &, Vector &source, Vector &result, idx_t count) {
+		auto result_validity = FlatVector::Validity(result);
+		FlatVector::Validity(source) = result_validity;
+		FileLogicalType::Validate(source, count, "Arrow FILE");
+		result.Reference(source);
+		FlatVector::Validity(result) = std::move(result_validity);
+	}
+};
+
 struct ArrowBit {
 	static unique_ptr<ArrowType> GetType(ClientContext &context, const ArrowSchema &schema,
 	                                     const ArrowSchemaMetadata &schema_metadata) {
@@ -570,6 +607,11 @@ struct ArrowGeometry {
 };
 
 void ArrowTypeExtensionSet::Initialize(const DBConfig &config) {
+	config.RegisterArrowExtension(
+	    {"vane.file", &PopulateArrowFileSchema, &ArrowFile::GetType,
+	     make_shared_ptr<ArrowTypeExtensionData>(FileLogicalType::Create(), FileLogicalType::Create(),
+	                                             &ArrowFile::ArrowToDuck, nullptr)});
+
 	// Types that are 1:1
 	config.RegisterArrowExtension({"arrow.uuid", "w:16", make_shared_ptr<ArrowTypeExtensionData>(LogicalType::UUID)});
 	config.RegisterArrowExtension(

--- a/external/duckdb/src/common/arrow/arrow_type_extension.cpp
+++ b/external/duckdb/src/common/arrow/arrow_type_extension.cpp
@@ -222,6 +222,9 @@ ArrowTypeExtension DBConfig::GetArrowExtension(ArrowExtensionMetadata info) cons
 
 ArrowTypeExtension DBConfig::GetArrowExtension(const LogicalType &type) const {
 	lock_guard<mutex> l(arrow_extensions->lock);
+	if (type.GetAlias() == FileLogicalType::TYPE_NAME && !FileLogicalType::IsFile(type)) {
+		throw InvalidInputException("The vane.file Arrow extension requires the canonical FILE logical type");
+	}
 	TypeInfo type_info(type);
 	if (!arrow_extensions->type_to_info[type_info].empty()) {
 		return GetArrowExtensionInternal(arrow_extensions->type_extensions,
@@ -234,6 +237,9 @@ ArrowTypeExtension DBConfig::GetArrowExtension(const LogicalType &type) const {
 
 bool DBConfig::HasArrowExtension(const LogicalType &type) const {
 	lock_guard<mutex> l(arrow_extensions->lock);
+	if (type.GetAlias() == FileLogicalType::TYPE_NAME && !FileLogicalType::IsFile(type)) {
+		return false;
+	}
 	TypeInfo type_info(type);
 	if (!arrow_extensions->type_to_info[type_info].empty()) {
 		return true;

--- a/external/duckdb/src/common/multi_file/multi_file_column_mapper.cpp
+++ b/external/duckdb/src/common/multi_file/multi_file_column_mapper.cpp
@@ -208,6 +208,12 @@ bool IsTriviallyMappable(const MultiFileColumnDefinition &global_column,
 	if (local_column.type != global_column.type) {
 		return false;
 	}
+	if (global_column.children.empty()) {
+		// The global schema did not request nested remapping. Local readers may still expose physical children for
+		// the same logical type (for example, Parquet LIST/MAP/UNION columns), but the complete value can be
+		// forwarded directly when the logical types and parent position already match.
+		return true;
+	}
 	if (local_column.children.size() != global_column.children.size()) {
 		// child count difference - cannot map trivially
 		return false;

--- a/external/duckdb/src/common/row_operations/row_aggregate.cpp
+++ b/external/duckdb/src/common/row_operations/row_aggregate.cpp
@@ -115,6 +115,7 @@ void RowOperations::FinalizeStates(RowOperationsState &state, TupleDataLayout &l
 		auto &aggr = aggregates[i];
 		AggregateInputData aggr_input_data(aggr.GetFunctionData(), state.allocator);
 		aggr.function.GetStateFinalizeCallback()(addresses_copy, aggr_input_data, target, result.size(), 0);
+		FileLogicalType::Validate(target, aggr.function.GetReturnType(), result.size(), "Aggregate function FILE");
 
 		// Move to the next aggregate state
 		VectorOperations::AddInPlace(addresses_copy, UnsafeNumericCast<int64_t>(aggr.payload_size), result.size());

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1746,7 +1746,9 @@ void FileLogicalType::Validate(const Value &value, const string &source) {
 	auto &type = value.type();
 	if (IsFile(type)) {
 		auto &children = StructValue::GetChildren(value);
-		D_ASSERT(children.size() == FIELD_COUNT);
+		if (children.size() != FIELD_COUNT) {
+			throw InvalidInputException("%s must contain exactly %llu fields", source, FIELD_COUNT);
+		}
 
 		auto position_is_valid = !children[POSITION].IsNull();
 		auto size_is_valid = !children[SIZE].IsNull();
@@ -1803,7 +1805,9 @@ void FileLogicalType::Validate(Vector &value, idx_t count, const string &source)
 		return;
 	}
 	auto &children = StructVector::GetEntries(value);
-	D_ASSERT(children.size() == FIELD_COUNT);
+	if (children.size() != FIELD_COUNT) {
+		throw InvalidInputException("%s must contain exactly %llu fields", source, FIELD_COUNT);
+	}
 
 	UnifiedVectorFormat value_data;
 	UnifiedVectorFormat url_data;

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1714,6 +1714,66 @@ bool FileLogicalType::IsFile(const LogicalType &type) {
 	       children[CHECKSUM].first == "checksum" && children[CHECKSUM].second == LogicalType::VARCHAR;
 }
 
+void FileLogicalType::Validate(Vector &value, idx_t count, const string &source) {
+	D_ASSERT(IsFile(value.GetType()));
+	auto &children = StructVector::GetEntries(value);
+	D_ASSERT(children.size() == FIELD_COUNT);
+
+	UnifiedVectorFormat value_data;
+	UnifiedVectorFormat url_data;
+	UnifiedVectorFormat position_data;
+	UnifiedVectorFormat size_data;
+	UnifiedVectorFormat checksum_data;
+	value.ToUnifiedFormat(count, value_data);
+	children[URL]->ToUnifiedFormat(count, url_data);
+	children[POSITION]->ToUnifiedFormat(count, position_data);
+	children[SIZE]->ToUnifiedFormat(count, size_data);
+	children[CHECKSUM]->ToUnifiedFormat(count, checksum_data);
+
+	auto positions = UnifiedVectorFormat::GetData<int64_t>(position_data);
+	auto sizes = UnifiedVectorFormat::GetData<int64_t>(size_data);
+	auto checksums = UnifiedVectorFormat::GetData<string_t>(checksum_data);
+	for (idx_t row = 0; row < count; row++) {
+		auto value_index = value_data.sel->get_index(row);
+		if (!value_data.validity.RowIsValid(value_index)) {
+			continue;
+		}
+
+		auto url_index = url_data.sel->get_index(row);
+		if (!url_data.validity.RowIsValid(url_index)) {
+			throw InvalidInputException("%s url cannot be NULL", source);
+		}
+
+		auto position_index = position_data.sel->get_index(row);
+		auto size_index = size_data.sel->get_index(row);
+		auto position_is_valid = position_data.validity.RowIsValid(position_index);
+		auto size_is_valid = size_data.validity.RowIsValid(size_index);
+		if (position_is_valid != size_is_valid) {
+			throw InvalidInputException("%s position and size must either both be NULL or both be non-NULL", source);
+		}
+		if (position_is_valid) {
+			auto position = positions[position_index];
+			auto size = sizes[size_index];
+			if (position < 0 || size < 0) {
+				throw InvalidInputException("%s position and size must be non-negative", source);
+			}
+			if (position > NumericLimits<int64_t>::Maximum() - size) {
+				throw InvalidInputException("%s byte range exceeds BIGINT", source);
+			}
+		}
+
+		auto checksum_index = checksum_data.sel->get_index(row);
+		if (checksum_data.validity.RowIsValid(checksum_index)) {
+			auto checksum = checksums[checksum_index].GetString();
+			auto separator = checksum.find(':');
+			if (separator == string::npos || separator == 0 || separator + 1 == checksum.size() ||
+			    checksum.find(':', separator + 1) != string::npos) {
+				throw InvalidInputException("%s checksum must have the form <algorithm>:<digest>", source);
+			}
+		}
+	}
+}
+
 LogicalType LogicalType::AGGREGATE_STATE(aggregate_state_t state_type) { // NOLINT
 	auto info = make_shared_ptr<AggregateStateTypeInfo>(std::move(state_type));
 	return LogicalType(LogicalTypeId::AGGREGATE_STATE, std::move(info));

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1748,62 +1748,89 @@ static void ValidateFileFieldType(const LogicalType &actual_type, idx_t field_in
 	}
 }
 
-void FileLogicalType::Validate(const Value &value, const string &source) {
+static void ValidateFileValue(const Value &value, const LogicalType &declared_type, const string &source) {
 	if (value.IsNull()) {
 		return;
 	}
-	auto &type = value.type();
-	if (IsFile(type)) {
+	if (!FileLogicalType::IsFile(declared_type) && !TypeVisitor::Contains(declared_type, FileLogicalType::IsFile)) {
+		return;
+	}
+	if (value.type().InternalType() != declared_type.InternalType()) {
+		throw InvalidInputException("%s value declared as %s has incompatible actual type %s", source, declared_type,
+		                            value.type());
+	}
+	if (FileLogicalType::IsFile(declared_type)) {
 		auto &children = StructValue::GetChildren(value);
-		if (children.size() != FIELD_COUNT) {
-			throw InvalidInputException("%s must contain exactly %llu fields", source, FIELD_COUNT);
+		if (children.size() != FileLogicalType::FIELD_COUNT) {
+			throw InvalidInputException("%s must contain exactly %llu fields", source, FileLogicalType::FIELD_COUNT);
 		}
-		for (idx_t field_index = 0; field_index < FIELD_COUNT; field_index++) {
+		for (idx_t field_index = 0; field_index < FileLogicalType::FIELD_COUNT; field_index++) {
 			ValidateFileFieldType(children[field_index].type(), field_index, source);
 		}
 
-		auto position_is_valid = !children[POSITION].IsNull();
-		auto size_is_valid = !children[SIZE].IsNull();
-		auto position = position_is_valid ? BigIntValue::Get(children[POSITION]) : 0;
-		auto size = size_is_valid ? BigIntValue::Get(children[SIZE]) : 0;
+		auto position_is_valid = !children[FileLogicalType::POSITION].IsNull();
+		auto size_is_valid = !children[FileLogicalType::SIZE].IsNull();
+		auto position = position_is_valid ? BigIntValue::Get(children[FileLogicalType::POSITION]) : 0;
+		auto size = size_is_valid ? BigIntValue::Get(children[FileLogicalType::SIZE]) : 0;
 		const string *checksum = nullptr;
-		if (!children[CHECKSUM].IsNull()) {
-			checksum = &StringValue::Get(children[CHECKSUM]);
+		if (!children[FileLogicalType::CHECKSUM].IsNull()) {
+			checksum = &StringValue::Get(children[FileLogicalType::CHECKSUM]);
 		}
-		ValidateFileFields(!children[URL].IsNull(), position_is_valid, position, size_is_valid, size, checksum, source);
-		return;
-	}
-	if (!TypeVisitor::Contains(type, IsFile)) {
+		ValidateFileFields(!children[FileLogicalType::URL].IsNull(), position_is_valid, position, size_is_valid, size,
+		                   checksum, source);
 		return;
 	}
 
-	switch (type.id()) {
+	switch (declared_type.id()) {
 	case LogicalTypeId::STRUCT:
-		for (auto &child : StructValue::GetChildren(value)) {
-			Validate(child, source);
+	case LogicalTypeId::UNION: {
+		auto &children = StructValue::GetChildren(value);
+		auto &declared_children = StructType::GetChildTypes(declared_type);
+		if (children.size() != declared_children.size()) {
+			throw InvalidInputException("%s container declared as %s must contain exactly %llu fields", source,
+			                            declared_type, declared_children.size());
 		}
-		return;
-	case LogicalTypeId::UNION:
-		Validate(UnionValue::GetValue(value), source);
-		return;
-	case LogicalTypeId::LIST:
-		for (auto &child : ListValue::GetChildren(value)) {
-			Validate(child, source);
+		if (declared_type.id() == LogicalTypeId::STRUCT) {
+			for (idx_t child_index = 0; child_index < children.size(); child_index++) {
+				ValidateFileValue(children[child_index], declared_children[child_index].second, source);
+			}
+			return;
 		}
-		return;
-	case LogicalTypeId::MAP:
-		for (auto &child : MapValue::GetChildren(value)) {
-			Validate(child, source);
+		if (children[0].type() != LogicalType::UTINYINT || children[0].IsNull()) {
+			throw InvalidInputException("%s UNION tag must be a non-NULL UTINYINT", source);
 		}
-		return;
-	case LogicalTypeId::ARRAY:
-		for (auto &child : ArrayValue::GetChildren(value)) {
-			Validate(child, source);
+		auto tag = UTinyIntValue::Get(children[0]);
+		if (tag >= UnionType::GetMemberCount(declared_type)) {
+			throw InvalidInputException("%s UNION tag is out of range", source);
 		}
+		ValidateFileValue(children[tag + 1], declared_children[tag + 1].second, source);
 		return;
-	default:
-		throw InternalException("Unsupported logical type containing FILE: %s", type.ToString());
 	}
+	case LogicalTypeId::LIST:
+	case LogicalTypeId::MAP:
+		for (auto &child : ListValue::GetChildren(value)) {
+			ValidateFileValue(child, ListType::GetChildType(declared_type), source);
+		}
+		return;
+	case LogicalTypeId::ARRAY: {
+		auto &children = ArrayValue::GetChildren(value);
+		auto declared_size = ArrayType::GetSize(declared_type);
+		if (children.size() != declared_size) {
+			throw InvalidInputException("%s ARRAY declared with %llu elements contains %llu values", source,
+			                            declared_size, children.size());
+		}
+		for (auto &child : children) {
+			ValidateFileValue(child, ArrayType::GetChildType(declared_type), source);
+		}
+		return;
+	}
+	default:
+		throw InternalException("Unsupported logical type containing FILE: %s", declared_type.ToString());
+	}
+}
+
+void FileLogicalType::Validate(const Value &value, const string &source) {
+	ValidateFileValue(value, value.type(), source);
 }
 
 void FileLogicalType::Validate(Vector &value, idx_t count, const string &source) {

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1945,6 +1945,9 @@ bool ArrayType::IsAnySize(const LogicalType &type) {
 }
 
 LogicalType ArrayType::ConvertToList(const LogicalType &type) {
+	if (FileLogicalType::IsFile(type)) {
+		return type;
+	}
 	switch (type.id()) {
 	case LogicalTypeId::ARRAY: {
 		return LogicalType::LIST(ConvertToList(ArrayType::GetChildType(type)));

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -1887,6 +1888,40 @@ void FileLogicalType::Validate(Vector &value, idx_t count, const string &source)
 		}
 		ValidateFileFields(url_data.validity.RowIsValid(url_index), position_is_valid, position, size_is_valid, size,
 		                   checksum_ptr, source);
+	}
+}
+
+void FileLogicalType::Validate(Vector &value, const LogicalType &declared_type, idx_t count, const string &source) {
+	if (!TypeVisitor::Contains(declared_type, IsFile)) {
+		return;
+	}
+	if (value.GetType() != declared_type) {
+		throw InvalidInputException("%s result has type %s, expected %s", source, value.GetType(), declared_type);
+	}
+	Validate(value, count, source);
+}
+
+void FileLogicalType::Validate(DataChunk &value, const vector<LogicalType> &declared_types, const string &source) {
+	bool contains_file = false;
+	for (auto &declared_type : declared_types) {
+		if (TypeVisitor::Contains(declared_type, IsFile)) {
+			contains_file = true;
+			break;
+		}
+	}
+	if (!contains_file) {
+		return;
+	}
+	if (value.ColumnCount() != declared_types.size()) {
+		throw InvalidInputException("%s result has %llu columns, expected %llu", source, value.ColumnCount(),
+		                            declared_types.size());
+	}
+	for (idx_t column_index = 0; column_index < declared_types.size(); column_index++) {
+		auto &declared_type = declared_types[column_index];
+		if (!TypeVisitor::Contains(declared_type, IsFile)) {
+			continue;
+		}
+		Validate(value.data[column_index], declared_type, value.size(), source);
 	}
 }
 

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1739,6 +1739,15 @@ static void ValidateFileFields(bool url_is_valid, bool position_is_valid, int64_
 	}
 }
 
+static void ValidateFileFieldType(const LogicalType &actual_type, idx_t field_index, const string &source) {
+	static const auto file_type = FileLogicalType::Create();
+	auto &expected_field = StructType::GetChildTypes(file_type)[field_index];
+	if (actual_type != expected_field.second) {
+		throw InvalidInputException("%s field \"%s\" must have type %s, not %s", source, expected_field.first,
+		                            expected_field.second, actual_type);
+	}
+}
+
 void FileLogicalType::Validate(const Value &value, const string &source) {
 	if (value.IsNull()) {
 		return;
@@ -1748,6 +1757,9 @@ void FileLogicalType::Validate(const Value &value, const string &source) {
 		auto &children = StructValue::GetChildren(value);
 		if (children.size() != FIELD_COUNT) {
 			throw InvalidInputException("%s must contain exactly %llu fields", source, FIELD_COUNT);
+		}
+		for (idx_t field_index = 0; field_index < FIELD_COUNT; field_index++) {
+			ValidateFileFieldType(children[field_index].type(), field_index, source);
 		}
 
 		auto position_is_valid = !children[POSITION].IsNull();
@@ -1807,6 +1819,9 @@ void FileLogicalType::Validate(Vector &value, idx_t count, const string &source)
 	auto &children = StructVector::GetEntries(value);
 	if (children.size() != FIELD_COUNT) {
 		throw InvalidInputException("%s must contain exactly %llu fields", source, FIELD_COUNT);
+	}
+	for (idx_t field_index = 0; field_index < FIELD_COUNT; field_index++) {
+		ValidateFileFieldType(children[field_index]->GetType(), field_index, source);
 	}
 
 	UnifiedVectorFormat value_data;

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1683,6 +1683,37 @@ LogicalType LogicalType::STRUCT(child_list_t<LogicalType> children) {
 	return LogicalType(LogicalTypeId::STRUCT, std::move(info));
 }
 
+LogicalType FileLogicalType::Create() {
+	child_list_t<LogicalType> children;
+	children.reserve(FIELD_COUNT);
+	children.emplace_back("url", LogicalType::VARCHAR);
+	children.emplace_back("content_type", LogicalType::VARCHAR);
+	children.emplace_back("position", LogicalType::BIGINT);
+	children.emplace_back("size", LogicalType::BIGINT);
+	children.emplace_back("checksum", LogicalType::VARCHAR);
+
+	auto result = LogicalType::STRUCT(std::move(children));
+	result.SetAlias(TYPE_NAME);
+	return result;
+}
+
+bool FileLogicalType::IsFile(const LogicalType &type) {
+	if (type.id() != LogicalTypeId::STRUCT || !type.AuxInfo() ||
+	    type.AuxInfo()->type != ExtraTypeInfoType::STRUCT_TYPE_INFO || !type.HasAlias() || type.HasExtensionInfo() ||
+	    type.GetAlias() != TYPE_NAME) {
+		return false;
+	}
+	auto &children = StructType::GetChildTypes(type);
+	if (children.size() != FIELD_COUNT) {
+		return false;
+	}
+	return children[URL].first == "url" && children[URL].second == LogicalType::VARCHAR &&
+	       children[CONTENT_TYPE].first == "content_type" && children[CONTENT_TYPE].second == LogicalType::VARCHAR &&
+	       children[POSITION].first == "position" && children[POSITION].second == LogicalType::BIGINT &&
+	       children[SIZE].first == "size" && children[SIZE].second == LogicalType::BIGINT &&
+	       children[CHECKSUM].first == "checksum" && children[CHECKSUM].second == LogicalType::VARCHAR;
+}
+
 LogicalType LogicalType::AGGREGATE_STATE(aggregate_state_t state_type) { // NOLINT
 	auto info = make_shared_ptr<AggregateStateTypeInfo>(std::move(state_type));
 	return LogicalType(LogicalTypeId::AGGREGATE_STATE, std::move(info));

--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1714,8 +1714,94 @@ bool FileLogicalType::IsFile(const LogicalType &type) {
 	       children[CHECKSUM].first == "checksum" && children[CHECKSUM].second == LogicalType::VARCHAR;
 }
 
+static void ValidateFileFields(bool url_is_valid, bool position_is_valid, int64_t position, bool size_is_valid,
+                               int64_t size, const string *checksum, const string &source) {
+	if (!url_is_valid) {
+		throw InvalidInputException("%s url cannot be NULL", source);
+	}
+	if (position_is_valid != size_is_valid) {
+		throw InvalidInputException("%s position and size must either both be NULL or both be non-NULL", source);
+	}
+	if (position_is_valid) {
+		if (position < 0 || size < 0) {
+			throw InvalidInputException("%s position and size must be non-negative", source);
+		}
+		if (position > NumericLimits<int64_t>::Maximum() - size) {
+			throw InvalidInputException("%s byte range exceeds BIGINT", source);
+		}
+	}
+	if (checksum) {
+		auto separator = checksum->find(':');
+		if (separator == string::npos || separator == 0 || separator + 1 == checksum->size() ||
+		    checksum->find(':', separator + 1) != string::npos) {
+			throw InvalidInputException("%s checksum must have the form <algorithm>:<digest>", source);
+		}
+	}
+}
+
+void FileLogicalType::Validate(const Value &value, const string &source) {
+	if (value.IsNull()) {
+		return;
+	}
+	auto &type = value.type();
+	if (IsFile(type)) {
+		auto &children = StructValue::GetChildren(value);
+		D_ASSERT(children.size() == FIELD_COUNT);
+
+		auto position_is_valid = !children[POSITION].IsNull();
+		auto size_is_valid = !children[SIZE].IsNull();
+		auto position = position_is_valid ? BigIntValue::Get(children[POSITION]) : 0;
+		auto size = size_is_valid ? BigIntValue::Get(children[SIZE]) : 0;
+		const string *checksum = nullptr;
+		if (!children[CHECKSUM].IsNull()) {
+			checksum = &StringValue::Get(children[CHECKSUM]);
+		}
+		ValidateFileFields(!children[URL].IsNull(), position_is_valid, position, size_is_valid, size, checksum, source);
+		return;
+	}
+	if (!TypeVisitor::Contains(type, IsFile)) {
+		return;
+	}
+
+	switch (type.id()) {
+	case LogicalTypeId::STRUCT:
+		for (auto &child : StructValue::GetChildren(value)) {
+			Validate(child, source);
+		}
+		return;
+	case LogicalTypeId::UNION:
+		Validate(UnionValue::GetValue(value), source);
+		return;
+	case LogicalTypeId::LIST:
+		for (auto &child : ListValue::GetChildren(value)) {
+			Validate(child, source);
+		}
+		return;
+	case LogicalTypeId::MAP:
+		for (auto &child : MapValue::GetChildren(value)) {
+			Validate(child, source);
+		}
+		return;
+	case LogicalTypeId::ARRAY:
+		for (auto &child : ArrayValue::GetChildren(value)) {
+			Validate(child, source);
+		}
+		return;
+	default:
+		throw InternalException("Unsupported logical type containing FILE: %s", type.ToString());
+	}
+}
+
 void FileLogicalType::Validate(Vector &value, idx_t count, const string &source) {
-	D_ASSERT(IsFile(value.GetType()));
+	if (!IsFile(value.GetType())) {
+		if (!TypeVisitor::Contains(value.GetType(), IsFile)) {
+			return;
+		}
+		for (idx_t row = 0; row < count; row++) {
+			Validate(value.GetValue(row), source);
+		}
+		return;
+	}
 	auto &children = StructVector::GetEntries(value);
 	D_ASSERT(children.size() == FIELD_COUNT);
 
@@ -1740,37 +1826,21 @@ void FileLogicalType::Validate(Vector &value, idx_t count, const string &source)
 		}
 
 		auto url_index = url_data.sel->get_index(row);
-		if (!url_data.validity.RowIsValid(url_index)) {
-			throw InvalidInputException("%s url cannot be NULL", source);
-		}
-
 		auto position_index = position_data.sel->get_index(row);
 		auto size_index = size_data.sel->get_index(row);
 		auto position_is_valid = position_data.validity.RowIsValid(position_index);
 		auto size_is_valid = size_data.validity.RowIsValid(size_index);
-		if (position_is_valid != size_is_valid) {
-			throw InvalidInputException("%s position and size must either both be NULL or both be non-NULL", source);
-		}
-		if (position_is_valid) {
-			auto position = positions[position_index];
-			auto size = sizes[size_index];
-			if (position < 0 || size < 0) {
-				throw InvalidInputException("%s position and size must be non-negative", source);
-			}
-			if (position > NumericLimits<int64_t>::Maximum() - size) {
-				throw InvalidInputException("%s byte range exceeds BIGINT", source);
-			}
-		}
-
+		auto position = position_is_valid ? positions[position_index] : 0;
+		auto size = size_is_valid ? sizes[size_index] : 0;
 		auto checksum_index = checksum_data.sel->get_index(row);
+		string checksum;
+		const string *checksum_ptr = nullptr;
 		if (checksum_data.validity.RowIsValid(checksum_index)) {
-			auto checksum = checksums[checksum_index].GetString();
-			auto separator = checksum.find(':');
-			if (separator == string::npos || separator == 0 || separator + 1 == checksum.size() ||
-			    checksum.find(':', separator + 1) != string::npos) {
-				throw InvalidInputException("%s checksum must have the form <algorithm>:<digest>", source);
-			}
+			checksum = checksums[checksum_index].GetString();
+			checksum_ptr = &checksum;
 		}
+		ValidateFileFields(url_data.validity.RowIsValid(url_index), position_is_valid, position, size_is_valid, size,
+		                   checksum_ptr, source);
 	}
 }
 

--- a/external/duckdb/src/common/types/value.cpp
+++ b/external/duckdb/src/common/types/value.cpp
@@ -745,6 +745,10 @@ Value Value::TIMESTAMP(int32_t year, int32_t month, int32_t day, int32_t hour, i
 Value Value::STRUCT(const LogicalType &type, vector<Value> struct_values) {
 	Value result;
 	auto child_types = StructType::GetChildTypes(type);
+	if (struct_values.size() != child_types.size()) {
+		throw InvalidInputException("STRUCT value requires %llu fields, but %llu values were provided",
+		                            child_types.size(), struct_values.size());
+	}
 	for (size_t i = 0; i < struct_values.size(); i++) {
 		struct_values[i] = struct_values[i].DefaultCastAs(child_types[i].second);
 	}

--- a/external/duckdb/src/common/types/value.cpp
+++ b/external/duckdb/src/common/types/value.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 #include "duckdb/common/uhugeint.hpp"
 #include "utf8proc_wrapper.hpp"
@@ -773,6 +774,10 @@ Value Value::VARIANT(vector<Value> val) {
 }
 
 void MapKeyCheck(value_set_t &unique_keys, const Value &key) {
+	if (TypeVisitor::Contains(key.type(), FileLogicalType::IsFile)) {
+		throw InvalidInputException("MAP does not support FILE keys");
+	}
+
 	// NULL key check.
 	if (key.IsNull()) {
 		MapVector::EvalMapInvalidReason(MapInvalidReason::NULL_KEY);

--- a/external/duckdb/src/common/types/vector.cpp
+++ b/external/duckdb/src/common/types/vector.cpp
@@ -2409,6 +2409,7 @@ const Vector &MapVector::GetValues(const Vector &vector) {
 
 MapInvalidReason MapVector::CheckMapValidity(Vector &map, idx_t count, const SelectionVector &sel) {
 	D_ASSERT(map.GetType().id() == LogicalTypeId::MAP);
+	const auto has_file_keys = TypeVisitor::Contains(MapType::KeyType(map.GetType()), FileLogicalType::IsFile);
 
 	// unify the MAP vector, which is a physical LIST vector
 	UnifiedVectorFormat map_data;
@@ -2432,6 +2433,9 @@ MapInvalidReason MapVector::CheckMapValidity(Vector &map, idx_t count, const Sel
 		value_set_t unique_keys;
 		auto length = map_entries[map_idx].length;
 		auto offset = map_entries[map_idx].offset;
+		if (has_file_keys && length > 0) {
+			throw InvalidInputException("MAP does not support FILE keys");
+		}
 
 		for (idx_t child_idx = 0; child_idx < length; child_idx++) {
 			auto key_idx = key_data.sel->get_index(offset + child_idx);

--- a/external/duckdb/src/execution/expression_executor/execute_constant.cpp
+++ b/external/duckdb/src/execution/expression_executor/execute_constant.cpp
@@ -14,6 +14,7 @@ unique_ptr<ExpressionState> ExpressionExecutor::InitializeState(const BoundConst
 void ExpressionExecutor::Execute(const BoundConstantExpression &expr, ExpressionState *state,
                                  const SelectionVector *sel, idx_t count, Vector &result) {
 	D_ASSERT(expr.value.type() == expr.return_type);
+	FileLogicalType::Validate(expr.value, "Constant FILE");
 	result.Reference(expr.value);
 }
 

--- a/external/duckdb/src/execution/expression_executor/execute_function.cpp
+++ b/external/duckdb/src/execution/expression_executor/execute_function.cpp
@@ -1,4 +1,3 @@
-#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/common/types/uuid.hpp"
@@ -196,13 +195,7 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	if (!execute_function_state.TryExecuteDictionaryExpression(expr, arguments, *state, result)) {
 		expr.function.GetFunctionCallback()(arguments, *state, result);
 	}
-	if (TypeVisitor::Contains(expr.return_type, FileLogicalType::IsFile)) {
-		if (result.GetType() != expr.return_type) {
-			throw InvalidInputException("Scalar function FILE result has type %s, expected %s", result.GetType(),
-			                            expr.return_type);
-		}
-		FileLogicalType::Validate(result, count, "Scalar function FILE");
-	}
+	FileLogicalType::Validate(result, expr.return_type, count, "Scalar function FILE");
 
 	VerifyNullHandling(expr, arguments, result);
 	D_ASSERT(result.GetType() == expr.return_type);

--- a/external/duckdb/src/execution/expression_executor/execute_function.cpp
+++ b/external/duckdb/src/execution/expression_executor/execute_function.cpp
@@ -196,6 +196,13 @@ void ExpressionExecutor::Execute(const BoundFunctionExpression &expr, Expression
 	if (!execute_function_state.TryExecuteDictionaryExpression(expr, arguments, *state, result)) {
 		expr.function.GetFunctionCallback()(arguments, *state, result);
 	}
+	if (TypeVisitor::Contains(expr.return_type, FileLogicalType::IsFile)) {
+		if (result.GetType() != expr.return_type) {
+			throw InvalidInputException("Scalar function FILE result has type %s, expected %s", result.GetType(),
+			                            expr.return_type);
+		}
+		FileLogicalType::Validate(result, count, "Scalar function FILE");
+	}
 
 	VerifyNullHandling(expr, arguments, result);
 	D_ASSERT(result.GetType() == expr.return_type);

--- a/external/duckdb/src/execution/operator/aggregate/physical_streaming_window.cpp
+++ b/external/duckdb/src/execution/operator/aggregate/physical_streaming_window.cpp
@@ -627,6 +627,7 @@ void PhysicalStreamingWindow::ExecuteFunctions(ExecutionContext &context, DataCh
 		default:
 			throw NotImplementedException("%s for StreamingWindow", ExpressionTypeToString(expr.GetExpressionType()));
 		}
+		FileLogicalType::Validate(result, wexpr.return_type, count, "Window function FILE");
 	}
 	gstate.row_number += NumericCast<int64_t>(count);
 }

--- a/external/duckdb/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
+++ b/external/duckdb/src/execution/operator/aggregate/physical_ungrouped_aggregate.cpp
@@ -673,6 +673,8 @@ void GlobalUngroupedAggregateState::Finalize(DataChunk &result, idx_t column_off
 		AggregateInputData aggr_input_data(aggregate.bind_info.get(), allocator);
 		aggregate.function.GetStateFinalizeCallback()(state_vector, aggr_input_data,
 		                                              result.data[column_offset + aggr_idx], 1, 0);
+		FileLogicalType::Validate(result.data[column_offset + aggr_idx], aggregate.return_type, 1,
+		                          "Aggregate function FILE");
 	}
 }
 

--- a/external/duckdb/src/execution/operator/exchange/repartition.cpp
+++ b/external/duckdb/src/execution/operator/exchange/repartition.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/execution/operator/exchange/repartition.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 #include <algorithm>
 #include <cstring>
@@ -19,6 +20,9 @@ void ValidateRangeOrders(const vector<BoundOrderByNode> &orders) {
 	for (const auto &order : orders) {
 		if (!order.expression) {
 			throw InvalidInputException("range repartition order expression cannot be null");
+		}
+		if (TypeVisitor::Contains(order.expression->return_type, FileLogicalType::IsFile)) {
+			throw InvalidInputException("range repartition does not support FILE values");
 		}
 		if (order.type != OrderType::ASCENDING && order.type != OrderType::DESCENDING) {
 			throw InvalidInputException("range repartition requires explicit ASC or DESC order");
@@ -60,6 +64,11 @@ std::vector<ExprRef> CopyRangeExpressions(const vector<BoundOrderByNode> &orders
 
 HashRepartitionConfig::HashRepartitionConfig(size_t num_partitions, std::vector<ExprRef> by)
     : num_partitions(num_partitions), by(std::move(by)) {
+	for (const auto &expression : this->by) {
+		if (expression && TypeVisitor::Contains(expression->return_type, FileLogicalType::IsFile)) {
+			throw InvalidInputException("hash repartition does not support FILE values");
+		}
+	}
 }
 
 std::vector<std::string> HashRepartitionConfig::multiline_display() const {

--- a/external/duckdb/src/execution/operator/projection/physical_pivot.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_pivot.cpp
@@ -30,6 +30,7 @@ static void InitializePivotDataForPhysicalPivot(PhysicalPivot &pivot, PhysicalPl
 		Vector result_vector(aggr_expr->return_type);
 		AggregateInputData aggr_input_data(aggr.bind_info.get(), physical_plan.ArenaRef());
 		aggr.function.GetStateFinalizeCallback()(state_vector, aggr_input_data, result_vector, 1, 0);
+		FileLogicalType::Validate(result_vector, aggr.return_type, 1, "Aggregate function FILE");
 		pivot.empty_aggregates.push_back(result_vector.GetValue(0));
 	}
 }

--- a/external/duckdb/src/execution/operator/projection/physical_projection.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_projection.cpp
@@ -8,6 +8,7 @@
 #include "duckdb/execution/external_block.hpp"
 #include "duckdb/parallel/thread_context.hpp"
 #include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -100,6 +101,10 @@ unique_ptr<LazyDataChunk> MakeStructExtractProjection(const LazyDataChunk &input
 		return nullptr;
 	}
 	auto &struct_type = input.logical_types[0];
+	if (TypeVisitor::Contains(struct_type, FileLogicalType::IsFile)) {
+		// FILE extraction must execute its bound callback so root validity masks hidden child values.
+		return nullptr;
+	}
 	vector<LogicalType> raw_types;
 	vector<string> raw_names;
 	auto child_count = StructType::GetChildCount(struct_type);

--- a/external/duckdb/src/execution/operator/projection/physical_tableinout_function.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_tableinout_function.cpp
@@ -8,10 +8,34 @@
 
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/limits.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/function_serialization.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
 namespace duckdb {
+
+static void ValidateTableFunctionFileBatch(ExecutionBatch &batch, const vector<LogicalType> &types) {
+	bool contains_file = false;
+	for (auto &type : types) {
+		if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+			contains_file = true;
+			break;
+		}
+	}
+	if (!contains_file) {
+		return;
+	}
+	if (batch.kind != ExecutionBatchKind::MATERIALIZED_CHUNK) {
+		throw InvalidInputException("Table function FILE batch output must be materialized");
+	}
+	if (!batch.materialized) {
+		if (batch.rows > 0) {
+			throw InvalidInputException("Table function FILE batch output has rows but no materialized payload");
+		}
+		return;
+	}
+	FileLogicalType::Validate(*batch.materialized, types, "Table function FILE");
+}
 
 static void ReferenceOrCast(ExecutionContext &context, Vector &target, Vector &source, idx_t position, idx_t count) {
 	if (target.GetType() == source.GetType()) {
@@ -122,6 +146,7 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 			SetOrdinality(chunk, this->ordinality_idx, state.current_ordinality_idx, ordinality);
 			state.current_ordinality_idx += ordinality;
 		}
+		FileLogicalType::Validate(chunk, types, "Table function FILE");
 		return result;
 	}
 	// when project_input is set we execute the input function row-by-row
@@ -159,6 +184,7 @@ OperatorResultType PhysicalTableInOutFunction::Execute(ExecutionContext &context
 		SetOrdinality(chunk, this->ordinality_idx, state.current_ordinality_idx, ordinality);
 		state.current_ordinality_idx += ordinality;
 	}
+	FileLogicalType::Validate(chunk, types, "Table function FILE");
 	if (result == OperatorResultType::FINISHED) {
 		return result;
 	}
@@ -181,7 +207,9 @@ OperatorResultType PhysicalTableInOutFunction::ExecuteBatch(ExecutionContext &co
 	auto &gstate = gstate_p.Cast<TableInOutGlobalState>();
 	auto &state = state_p.Cast<TableInOutLocalState>();
 	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
-	return function.in_out_function_batch(context, data, input, output);
+	auto result = function.in_out_function_batch(context, data, input, output);
+	ValidateTableFunctionFileBatch(output, types);
+	return result;
 }
 
 ExecutionBatchRequirement PhysicalTableInOutFunction::GetExecutionBatchRequirement(PipelineOperatorRole role) const {
@@ -239,6 +267,7 @@ OperatorFinalizeResultType PhysicalTableInOutFunction::FinalExecute(ExecutionCon
 	}
 	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
 	auto result = function.in_out_function_final(context, data, chunk);
+	FileLogicalType::Validate(chunk, types, "Table function FILE");
 	return result;
 }
 
@@ -252,7 +281,9 @@ OperatorFinalizeResultType PhysicalTableInOutFunction::FinalExecuteBatch(Executi
 	auto &gstate = gstate_p.Cast<TableInOutGlobalState>();
 	auto &state = state_p.Cast<TableInOutLocalState>();
 	TableFunctionInput data(bind_data.get(), state.local_state.get(), gstate.global_state.get());
-	return function.in_out_function_final_batch(context, data, batch);
+	auto result = function.in_out_function_final_batch(context, data, batch);
+	ValidateTableFunctionFileBatch(batch, types);
+	return result;
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
+++ b/external/duckdb/src/execution/operator/projection/physical_udf_inout.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/udf_executor.hpp"
 #include "duckdb/execution/execution_context.hpp"
 #include "duckdb/execution/external_block.hpp"
@@ -3408,6 +3409,12 @@ static LogicalType UDFTableFunctionSerializationReturnType(const LogicalType &re
 	return return_type == LogicalType::VARCHAR ? LogicalType::BIGINT : LogicalType::VARCHAR;
 }
 
+static void RejectFileTableUDFType(const LogicalType &type) {
+	if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+		throw BinderException("FILE inputs and outputs are not supported by Python UDFs yet");
+	}
+}
+
 static void UDFTableFunctionSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data,
                                       const TableFunction &) {
 	if (!bind_data) {
@@ -3428,6 +3435,8 @@ static unique_ptr<FunctionData> UDFTableFunctionDeserialize(Deserializer &deseri
 	auto payload = deserializer.ReadProperty<Value>(101, "payload");
 	auto return_type = deserializer.ReadProperty<LogicalType>(102, "return_type");
 	auto payload_return_type = udf_helpers::ResolvePayloadReturnType(payload);
+	RejectFileTableUDFType(return_type);
+	RejectFileTableUDFType(payload_return_type);
 	if (payload_return_type != return_type) {
 		throw SerializationException("udf: serialized return type '%s' does not match payload return type '%s'",
 		                             return_type.ToString(), payload_return_type.ToString());
@@ -3508,6 +3517,12 @@ static unique_ptr<FunctionData> UDFRegisteredBind(ClientContext &context, TableF
 	auto &info = input.info->Cast<UDFTableInfo>();
 	return_types = info.output_types;
 	return_names = info.output_names;
+	for (auto &input_type : input.input_table_types) {
+		RejectFileTableUDFType(input_type);
+	}
+	for (auto &return_type : return_types) {
+		RejectFileTableUDFType(return_type);
+	}
 
 	LogicalType return_type;
 	if (return_types.size() == 1) {

--- a/external/duckdb/src/execution/operator/scan/physical_table_scan.cpp
+++ b/external/duckdb/src/execution/operator/scan/physical_table_scan.cpp
@@ -191,6 +191,7 @@ SourceResultType PhysicalTableScan::GetDataInternal(ExecutionContext &context, D
 		// inconsistencies
 		ValidateAsyncStrategyResult(execution_strategy, input_execution_mode, data.results_execution_mode,
 		                            initial_async_result, output_async_result, chunk.size());
+		FileLogicalType::Validate(chunk, types, "Table function FILE");
 
 		// Handle results
 		switch (output_async_result) {
@@ -222,8 +223,11 @@ SourceResultType PhysicalTableScan::GetDataInternal(ExecutionContext &context, D
 
 	if (g_state.in_out_final) {
 		function.in_out_function_final(context, data, chunk);
+		FileLogicalType::Validate(chunk, types, "Table function FILE");
 	}
-	switch (function.in_out_function(context, data, g_state.input_chunk, chunk)) {
+	auto in_out_result = function.in_out_function(context, data, g_state.input_chunk, chunk);
+	FileLogicalType::Validate(chunk, types, "Table function FILE");
+	switch (in_out_result) {
 	case OperatorResultType::BLOCKED: {
 		auto guard = g_state.Lock();
 		return g_state.BlockSource(guard, input.interrupt_state);
@@ -236,6 +240,7 @@ SourceResultType PhysicalTableScan::GetDataInternal(ExecutionContext &context, D
 
 	if (chunk.size() == 0 && function.in_out_function_final) {
 		function.in_out_function_final(context, data, chunk);
+		FileLogicalType::Validate(chunk, types, "Table function FILE");
 		g_state.in_out_final = true;
 	}
 	return chunk.size() == 0 ? SourceResultType::FINISHED : SourceResultType::HAVE_MORE_OUTPUT;

--- a/external/duckdb/src/execution/radix_partitioned_hashtable.cpp
+++ b/external/duckdb/src/execution/radix_partitioned_hashtable.cpp
@@ -1012,6 +1012,8 @@ SourceResultType RadixPartitionedHashTable::GetData(ExecutionContext &context, D
 				if (aggr.function.HasStateDestructorCallback()) {
 					aggr.function.GetStateDestructorCallback()(state_vector, aggr_input_data, 1);
 				}
+				FileLogicalType::Validate(chunk.data[null_groups.size() + i], aggr.return_type, 1,
+				                          "Aggregate function FILE");
 			}
 			// Place the grouping values (all the groups of the grouping_set condensed into a single value)
 			// Behind the null groups + aggregates

--- a/external/duckdb/src/function/aggregate/distributive/minmax.cpp
+++ b/external/duckdb/src/function/aggregate/distributive/minmax.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/operator/comparison_operators.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/null_value.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
@@ -333,6 +334,9 @@ static AggregateFunction GetMinMaxOperator(const LogicalType &type) {
 template <class OP, class OP_STRING, class OP_VECTOR>
 unique_ptr<FunctionData> BindMinMax(ClientContext &context, AggregateFunction &function,
                                     vector<unique_ptr<Expression>> &arguments) {
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("%s does not support FILE values", function.name);
+	}
 	// We should also push collations for non-VARCHAR here, but we aren't ready for it yet (see internal #8704)
 	const auto collation = arguments[0]->return_type.id() == LogicalTypeId::VARCHAR &&
 	                       (!StringType::GetCollation(arguments[0]->return_type).empty() ||
@@ -518,6 +522,9 @@ void SpecializeMinMaxNFunction(PhysicalType arg_type, AggregateFunction &functio
 template <class COMPARATOR>
 unique_ptr<FunctionData> MinMaxNBind(ClientContext &context, AggregateFunction &function,
                                      vector<unique_ptr<Expression>> &arguments) {
+	if (TypeVisitor::Contains(arguments[0]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("%s does not support FILE values", function.name);
+	}
 	for (auto &arg : arguments) {
 		if (arg->return_type.id() == LogicalTypeId::UNKNOWN) {
 			throw ParameterNotResolvedException();

--- a/external/duckdb/src/function/cast/cast_function_set.cpp
+++ b/external/duckdb/src/function/cast/cast_function_set.cpp
@@ -10,6 +10,8 @@
 #include "duckdb/main/settings.hpp"
 
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/type_map.hpp"
 #include "duckdb/function/cast_rules.hpp"
 #include "duckdb/planner/collation_binding.hpp"
@@ -56,14 +58,89 @@ CollationBinding &CollationBinding::Get(DatabaseInstance &db) {
 	return DBConfig::GetConfig(db).GetCollationBinding();
 }
 
+static bool FileCastPreservesIdentity(const LogicalType &source, const LogicalType &target) {
+	const auto source_is_file = FileLogicalType::IsFile(source);
+	const auto target_is_file = FileLogicalType::IsFile(target);
+	if (source_is_file || target_is_file) {
+		return (source_is_file && target_is_file) || (source.id() == LogicalTypeId::SQLNULL && target_is_file);
+	}
+
+	const auto source_contains_file = TypeVisitor::Contains(source, FileLogicalType::IsFile);
+	const auto target_contains_file = TypeVisitor::Contains(target, FileLogicalType::IsFile);
+	if (!source_contains_file && !target_contains_file) {
+		return true;
+	}
+	if (source.id() == LogicalTypeId::SQLNULL) {
+		return true;
+	}
+
+	const auto source_is_sequence = source.id() == LogicalTypeId::LIST || source.id() == LogicalTypeId::ARRAY;
+	const auto target_is_sequence = target.id() == LogicalTypeId::LIST || target.id() == LogicalTypeId::ARRAY;
+	if (source_is_sequence || target_is_sequence) {
+		if (!source_is_sequence || !target_is_sequence) {
+			return false;
+		}
+		auto &source_child =
+		    source.id() == LogicalTypeId::LIST ? ListType::GetChildType(source) : ArrayType::GetChildType(source);
+		auto &target_child =
+		    target.id() == LogicalTypeId::LIST ? ListType::GetChildType(target) : ArrayType::GetChildType(target);
+		return FileCastPreservesIdentity(source_child, target_child);
+	}
+
+	if (source.id() == LogicalTypeId::MAP || target.id() == LogicalTypeId::MAP) {
+		if (source.id() != LogicalTypeId::MAP || target.id() != LogicalTypeId::MAP) {
+			return false;
+		}
+		return FileCastPreservesIdentity(MapType::KeyType(source), MapType::KeyType(target)) &&
+		       FileCastPreservesIdentity(MapType::ValueType(source), MapType::ValueType(target));
+	}
+
+	if (source.id() != LogicalTypeId::STRUCT || target.id() != LogicalTypeId::STRUCT) {
+		return false;
+	}
+	auto &source_children = StructType::GetChildTypes(source);
+	auto &target_children = StructType::GetChildTypes(target);
+	if (StructType::IsUnnamed(source) || StructType::IsUnnamed(target)) {
+		if (source_children.size() != target_children.size()) {
+			return false;
+		}
+		for (idx_t child_index = 0; child_index < source_children.size(); child_index++) {
+			if (!FileCastPreservesIdentity(source_children[child_index].second, target_children[child_index].second)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	for (auto &source_child : source_children) {
+		optional_idx target_index;
+		for (idx_t child_index = 0; child_index < target_children.size(); child_index++) {
+			if (StringUtil::CIEquals(source_child.first, target_children[child_index].first)) {
+				target_index = child_index;
+				break;
+			}
+		}
+		if (!target_index.IsValid()) {
+			if (TypeVisitor::Contains(source_child.second, FileLogicalType::IsFile)) {
+				return false;
+			}
+			continue;
+		}
+		if (!FileCastPreservesIdentity(source_child.second, target_children[target_index.GetIndex()].second)) {
+			return false;
+		}
+	}
+	// Target-only fields are populated with NULL by DuckDB's named STRUCT cast. A target-only FILE is therefore a
+	// valid root-NULL FILE rather than a constructor bypass.
+	return true;
+}
+
 BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const LogicalType &target,
                                                GetCastFunctionInput &get_input) {
 	if (source == target) {
 		return DefaultCasts::NopCast;
 	}
-	const auto source_is_file = FileLogicalType::IsFile(source);
-	const auto target_is_file = FileLogicalType::IsFile(target);
-	if (source_is_file != target_is_file && source.id() != LogicalTypeId::SQLNULL) {
+	if (!FileCastPreservesIdentity(source, target)) {
 		throw BinderException(get_input.query_location, "Cannot cast %s to %s", source.ToString(), target.ToString());
 	}
 	// the first function is the default

--- a/external/duckdb/src/function/cast/cast_function_set.cpp
+++ b/external/duckdb/src/function/cast/cast_function_set.cpp
@@ -59,12 +59,13 @@ CollationBinding &CollationBinding::Get(DatabaseInstance &db) {
 }
 
 static bool FileCastPreservesIdentity(const LogicalType &source, const LogicalType &target) {
-	const auto source_is_file = FileLogicalType::IsFile(source);
-	const auto target_is_file = FileLogicalType::IsFile(target);
-	if (source_is_file || target_is_file) {
-		return (source_is_file && target_is_file) || (source.id() == LogicalTypeId::SQLNULL && target_is_file);
+	// ANY and TEMPLATE are binder placeholders that resolve to the source type rather than executable casts.
+	if (target.id() == LogicalTypeId::ANY || target.id() == LogicalTypeId::TEMPLATE) {
+		return true;
 	}
 
+	const auto source_is_file = FileLogicalType::IsFile(source);
+	const auto target_is_file = FileLogicalType::IsFile(target);
 	const auto source_contains_file = TypeVisitor::Contains(source, FileLogicalType::IsFile);
 	const auto target_contains_file = TypeVisitor::Contains(target, FileLogicalType::IsFile);
 	if (!source_contains_file && !target_contains_file) {
@@ -72,6 +73,49 @@ static bool FileCastPreservesIdentity(const LogicalType &source, const LogicalTy
 	}
 	if (source.id() == LogicalTypeId::SQLNULL) {
 		return true;
+	}
+	if (target.IsNested() && !target.AuxInfo()) {
+		// Generic nested function arguments are resolved to the concrete source type by their bind callbacks. FILE
+		// itself must still use its dedicated overload instead of matching a generic STRUCT argument.
+		return source.id() == target.id() && !source_is_file;
+	}
+	if (source.IsNested() && !source.AuxInfo()) {
+		return false;
+	}
+
+	if (source.id() == LogicalTypeId::UNION && target.id() == LogicalTypeId::UNION) {
+		for (idx_t source_index = 0; source_index < UnionType::GetMemberCount(source); source_index++) {
+			auto &source_name = UnionType::GetMemberName(source, source_index);
+			optional_idx target_index;
+			for (idx_t candidate_index = 0; candidate_index < UnionType::GetMemberCount(target); candidate_index++) {
+				if (StringUtil::CIEquals(source_name, UnionType::GetMemberName(target, candidate_index))) {
+					target_index = candidate_index;
+					break;
+				}
+			}
+			if (!target_index.IsValid() ||
+			    !FileCastPreservesIdentity(UnionType::GetMemberType(source, source_index),
+			                               UnionType::GetMemberType(target, target_index.GetIndex()))) {
+				return false;
+			}
+		}
+		// Target-only members can never be selected by a value from the source UNION.
+		return true;
+	}
+	if (target.id() == LogicalTypeId::UNION) {
+		for (idx_t target_index = 0; target_index < UnionType::GetMemberCount(target); target_index++) {
+			if (FileCastPreservesIdentity(source, UnionType::GetMemberType(target, target_index))) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (source.id() == LogicalTypeId::UNION) {
+		return false;
+	}
+
+	if (source_is_file || target_is_file) {
+		return source_is_file && target_is_file;
 	}
 
 	const auto source_is_sequence = source.id() == LogicalTypeId::LIST || source.id() == LogicalTypeId::ARRAY;
@@ -258,6 +302,9 @@ private:
 
 int64_t CastFunctionSet::ImplicitCastCost(optional_ptr<ClientContext> context, const LogicalType &source,
                                           const LogicalType &target) {
+	if (!FileCastPreservesIdentity(source, target)) {
+		return -1;
+	}
 	// check if a cast has been registered
 	if (map_info) {
 		auto entry = map_info->GetEntry(source, target);

--- a/external/duckdb/src/function/cast/cast_function_set.cpp
+++ b/external/duckdb/src/function/cast/cast_function_set.cpp
@@ -1,5 +1,12 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/function/cast/cast_function_set.hpp"
 
+#include "duckdb/common/exception/binder_exception.hpp"
 #include "duckdb/main/settings.hpp"
 
 #include "duckdb/common/pair.hpp"
@@ -53,6 +60,11 @@ BoundCastInfo CastFunctionSet::GetCastFunction(const LogicalType &source, const 
                                                GetCastFunctionInput &get_input) {
 	if (source == target) {
 		return DefaultCasts::NopCast;
+	}
+	const auto source_is_file = FileLogicalType::IsFile(source);
+	const auto target_is_file = FileLogicalType::IsFile(target);
+	if (source_is_file != target_is_file && source.id() != LogicalTypeId::SQLNULL) {
+		throw BinderException(get_input.query_location, "Cannot cast %s to %s", source.ToString(), target.ToString());
 	}
 	// the first function is the default
 	// we iterate the set of bind functions backwards

--- a/external/duckdb/src/function/cast_rules.cpp
+++ b/external/duckdb/src/function/cast_rules.cpp
@@ -363,6 +363,10 @@ int64_t CastRules::ImplicitCast(const LogicalType &from, const LogicalType &to) 
 		// NULL expression can be cast to anything
 		return TargetTypeCost(to);
 	}
+	if (to.id() == LogicalTypeId::SQLNULL) {
+		// SQLNULL function arguments are exact overloads for untyped NULL, not implicit cast targets.
+		return -1;
+	}
 	if (from.id() == LogicalTypeId::ANY && to.IsTemplated()) {
 		// This can happen when changing a function from using ANY to using TEMPLATE.
 		return TargetTypeCost(to);

--- a/external/duckdb/src/function/function.cpp
+++ b/external/duckdb/src/function/function.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/function/built_in_functions.hpp"
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table/datasource_scan.hpp"
@@ -17,6 +18,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/main/extension_entries.hpp"
 #include "duckdb/execution/operator/projection/physical_udf_inout.hpp"
+#include "duckdb/parser/parsed_data/create_type_info.hpp"
 
 namespace duckdb {
 
@@ -101,6 +103,14 @@ string BaseScalarFunction::ToString() const {
 
 // add your initializer for new functions here
 void BuiltinFunctions::Initialize() {
+	CreateTypeInfo file_type_info(FileLogicalType::TYPE_NAME, FileLogicalType::Create());
+	file_type_info.internal = true;
+	file_type_info.temporary = true;
+	catalog.CreateType(transaction, file_type_info);
+	for (auto &function : FileFunctions::GetFunctions()) {
+		AddFunction(std::move(function));
+	}
+
 	RegisterTableScanFunctions();
 	RegisterSQLiteFunctions();
 	RegisterReadFunctions();

--- a/external/duckdb/src/function/function_list.cpp
+++ b/external/duckdb/src/function/function_list.cpp
@@ -183,7 +183,7 @@ static const StaticFunctionDefinition function[] = {
 	DUCKDB_SCALAR_FUNCTION(StructConcatFun),
 	DUCKDB_SCALAR_FUNCTION(StructContainsFun),
 	DUCKDB_SCALAR_FUNCTION_SET(StructExtractFun),
-	DUCKDB_SCALAR_FUNCTION(StructExtractAtFun),
+	DUCKDB_SCALAR_FUNCTION_SET(StructExtractAtFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(StructHasFun),
 	DUCKDB_SCALAR_FUNCTION_ALIAS(StructIndexofFun),
 	DUCKDB_SCALAR_FUNCTION(StructPackFun),

--- a/external/duckdb/src/function/scalar/CMakeLists.txt
+++ b/external/duckdb/src/function/scalar/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library_unity(
   OBJECT
   compressed_materialization_utils.cpp
   create_sort_key.cpp
+  file.cpp
   strftime_format.cpp
   nested_functions.cpp
   pragma_functions.cpp

--- a/external/duckdb/src/function/scalar/create_sort_key.cpp
+++ b/external/duckdb/src/function/scalar/create_sort_key.cpp
@@ -824,6 +824,9 @@ unique_ptr<FunctionData> DecodeSortKeyBind(ClientContext &context, ScalarFunctio
 		const auto &col_def = col_list.GetColumn(PhysicalIndex(0));
 		const auto &col_name = col_def.GetName();
 		const auto &col_type = TransformStringToLogicalType(col_def.GetType().ToString(), context);
+		if (TypeVisitor::Contains(col_type, FileLogicalType::IsFile)) {
+			throw BinderException("decode_sort_key does not support FILE values");
+		}
 
 		// Keep track of this to validate the arguments
 		const auto physical_type = col_type.InternalType();

--- a/external/duckdb/src/function/scalar/create_sort_key.cpp
+++ b/external/duckdb/src/function/scalar/create_sort_key.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/enums/order_type.hpp"
 #include "duckdb/common/radix.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -49,6 +50,9 @@ unique_ptr<FunctionData> CreateSortKeyBind(ClientContext &context, ScalarFunctio
 	bool all_constant = true;
 	idx_t constant_size = 0;
 	for (idx_t i = 0; i < arguments.size(); i += 2) {
+		if (TypeVisitor::Contains(arguments[i]->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("create_sort_key does not support FILE values");
+		}
 		auto physical_type = arguments[i]->return_type.InternalType();
 		if (!TypeIsConstantSize(physical_type)) {
 			all_constant = false;

--- a/external/duckdb/src/function/scalar/file.cpp
+++ b/external/duckdb/src/function/scalar/file.cpp
@@ -11,7 +11,7 @@
 #include "duckdb/function/scalar/file_functions.hpp"
 
 #include "duckdb/common/exception.hpp"
-#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
@@ -19,58 +19,8 @@ namespace duckdb {
 
 namespace {
 
-static void ValidateFileArguments(DataChunk &args) {
-	UnifiedVectorFormat url_data;
-	UnifiedVectorFormat position_data;
-	UnifiedVectorFormat size_data;
-	UnifiedVectorFormat checksum_data;
-	args.data[FileLogicalType::URL].ToUnifiedFormat(args.size(), url_data);
-	args.data[FileLogicalType::POSITION].ToUnifiedFormat(args.size(), position_data);
-	args.data[FileLogicalType::SIZE].ToUnifiedFormat(args.size(), size_data);
-	args.data[FileLogicalType::CHECKSUM].ToUnifiedFormat(args.size(), checksum_data);
-
-	auto positions = UnifiedVectorFormat::GetData<int64_t>(position_data);
-	auto sizes = UnifiedVectorFormat::GetData<int64_t>(size_data);
-	auto checksums = UnifiedVectorFormat::GetData<string_t>(checksum_data);
-	for (idx_t row = 0; row < args.size(); row++) {
-		auto url_index = url_data.sel->get_index(row);
-		if (!url_data.validity.RowIsValid(url_index)) {
-			throw InvalidInputException("file() url cannot be NULL");
-		}
-
-		auto position_index = position_data.sel->get_index(row);
-		auto size_index = size_data.sel->get_index(row);
-		auto position_is_valid = position_data.validity.RowIsValid(position_index);
-		auto size_is_valid = size_data.validity.RowIsValid(size_index);
-		if (position_is_valid != size_is_valid) {
-			throw InvalidInputException("file() position and size must either both be NULL or both be non-NULL");
-		}
-		if (position_is_valid) {
-			auto position = positions[position_index];
-			auto size = sizes[size_index];
-			if (position < 0 || size < 0) {
-				throw InvalidInputException("file() position and size must be non-negative");
-			}
-			if (position > NumericLimits<int64_t>::Maximum() - size) {
-				throw InvalidInputException("file() byte range exceeds BIGINT");
-			}
-		}
-
-		auto checksum_index = checksum_data.sel->get_index(row);
-		if (checksum_data.validity.RowIsValid(checksum_index)) {
-			auto checksum = checksums[checksum_index].GetString();
-			auto separator = checksum.find(':');
-			if (separator == string::npos || separator == 0 || separator + 1 == checksum.size() ||
-			    checksum.find(':', separator + 1) != string::npos) {
-				throw InvalidInputException("file() checksum must have the form <algorithm>:<digest>");
-			}
-		}
-	}
-}
-
 static void FileConstructorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	D_ASSERT(args.ColumnCount() == FileLogicalType::FIELD_COUNT);
-	ValidateFileArguments(args);
 
 	bool all_constant = true;
 	auto &children = StructVector::GetEntries(result);
@@ -81,6 +31,7 @@ static void FileConstructorFunction(DataChunk &args, ExpressionState &state, Vec
 		children[index]->Reference(args.data[index]);
 	}
 	result.SetVectorType(all_constant ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
+	FileLogicalType::Validate(result, args.size(), "file()");
 	result.Verify(args.size());
 }
 
@@ -144,6 +95,28 @@ static ScalarFunction GetFileComparison() {
 }
 
 } // namespace
+
+unique_ptr<FunctionData> BindFileCollectionSearch(ClientContext &, ScalarFunction &,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	for (auto &argument : arguments) {
+		if (TypeVisitor::Contains(argument->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("Collection search functions do not support FILE values");
+		}
+	}
+	return nullptr;
+}
+
+unique_ptr<FunctionData> BindFileMapSearch(ClientContext &, ScalarFunction &,
+                                           vector<unique_ptr<Expression>> &arguments) {
+	D_ASSERT(arguments.size() == 2);
+	auto &map_type = arguments[0]->return_type;
+	if ((map_type.id() == LogicalTypeId::MAP &&
+	     TypeVisitor::Contains(MapType::KeyType(map_type), FileLogicalType::IsFile)) ||
+	    TypeVisitor::Contains(arguments[1]->return_type, FileLogicalType::IsFile)) {
+		throw BinderException("Collection search functions do not support FILE values");
+	}
+	return nullptr;
+}
 
 vector<ScalarFunction> FileFunctions::GetFunctions() {
 	vector<ScalarFunction> result;

--- a/external/duckdb/src/function/scalar/file.cpp
+++ b/external/duckdb/src/function/scalar/file.cpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar/file.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "duckdb/function/scalar/file_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static void ValidateFileArguments(DataChunk &args) {
+	UnifiedVectorFormat url_data;
+	UnifiedVectorFormat position_data;
+	UnifiedVectorFormat size_data;
+	UnifiedVectorFormat checksum_data;
+	args.data[FileLogicalType::URL].ToUnifiedFormat(args.size(), url_data);
+	args.data[FileLogicalType::POSITION].ToUnifiedFormat(args.size(), position_data);
+	args.data[FileLogicalType::SIZE].ToUnifiedFormat(args.size(), size_data);
+	args.data[FileLogicalType::CHECKSUM].ToUnifiedFormat(args.size(), checksum_data);
+
+	auto positions = UnifiedVectorFormat::GetData<int64_t>(position_data);
+	auto sizes = UnifiedVectorFormat::GetData<int64_t>(size_data);
+	auto checksums = UnifiedVectorFormat::GetData<string_t>(checksum_data);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto url_index = url_data.sel->get_index(row);
+		if (!url_data.validity.RowIsValid(url_index)) {
+			throw InvalidInputException("file() url cannot be NULL");
+		}
+
+		auto position_index = position_data.sel->get_index(row);
+		auto size_index = size_data.sel->get_index(row);
+		auto position_is_valid = position_data.validity.RowIsValid(position_index);
+		auto size_is_valid = size_data.validity.RowIsValid(size_index);
+		if (position_is_valid != size_is_valid) {
+			throw InvalidInputException("file() position and size must either both be NULL or both be non-NULL");
+		}
+		if (position_is_valid) {
+			auto position = positions[position_index];
+			auto size = sizes[size_index];
+			if (position < 0 || size < 0) {
+				throw InvalidInputException("file() position and size must be non-negative");
+			}
+			if (position > NumericLimits<int64_t>::Maximum() - size) {
+				throw InvalidInputException("file() byte range exceeds BIGINT");
+			}
+		}
+
+		auto checksum_index = checksum_data.sel->get_index(row);
+		if (checksum_data.validity.RowIsValid(checksum_index)) {
+			auto checksum = checksums[checksum_index].GetString();
+			auto separator = checksum.find(':');
+			if (separator == string::npos || separator == 0 || separator + 1 == checksum.size() ||
+			    checksum.find(':', separator + 1) != string::npos) {
+				throw InvalidInputException("file() checksum must have the form <algorithm>:<digest>");
+			}
+		}
+	}
+}
+
+static void FileConstructorFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == FileLogicalType::FIELD_COUNT);
+	ValidateFileArguments(args);
+
+	bool all_constant = true;
+	auto &children = StructVector::GetEntries(result);
+	for (idx_t index = 0; index < args.ColumnCount(); index++) {
+		if (args.data[index].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			all_constant = false;
+		}
+		children[index]->Reference(args.data[index]);
+	}
+	result.SetVectorType(all_constant ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
+	result.Verify(args.size());
+}
+
+template <bool NEGATE>
+static void FileComparisonFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &left_children = StructVector::GetEntries(args.data[0]);
+	auto &right_children = StructVector::GetEntries(args.data[1]);
+	D_ASSERT(left_children.size() == FileLogicalType::FIELD_COUNT);
+	D_ASSERT(right_children.size() == FileLogicalType::FIELD_COUNT);
+
+	for (idx_t index = 0; index < FileLogicalType::FIELD_COUNT; index++) {
+		Vector field_equal(LogicalType::BOOLEAN);
+		VectorOperations::Equals(*left_children[index], *right_children[index], field_equal, args.size());
+		if (index == 0) {
+			result.Reference(field_equal);
+		} else {
+			Vector conjunction(LogicalType::BOOLEAN);
+			VectorOperations::And(field_equal, result, conjunction, args.size());
+			result.Reference(conjunction);
+		}
+	}
+
+	if (NEGATE) {
+		Vector negated_result(LogicalType::BOOLEAN);
+		VectorOperations::Not(result, negated_result, args.size());
+		result.Reference(negated_result);
+	}
+
+	UnifiedVectorFormat left_data;
+	UnifiedVectorFormat right_data;
+	args.data[0].ToUnifiedFormat(args.size(), left_data);
+	args.data[1].ToUnifiedFormat(args.size(), right_data);
+	if (!left_data.validity.AllValid() || !right_data.validity.AllValid()) {
+		result.Flatten(args.size());
+		auto &result_validity = FlatVector::Validity(result);
+		for (idx_t row = 0; row < args.size(); row++) {
+			auto left_index = left_data.sel->get_index(row);
+			auto right_index = right_data.sel->get_index(row);
+			if (!left_data.validity.RowIsValid(left_index) || !right_data.validity.RowIsValid(right_index)) {
+				result_validity.SetInvalid(row);
+			}
+		}
+	}
+}
+
+static ScalarFunction GetFileConstructor() {
+	vector<LogicalType> arguments {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::BIGINT,
+	                               LogicalType::VARCHAR};
+	ScalarFunction function("file", std::move(arguments), FileLogicalType::Create(), FileConstructorFunction);
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	function.SetFallible();
+	return function;
+}
+
+template <bool NEGATE>
+static ScalarFunction GetFileComparison() {
+	auto file_type = FileLogicalType::Create();
+	auto name = NEGATE ? FileLogicalType::NOT_EQUAL_FUNCTION_NAME : FileLogicalType::EQUAL_FUNCTION_NAME;
+	return ScalarFunction(name, {file_type, file_type}, LogicalType::BOOLEAN, FileComparisonFunction<NEGATE>);
+}
+
+} // namespace
+
+vector<ScalarFunction> FileFunctions::GetFunctions() {
+	vector<ScalarFunction> result;
+	result.push_back(GetFileConstructor());
+	result.push_back(GetFileComparison<false>());
+	result.push_back(GetFileComparison<true>());
+	return result;
+}
+
+} // namespace duckdb

--- a/external/duckdb/src/function/scalar/list/contains_or_position.cpp
+++ b/external/duckdb/src/function/scalar/list/contains_or_position.cpp
@@ -1,21 +1,11 @@
 #include "duckdb/function/scalar/list_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
-#include "duckdb/common/type_visitor.hpp"
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 
 namespace duckdb {
-
-static unique_ptr<FunctionData> ListSearchBind(ClientContext &, ScalarFunction &,
-                                               vector<unique_ptr<Expression>> &arguments) {
-	for (auto &argument : arguments) {
-		if (TypeVisitor::Contains(argument->return_type, FileLogicalType::IsFile)) {
-			throw BinderException("List search functions do not support FILE values");
-		}
-	}
-	return nullptr;
-}
 
 template <class RETURN_TYPE, bool FIND_NULLS = false>
 static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector &result) {
@@ -39,12 +29,12 @@ static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector 
 
 ScalarFunction ListContainsFun::GetFunction() {
 	return ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
-	                      LogicalType::BOOLEAN, ListSearchFunction<bool>, ListSearchBind);
+	                      LogicalType::BOOLEAN, ListSearchFunction<bool>, BindFileCollectionSearch);
 }
 
 ScalarFunction ListPositionFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
-	                          LogicalType::INTEGER, ListSearchFunction<int32_t, true>, ListSearchBind);
+	                          LogicalType::INTEGER, ListSearchFunction<int32_t, true>, BindFileCollectionSearch);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/external/duckdb/src/function/scalar/list/contains_or_position.cpp
+++ b/external/duckdb/src/function/scalar/list/contains_or_position.cpp
@@ -1,10 +1,21 @@
 #include "duckdb/function/scalar/list_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 
 namespace duckdb {
+
+static unique_ptr<FunctionData> ListSearchBind(ClientContext &, ScalarFunction &,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	for (auto &argument : arguments) {
+		if (TypeVisitor::Contains(argument->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("List search functions do not support FILE values");
+		}
+	}
+	return nullptr;
+}
 
 template <class RETURN_TYPE, bool FIND_NULLS = false>
 static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector &result) {
@@ -28,12 +39,12 @@ static void ListSearchFunction(DataChunk &input, ExpressionState &state, Vector 
 
 ScalarFunction ListContainsFun::GetFunction() {
 	return ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
-	                      LogicalType::BOOLEAN, ListSearchFunction<bool>);
+	                      LogicalType::BOOLEAN, ListSearchFunction<bool>, ListSearchBind);
 }
 
 ScalarFunction ListPositionFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::LIST(LogicalType::TEMPLATE("T")), LogicalType::TEMPLATE("T")},
-	                          LogicalType::INTEGER, ListSearchFunction<int32_t, true>);
+	                          LogicalType::INTEGER, ListSearchFunction<int32_t, true>, ListSearchBind);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	return fun;
 }

--- a/external/duckdb/src/function/scalar/list/list_extract.cpp
+++ b/external/duckdb/src/function/scalar/list/list_extract.cpp
@@ -178,6 +178,9 @@ ScalarFunctionSet ArrayExtractFun::GetFunctions() {
 	array_extract_set.AddFunction(sfun);
 	array_extract_set.AddFunction(GetKeyExtractFunction());
 	array_extract_set.AddFunction(GetIndexExtractFunction());
+	auto null_key_extract = GetKeyExtractFunction();
+	null_key_extract.arguments[0] = LogicalType::SQLNULL;
+	array_extract_set.AddFunction(std::move(null_key_extract));
 	auto file_key_extract = GetKeyExtractFunction();
 	file_key_extract.arguments[0] = FileLogicalType::Create();
 	array_extract_set.AddFunction(std::move(file_key_extract));

--- a/external/duckdb/src/function/scalar/list/list_extract.cpp
+++ b/external/duckdb/src/function/scalar/list/list_extract.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/pair.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/uhugeint.hpp"
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
@@ -177,6 +178,12 @@ ScalarFunctionSet ArrayExtractFun::GetFunctions() {
 	array_extract_set.AddFunction(sfun);
 	array_extract_set.AddFunction(GetKeyExtractFunction());
 	array_extract_set.AddFunction(GetIndexExtractFunction());
+	auto file_key_extract = GetKeyExtractFunction();
+	file_key_extract.arguments[0] = FileLogicalType::Create();
+	array_extract_set.AddFunction(std::move(file_key_extract));
+	auto file_index_extract = GetIndexExtractFunction();
+	file_index_extract.arguments[0] = FileLogicalType::Create();
+	array_extract_set.AddFunction(std::move(file_index_extract));
 	return array_extract_set;
 }
 

--- a/external/duckdb/src/function/scalar/list/list_intersect.cpp
+++ b/external/duckdb/src/function/scalar/list/list_intersect.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar/list_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/function/create_sort_key.hpp"
 #include "duckdb/common/string_map_set.hpp"
@@ -181,6 +182,7 @@ static void ListIntersectFunction(DataChunk &args, ExpressionState &state, Vecto
 static unique_ptr<FunctionData> ListIntersectBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
 	D_ASSERT(bound_function.arguments.size() == 2);
+	BindFileCollectionSearch(context, bound_function, arguments);
 	arguments[0] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[0]));
 	arguments[1] = BoundCastExpression::AddArrayCastToList(context, std::move(arguments[1]));
 	return nullptr;

--- a/external/duckdb/src/function/scalar/map/map_contains.cpp
+++ b/external/duckdb/src/function/scalar/map/map_contains.cpp
@@ -1,3 +1,4 @@
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/function/scalar/map_functions.hpp"
@@ -23,7 +24,7 @@ ScalarFunction MapContainsFun::GetFunction() {
 	auto val_type = LogicalType::TEMPLATE("V");
 
 	ScalarFunction fun("map_contains", {LogicalType::MAP(key_type, val_type), key_type}, LogicalType::BOOLEAN,
-	                   MapContainsFunction);
+	                   MapContainsFunction, BindFileMapSearch);
 	return fun;
 }
 

--- a/external/duckdb/src/function/scalar/struct/functions.json
+++ b/external/duckdb/src/function/scalar/struct/functions.json
@@ -11,7 +11,7 @@
         "parameters": "struct,'entry'",
         "description": "Extract the entry from the STRUCT by position (starts at 1!).",
         "example": "struct_extract_at({'i': 3, 'v2': 3, 'v3': 0}, 2)",
-        "type": "scalar_function",
+        "type": "scalar_function_set",
         "extra_functions": ["static unique_ptr<FunctionData> GetBindData(idx_t index);"]
     },
     {

--- a/external/duckdb/src/function/scalar/struct/remap_struct.cpp
+++ b/external/duckdb/src/function/scalar/struct/remap_struct.cpp
@@ -1,4 +1,11 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
@@ -560,6 +567,11 @@ unique_ptr<FunctionData> RemapStructBind(ClientContext &context, ScalarFunction 
 			throw BinderException("Struct remap can only remap nested types, not '%s'", arg->return_type.ToString());
 		} else if (arg->return_type.id() == LogicalTypeId::STRUCT && StructType::IsUnnamed(arg->return_type)) {
 			throw BinderException("Struct remap can only remap named structs");
+		}
+	}
+	for (auto &argument : arguments) {
+		if (TypeVisitor::Contains(argument->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("remap_struct does not support FILE values");
 		}
 	}
 	auto &from_type = arguments[0]->return_type;

--- a/external/duckdb/src/function/scalar/struct/struct_concat.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_concat.cpp
@@ -53,6 +53,9 @@ static unique_ptr<FunctionData> StructConcatBind(ClientContext &context, ScalarF
 		if (arg->return_type.id() != LogicalTypeId::STRUCT) {
 			throw InvalidInputException("struct_concat: Argument at position \"%d\" is not a STRUCT", arg_idx + 1);
 		}
+		if (FileLogicalType::IsFile(arg->return_type)) {
+			throw BinderException("struct_concat does not support FILE values");
+		}
 
 		const auto &child_types = StructType::GetChildTypes(arg->return_type);
 		for (const auto &child : child_types) {

--- a/external/duckdb/src/function/scalar/struct/struct_contains.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_contains.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/function/scalar/list/contains_or_position.hpp"
@@ -228,6 +229,9 @@ static unique_ptr<FunctionData> StructContainsBind(ClientContext &context, Scala
 
 		new_child_types.push_back(max_child_type);
 		bound_function.arguments[1] = max_child_type;
+	}
+	if (TypeVisitor::Contains(max_child_type, FileLogicalType::IsFile)) {
+		throw BinderException("Collection search functions do not support FILE values");
 	}
 
 	child_list_t<LogicalType> cast_children;

--- a/external/duckdb/src/function/scalar/struct/struct_extract.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_extract.cpp
@@ -12,6 +12,8 @@
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/storage/statistics/struct_stats.hpp"
 #include "duckdb/function/scalar/struct_utils.hpp"
+#include "duckdb/common/type_visitor.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
 
 namespace duckdb {
 
@@ -30,6 +32,37 @@ static void StructExtractFunction(DataChunk &args, ExpressionState &state, Vecto
 	result.Verify(args.size());
 }
 
+static void FileAwareStructExtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &func_expr = state.expr.Cast<BoundFunctionExpression>();
+	auto &info = func_expr.bind_info->Cast<StructExtractBindData>();
+	auto &file = args.data[0];
+
+	file.Verify(args.size());
+	auto &children = StructVector::GetEntries(file);
+	D_ASSERT(info.index < children.size());
+	auto &file_child = children[info.index];
+
+	UnifiedVectorFormat file_data;
+	file.ToUnifiedFormat(args.size(), file_data);
+	if (file_data.validity.AllValid()) {
+		result.Reference(*file_child);
+		result.Verify(args.size());
+		return;
+	}
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	VectorOperations::Copy(*file_child, result, args.size(), 0, 0);
+	result.Flatten(args.size());
+	auto &result_validity = FlatVector::Validity(result);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto file_index = file_data.sel->get_index(row);
+		if (!file_data.validity.RowIsValid(file_index)) {
+			result_validity.SetInvalid(row);
+		}
+	}
+	result.Verify(args.size());
+}
+
 static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, ScalarFunction &bound_function,
                                                   vector<unique_ptr<Expression>> &arguments) {
 	D_ASSERT(bound_function.arguments.size() == 2);
@@ -38,6 +71,10 @@ static unique_ptr<FunctionData> StructExtractBind(ClientContext &context, Scalar
 		throw ParameterNotResolvedException();
 	}
 	D_ASSERT(LogicalTypeId::STRUCT == child_type.id());
+	if (TypeVisitor::Contains(child_type, FileLogicalType::IsFile)) {
+		bound_function.SetFunctionCallback(FileAwareStructExtractFunction);
+		bound_function.SetStatisticsCallback(nullptr);
+	}
 	auto &struct_children = StructType::GetChildTypes(child_type);
 	if (struct_children.empty()) {
 		throw InternalException("Can't extract something from an empty struct");
@@ -102,6 +139,10 @@ static unique_ptr<FunctionData> StructExtractBindInternal(ClientContext &context
 		throw ParameterNotResolvedException();
 	}
 	D_ASSERT(LogicalTypeId::STRUCT == child_type.id());
+	if (TypeVisitor::Contains(child_type, FileLogicalType::IsFile)) {
+		bound_function.SetFunctionCallback(FileAwareStructExtractFunction);
+		bound_function.SetStatisticsCallback(nullptr);
+	}
 	auto &struct_children = StructType::GetChildTypes(child_type);
 	if (struct_children.empty()) {
 		throw InternalException("Can't extract something from an empty struct");
@@ -179,8 +220,13 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 	return struct_extract_set;
 }
 
-ScalarFunction StructExtractAtFun::GetFunction() {
-	return GetExtractAtFunction();
+ScalarFunctionSet StructExtractAtFun::GetFunctions() {
+	ScalarFunctionSet struct_extract_at_set("struct_extract_at");
+	struct_extract_at_set.AddFunction(GetExtractAtFunction());
+	auto file_extract_at = GetExtractAtFunction();
+	file_extract_at.arguments[0] = FileLogicalType::Create();
+	struct_extract_at_set.AddFunction(std::move(file_extract_at));
+	return struct_extract_at_set;
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/scalar/struct/struct_extract.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_extract.cpp
@@ -214,6 +214,12 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 	ScalarFunctionSet struct_extract_set("struct_extract");
 	struct_extract_set.AddFunction(GetKeyExtractFunction());
 	struct_extract_set.AddFunction(GetIndexExtractFunction());
+	auto null_key_extract = GetKeyExtractFunction();
+	null_key_extract.arguments[0] = LogicalType::SQLNULL;
+	struct_extract_set.AddFunction(std::move(null_key_extract));
+	auto null_index_extract = GetIndexExtractFunction();
+	null_index_extract.arguments[0] = LogicalType::SQLNULL;
+	struct_extract_set.AddFunction(std::move(null_index_extract));
 	auto file_key_extract = GetKeyExtractFunction();
 	file_key_extract.arguments[0] = FileLogicalType::Create();
 	struct_extract_set.AddFunction(std::move(file_key_extract));
@@ -226,6 +232,9 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 ScalarFunctionSet StructExtractAtFun::GetFunctions() {
 	ScalarFunctionSet struct_extract_at_set("struct_extract_at");
 	struct_extract_at_set.AddFunction(GetExtractAtFunction());
+	auto null_extract_at = GetExtractAtFunction();
+	null_extract_at.arguments[0] = LogicalType::SQLNULL;
+	struct_extract_at_set.AddFunction(std::move(null_extract_at));
 	auto file_extract_at = GetExtractAtFunction();
 	file_extract_at.arguments[0] = FileLogicalType::Create();
 	struct_extract_at_set.AddFunction(std::move(file_extract_at));

--- a/external/duckdb/src/function/scalar/struct/struct_extract.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_extract.cpp
@@ -147,7 +147,7 @@ static unique_ptr<FunctionData> StructExtractBindInternal(ClientContext &context
 	if (struct_children.empty()) {
 		throw InternalException("Can't extract something from an empty struct");
 	}
-	if (struct_extract && !StructType::IsUnnamed(child_type)) {
+	if (struct_extract && !StructType::IsUnnamed(child_type) && !FileLogicalType::IsFile(child_type)) {
 		throw BinderException(
 		    "struct_extract with an integer key can only be used on unnamed structs, use a string key instead");
 	}
@@ -214,9 +214,12 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 	ScalarFunctionSet struct_extract_set("struct_extract");
 	struct_extract_set.AddFunction(GetKeyExtractFunction());
 	struct_extract_set.AddFunction(GetIndexExtractFunction());
-	auto file_extract = GetKeyExtractFunction();
-	file_extract.arguments[0] = FileLogicalType::Create();
-	struct_extract_set.AddFunction(std::move(file_extract));
+	auto file_key_extract = GetKeyExtractFunction();
+	file_key_extract.arguments[0] = FileLogicalType::Create();
+	struct_extract_set.AddFunction(std::move(file_key_extract));
+	auto file_index_extract = GetIndexExtractFunction();
+	file_index_extract.arguments[0] = FileLogicalType::Create();
+	struct_extract_set.AddFunction(std::move(file_index_extract));
 	return struct_extract_set;
 }
 

--- a/external/duckdb/src/function/scalar/struct/struct_extract.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_extract.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
@@ -167,6 +173,9 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 	ScalarFunctionSet struct_extract_set("struct_extract");
 	struct_extract_set.AddFunction(GetKeyExtractFunction());
 	struct_extract_set.AddFunction(GetIndexExtractFunction());
+	auto file_extract = GetKeyExtractFunction();
+	file_extract.arguments[0] = FileLogicalType::Create();
+	struct_extract_set.AddFunction(std::move(file_extract));
 	return struct_extract_set;
 }
 

--- a/external/duckdb/src/function/scalar/udf.cpp
+++ b/external/duckdb/src/function/scalar/udf.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -35,6 +36,12 @@ bool UDFFunctionData::Equals(const FunctionData &other_p) const {
 }
 
 namespace udf_helpers {
+
+static void RejectFileType(const LogicalType &type) {
+	if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+		throw BinderException("FILE inputs and outputs are not supported by Python UDFs yet");
+	}
+}
 
 void ThrowIfNotConstant(const Expression &arg, const string &name) {
 	if (!arg.IsFoldable()) {
@@ -203,6 +210,10 @@ unique_ptr<FunctionData> UDFBind(ClientContext &context, ScalarFunction &bound_f
 	}
 
 	auto return_type = udf_helpers::ResolvePayloadReturnType(payload);
+	udf_helpers::RejectFileType(return_type);
+	for (idx_t argument_index = 0; argument_index < payload_index; argument_index++) {
+		udf_helpers::RejectFileType(arguments[argument_index]->return_type);
+	}
 
 	// Remove payload from arguments, manually handling varargs case
 	// (Function::EraseArgument requires arguments.size() == bound_function.arguments.size(),
@@ -243,6 +254,11 @@ unique_ptr<FunctionData> UDFDeserialize(Deserializer &deserializer, ScalarFuncti
 	auto payload = deserializer.ReadProperty<Value>(101, "payload");
 	auto return_type = deserializer.ReadProperty<LogicalType>(102, "return_type");
 	auto payload_return_type = udf_helpers::ResolvePayloadReturnType(payload);
+	udf_helpers::RejectFileType(return_type);
+	udf_helpers::RejectFileType(payload_return_type);
+	for (auto &argument : function.arguments) {
+		udf_helpers::RejectFileType(argument);
+	}
 	if (payload_return_type != return_type) {
 		throw SerializationException("udf: serialized return type '%s' does not match payload return type '%s'",
 		                             return_type.ToString(), payload_return_type.ToString());

--- a/external/duckdb/src/function/table/arrow/arrow_array_scan_state.cpp
+++ b/external/duckdb/src/function/table/arrow/arrow_array_scan_state.cpp
@@ -30,8 +30,16 @@ void ArrowArrayScanState::AddDictionary(unique_ptr<Vector> dictionary_p, ArrowAr
 	D_ASSERT(owned_data);
 	D_ASSERT(arrow_dict);
 	arrow_dictionary = arrow_dict;
+	dictionary_owned_data = owned_data;
 	// Make sure the data referenced by the dictionary stays alive
-	dictionary->GetBuffer()->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(owned_data));
+	auto owner_buffer = dictionary->GetBuffer();
+	if (!owner_buffer) {
+		// STRUCT vectors have no primary data buffer; their children live in the auxiliary buffer instead.
+		owner_buffer = dictionary->GetAuxiliary();
+	}
+	if (owner_buffer) {
+		owner_buffer->SetAuxiliaryData(make_uniq<ArrowAuxiliaryData>(owned_data));
+	}
 }
 
 bool ArrowArrayScanState::HasDictionary() const {

--- a/external/duckdb/src/function/table/arrow/arrow_duck_schema.cpp
+++ b/external/duckdb/src/function/table/arrow/arrow_duck_schema.cpp
@@ -347,6 +347,9 @@ LogicalType ArrowType::GetDuckType(bool use_dictionary) const {
 	if (!use_dictionary) {
 		return type;
 	}
+	if (FileLogicalType::IsFile(type)) {
+		return type;
+	}
 	// Dictionaries can exist in arbitrarily nested schemas
 	// have to reconstruct the type
 	auto id = type.id();

--- a/external/duckdb/src/function/table/arrow_conversion.cpp
+++ b/external/duckdb/src/function/table/arrow_conversion.cpp
@@ -143,33 +143,52 @@ static ArrowListOffsetData ConvertArrowListViewOffsetsTemplated(Vector &vector, 
 	auto &start_offset = result.start_offset;
 	auto &list_size = result.list_size;
 
-	list_size = 0;
 	auto offsets = ArrowBufferData<BUFFER_TYPE>(array, 1) + effective_offset;
 	auto sizes = ArrowBufferData<BUFFER_TYPE>(array, 2) + effective_offset;
 
 	// In ListArrays the offsets have to be sequential
 	// ListViewArrays do not have this same constraint
-	// for that reason we need to keep track of the lowest offset, so we can skip all the data that comes before it
-	// when we scan the child data
+	// For that reason we scan the full span between the lowest referenced offset and the highest referenced end.
+	// Gaps inside that span are masked by child_reachability below.
 
-	auto lowest_offset = size ? offsets[0] : 0;
+	bool has_referenced_children = false;
+	idx_t lowest_offset = 0;
+	idx_t highest_offset = 0;
 	auto list_data = FlatVector::GetData<list_entry_t>(vector);
 	for (idx_t i = 0; i < size; i++) {
 		auto &le = list_data[i];
-		le.offset = offsets[i];
-		le.length = sizes[i];
-		list_size += le.length;
-		if (sizes[i] != 0) {
-			lowest_offset = MinValue(lowest_offset, offsets[i]);
+		le.offset = NumericCast<idx_t>(offsets[i]);
+		le.length = NumericCast<idx_t>(sizes[i]);
+		if (le.length == 0) {
+			continue;
+		}
+		if (le.offset > NumericLimits<idx_t>::Maximum() - le.length) {
+			throw InvalidInputException("Arrow ListView offset and size overflow");
+		}
+		auto end_offset = le.offset + le.length;
+		if (!has_referenced_children) {
+			lowest_offset = le.offset;
+			highest_offset = end_offset;
+			has_referenced_children = true;
+		} else {
+			lowest_offset = MinValue(lowest_offset, le.offset);
+			highest_offset = MaxValue(highest_offset, end_offset);
 		}
 	}
-	start_offset = lowest_offset;
-	if (start_offset) {
-		// We start scanning the child data at the 'start_offset' so we need to fix up the created list entries
+	if (!has_referenced_children) {
+		start_offset = 0;
+		list_size = 0;
 		for (idx_t i = 0; i < size; i++) {
-			auto &le = list_data[i];
-			le.offset = le.offset <= start_offset ? 0 : le.offset - start_offset;
+			list_data[i].offset = 0;
 		}
+		return result;
+	}
+	start_offset = lowest_offset;
+	list_size = highest_offset - lowest_offset;
+	// We start scanning the child data at start_offset, so normalize every referenced list entry to that window.
+	for (idx_t i = 0; i < size; i++) {
+		auto &le = list_data[i];
+		le.offset = le.length == 0 ? 0 : le.offset - start_offset;
 	}
 	return result;
 }

--- a/external/duckdb/src/function/table/arrow_conversion.cpp
+++ b/external/duckdb/src/function/table/arrow_conversion.cpp
@@ -138,7 +138,7 @@ static ArrowListOffsetData ConvertArrowListOffsetsTemplated(Vector &vector, Arro
 
 template <class BUFFER_TYPE>
 static ArrowListOffsetData ConvertArrowListViewOffsetsTemplated(Vector &vector, ArrowArray &array, idx_t size,
-                                                                idx_t effective_offset) {
+                                                                idx_t effective_offset, const ValidityMask &list_mask) {
 	ArrowListOffsetData result;
 	auto &start_offset = result.start_offset;
 	auto &list_size = result.list_size;
@@ -157,6 +157,11 @@ static ArrowListOffsetData ConvertArrowListViewOffsetsTemplated(Vector &vector, 
 	auto list_data = FlatVector::GetData<list_entry_t>(vector);
 	for (idx_t i = 0; i < size; i++) {
 		auto &le = list_data[i];
+		if (!list_mask.RowIsValid(i)) {
+			le.offset = 0;
+			le.length = 0;
+			continue;
+		}
 		le.offset = NumericCast<idx_t>(offsets[i]);
 		le.length = NumericCast<idx_t>(sizes[i]);
 		if (le.length == 0) {
@@ -194,15 +199,16 @@ static ArrowListOffsetData ConvertArrowListViewOffsetsTemplated(Vector &vector, 
 }
 
 static ArrowListOffsetData ConvertArrowListOffsets(Vector &vector, ArrowArray &array, idx_t size,
-                                                   const ArrowType &arrow_type, idx_t effective_offset) {
+                                                   const ArrowType &arrow_type, idx_t effective_offset,
+                                                   const ValidityMask &list_mask) {
 	auto &list_info = arrow_type.GetTypeInfo<ArrowListInfo>();
 	auto size_type = list_info.GetSizeType();
 	if (list_info.IsView()) {
 		if (size_type == ArrowVariableSizeType::NORMAL) {
-			return ConvertArrowListViewOffsetsTemplated<uint32_t>(vector, array, size, effective_offset);
+			return ConvertArrowListViewOffsetsTemplated<uint32_t>(vector, array, size, effective_offset, list_mask);
 		} else {
 			D_ASSERT(size_type == ArrowVariableSizeType::SUPER_SIZE);
-			return ConvertArrowListViewOffsetsTemplated<uint64_t>(vector, array, size, effective_offset);
+			return ConvertArrowListViewOffsetsTemplated<uint64_t>(vector, array, size, effective_offset, list_mask);
 		}
 	} else {
 		if (size_type == ArrowVariableSizeType::NORMAL) {
@@ -219,9 +225,18 @@ static void ArrowToDuckDBList(Vector &vector, ArrowArray &array, idx_t chunk_off
                               const ValidityMask *parent_mask, int64_t parent_offset) {
 	auto &list_info = arrow_type.GetTypeInfo<ArrowListInfo>();
 	ArrowToDuckDBConversion::SetValidityMask(vector, array, chunk_offset, size, parent_offset, nested_offset);
+	auto &list_mask = FlatVector::Validity(vector);
+	if (parent_mask && !parent_mask->AllValid()) {
+		//! Since this List is owned by a struct we must guarantee their validity map matches on Null
+		for (idx_t i = 0; i < size; i++) {
+			if (!parent_mask->RowIsValid(i)) {
+				list_mask.SetInvalid(i);
+			}
+		}
+	}
 
 	auto effective_offset = GetEffectiveOffset(array, parent_offset, chunk_offset, nested_offset);
-	auto list_data = ConvertArrowListOffsets(vector, array, size, arrow_type, effective_offset);
+	auto list_data = ConvertArrowListOffsets(vector, array, size, arrow_type, effective_offset, list_mask);
 	auto &start_offset = list_data.start_offset;
 	auto &list_size = list_data.list_size;
 
@@ -230,17 +245,6 @@ static void ArrowToDuckDBList(Vector &vector, ArrowArray &array, idx_t chunk_off
 	auto &child_vector = ListVector::GetEntry(vector);
 	ArrowToDuckDBConversion::SetValidityMask(child_vector, *array.children[0], chunk_offset, list_size, array.offset,
 	                                         NumericCast<int64_t>(start_offset));
-	auto &list_mask = FlatVector::Validity(vector);
-	if (parent_mask) {
-		//! Since this List is owned by a struct we must guarantee their validity map matches on Null
-		if (!parent_mask->AllValid()) {
-			for (idx_t i = 0; i < size; i++) {
-				if (!parent_mask->RowIsValid(i)) {
-					list_mask.SetInvalid(i);
-				}
-			}
-		}
-	}
 	auto &child_state = array_state.GetChild(0);
 	auto &child_array = *array.children[0];
 	auto &child_type = list_info.GetChild();

--- a/external/duckdb/src/function/table/arrow_conversion.cpp
+++ b/external/duckdb/src/function/table/arrow_conversion.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/types/arrow_aux_data.hpp"
 #include "duckdb/common/types/arrow_string_view_type.hpp"
 #include "duckdb/common/types/hugeint.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/table/arrow.hpp"
 
@@ -1559,6 +1560,7 @@ void ArrowTableFunction::ArrowToDuckDB(ArrowScanLocalState &scan_state, const ar
 		default:
 			throw NotImplementedException("ArrowArrayPhysicalType not recognized");
 		}
+		FileLogicalType::Validate(output.data[idx], output.size(), "Arrow FILE");
 	}
 }
 

--- a/external/duckdb/src/function/table/arrow_conversion.cpp
+++ b/external/duckdb/src/function/table/arrow_conversion.cpp
@@ -224,11 +224,31 @@ static void ArrowToDuckDBList(Vector &vector, ArrowArray &array, idx_t chunk_off
 	auto &child_state = array_state.GetChild(0);
 	auto &child_array = *array.children[0];
 	auto &child_type = list_info.GetChild();
+	ValidityMask child_reachability(list_size);
+	ValidityMask *child_parent_mask = nullptr;
+	if (list_size > 0 && (!list_mask.AllValid() || list_info.IsView())) {
+		child_reachability.SetAllInvalid(list_size);
+		auto list_entries = FlatVector::GetData<list_entry_t>(vector);
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (!list_mask.RowIsValid(row_idx)) {
+				continue;
+			}
+			auto &entry = list_entries[row_idx];
+			D_ASSERT(entry.offset + entry.length <= list_size);
+			for (idx_t child_idx = entry.offset; child_idx < entry.offset + entry.length; child_idx++) {
+				child_reachability.SetValid(child_idx);
+			}
+		}
+		if (!child_reachability.CheckAllValid(list_size)) {
+			FlatVector::Validity(child_vector).Combine(child_reachability, list_size);
+			child_parent_mask = &child_reachability;
+		}
+	}
 
 	if (list_size == 0 && start_offset == 0) {
 		D_ASSERT(!child_array.dictionary);
 		ArrowToDuckDBConversion::ColumnArrowToDuckDB(child_vector, child_array, chunk_offset, child_state, list_size,
-		                                             child_type, -1);
+		                                             child_type, -1, child_parent_mask);
 		return;
 	}
 
@@ -238,16 +258,16 @@ static void ArrowToDuckDBList(Vector &vector, ArrowArray &array, idx_t chunk_off
 		// TODO: add support for offsets
 		ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(child_vector, child_array, chunk_offset, child_state,
 		                                                       list_size, child_type,
-		                                                       NumericCast<int64_t>(start_offset));
+		                                                       NumericCast<int64_t>(start_offset), child_parent_mask);
 		break;
 	case ArrowArrayPhysicalType::RUN_END_ENCODED:
-		ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(child_vector, child_array, chunk_offset, child_state,
-		                                                          list_size, child_type,
-		                                                          NumericCast<int64_t>(start_offset));
+		ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(
+		    child_vector, child_array, chunk_offset, child_state, list_size, child_type,
+		    NumericCast<int64_t>(start_offset), child_parent_mask);
 		break;
 	case ArrowArrayPhysicalType::DEFAULT:
 		ArrowToDuckDBConversion::ColumnArrowToDuckDB(child_vector, child_array, chunk_offset, child_state, list_size,
-		                                             child_type, NumericCast<int64_t>(start_offset));
+		                                             child_type, NumericCast<int64_t>(start_offset), child_parent_mask);
 		break;
 	default:
 		throw NotImplementedException("ArrowArrayPhysicalType not recognized");
@@ -1205,6 +1225,15 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 		auto members = UnionType::CopyMemberTypes(vector.GetType());
 
 		auto &validity_mask = FlatVector::Validity(vector);
+		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+			if (!validity_mask.RowIsValid(row_idx)) {
+				continue;
+			}
+			auto tag = type_ids[row_idx];
+			if (tag < 0 || NumericCast<idx_t>(tag) >= NumericCast<idx_t>(array.n_children)) {
+				throw InvalidInputException("Arrow union tag out of range: %d", tag);
+			}
+		}
 		auto &union_info = arrow_type.GetTypeInfo<ArrowStructInfo>();
 		duckdb::vector<Vector> children;
 		for (idx_t child_idx = 0; child_idx < NumericCast<idx_t>(array.n_children); child_idx++) {
@@ -1215,20 +1244,32 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 
 			ArrowToDuckDBConversion::SetValidityMask(child, child_array, chunk_offset, size,
 			                                         NumericCast<int64_t>(parent_offset), nested_offset);
+			ValidityMask active_rows(size);
+			active_rows.SetAllInvalid(size);
+			for (idx_t row_idx = 0; row_idx < size; row_idx++) {
+				if (validity_mask.RowIsValid(row_idx) && NumericCast<idx_t>(type_ids[row_idx]) == child_idx) {
+					active_rows.SetValid(row_idx);
+				}
+			}
+			ValidityMask *child_parent_mask = nullptr;
+			if (!active_rows.CheckAllValid(size)) {
+				FlatVector::Validity(child).Combine(active_rows, size);
+				child_parent_mask = &active_rows;
+			}
 			auto array_physical_type = child_type.GetPhysicalType();
 
 			switch (array_physical_type) {
 			case ArrowArrayPhysicalType::DICTIONARY_ENCODED:
 				ArrowToDuckDBConversion::ColumnArrowToDuckDBDictionary(child, child_array, chunk_offset, child_state,
-				                                                       size, child_type);
+				                                                       size, child_type, -1, child_parent_mask);
 				break;
 			case ArrowArrayPhysicalType::RUN_END_ENCODED:
 				ArrowToDuckDBConversion::ColumnArrowToDuckDBRunEndEncoded(child, child_array, chunk_offset, child_state,
-				                                                          size, child_type);
+				                                                          size, child_type, -1, child_parent_mask);
 				break;
 			case ArrowArrayPhysicalType::DEFAULT:
 				ArrowToDuckDBConversion::ColumnArrowToDuckDB(child, child_array, chunk_offset, child_state, size,
-				                                             child_type, nested_offset, &validity_mask, false);
+				                                             child_type, nested_offset, child_parent_mask, false);
 				break;
 			default:
 				throw NotImplementedException("ArrowArrayPhysicalType not recognized");
@@ -1238,12 +1279,11 @@ void ArrowToDuckDBConversion::ColumnArrowToDuckDB(Vector &vector, ArrowArray &ar
 		}
 
 		for (idx_t row_idx = 0; row_idx < size; row_idx++) {
-			auto tag = NumericCast<uint8_t>(type_ids[row_idx]);
-
-			auto out_of_range = tag >= array.n_children;
-			if (out_of_range) {
-				throw InvalidInputException("Arrow union tag out of range: %d", tag);
+			if (!validity_mask.RowIsValid(row_idx)) {
+				vector.SetValue(row_idx, Value(vector.GetType()));
+				continue;
 			}
+			auto tag = NumericCast<uint8_t>(type_ids[row_idx]);
 
 			const Value &value = children[tag].GetValue(row_idx);
 			vector.SetValue(row_idx, value.IsNull() ? Value() : Value::UNION(members, tag, value));

--- a/external/duckdb/src/function/window/window_executor.cpp
+++ b/external/duckdb/src/function/window/window_executor.cpp
@@ -53,6 +53,7 @@ void WindowExecutor::Evaluate(ExecutionContext &context, idx_t row_idx, DataChun
 
 	const auto count = eval_chunk.size();
 	EvaluateInternal(context, eval_chunk, result, count, row_idx, sink);
+	FileLogicalType::Validate(result, wexpr.return_type, count, "Window function FILE");
 
 	result.Verify(count);
 }

--- a/external/duckdb/src/include/duckdb/common/arrow/arrow_converter.hpp
+++ b/external/duckdb/src/include/duckdb/common/arrow/arrow_converter.hpp
@@ -15,6 +15,8 @@
 
 namespace duckdb {
 class ArrowTypeExtensionData;
+class ArrowTypeExtension;
+class ClientContext;
 struct DBConfig;
 struct ArrowConverter {
 	DUCKDB_API static void ToArrowSchema(ArrowSchema *out_schema, const vector<LogicalType> &types,
@@ -42,5 +44,9 @@ struct DuckDBArrowSchemaHolder {
 	vector<unsafe_unique_array<char>> metadata_info;
 	vector<unsafe_unique_array<char>> extension_format;
 };
+
+DUCKDB_API void PopulateArrowFileSchema(DuckDBArrowSchemaHolder &root_holder, ArrowSchema &child,
+                                        const LogicalType &type, ClientContext &context,
+                                        const ArrowTypeExtension &extension);
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/common/type_visitor.hpp
+++ b/external/duckdb/src/include/duckdb/common/type_visitor.hpp
@@ -24,6 +24,11 @@ struct TypeVisitor {
 
 template <class F>
 inline LogicalType TypeVisitor::VisitReplace(const LogicalType &type, F &&func) {
+	// FILE is a governed logical value, not a generic STRUCT whose children may be rewritten independently.
+	// Treat it as an atomic type so recursive rewrites cannot silently erase its alias and invariants.
+	if (FileLogicalType::IsFile(type)) {
+		return func(type);
+	}
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT: {
 		if (!type.AuxInfo()) {

--- a/external/duckdb/src/include/duckdb/common/types.hpp
+++ b/external/duckdb/src/include/duckdb/common/types.hpp
@@ -530,6 +530,7 @@ struct FileLogicalType {
 
 	DUCKDB_API static LogicalType Create();
 	DUCKDB_API static bool IsFile(const LogicalType &type);
+	DUCKDB_API static void Validate(Vector &value, idx_t count, const string &source);
 };
 
 struct MapType {

--- a/external/duckdb/src/include/duckdb/common/types.hpp
+++ b/external/duckdb/src/include/duckdb/common/types.hpp
@@ -514,6 +514,24 @@ struct StructType {
 	DUCKDB_API static bool IsUnnamed(const LogicalType &type);
 };
 
+struct FileLogicalType {
+	static constexpr const char *TYPE_NAME = "FILE";
+	static constexpr const char *EQUAL_FUNCTION_NAME = "__vane_file_equal";
+	static constexpr const char *NOT_EQUAL_FUNCTION_NAME = "__vane_file_not_equal";
+
+	enum FieldIndex : idx_t {
+		URL = 0,
+		CONTENT_TYPE = 1,
+		POSITION = 2,
+		SIZE = 3,
+		CHECKSUM = 4,
+		FIELD_COUNT = 5,
+	};
+
+	DUCKDB_API static LogicalType Create();
+	DUCKDB_API static bool IsFile(const LogicalType &type);
+};
+
 struct MapType {
 	DUCKDB_API static const LogicalType &KeyType(const LogicalType &type);
 	DUCKDB_API static const LogicalType &ValueType(const LogicalType &type);

--- a/external/duckdb/src/include/duckdb/common/types.hpp
+++ b/external/duckdb/src/include/duckdb/common/types.hpp
@@ -30,6 +30,7 @@ class Vector;
 class ClientContext;
 class ParsedExpression;
 class CoordinateReferenceSystem;
+class DataChunk;
 
 struct string_t; // NOLINT: mimic std casing
 
@@ -532,6 +533,9 @@ struct FileLogicalType {
 	DUCKDB_API static bool IsFile(const LogicalType &type);
 	DUCKDB_API static void Validate(const Value &value, const string &source);
 	DUCKDB_API static void Validate(Vector &value, idx_t count, const string &source);
+	DUCKDB_API static void Validate(Vector &value, const LogicalType &declared_type, idx_t count,
+	                                const string &source);
+	DUCKDB_API static void Validate(DataChunk &value, const vector<LogicalType> &declared_types, const string &source);
 };
 
 struct MapType {

--- a/external/duckdb/src/include/duckdb/common/types.hpp
+++ b/external/duckdb/src/include/duckdb/common/types.hpp
@@ -530,6 +530,7 @@ struct FileLogicalType {
 
 	DUCKDB_API static LogicalType Create();
 	DUCKDB_API static bool IsFile(const LogicalType &type);
+	DUCKDB_API static void Validate(const Value &value, const string &source);
 	DUCKDB_API static void Validate(Vector &value, idx_t count, const string &source);
 };
 

--- a/external/duckdb/src/include/duckdb/function/scalar/file_functions.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar/file_functions.hpp
@@ -18,4 +18,9 @@ struct FileFunctions {
 	static vector<ScalarFunction> GetFunctions();
 };
 
+DUCKDB_API unique_ptr<FunctionData> BindFileCollectionSearch(ClientContext &context, ScalarFunction &function,
+                                                             vector<unique_ptr<Expression>> &arguments);
+DUCKDB_API unique_ptr<FunctionData> BindFileMapSearch(ClientContext &context, ScalarFunction &function,
+                                                      vector<unique_ptr<Expression>> &arguments);
+
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/function/scalar/file_functions.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar/file_functions.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar/file_functions.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+struct FileFunctions {
+	static vector<ScalarFunction> GetFunctions();
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/function/scalar/struct_functions.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar/struct_functions.hpp
@@ -32,7 +32,7 @@ struct StructExtractAtFun {
 	static constexpr const char *Example = "struct_extract_at({'i': 3, 'v2': 3, 'v3': 0}, 2)";
 	static constexpr const char *Categories = "";
 
-	static ScalarFunction GetFunction();
+	static ScalarFunctionSet GetFunctions();
 	static unique_ptr<FunctionData> GetBindData(idx_t index);
 };
 

--- a/external/duckdb/src/include/duckdb/function/table/arrow.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/arrow.hpp
@@ -99,6 +99,8 @@ public:
 	optional_ptr<ArrowArray> arrow_dictionary = nullptr;
 	// Cache the (optional) dictionary of this array
 	unique_ptr<Vector> dictionary;
+	//! Keep the Arrow dictionary alive while its cached Vector is reused across batches
+	shared_ptr<ArrowArrayWrapper> dictionary_owned_data;
 	//! Run-end-encoding state
 	ArrowRunEndEncodingState run_end_encoding;
 	ClientContext &context;

--- a/external/duckdb/src/main/appender.cpp
+++ b/external/duckdb/src/main/appender.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/common/operator/decimal_cast_operators.hpp"
 #include "duckdb/common/operator/string_cast.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
@@ -27,6 +28,19 @@
 #include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
+
+static void ValidateAppenderFiles(DataChunk &chunk) {
+	for (auto &column : chunk.data) {
+		if (TypeVisitor::Contains(column.GetType(), FileLogicalType::IsFile)) {
+			FileLogicalType::Validate(column, chunk.size(), "Appender FILE");
+		}
+	}
+}
+
+static void AppendValidatedChunk(ColumnDataCollection &collection, DataChunk &chunk) {
+	ValidateAppenderFiles(chunk);
+	collection.Append(chunk);
+}
 
 BaseAppender::BaseAppender(Allocator &allocator, const AppenderType type_p)
     : allocator(allocator), column(0), appender_type(type_p) {
@@ -317,18 +331,22 @@ void duckdb::BaseAppender::Append(DataChunk &target, const Value &value, idx_t c
 		throw InvalidInputException("Too many rows for chunk!");
 	}
 
-	if (value.type() == target.GetTypes()[col]) {
-		target.SetValue(col, row, value);
-	} else {
-		Value new_value;
+	const auto &target_type = target.data[col].GetType();
+	const Value *append_value = &value;
+	Value cast_value;
+	if (value.type() != target_type) {
 		string error_msg;
-		if (value.DefaultTryCastAs(target.GetTypes()[col], new_value, &error_msg)) {
-			target.SetValue(col, row, new_value);
+		if (value.DefaultTryCastAs(target_type, cast_value, &error_msg)) {
+			append_value = &cast_value;
 		} else {
-			throw InvalidInputException("type mismatch in Append, expected %s, got %s for column %d",
-			                            target.GetTypes()[col], value.type(), col);
+			throw InvalidInputException("type mismatch in Append, expected %s, got %s for column %d", target_type,
+			                            value.type(), col);
 		}
 	}
+	if (TypeVisitor::Contains(target_type, FileLogicalType::IsFile)) {
+		FileLogicalType::Validate(*append_value, "Appender FILE");
+	}
+	target.SetValue(col, row, *append_value);
 }
 
 template <>
@@ -341,7 +359,7 @@ void BaseAppender::Append(std::nullptr_t value) {
 }
 
 void BaseAppender::AppendValue(const Value &value) {
-	chunk.SetValue(column, chunk.size(), value);
+	Append(chunk, value, column, chunk.size());
 	column++;
 }
 
@@ -351,7 +369,7 @@ void BaseAppender::AppendDataChunk(DataChunk &chunk_p) {
 
 	// Early-out, if types match.
 	if (chunk_types == appender_types) {
-		collection->Append(chunk_p);
+		AppendValidatedChunk(*collection, chunk_p);
 		if (ShouldFlush()) {
 			Flush();
 		}
@@ -384,7 +402,7 @@ void BaseAppender::AppendDataChunk(DataChunk &chunk_p) {
 		}
 	}
 
-	collection->Append(cast_chunk);
+	AppendValidatedChunk(*collection, cast_chunk);
 	if (ShouldFlush()) {
 		Flush();
 	}
@@ -394,7 +412,7 @@ void BaseAppender::FlushChunk() {
 	if (chunk.size() == 0) {
 		return;
 	}
-	collection->Append(chunk);
+	AppendValidatedChunk(*collection, chunk);
 	chunk.Reset();
 	if (ShouldFlush()) {
 		Flush();

--- a/external/duckdb/src/main/capi/arrow-c.cpp
+++ b/external/duckdb/src/main/capi/arrow-c.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/arrow/arrow.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/prepared_statement_data.hpp"
@@ -139,6 +140,7 @@ duckdb_error_data duckdb_data_chunk_from_arrow(duckdb_connection connection, str
 				return duckdb_create_error_data(DUCKDB_ERROR_NOT_IMPLEMENTED,
 				                                "Only Default Physical Types are currently supported");
 			}
+			duckdb::FileLogicalType::Validate(dchunk->data[i], dchunk->size(), "Arrow FILE");
 		} catch (const duckdb::Exception &ex) {
 			return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, ex.what());
 		} catch (const std::exception &ex) {

--- a/external/duckdb/src/main/capi/arrow-c.cpp
+++ b/external/duckdb/src/main/capi/arrow-c.cpp
@@ -58,9 +58,6 @@ duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options arrow_options,
 	    *arrow_options_wrapper->properties.client_context, dchunk->GetTypes());
 
 	try {
-		for (idx_t column_index = 0; column_index < dchunk->ColumnCount(); column_index++) {
-			duckdb::FileLogicalType::Validate(dchunk->data[column_index], dchunk->size(), "Arrow FILE");
-		}
 		ArrowConverter::ToArrowArray(*dchunk, out_arrow_array, arrow_options_wrapper->properties, extension_type_cast);
 	} catch (const duckdb::Exception &ex) {
 		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, ex.what());
@@ -244,8 +241,16 @@ duckdb_state duckdb_query_arrow_array(duckdb_arrow result, duckdb_arrow_array *o
 	}
 	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
 	    *wrapper->result->client_properties.client_context, wrapper->result->types);
-	ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
-	                             wrapper->result->client_properties, extension_type_cast);
+	try {
+		ArrowConverter::ToArrowArray(*wrapper->current_chunk, reinterpret_cast<ArrowArray *>(*out_array),
+		                             wrapper->result->client_properties, extension_type_cast);
+	} catch (const std::exception &ex) {
+		wrapper->result->SetError(duckdb::ErrorData(ex));
+		return DuckDBError;
+	} catch (...) { // LCOV_EXCL_START
+		wrapper->result->SetError(duckdb::ErrorData("Unknown error occurred during conversion"));
+		return DuckDBError;
+	} // LCOV_EXCL_STOP
 	return DuckDBSuccess;
 }
 
@@ -258,8 +263,14 @@ void duckdb_result_arrow_array(duckdb_result result, duckdb_data_chunk chunk, du
 	auto extension_type_cast = duckdb::ArrowTypeExtensionData::GetExtensionTypes(
 	    *result_data.result->client_properties.client_context, result_data.result->types);
 
-	ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
-	                             result_data.result->client_properties, extension_type_cast);
+	try {
+		ArrowConverter::ToArrowArray(*dchunk, reinterpret_cast<ArrowArray *>(*out_array),
+		                             result_data.result->client_properties, extension_type_cast);
+	} catch (const std::exception &ex) {
+		result_data.result->SetError(duckdb::ErrorData(ex));
+	} catch (...) { // LCOV_EXCL_START
+		result_data.result->SetError(duckdb::ErrorData("Unknown error occurred during conversion"));
+	} // LCOV_EXCL_STOP
 }
 
 idx_t duckdb_arrow_row_count(duckdb_arrow result) {

--- a/external/duckdb/src/main/capi/arrow-c.cpp
+++ b/external/duckdb/src/main/capi/arrow-c.cpp
@@ -58,6 +58,9 @@ duckdb_error_data duckdb_data_chunk_to_arrow(duckdb_arrow_options arrow_options,
 	    *arrow_options_wrapper->properties.client_context, dchunk->GetTypes());
 
 	try {
+		for (idx_t column_index = 0; column_index < dchunk->ColumnCount(); column_index++) {
+			duckdb::FileLogicalType::Validate(dchunk->data[column_index], dchunk->size(), "Arrow FILE");
+		}
 		ArrowConverter::ToArrowArray(*dchunk, out_arrow_array, arrow_options_wrapper->properties, extension_type_cast);
 	} catch (const duckdb::Exception &ex) {
 		return duckdb_create_error_data(DUCKDB_ERROR_INVALID_INPUT, ex.what());

--- a/external/duckdb/src/main/capi/scalar_function-c.cpp
+++ b/external/duckdb/src/main/capi/scalar_function-c.cpp
@@ -523,8 +523,13 @@ duckdb_state duckdb_register_scalar_function_set(duckdb_connection connection, d
 		    duckdb::TypeVisitor::Contains(scalar_function.GetReturnType(), duckdb::LogicalTypeId::ANY)) {
 			return DuckDBError;
 		}
+		if (duckdb::TypeVisitor::Contains(scalar_function.GetReturnType(), duckdb::FileLogicalType::IsFile) ||
+		    duckdb::TypeVisitor::Contains(scalar_function.varargs, duckdb::FileLogicalType::IsFile)) {
+			return DuckDBError;
+		}
 		for (const auto &argument : scalar_function.arguments) {
-			if (duckdb::TypeVisitor::Contains(argument, duckdb::LogicalTypeId::INVALID)) {
+			if (duckdb::TypeVisitor::Contains(argument, duckdb::LogicalTypeId::INVALID) ||
+			    duckdb::TypeVisitor::Contains(argument, duckdb::FileLogicalType::IsFile)) {
 				return DuckDBError;
 			}
 		}

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/common/exception/transaction_exception.hpp"
 #include "duckdb/common/progress_bar/progress_bar.hpp"
 #include "duckdb/common/serializer/buffered_file_writer.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/execution/operator/helper/physical_result_collector.hpp"
@@ -34,6 +35,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
 #include "duckdb/parser/parsed_data/create_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/statement/drop_statement.hpp"
@@ -1295,6 +1297,20 @@ void ClientContext::DisableProfiling() {
 }
 
 void ClientContext::RegisterFunction(CreateFunctionInfo &info) {
+	if (info.type == CatalogType::SCALAR_FUNCTION_ENTRY) {
+		auto &scalar_info = info.Cast<CreateScalarFunctionInfo>();
+		for (auto &function : scalar_info.functions.functions) {
+			if (TypeVisitor::Contains(function.GetReturnType(), FileLogicalType::IsFile) ||
+			    TypeVisitor::Contains(function.varargs, FileLogicalType::IsFile)) {
+				throw InvalidInputException("FILE inputs and outputs are not supported by scalar UDFs yet");
+			}
+			for (auto &argument : function.arguments) {
+				if (TypeVisitor::Contains(argument, FileLogicalType::IsFile)) {
+					throw InvalidInputException("FILE inputs and outputs are not supported by scalar UDFs yet");
+				}
+			}
+		}
+	}
 	RunFunctionInTransaction([&]() {
 		auto existing_function = Catalog::GetEntry<ScalarFunctionCatalogEntry>(*this, INVALID_CATALOG, info.schema,
 		                                                                       info.name, OnEntryNotFound::RETURN_NULL);

--- a/external/duckdb/src/main/relation/distinct_relation.cpp
+++ b/external/duckdb/src/main/relation/distinct_relation.cpp
@@ -5,6 +5,7 @@
 // Modified by Vane contributors.
 
 #include "duckdb/main/relation/distinct_relation.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/query_node.hpp"
@@ -56,6 +57,9 @@ BoundStatement DistinctRelation::BindAsInput(Binder &binder) {
 	targets.reserve(visible_columns.size());
 	for (auto &column : visible_columns) {
 		auto target = relation_binder.Bind(column);
+		if (TypeVisitor::Contains(target->return_type, FileLogicalType::IsFile)) {
+			throw BinderException(target->GetQueryLocation(), "DISTINCT does not support FILE values");
+		}
 		ExpressionBinder::PushCollation(binder.context, target, target->return_type);
 		targets.push_back(std::move(target));
 	}

--- a/external/duckdb/src/main/relation/repartition_relation.cpp
+++ b/external/duckdb/src/main/relation/repartition_relation.cpp
@@ -3,6 +3,7 @@
 
 #include "duckdb/main/relation/repartition_relation.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/operator/exchange/repartition.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
@@ -56,6 +57,9 @@ BoundStatement RepartitionRelation::BindAsInput(Binder &binder) {
 		auto expr_copy = expr->Copy();
 		auto bound_expr = relation_binder.Bind(expr_copy);
 		if (bound_expr) {
+			if (TypeVisitor::Contains(bound_expr->return_type, FileLogicalType::IsFile)) {
+				throw BinderException(bound_expr->GetQueryLocation(), "Repartition keys do not support FILE values");
+			}
 			partition_exprs.emplace_back(bound_expr->Copy());
 			bound_partition_exprs.push_back(std::move(bound_expr));
 		}

--- a/external/duckdb/src/optimizer/filter_combiner.cpp
+++ b/external/duckdb/src/optimizer/filter_combiner.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/optimizer/filter_combiner.hpp"
 
 #include "duckdb/common/enums/expression_type.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/string_common.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
@@ -202,6 +203,9 @@ static bool TryGetBoundColumnIndex(const vector<ColumnIndex> &column_ids, const 
 		auto &func = expr.Cast<BoundFunctionExpression>();
 		if (func.function.name == "struct_extract" || func.function.name == "struct_extract_at") {
 			auto &child_expr = func.children[0];
+			if (TypeVisitor::Contains(child_expr->return_type, FileLogicalType::IsFile)) {
+				return false;
+			}
 			return TryGetBoundColumnIndex(column_ids, *child_expr, result);
 		}
 		return false;

--- a/external/duckdb/src/optimizer/remove_unused_columns.cpp
+++ b/external/duckdb/src/optimizer/remove_unused_columns.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/assert.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/aggregate/distributive_functions.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/parser/parsed_data/vacuum_info.hpp"
@@ -911,6 +912,10 @@ bool BaseColumnPruner::HandleStructExtract(unique_ptr<Expression> &expr_p,
 	auto &function = expr_p->Cast<BoundFunctionExpression>();
 	auto &child = function.children[0];
 	D_ASSERT(child->return_type.id() == LogicalTypeId::STRUCT);
+	if (TypeVisitor::Contains(child->return_type, FileLogicalType::IsFile)) {
+		// FILE extraction must retain the parent vector so its root validity can mask hidden child values.
+		return false;
+	}
 	auto &bind_data = function.bind_info->Cast<StructExtractBindData>();
 	// struct extract, check if left child is a bound column ref
 	if (child->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF) {

--- a/external/duckdb/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
 #include "duckdb/common/operator/cast_operators.hpp"
 #include "duckdb/common/pair.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
@@ -214,6 +215,16 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		}
 	} else if (depth > 0 && !aggregate_binder.HasBoundColumns()) {
 		return BindResult("Aggregate with only constant parameters has to be bound in the root subquery");
+	}
+
+	if (aggr.order_bys) {
+		for (auto &order : aggr.order_bys->orders) {
+			auto &order_expr = BoundExpression::GetExpression(*order.expression);
+			if (TypeVisitor::Contains(order_expr->return_type, FileLogicalType::IsFile)) {
+				throw BinderException(order_expr->GetQueryLocation(),
+				                      "Aggregate ORDER BY does not support FILE values");
+			}
+		}
 	}
 
 	if (aggr.filter) {

--- a/external/duckdb/src/planner/binder/expression/bind_aggregate_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_aggregate_expression.cpp
@@ -264,6 +264,13 @@ BindResult BaseSelectBinder::BindAggregate(FunctionExpression &aggr, AggregateFu
 		arguments.push_back(child->return_type);
 		children.push_back(std::move(child));
 	}
+	if (aggr.distinct) {
+		for (auto &type : types) {
+			if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+				throw BinderException(aggr, "DISTINCT aggregates do not support FILE values");
+			}
+		}
+	}
 
 	// bind the aggregate
 	FunctionBinder function_binder(binder);

--- a/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -1,4 +1,12 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/parser/expression/comparison_expression.hpp"
+#include "duckdb/parser/expression/bound_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -7,6 +15,7 @@
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/catalog/catalog_entry/collate_catalog_entry.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 #include "duckdb/function/scalar/string_functions.hpp"
 
@@ -61,6 +70,27 @@ static bool SwitchVarcharComparison(const LogicalType &type) {
 bool BoundComparisonExpression::TryBindComparison(ClientContext &context, const LogicalType &left_type,
                                                   const LogicalType &right_type, LogicalType &result_type,
                                                   ExpressionType comparison_type) {
+	const auto left_is_file = FileLogicalType::IsFile(left_type);
+	const auto right_is_file = FileLogicalType::IsFile(right_type);
+	if (left_is_file || right_is_file) {
+		if (comparison_type != ExpressionType::COMPARE_EQUAL && comparison_type != ExpressionType::COMPARE_NOTEQUAL) {
+			return false;
+		}
+		if ((!left_is_file && left_type.id() != LogicalTypeId::SQLNULL) ||
+		    (!right_is_file && right_type.id() != LogicalTypeId::SQLNULL)) {
+			return false;
+		}
+		if (left_is_file && right_is_file && left_type != right_type) {
+			return false;
+		}
+		result_type = left_is_file ? left_type : right_type;
+		return true;
+	}
+	if (TypeVisitor::Contains(left_type, FileLogicalType::IsFile) ||
+	    TypeVisitor::Contains(right_type, FileLogicalType::IsFile)) {
+		return false;
+	}
+
 	LogicalType res;
 	bool is_equality;
 	switch (comparison_type) {
@@ -176,6 +206,18 @@ BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t de
 		return BindResult(BinderException(expr,
 		                                  "Cannot compare values of type %s and type %s - an explicit cast is required",
 		                                  left_sql_type.ToString(), right_sql_type.ToString()));
+	}
+	if (FileLogicalType::IsFile(input_type)) {
+		vector<unique_ptr<ParsedExpression>> children;
+		children.push_back(make_uniq<BoundExpression>(std::move(left)));
+		children.push_back(make_uniq<BoundExpression>(std::move(right)));
+		auto function_name = expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL
+		                         ? FileLogicalType::EQUAL_FUNCTION_NAME
+		                         : FileLogicalType::NOT_EQUAL_FUNCTION_NAME;
+		unique_ptr<ParsedExpression> function =
+		    make_uniq<FunctionExpression>(SYSTEM_CATALOG, DEFAULT_SCHEMA, function_name, std::move(children));
+		function->SetQueryLocation(expr.GetQueryLocation());
+		return BindExpression(function, depth);
 	}
 	// add casts (if necessary)
 	left = BoundCastExpression::AddCastToType(context, std::move(left), input_type,

--- a/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -6,11 +6,13 @@
 
 #include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
+#include "duckdb/parser/expression/conjunction_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/catalog/catalog_entry/collate_catalog_entry.hpp"
@@ -184,6 +186,36 @@ LogicalType ExpressionBinder::GetExpressionReturnType(const Expression &expr) {
 	return expr.return_type;
 }
 
+static unique_ptr<ParsedExpression> FileFieldExpression(const Expression &file, idx_t field_index) {
+	vector<unique_ptr<ParsedExpression>> children;
+	children.push_back(make_uniq<BoundExpression>(file.Copy()));
+	children.push_back(make_uniq<ConstantExpression>(Value(StructType::GetChildName(file.return_type, field_index))));
+	return make_uniq<OperatorExpression>(ExpressionType::STRUCT_EXTRACT, std::move(children));
+}
+
+static unique_ptr<ParsedExpression> FileComparisonExpression(const Expression &left, const Expression &right,
+                                                             ExpressionType comparison_type) {
+	vector<unique_ptr<ParsedExpression>> fields_equal;
+	fields_equal.reserve(FileLogicalType::FIELD_COUNT);
+	for (idx_t field_index = 0; field_index < FileLogicalType::FIELD_COUNT; field_index++) {
+		fields_equal.push_back(make_uniq<ComparisonExpression>(ExpressionType::COMPARE_EQUAL,
+		                                                       FileFieldExpression(left, field_index),
+		                                                       FileFieldExpression(right, field_index)));
+	}
+
+	unique_ptr<ParsedExpression> result =
+	    make_uniq<ConjunctionExpression>(ExpressionType::CONJUNCTION_AND, std::move(fields_equal));
+	if (comparison_type == ExpressionType::COMPARE_NOTEQUAL) {
+		result = make_uniq<OperatorExpression>(ExpressionType::OPERATOR_NOT, std::move(result));
+	}
+	return result;
+}
+
+static bool CanExpandFileComparison(const Expression &expression) {
+	return !expression.HasSubquery() && !expression.IsVolatile() &&
+	       expression.GetExpressionClass() != ExpressionClass::BOUND_EXPANDED;
+}
+
 BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t depth) {
 	// first try to bind the children of the case expression
 	ErrorData error;
@@ -208,6 +240,14 @@ BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t de
 		                                  left_sql_type.ToString(), right_sql_type.ToString()));
 	}
 	if (FileLogicalType::IsFile(input_type)) {
+		left = BoundCastExpression::AddCastToType(context, std::move(left), input_type);
+		right = BoundCastExpression::AddCastToType(context, std::move(right), input_type);
+		if (CanExpandFileComparison(*left) && CanExpandFileComparison(*right)) {
+			auto comparison = FileComparisonExpression(*left, *right, expr.GetExpressionType());
+			comparison->SetQueryLocation(expr.GetQueryLocation());
+			return BindExpression(comparison, depth);
+		}
+
 		vector<unique_ptr<ParsedExpression>> children;
 		children.push_back(make_uniq<BoundExpression>(std::move(left)));
 		children.push_back(make_uniq<BoundExpression>(std::move(right)));

--- a/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -6,6 +6,8 @@
 
 #include "duckdb/parser/expression/comparison_expression.hpp"
 #include "duckdb/parser/expression/bound_expression.hpp"
+#include "duckdb/parser/expression/cast_expression.hpp"
+#include "duckdb/parser/expression/collate_expression.hpp"
 #include "duckdb/parser/expression/conjunction_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
@@ -190,7 +192,13 @@ static unique_ptr<ParsedExpression> FileFieldExpression(const Expression &file, 
 	vector<unique_ptr<ParsedExpression>> children;
 	children.push_back(make_uniq<BoundExpression>(file.Copy()));
 	children.push_back(make_uniq<ConstantExpression>(Value(StructType::GetChildName(file.return_type, field_index))));
-	return make_uniq<OperatorExpression>(ExpressionType::STRUCT_EXTRACT, std::move(children));
+	unique_ptr<ParsedExpression> result =
+	    make_uniq<OperatorExpression>(ExpressionType::STRUCT_EXTRACT, std::move(children));
+	if (StructType::GetChildType(file.return_type, field_index).id() == LogicalTypeId::VARCHAR) {
+		result = make_uniq<CastExpression>(LogicalType::VARCHAR, std::move(result));
+		result = make_uniq<CollateExpression>("binary", std::move(result));
+	}
+	return result;
 }
 
 static unique_ptr<ParsedExpression> FileComparisonExpression(const Expression &left, const Expression &right,

--- a/external/duckdb/src/planner/binder/expression/bind_parameter_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_parameter_expression.cpp
@@ -1,3 +1,10 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
+#include "duckdb/common/types.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
@@ -20,6 +27,7 @@ BindResult ExpressionBinder::BindExpression(ParameterExpression &expr, idx_t dep
 	if (param_data_it != parameter_data.end()) {
 		// it has! emit a constant directly
 		auto &data = param_data_it->second;
+		FileLogicalType::Validate(data.GetValue(), "Query parameter FILE");
 		auto return_type = parameters->GetReturnType(parameter_id);
 		bool is_literal =
 		    return_type.id() == LogicalTypeId::INTEGER_LITERAL || return_type.id() == LogicalTypeId::STRING_LITERAL;

--- a/external/duckdb/src/planner/binder/expression/bind_subquery_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_subquery_expression.cpp
@@ -1,4 +1,11 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/parser/expression/subquery_expression.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
@@ -157,6 +164,17 @@ BindResult ExpressionBinder::BindExpression(SubqueryExpression &expr, idx_t dept
 
 	auto result = make_uniq<BoundSubqueryExpression>(return_type);
 	if (expr.subquery_type == SubqueryType::ANY) {
+		for (auto &child : child_expressions) {
+			if (TypeVisitor::Contains(child->return_type, FileLogicalType::IsFile)) {
+				throw BinderException(expr, "FILE does not support quantified subquery comparisons");
+			}
+		}
+		for (auto &type : bound_node.types) {
+			if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+				throw BinderException(expr, "FILE does not support quantified subquery comparisons");
+			}
+		}
+
 		// ANY comparison
 		// cast child and subquery child to equivalent types
 		// Special case: if we have a single struct child and multiple subquery types,

--- a/external/duckdb/src/planner/binder/expression/bind_window_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_window_expression.cpp
@@ -237,6 +237,10 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 	}
 	for (auto &part_expr : window.partitions) {
 		auto &bound_partition = BoundExpression::GetExpression(*part_expr);
+		if (TypeVisitor::Contains(bound_partition->return_type, FileLogicalType::IsFile)) {
+			throw BinderException(bound_partition->GetQueryLocation(),
+			                      "Window PARTITION BY does not support FILE values");
+		}
 		ExpressionBinder::PushCollation(context, bound_partition, bound_partition->return_type);
 	}
 	for (auto &order : window.orders) {
@@ -271,6 +275,13 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 		}
 		types.push_back(bound->return_type);
 		children.push_back(std::move(bound));
+	}
+	if (window.distinct) {
+		for (auto &type : types) {
+			if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+				throw BinderException(error_context, "DISTINCT window aggregates do not support FILE values");
+			}
+		}
 	}
 	//  Determine the function type.
 	LogicalType sql_type;

--- a/external/duckdb/src/planner/binder/expression/bind_window_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_window_expression.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
@@ -385,6 +386,9 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 		auto type = config.ResolveOrder(context, order.type);
 		auto null_order = config.ResolveNullOrder(context, type, order.null_order);
 		auto expression = GetExpression(order.expression);
+		if (TypeVisitor::Contains(expression->return_type, FileLogicalType::IsFile)) {
+			throw BinderException(expression->GetQueryLocation(), "Window ORDER BY does not support FILE values");
+		}
 		result->orders.emplace_back(type, null_order, std::move(expression));
 	}
 
@@ -393,6 +397,9 @@ BindResult BaseSelectBinder::BindWindow(WindowExpression &window, idx_t depth) {
 		auto type = config.ResolveOrder(context, order.type);
 		auto null_order = config.ResolveNullOrder(context, type, order.null_order);
 		auto expression = GetExpression(order.expression);
+		if (TypeVisitor::Contains(expression->return_type, FileLogicalType::IsFile)) {
+			throw BinderException(expression->GetQueryLocation(), "Window ORDER BY does not support FILE values");
+		}
 		result->arg_orders.emplace_back(type, null_order, std::move(expression));
 	}
 

--- a/external/duckdb/src/planner/binder/query_node/bind_recursive_cte_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_recursive_cte_node.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/common/enums/deprecated_using_key_syntax.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression_map.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
@@ -87,6 +88,9 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 	for (auto &expr : statement.key_targets) {
 		auto bound_expr = expression_binder.Bind(expr);
 		D_ASSERT(bound_expr->type == ExpressionType::BOUND_COLUMN_REF);
+		if (TypeVisitor::Contains(bound_expr->return_type, FileLogicalType::IsFile)) {
+			throw BinderException(bound_expr->GetQueryLocation(), "Recursive CTE keys do not support FILE values");
+		}
 		key_targets.push_back(std::move(bound_expr));
 	}
 
@@ -121,6 +125,14 @@ BoundStatement Binder::BindNode(RecursiveCTENode &statement) {
 	// Check if there is a reference to the recursive or recurring table, if not create a set operator.
 	auto cte_binding = right_binder->GetCTEBinding(BindingAlias(ctename));
 	bool ref_cte = cte_binding && cte_binding->IsReferenced();
+	const bool uses_full_row_distinct = !union_all && (!is_using_key || (!ref_cte && !ref_recurring));
+	if (uses_full_row_distinct) {
+		for (const auto &type : result.types) {
+			if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+				throw BinderException("Recursive UNION does not support FILE values");
+			}
+		}
+	}
 	if (!ref_cte && !ref_recurring) {
 		auto root =
 		    make_uniq<LogicalSetOperation>(setop_index, result.types.size(), std::move(left_node),

--- a/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
@@ -334,6 +334,9 @@ void Binder::BindModifiers(BoundQueryNode &result, idx_t table_index, const vect
 				}
 			}
 			for (auto &expr : distinct.target_distincts) {
+				if (TypeVisitor::Contains(expr->return_type, FileLogicalType::IsFile)) {
+					throw BinderException(expr->GetQueryLocation(), "DISTINCT does not support FILE values");
+				}
 				ExpressionBinder::PushCollation(context, expr, expr->return_type);
 			}
 			break;
@@ -515,6 +518,9 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 			LogicalType group_type;
 			auto bound_expr = group_binder.Bind(group_expressions[i], &group_type);
 			D_ASSERT(bound_expr->return_type.id() != LogicalTypeId::INVALID);
+			if (TypeVisitor::Contains(bound_expr->return_type, FileLogicalType::IsFile)) {
+				throw BinderException(bound_expr->GetQueryLocation(), "GROUP BY does not support FILE values");
+			}
 
 			// find out whether the expression contains a subquery, it can't be copied if so
 			auto &bound_expr_ref = *bound_expr;
@@ -655,6 +661,9 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 
 	for (auto &group_by_all_index : group_by_all_indexes) {
 		auto &expr = result.select_list[group_by_all_index];
+		if (TypeVisitor::Contains(expr->return_type, FileLogicalType::IsFile)) {
+			throw BinderException(expr->GetQueryLocation(), "GROUP BY does not support FILE values");
+		}
 		auto group_ref = make_uniq<BoundColumnRefExpression>(
 		    expr->return_type, ColumnBinding(result.group_index, result.groups.group_expressions.size()));
 		result.groups.group_expressions.push_back(std::move(expr));

--- a/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/aggregate/distributive_function_utils.hpp"
@@ -368,6 +369,9 @@ void Binder::BindModifiers(BoundQueryNode &result, idx_t table_index, const vect
 			}
 			for (auto &order_node : order.orders) {
 				auto &expr = order_node.expression;
+				if (TypeVisitor::Contains(expr->return_type, FileLogicalType::IsFile)) {
+					throw BinderException(expr->GetQueryLocation(), "ORDER BY does not support FILE values");
+				}
 				ExpressionBinder::PushCollation(context, order_node.expression, expr->return_type);
 			}
 			break;

--- a/external/duckdb/src/planner/binder/query_node/bind_setop_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_setop_node.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression_binder/select_bind_state.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 
 namespace duckdb {
 
@@ -286,6 +287,13 @@ BoundStatement Binder::BindNode(SetOperationNode &statement) {
 				}
 			}
 			result.types.push_back(result_type);
+		}
+	}
+	if (result.setop_type == SetOperationType::INTERSECT || result.setop_type == SetOperationType::EXCEPT) {
+		for (auto &type : result.types) {
+			if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+				throw BinderException("INTERSECT and EXCEPT do not support FILE values");
+			}
 		}
 	}
 

--- a/external/duckdb/src/planner/binder/query_node/plan_subquery.cpp
+++ b/external/duckdb/src/planner/binder/query_node/plan_subquery.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/common/enums/logical_operator_type.hpp"
 #include "duckdb/planner/operator/logical_dependent_join.hpp"
 #include "duckdb/planner/subquery/recursive_dependent_join_planner.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/scalar/generic_functions.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
 #include "duckdb/main/settings.hpp"
@@ -252,6 +253,20 @@ static bool PerformDelimOnType(const LogicalType &type) {
 }
 
 static bool PerformDuplicateElimination(Binder &binder, CorrelatedColumns &correlated_columns) {
+	bool contains_file = false;
+	for (auto &col : correlated_columns) {
+		if (TypeVisitor::Contains(col.type, FileLogicalType::IsFile)) {
+			contains_file = true;
+			break;
+		}
+	}
+	if (contains_file) {
+		auto binding = ColumnBinding(binder.GenerateTableIndex(), 0);
+		CorrelatedColumnInfo info(binding, LogicalType::BIGINT, "delim_index", 0);
+		correlated_columns.AddColumn(std::move(info));
+		correlated_columns.SetDelimIndexToZero();
+		return false;
+	}
 	if (!ClientConfig::GetConfig(binder.context).enable_optimizer) {
 		// if optimizations are disabled we always do a delim join
 		return true;
@@ -280,6 +295,13 @@ static unique_ptr<Expression> PlanCorrelatedSubquery(Binder &binder, BoundSubque
                                                      unique_ptr<LogicalOperator> plan) {
 	auto &correlated_columns = expr.binder->correlated_columns;
 	// FIXME: there should be a way of disabling decorrelation for ANY queries as well, but not for now...
+	if (expr.subquery_type == SubqueryType::ANY) {
+		for (auto &col : correlated_columns) {
+			if (TypeVisitor::Contains(col.type, FileLogicalType::IsFile)) {
+				throw BinderException("Correlated quantified subqueries do not support FILE values");
+			}
+		}
+	}
 	bool perform_delim =
 	    expr.subquery_type == SubqueryType::ANY ? true : PerformDuplicateElimination(binder, correlated_columns);
 	D_ASSERT(expr.IsCorrelated());

--- a/external/duckdb/src/planner/binder/statement/bind_copy.cpp
+++ b/external/duckdb/src/planner/binder/statement/bind_copy.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/filename_pattern.hpp"
 #include "duckdb/common/local_file_system.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/table/read_csv.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/relation.hpp"
@@ -291,6 +292,11 @@ BoundStatement Binder::BindCopyTo(CopyStatement &stmt, const CopyFunction &funct
 				select_node.types.push_back(expr->return_type);
 			}
 			select_node.plan = std::move(projection);
+		}
+	}
+	for (const auto partition_col : partition_cols) {
+		if (TypeVisitor::Contains(select_node.types[partition_col], FileLogicalType::IsFile)) {
+			throw BinderException("PARTITION_BY does not support FILE values");
 		}
 	}
 

--- a/external/duckdb/src/planner/binder/tableref/bind_pivot.cpp
+++ b/external/duckdb/src/planner/binder/tableref/bind_pivot.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/common/types/value_map.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/expression/operator_expression.hpp"
 #include "duckdb/planner/tableref/bound_pivotref.hpp"
@@ -534,6 +535,9 @@ static void BindPivotInList(unique_ptr<ParsedExpression> &expr, vector<Value> &v
 			throw BinderException(expr->GetQueryLocation(), "PIVOT IN list must contain constant expressions");
 		}
 		auto folded_value = ExpressionExecutor::EvaluateScalar(binder.context, *bound_expr);
+		if (TypeVisitor::Contains(folded_value.type(), FileLogicalType::IsFile)) {
+			throw BinderException(expr->GetQueryLocation(), "PIVOT IN list does not support FILE values");
+		}
 		values.push_back(folded_value);
 	} break;
 	}

--- a/external/duckdb/src/planner/expression/bound_cast_expression.cpp
+++ b/external/duckdb/src/planner/expression/bound_cast_expression.cpp
@@ -1,8 +1,15 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_default_expression.hpp"
 #include "duckdb/planner/expression/bound_parameter_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/cast_rules.hpp"
 #include "duckdb/function/cast/cast_function_set.hpp"
 #include "duckdb/main/config.hpp"
@@ -53,6 +60,11 @@ static unique_ptr<Expression> AddCastToTypeInternal(unique_ptr<Expression> expr,
 	D_ASSERT(expr);
 	if (expr->GetExpressionClass() == ExpressionClass::BOUND_PARAMETER) {
 		auto &parameter = expr->Cast<BoundParameterExpression>();
+		auto target_contains_file = TypeVisitor::Contains(target_type, FileLogicalType::IsFile);
+		if (target_contains_file && parameter.parameter_data->return_type != target_type) {
+			throw BinderException(get_input.query_location,
+			                      "Cannot infer a parameter as FILE; construct it with file(...) instead");
+		}
 		if (!target_type.IsValid()) {
 			// invalidate the parameter
 			parameter.parameter_data->return_type = LogicalType::INVALID;

--- a/external/duckdb/src/planner/expression_binder.cpp
+++ b/external/duckdb/src/planner/expression_binder.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/planner/expression_binder.hpp"
 
 #include "duckdb/parser/expression/list.hpp"
@@ -281,6 +287,9 @@ bool ExpressionBinder::ContainsType(const LogicalType &type, LogicalTypeId targe
 LogicalType ExpressionBinder::ExchangeType(const LogicalType &type, LogicalTypeId target, LogicalType new_type) {
 	if (type.id() == target) {
 		return new_type;
+	}
+	if (!ContainsType(type, target)) {
+		return type;
 	}
 	switch (type.id()) {
 	case LogicalTypeId::STRUCT: {

--- a/external/duckdb/test/api/capi/test_capi_any_invalid_type.cpp
+++ b/external/duckdb/test/api/capi/test_capi_any_invalid_type.cpp
@@ -217,6 +217,39 @@ TEST_CASE("Test scalar functions with INVALID and ANY types", "[capi]") {
 	duckdb_destroy_logical_type(&invalid_type);
 }
 
+TEST_CASE("Test scalar functions with FILE types", "[capi][file]") {
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+
+	duckdb_result result;
+	REQUIRE(duckdb_query(tester.connection, "SELECT NULL::FILE", &result) == DuckDBSuccess);
+	auto file_type = duckdb_column_logical_type(&result, 0);
+	auto nested_file_type = duckdb_create_list_type(file_type);
+	auto boolean_type = duckdb_create_logical_type(DUCKDB_TYPE_BOOLEAN);
+
+	auto function = DummyScalarFunction();
+	duckdb_scalar_function_set_return_type(function, file_type);
+	REQUIRE(duckdb_register_scalar_function(tester.connection, function) == DuckDBError);
+	duckdb_destroy_scalar_function(&function);
+
+	function = DummyScalarFunction();
+	duckdb_scalar_function_add_parameter(function, nested_file_type);
+	duckdb_scalar_function_set_return_type(function, boolean_type);
+	REQUIRE(duckdb_register_scalar_function(tester.connection, function) == DuckDBError);
+	duckdb_destroy_scalar_function(&function);
+
+	function = DummyScalarFunction();
+	duckdb_scalar_function_set_varargs(function, file_type);
+	duckdb_scalar_function_set_return_type(function, boolean_type);
+	REQUIRE(duckdb_register_scalar_function(tester.connection, function) == DuckDBError);
+	duckdb_destroy_scalar_function(&function);
+
+	duckdb_destroy_logical_type(&boolean_type);
+	duckdb_destroy_logical_type(&nested_file_type);
+	duckdb_destroy_logical_type(&file_type);
+	duckdb_destroy_result(&result);
+}
+
 void my_dummy_bind(duckdb_bind_info) {
 }
 

--- a/external/duckdb/test/api/capi/test_capi_appender.cpp
+++ b/external/duckdb/test/api/capi/test_capi_appender.cpp
@@ -1048,6 +1048,115 @@ TEST_CASE("Test append duckdb_value values in C API", "[capi]") {
 	tester.Cleanup();
 }
 
+TEST_CASE("Test FILE validation in C API appender", "[capi][file]") {
+	CAPITester tester;
+	REQUIRE(tester.OpenDatabase(nullptr));
+	REQUIRE_NO_FAIL(tester.Query("CREATE TABLE files(value FILE)"));
+
+	SECTION("duckdb_append_value rejects an invalid FILE") {
+		duckdb_appender appender;
+		REQUIRE(duckdb_appender_create(tester.connection, nullptr, "files", &appender) == DuckDBSuccess);
+		auto file_type = duckdb_appender_column_type(appender, 0);
+
+		duckdb_value fields[5];
+		for (auto &field : fields) {
+			field = duckdb_create_null_value();
+		}
+		auto file_value = duckdb_create_struct_value(file_type, fields);
+		REQUIRE(file_value != nullptr);
+		REQUIRE(duckdb_append_value(appender, file_value) == DuckDBError);
+		REQUIRE(string(duckdb_appender_error(appender)) == "Appender FILE url cannot be NULL");
+
+		duckdb_destroy_value(&file_value);
+		for (auto &field : fields) {
+			duckdb_destroy_value(&field);
+		}
+		duckdb_destroy_logical_type(&file_type);
+		REQUIRE(duckdb_appender_destroy(&appender) == DuckDBSuccess);
+	}
+
+	SECTION("duckdb_append_data_chunk rejects an invalid FILE") {
+		duckdb_appender appender;
+		REQUIRE(duckdb_appender_create(tester.connection, nullptr, "files", &appender) == DuckDBSuccess);
+		auto file_type = duckdb_appender_column_type(appender, 0);
+		auto data_chunk = duckdb_create_data_chunk(&file_type, 1);
+		REQUIRE(data_chunk != nullptr);
+
+		auto file_vector = duckdb_data_chunk_get_vector(data_chunk, 0);
+		duckdb_vector_assign_string_element(duckdb_struct_vector_get_child(file_vector, 0), 0, "object");
+		auto position =
+		    reinterpret_cast<int64_t *>(duckdb_vector_get_data(duckdb_struct_vector_get_child(file_vector, 2)));
+		auto size = reinterpret_cast<int64_t *>(duckdb_vector_get_data(duckdb_struct_vector_get_child(file_vector, 3)));
+		position[0] = -1;
+		size[0] = 1;
+		duckdb_vector_assign_string_element(duckdb_struct_vector_get_child(file_vector, 4), 0, "sha256:digest");
+		duckdb_data_chunk_set_size(data_chunk, 1);
+
+		REQUIRE(duckdb_append_data_chunk(appender, data_chunk) == DuckDBError);
+		REQUIRE(string(duckdb_appender_error(appender)) == "Appender FILE position and size must be non-negative");
+
+		duckdb_destroy_data_chunk(&data_chunk);
+		duckdb_destroy_logical_type(&file_type);
+		REQUIRE(duckdb_appender_destroy(&appender) == DuckDBSuccess);
+	}
+
+	SECTION("nested FILE values are validated") {
+		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE nested_files(value STRUCT(payload FILE))"));
+		duckdb_appender appender;
+		REQUIRE(duckdb_appender_create(tester.connection, nullptr, "nested_files", &appender) == DuckDBSuccess);
+		auto struct_type = duckdb_appender_column_type(appender, 0);
+		auto file_type = duckdb_struct_type_child_type(struct_type, 0);
+
+		duckdb_value file_fields[] = {duckdb_create_varchar("object"), duckdb_create_null_value(),
+		                              duckdb_create_null_value(), duckdb_create_null_value(),
+		                              duckdb_create_varchar("invalid")};
+		auto file_value = duckdb_create_struct_value(file_type, file_fields);
+		REQUIRE(file_value != nullptr);
+		auto struct_value = duckdb_create_struct_value(struct_type, &file_value);
+		REQUIRE(struct_value != nullptr);
+		REQUIRE(duckdb_append_value(appender, struct_value) == DuckDBError);
+		REQUIRE(string(duckdb_appender_error(appender)) ==
+		        "Appender FILE checksum must have the form <algorithm>:<digest>");
+
+		duckdb_destroy_value(&struct_value);
+		duckdb_destroy_value(&file_value);
+		for (auto &field : file_fields) {
+			duckdb_destroy_value(&field);
+		}
+		duckdb_destroy_logical_type(&file_type);
+		duckdb_destroy_logical_type(&struct_type);
+		REQUIRE(duckdb_appender_destroy(&appender) == DuckDBSuccess);
+	}
+
+	SECTION("NULL nested parents hide invalid FILE children") {
+		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE nested_files(value STRUCT(payload FILE))"));
+		duckdb_appender appender;
+		REQUIRE(duckdb_appender_create(tester.connection, nullptr, "nested_files", &appender) == DuckDBSuccess);
+		auto struct_type = duckdb_appender_column_type(appender, 0);
+		auto data_chunk = duckdb_create_data_chunk(&struct_type, 1);
+		REQUIRE(data_chunk != nullptr);
+
+		auto struct_vector = duckdb_data_chunk_get_vector(data_chunk, 0);
+		auto file_vector = duckdb_struct_vector_get_child(struct_vector, 0);
+		auto url_vector = duckdb_struct_vector_get_child(file_vector, 0);
+		duckdb_vector_ensure_validity_writable(url_vector);
+		duckdb_validity_set_row_invalid(duckdb_vector_get_validity(url_vector), 0);
+		duckdb_vector_ensure_validity_writable(struct_vector);
+		duckdb_validity_set_row_invalid(duckdb_vector_get_validity(struct_vector), 0);
+		duckdb_data_chunk_set_size(data_chunk, 1);
+
+		REQUIRE(duckdb_append_data_chunk(appender, data_chunk) == DuckDBSuccess);
+		REQUIRE(duckdb_appender_close(appender) == DuckDBSuccess);
+		auto result = tester.Query("SELECT value IS NULL FROM nested_files");
+		REQUIRE_NO_FAIL(*result);
+		REQUIRE(result->Fetch<bool>(0, 0));
+
+		duckdb_destroy_data_chunk(&data_chunk);
+		duckdb_destroy_logical_type(&struct_type);
+		REQUIRE(duckdb_appender_destroy(&appender) == DuckDBSuccess);
+	}
+}
+
 TEST_CASE("Test append to different catalog in C API") {
 	CAPITester tester;
 	REQUIRE(tester.OpenDatabase(nullptr));

--- a/external/duckdb/test/api/capi/test_capi_arrow.cpp
+++ b/external/duckdb/test/api/capi/test_capi_arrow.cpp
@@ -1,6 +1,7 @@
 #include "capi_tester.hpp"
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/common/arrow/arrow_converter.hpp"
+#include "duckdb/common/arrow/schema_metadata.hpp"
 
 using namespace duckdb;
 using namespace std;
@@ -300,6 +301,32 @@ TEST_CASE("Test arrow in C API", "[capi][arrow]") {
 TEST_CASE("Test C-API Arrow conversion functions", "[capi][arrow]") {
 	CAPITester tester;
 	REQUIRE(tester.OpenDatabase(nullptr));
+
+	SECTION("malformed FILE aliases stay ordinary Arrow structs") {
+		auto child_type = duckdb_create_logical_type(DUCKDB_TYPE_VARCHAR);
+		const char *child_names[] = {"url"};
+		auto malformed_file = duckdb_create_struct_type(&child_type, child_names, 1);
+		duckdb_logical_type_set_alias(malformed_file, "FILE");
+
+		duckdb_logical_type types[] = {malformed_file};
+		const char *names[] = {"value"};
+		ArrowSchemaWrapper arrow_schema;
+		duckdb_arrow_options arrow_options;
+		duckdb_connection_get_arrow_options(tester.connection, &arrow_options);
+		auto error = duckdb_to_arrow_schema(arrow_options, types, names, 1, &arrow_schema.arrow_schema);
+		duckdb_destroy_arrow_options(&arrow_options);
+
+		REQUIRE(error == nullptr);
+		REQUIRE(arrow_schema.arrow_schema.n_children == 1);
+		auto &field = *arrow_schema.arrow_schema.children[0];
+		REQUIRE(string(field.format) == "+s");
+		REQUIRE(field.n_children == 1);
+		ArrowSchemaMetadata metadata(field.metadata);
+		REQUIRE_FALSE(metadata.HasExtension());
+
+		duckdb_destroy_logical_type(&malformed_file);
+		duckdb_destroy_logical_type(&child_type);
+	}
 
 	SECTION("roundtrip: duckdb table -> arrow -> duckdb chunk, validate correctness") {
 		// 1. Create and populate table

--- a/external/duckdb/test/api/capi/test_capi_arrow.cpp
+++ b/external/duckdb/test/api/capi/test_capi_arrow.cpp
@@ -376,11 +376,11 @@ TEST_CASE("Test C-API Arrow conversion functions", "[capi][arrow]") {
 
 	SECTION("DuckDB-to-Arrow conversion validates FILE values") {
 		duckdb_result result;
-		REQUIRE(duckdb_query(tester.connection, "SELECT NULL::FILE AS value", &result) == DuckDBSuccess);
-		auto file_type = duckdb_column_logical_type(&result, 0);
-		auto chunk = duckdb_create_data_chunk(&file_type, 1);
+		REQUIRE(duckdb_query(tester.connection, "SELECT file('valid', NULL, NULL, NULL, NULL) AS value", &result) ==
+		        DuckDBSuccess);
+		auto chunk = duckdb_result_get_chunk(result, 0);
 		REQUIRE(chunk != nullptr);
-		duckdb_data_chunk_set_size(chunk, 1);
+		auto file_type = duckdb_column_logical_type(&result, 0);
 
 		auto file_vector = duckdb_data_chunk_get_vector(chunk, 0);
 		auto url_vector = duckdb_struct_vector_get_child(file_vector, FileLogicalType::URL);
@@ -395,6 +395,14 @@ TEST_CASE("Test C-API Arrow conversion functions", "[capi][arrow]") {
 		REQUIRE(error != nullptr);
 		REQUIRE(StringUtil::Contains(duckdb_error_data_message(error), "Arrow FILE url cannot be NULL"));
 		REQUIRE(arrow_array.release == nullptr);
+
+		ArrowArray legacy_arrow_array;
+		legacy_arrow_array.Init();
+		auto legacy_arrow_array_handle = reinterpret_cast<duckdb_arrow_array>(&legacy_arrow_array);
+		duckdb_result_arrow_array(result, chunk, &legacy_arrow_array_handle);
+		REQUIRE(legacy_arrow_array.release == nullptr);
+		REQUIRE(duckdb_result_error(&result) != nullptr);
+		REQUIRE(StringUtil::Contains(duckdb_result_error(&result), "Arrow FILE url cannot be NULL"));
 
 		duckdb_destroy_error_data(&error);
 		duckdb_destroy_arrow_options(&arrow_options);

--- a/external/duckdb/test/api/capi/test_capi_arrow.cpp
+++ b/external/duckdb/test/api/capi/test_capi_arrow.cpp
@@ -328,6 +328,52 @@ TEST_CASE("Test C-API Arrow conversion functions", "[capi][arrow]") {
 		duckdb_destroy_logical_type(&child_type);
 	}
 
+	SECTION("Arrow-to-DuckDB conversion validates FILE values") {
+		duckdb_result result;
+		REQUIRE(duckdb_query(tester.connection, "SELECT file('valid', NULL, NULL, NULL, NULL) AS value", &result) ==
+		        DuckDBSuccess);
+		auto chunk = duckdb_result_get_chunk(result, 0);
+		REQUIRE(chunk != nullptr);
+
+		duckdb_arrow_options arrow_options;
+		duckdb_connection_get_arrow_options(tester.connection, &arrow_options);
+		ArrowArray arrow_array;
+		auto error = duckdb_data_chunk_to_arrow(arrow_options, chunk, &arrow_array);
+		REQUIRE(error == nullptr);
+
+		auto file_type = duckdb_column_logical_type(&result, 0);
+		duckdb_logical_type types[] = {file_type};
+		const char *names[] = {"value"};
+		ArrowSchemaWrapper arrow_schema;
+		error = duckdb_to_arrow_schema(arrow_options, types, names, 1, &arrow_schema.arrow_schema);
+		REQUIRE(error == nullptr);
+		duckdb_destroy_arrow_options(&arrow_options);
+
+		duckdb_arrow_converted_schema converted_schema = nullptr;
+		error = duckdb_schema_from_arrow(tester.connection, &arrow_schema.arrow_schema, &converted_schema);
+		REQUIRE(error == nullptr);
+
+		REQUIRE(arrow_array.n_children == 1);
+		auto file_array = arrow_array.children[0];
+		REQUIRE(file_array->n_children == FileLogicalType::FIELD_COUNT);
+		auto url_array = file_array->children[FileLogicalType::URL];
+		uint8_t invalid_url = 0;
+		url_array->null_count = 1;
+		url_array->buffers[0] = &invalid_url;
+
+		duckdb_data_chunk out_chunk = nullptr;
+		error = duckdb_data_chunk_from_arrow(tester.connection, &arrow_array, converted_schema, &out_chunk);
+		REQUIRE(error != nullptr);
+		REQUIRE(StringUtil::Contains(duckdb_error_data_message(error), "Arrow FILE url cannot be NULL"));
+		REQUIRE(out_chunk == nullptr);
+		duckdb_destroy_error_data(&error);
+
+		duckdb_destroy_arrow_converted_schema(&converted_schema);
+		duckdb_destroy_logical_type(&file_type);
+		duckdb_destroy_data_chunk(&chunk);
+		duckdb_destroy_result(&result);
+	}
+
 	SECTION("roundtrip: duckdb table -> arrow -> duckdb chunk, validate correctness") {
 		// 1. Create and populate table
 		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE big_table(i INTEGER);"));

--- a/external/duckdb/test/api/capi/test_capi_arrow.cpp
+++ b/external/duckdb/test/api/capi/test_capi_arrow.cpp
@@ -374,6 +374,35 @@ TEST_CASE("Test C-API Arrow conversion functions", "[capi][arrow]") {
 		duckdb_destroy_result(&result);
 	}
 
+	SECTION("DuckDB-to-Arrow conversion validates FILE values") {
+		duckdb_result result;
+		REQUIRE(duckdb_query(tester.connection, "SELECT NULL::FILE AS value", &result) == DuckDBSuccess);
+		auto file_type = duckdb_column_logical_type(&result, 0);
+		auto chunk = duckdb_create_data_chunk(&file_type, 1);
+		REQUIRE(chunk != nullptr);
+		duckdb_data_chunk_set_size(chunk, 1);
+
+		auto file_vector = duckdb_data_chunk_get_vector(chunk, 0);
+		auto url_vector = duckdb_struct_vector_get_child(file_vector, FileLogicalType::URL);
+		duckdb_vector_ensure_validity_writable(url_vector);
+		duckdb_validity_set_row_invalid(duckdb_vector_get_validity(url_vector), 0);
+
+		duckdb_arrow_options arrow_options;
+		duckdb_connection_get_arrow_options(tester.connection, &arrow_options);
+		ArrowArray arrow_array;
+		arrow_array.Init();
+		auto error = duckdb_data_chunk_to_arrow(arrow_options, chunk, &arrow_array);
+		REQUIRE(error != nullptr);
+		REQUIRE(StringUtil::Contains(duckdb_error_data_message(error), "Arrow FILE url cannot be NULL"));
+		REQUIRE(arrow_array.release == nullptr);
+
+		duckdb_destroy_error_data(&error);
+		duckdb_destroy_arrow_options(&arrow_options);
+		duckdb_destroy_data_chunk(&chunk);
+		duckdb_destroy_logical_type(&file_type);
+		duckdb_destroy_result(&result);
+	}
+
 	SECTION("roundtrip: duckdb table -> arrow -> duckdb chunk, validate correctness") {
 		// 1. Create and populate table
 		REQUIRE_NO_FAIL(tester.Query("CREATE TABLE big_table(i INTEGER);"));

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -203,6 +203,16 @@ TEST_CASE("FILE query parameters are validated before storage", "[api][file]") {
 		children[FileLogicalType::CHECKSUM] = make_uniq<Vector>(LogicalType::BIGINT);
 		REQUIRE_THROWS_WITH(FileLogicalType::Validate(malformed_vector, 1, "Vector FILE"),
 		                    Catch::Matchers::Contains("must have type VARCHAR, not BIGINT"));
+
+		auto actual_outer_type = LogicalType::STRUCT({{"payload", malformed_type}});
+		auto malformed_inner =
+		    Value::STRUCT(malformed_type, {Value("nested"), Value(), Value(), Value(), Value::BIGINT(1)});
+		auto nested_file = Value::STRUCT(actual_outer_type, {std::move(malformed_inner)});
+		nested_file.Reinterpret(LogicalType::STRUCT({{"payload", file_type}}));
+		result = con.Query("SELECT ?", nested_file);
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(),
+		                             "Query parameter FILE field \"checksum\" must have type VARCHAR, not BIGINT"));
 	}
 
 	SECTION("valid FILE values remain accepted") {
@@ -216,4 +226,21 @@ TEST_CASE("FILE query parameters are validated before storage", "[api][file]") {
 		REQUIRE(CHECK_COLUMN(result, 1, {0}));
 		REQUIRE(CHECK_COLUMN(result, 2, {1}));
 	}
+}
+
+TEST_CASE("Native scalar UDF FILE signatures are rejected", "[api][file]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	scalar_function_t function = [](DataChunk &, ExpressionState &, Vector &) {
+	};
+	auto file_type = FileLogicalType::Create();
+	auto nested_file_type = LogicalType::STRUCT({{"payload", file_type}});
+
+	REQUIRE_THROWS_WITH(con.CreateVectorizedFunction("file_return_udf", {}, file_type, function),
+	                    Catch::Matchers::Contains("FILE inputs and outputs are not supported by scalar UDFs yet"));
+	REQUIRE_THROWS_WITH(
+	    con.CreateVectorizedFunction("file_input_udf", {nested_file_type}, LogicalType::BOOLEAN, function),
+	    Catch::Matchers::Contains("FILE inputs and outputs are not supported by scalar UDFs yet"));
+	REQUIRE_THROWS_WITH(con.CreateVectorizedFunction("file_varargs_udf", {}, LogicalType::BOOLEAN, function, file_type),
+	                    Catch::Matchers::Contains("FILE inputs and outputs are not supported by scalar UDFs yet"));
 }

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -183,6 +183,28 @@ TEST_CASE("FILE query parameters are validated before storage", "[api][file]") {
 		REQUIRE(StringUtil::Contains(result->GetError(), "Query parameter FILE must contain exactly 5 fields"));
 	}
 
+	SECTION("malformed FILE field types are rejected safely") {
+		auto file_type = FileLogicalType::Create();
+		auto malformed_type = LogicalType::STRUCT({{"url", LogicalType::VARCHAR},
+		                                           {"content_type", LogicalType::VARCHAR},
+		                                           {"position", LogicalType::BIGINT},
+		                                           {"size", LogicalType::BIGINT},
+		                                           {"checksum", LogicalType::BIGINT}});
+		auto malformed_file =
+		    Value::STRUCT(malformed_type, {Value("object"), Value(), Value(), Value(), Value::BIGINT(1)});
+		malformed_file.Reinterpret(file_type);
+		auto result = con.Query("SELECT ?", malformed_file);
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(),
+		                             "Query parameter FILE field \"checksum\" must have type VARCHAR, not BIGINT"));
+
+		Vector malformed_vector(file_type);
+		auto &children = StructVector::GetEntries(malformed_vector);
+		children[FileLogicalType::CHECKSUM] = make_uniq<Vector>(LogicalType::BIGINT);
+		REQUIRE_THROWS_WITH(FileLogicalType::Validate(malformed_vector, 1, "Vector FILE"),
+		                    Catch::Matchers::Contains("must have type VARCHAR, not BIGINT"));
+	}
+
 	SECTION("valid FILE values remain accepted") {
 		auto valid_file =
 		    Value::STRUCT(FileLogicalType::Create(), {Value("object"), Value("application/octet-stream"),

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -1,4 +1,5 @@
 #include "catch.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
 #include "test_helpers.hpp"
 
 using namespace duckdb;
@@ -243,4 +244,23 @@ TEST_CASE("Native scalar UDF FILE signatures are rejected", "[api][file]") {
 	    Catch::Matchers::Contains("FILE inputs and outputs are not supported by scalar UDFs yet"));
 	REQUIRE_THROWS_WITH(con.CreateVectorizedFunction("file_varargs_udf", {}, LogicalType::BOOLEAN, function, file_type),
 	                    Catch::Matchers::Contains("FILE inputs and outputs are not supported by scalar UDFs yet"));
+}
+
+static void InvalidExtensionFileFunction(DataChunk &, ExpressionState &, Vector &result) {
+	result.Reference(Value::STRUCT(FileLogicalType::Create(), {Value(), Value(), Value(), Value(), Value()}));
+}
+
+TEST_CASE("Extension scalar FILE results are validated", "[api][file]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	ExtensionLoader loader(*db.instance, "test_file_extension");
+	loader.RegisterFunction(
+	    ScalarFunction("invalid_extension_file", {}, FileLogicalType::Create(), InvalidExtensionFileFunction));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE files(value FILE)"));
+	auto result = con.Query("INSERT INTO files SELECT invalid_extension_file()");
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "Scalar function FILE url cannot be NULL"));
+	auto count = con.Query("SELECT count(*) FROM files");
+	REQUIRE(CHECK_COLUMN(count, 0, {0}));
 }

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -229,6 +229,30 @@ TEST_CASE("FILE query parameters are validated before storage", "[api][file]") {
 	}
 }
 
+TEST_CASE("FILE constants from relation APIs are validated before storage", "[api][file]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE files(value FILE)"));
+	auto names = duckdb::vector<duckdb::string> {"value"};
+
+	auto invalid_file = Value::STRUCT(FileLogicalType::Create(), {Value(), Value(), Value(), Value(), Value()});
+	auto invalid_values = duckdb::vector<duckdb::vector<Value>> {{std::move(invalid_file)}};
+	REQUIRE_THROWS_WITH(con.Values(invalid_values, names)->Insert("files"),
+	                    Catch::Matchers::Contains("Constant FILE url cannot be NULL"));
+	auto count = con.Query("SELECT count(*) FROM files");
+	REQUIRE(CHECK_COLUMN(count, 0, {0}));
+
+	auto valid_file =
+	    Value::STRUCT(FileLogicalType::Create(), {Value("object"), Value("application/octet-stream"), Value::BIGINT(0),
+	                                              Value::BIGINT(1), Value("sha256:digest")});
+	auto valid_values = duckdb::vector<duckdb::vector<Value>> {{std::move(valid_file)}};
+	REQUIRE_NOTHROW(con.Values(valid_values, names)->Insert("files"));
+	auto result = con.Query("SELECT value.url, value.position, value.size FROM files");
+	REQUIRE(CHECK_COLUMN(result, 0, {"object"}));
+	REQUIRE(CHECK_COLUMN(result, 1, {0}));
+	REQUIRE(CHECK_COLUMN(result, 2, {1}));
+}
+
 TEST_CASE("Native scalar UDF FILE signatures are rejected", "[api][file]") {
 	DuckDB db(nullptr);
 	Connection con(db);

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -165,6 +165,24 @@ TEST_CASE("FILE query parameters are validated before storage", "[api][file]") {
 		REQUIRE(CHECK_COLUMN(count, 0, {0}));
 	}
 
+	SECTION("malformed FILE field counts are rejected safely") {
+		auto file_type = FileLogicalType::Create();
+		REQUIRE_THROWS_WITH(Value::STRUCT(file_type, {Value("object"), Value(), Value(), Value()}),
+		                    Catch::Matchers::Contains("STRUCT value requires 5 fields, but 4 values were provided"));
+		REQUIRE_THROWS_WITH(Value::STRUCT(file_type, {Value("object"), Value(), Value(), Value(), Value(), Value()}),
+		                    Catch::Matchers::Contains("STRUCT value requires 5 fields, but 6 values were provided"));
+
+		auto four_field_type = LogicalType::STRUCT({{"url", LogicalType::VARCHAR},
+		                                            {"content_type", LogicalType::VARCHAR},
+		                                            {"position", LogicalType::BIGINT},
+		                                            {"size", LogicalType::BIGINT}});
+		auto malformed_file = Value::STRUCT(four_field_type, {Value("object"), Value(), Value(), Value()});
+		malformed_file.Reinterpret(std::move(file_type));
+		auto result = con.Query("SELECT ?", malformed_file);
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Query parameter FILE must contain exactly 5 fields"));
+	}
+
 	SECTION("valid FILE values remain accepted") {
 		auto valid_file =
 		    Value::STRUCT(FileLogicalType::Create(), {Value("object"), Value("application/octet-stream"),

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -264,3 +264,99 @@ TEST_CASE("Extension scalar FILE results are validated", "[api][file]") {
 	auto count = con.Query("SELECT count(*) FROM files");
 	REQUIRE(CHECK_COLUMN(count, 0, {0}));
 }
+
+static duckdb::unique_ptr<duckdb::FunctionData>
+InvalidExtensionFileTableBind(duckdb::ClientContext &, duckdb::TableFunctionBindInput &,
+                              duckdb::vector<duckdb::LogicalType> &return_types,
+                              duckdb::vector<duckdb::string> &names) {
+	return_types.push_back(FileLogicalType::Create());
+	names.push_back("value");
+	return nullptr;
+}
+
+static void InvalidExtensionFileTableFunction(ClientContext &, TableFunctionInput &, DataChunk &output) {
+	output.SetValue(0, 0, Value::STRUCT(FileLogicalType::Create(), {Value(), Value(), Value(), Value(), Value()}));
+	output.SetCardinality(1);
+}
+
+TEST_CASE("Extension table FILE results are validated", "[api][file]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	ExtensionLoader loader(*db.instance, "test_file_extension");
+	loader.RegisterFunction(
+	    TableFunction("invalid_extension_files", {}, InvalidExtensionFileTableFunction, InvalidExtensionFileTableBind));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE files(value FILE)"));
+	auto result = con.Query("INSERT INTO files SELECT * FROM invalid_extension_files()");
+	REQUIRE(result->HasError());
+	REQUIRE(StringUtil::Contains(result->GetError(), "Table function FILE url cannot be NULL"));
+	auto count = con.Query("SELECT count(*) FROM files");
+	REQUIRE(CHECK_COLUMN(count, 0, {0}));
+}
+
+static idx_t InvalidExtensionFileAggregateStateSize(const AggregateFunction &) {
+	return sizeof(uint8_t);
+}
+
+static void InvalidExtensionFileAggregateInitialize(const AggregateFunction &, data_ptr_t state) {
+	*state = 0;
+}
+
+static void InvalidExtensionFileAggregateUpdate(Vector[], AggregateInputData &, idx_t, Vector &, idx_t) {
+}
+
+static void InvalidExtensionFileAggregateCombine(Vector &, Vector &, AggregateInputData &, idx_t) {
+}
+
+static void InvalidExtensionFileAggregateFinalize(Vector &, AggregateInputData &, Vector &result, idx_t count,
+                                                  idx_t offset) {
+	auto invalid_file = Value::STRUCT(FileLogicalType::Create(), {Value(), Value(), Value(), Value(), Value()});
+	for (idx_t row = 0; row < count; row++) {
+		result.SetValue(offset + row, invalid_file);
+	}
+}
+
+TEST_CASE("Extension aggregate FILE results are validated", "[api][file]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	ExtensionLoader loader(*db.instance, "test_file_extension");
+	loader.RegisterFunction(
+	    AggregateFunction("invalid_extension_file_aggregate", {LogicalType::BIGINT}, FileLogicalType::Create(),
+	                      InvalidExtensionFileAggregateStateSize, InvalidExtensionFileAggregateInitialize,
+	                      InvalidExtensionFileAggregateUpdate, InvalidExtensionFileAggregateCombine,
+	                      InvalidExtensionFileAggregateFinalize, FunctionNullHandling::SPECIAL_HANDLING));
+
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE files(value FILE)"));
+
+	SECTION("ungrouped aggregate output") {
+		auto result =
+		    con.Query("INSERT INTO files SELECT invalid_extension_file_aggregate(i) FROM range(1) AS input(i)");
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Aggregate function FILE url cannot be NULL"));
+	}
+
+	SECTION("grouped aggregate output") {
+		auto result = con.Query(
+		    "INSERT INTO files SELECT invalid_extension_file_aggregate(i) FROM range(1) AS input(i) GROUP BY i");
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Aggregate function FILE url cannot be NULL"));
+	}
+
+	SECTION("window aggregate output") {
+		auto result =
+		    con.Query("INSERT INTO files SELECT invalid_extension_file_aggregate(i) OVER () FROM range(1) AS input(i)");
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Window function FILE url cannot be NULL"));
+	}
+
+	SECTION("streaming window aggregate output") {
+		auto result = con.Query(
+		    "INSERT INTO files SELECT invalid_extension_file_aggregate(i) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND "
+		    "CURRENT ROW) FROM range(1) AS input(i)");
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Window function FILE url cannot be NULL"));
+	}
+
+	auto count = con.Query("SELECT count(*) FROM files");
+	REQUIRE(CHECK_COLUMN(count, 0, {0}));
+}

--- a/external/duckdb/test/api/test_pending_with_parameters.cpp
+++ b/external/duckdb/test/api/test_pending_with_parameters.cpp
@@ -133,3 +133,47 @@ TEST_CASE("Pending Query with Parameters with transactions", "[api]") {
 	CheckSimpleQueryAfterModification(con1);
 	CheckSimpleQueryAfterModification(con2);
 }
+
+TEST_CASE("FILE query parameters are validated before storage", "[api][file]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	REQUIRE_NO_FAIL(con.Query("CREATE TABLE files(value FILE)"));
+
+	SECTION("top-level FILE values are validated") {
+		auto invalid_file = Value::STRUCT(FileLogicalType::Create(), {Value(), Value(), Value(), Value(), Value()});
+		auto result = con.Query("INSERT INTO files VALUES (?)", invalid_file);
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(), "Query parameter FILE url cannot be NULL"));
+
+		auto count = con.Query("SELECT count(*) FROM files");
+		REQUIRE(CHECK_COLUMN(count, 0, {0}));
+	}
+
+	SECTION("nested FILE values are validated recursively") {
+		REQUIRE_NO_FAIL(con.Query("CREATE TABLE nested_files(value STRUCT(payload FILE))"));
+		auto file_type = FileLogicalType::Create();
+		auto invalid_file = Value::STRUCT(file_type, {Value("object"), Value(), Value(), Value(), Value("invalid")});
+		auto struct_type = LogicalType::STRUCT({{"payload", file_type}});
+		auto nested_file = Value::STRUCT(struct_type, {std::move(invalid_file)});
+
+		auto result = con.Query("INSERT INTO nested_files VALUES (?)", nested_file);
+		REQUIRE(result->HasError());
+		REQUIRE(StringUtil::Contains(result->GetError(),
+		                             "Query parameter FILE checksum must have the form <algorithm>:<digest>"));
+
+		auto count = con.Query("SELECT count(*) FROM nested_files");
+		REQUIRE(CHECK_COLUMN(count, 0, {0}));
+	}
+
+	SECTION("valid FILE values remain accepted") {
+		auto valid_file =
+		    Value::STRUCT(FileLogicalType::Create(), {Value("object"), Value("application/octet-stream"),
+		                                              Value::BIGINT(0), Value::BIGINT(1), Value("sha256:digest")});
+		REQUIRE_NO_FAIL(con.Query("INSERT INTO files VALUES (?)", valid_file));
+
+		auto result = con.Query("SELECT value.url, value.position, value.size FROM files");
+		REQUIRE(CHECK_COLUMN(result, 0, {"object"}));
+		REQUIRE(CHECK_COLUMN(result, 1, {0}));
+		REQUIRE(CHECK_COLUMN(result, 2, {1}));
+	}
+}

--- a/src/vane_py/python_udf.cpp
+++ b/src/vane_py/python_udf.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
 #include "duckdb/common/arrow/arrow_appender.hpp"
 #include "duckdb/common/arrow/result_arrow_wrapper.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "vane_python/arrow/arrow_array_stream.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/function/function.hpp"
@@ -22,6 +23,7 @@
 #include "vane_python/arrow/arrow_export_utils.hpp"
 #include "duckdb/common/types/arrow_aux_data.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb/planner/expression.hpp"
 #include "duckdb/function/table/arrow/arrow_duck_schema.hpp"
 #include "vane_python/python_conversion.hpp"
 #include <mutex>
@@ -446,6 +448,19 @@ static std::pair<bool, double> ParseOptionalNonNegativeDouble(const py::object &
 	return std::make_pair(true, parsed);
 }
 
+static unique_ptr<FunctionData> BindPythonUDF(ClientContext &, ScalarFunction &bound_function,
+                                              vector<unique_ptr<Expression>> &arguments) {
+	if (TypeVisitor::Contains(bound_function.GetReturnType(), FileLogicalType::IsFile)) {
+		throw BinderException("FILE inputs and outputs are not supported by Python UDFs yet");
+	}
+	for (auto &argument : arguments) {
+		if (TypeVisitor::Contains(argument->return_type, FileLogicalType::IsFile)) {
+			throw BinderException("FILE inputs and outputs are not supported by Python UDFs yet");
+		}
+	}
+	return nullptr;
+}
+
 struct PythonUDFData {
 public:
 	PythonUDFData(const string &name, bool vectorized, FunctionNullHandling null_handling)
@@ -467,6 +482,14 @@ public:
 	void Verify() {
 		if (return_type == LogicalType::INVALID) {
 			throw InvalidInputException("Could not infer the return type, please set it explicitly");
+		}
+		if (TypeVisitor::Contains(return_type, FileLogicalType::IsFile)) {
+			throw InvalidInputException("FILE inputs and outputs are not supported by Python UDFs yet");
+		}
+		for (auto &parameter : parameters) {
+			if (TypeVisitor::Contains(parameter, FileLogicalType::IsFile)) {
+				throw InvalidInputException("FILE inputs and outputs are not supported by Python UDFs yet");
+			}
 		}
 	}
 
@@ -572,7 +595,7 @@ public:
 		}
 		FunctionStability function_side_effects =
 		    side_effects ? FunctionStability::VOLATILE : FunctionStability::CONSISTENT;
-		ScalarFunction scalar_function(name, std::move(parameters), return_type, func, nullptr, nullptr, nullptr,
+		ScalarFunction scalar_function(name, std::move(parameters), return_type, func, BindPythonUDF, nullptr, nullptr,
 		                               nullptr, varargs, function_side_effects, null_handling);
 		return scalar_function;
 	}

--- a/src/vane_py/python_udf_utils.cpp
+++ b/src/vane_py/python_udf_utils.cpp
@@ -13,6 +13,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/type_visitor.hpp"
 #include "duckdb/function/function_binder.hpp"
 #include "duckdb/function/scalar/udf_functions.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
@@ -30,6 +31,12 @@ namespace {
 constexpr idx_t DEFAULT_UDF_TARGET_MAX_BATCH_BYTES = 134217728;
 constexpr const char *UDF_TARGET_MAX_BATCH_BYTES_ENV = "VANE_UDF_TARGET_MAX_BATCH_BYTES";
 static std::atomic<uint64_t> registered_expression_sequence {0};
+
+static void RejectFileUDFType(const LogicalType &type) {
+	if (TypeVisitor::Contains(type, FileLogicalType::IsFile)) {
+		throw InvalidInputException("FILE inputs and outputs are not supported by Python UDFs yet");
+	}
+}
 
 static Value BuildShapeValue(const vector<idx_t> &shape) {
 	vector<Value> shape_values;
@@ -393,10 +400,12 @@ Value BuildPythonUDFPayload(
 			auto name_obj = item.first;
 			auto type_obj = item.second;
 			auto type = py::cast<shared_ptr<DuckDBPyType>>(type_obj);
+			RejectFileUDFType(type->Type());
 			output_names.push_back(std::string(py::str(name_obj)));
 			output_logical_types.push_back(type->Type());
 		}
 	} else if (return_type) {
+		RejectFileUDFType(return_type->Type());
 		output_names.emplace_back("value");
 		output_logical_types.push_back(return_type->Type());
 	} else {
@@ -462,6 +471,10 @@ Value BuildScalarUDFPayload(const string &name, const py::function &udf, const s
 	ValidateUDFCallableShape(udf, execution_backend);
 	if (!return_type) {
 		throw InvalidInputException("map requires return_type");
+	}
+	RejectFileUDFType(return_type->Type());
+	for (auto &passthrough_type : passthrough_types) {
+		RejectFileUDFType(passthrough_type);
 	}
 	if (default_parallelism == 0) {
 		throw InvalidInputException("default_parallelism must be a positive integer");

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -1277,6 +1277,53 @@ def test_file_type_arrow_ignores_children_of_null_lists(connection):
     ]
 
 
+def test_file_type_arrow_list_view_validates_sparse_child_span(connection):
+    pa = pytest.importorskip("pyarrow")
+    if not hasattr(pa, "ListViewArray"):
+        pytest.skip("The PyArrow version does not support ListViewArray")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+    file_field = pa.field(
+        "item",
+        file_storage_type,
+        metadata={
+            b"ARROW:extension:name": b"vane.file",
+            b"ARROW:extension:metadata": b"",
+        },
+    )
+    file_values = [
+        {
+            "url": None,
+            "content_type": None,
+            "position": None,
+            "size": None,
+            "checksum": None,
+        }
+        for _ in range(101)
+    ]
+    file_values[0]["url"] = "first"
+    file_values[100]["url"] = "last"
+    list_type = pa.list_view(file_field)
+    list_values = pa.ListViewArray.from_arrays(
+        offsets=pa.array([0, 100], type=pa.int32()),
+        sizes=pa.array([1, 1], type=pa.int32()),
+        values=pa.array(file_values, type=file_storage_type),
+        type=list_type,
+    )
+    arrow_table = pa.Table.from_arrays([list_values], schema=pa.schema([pa.field("value", list_type)]))
+
+    rows = connection.from_arrow(arrow_table).project("typeof(value[1]), (value[1]).url").fetchall()
+    assert rows == [("FILE", "first"), ("FILE", "last")]
+
+
 def test_file_type_round_trips_through_local_exchange(connection):
     pytest.importorskip("pyarrow")
 

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -55,6 +55,20 @@ def test_file_supports_all_struct_extraction_forms(connection):
     assert rows == [(url, url, url, url, url, url, url), (None, None, None, None, None, None, None)]
 
 
+def test_file_extract_overloads_preserve_untyped_null_binding(connection):
+    row = connection.execute(
+        """
+        SELECT
+            struct_extract(NULL, 'url'),
+            struct_extract(NULL, 1),
+            struct_extract_at(NULL, 1),
+            array_extract(NULL, 'url')
+        """
+    ).fetchone()
+
+    assert row == (None, None, None, None)
+
+
 @pytest.mark.parametrize(
     ("expression", "message"),
     [
@@ -735,12 +749,18 @@ def test_file_rejects_struct_remapping_bypasses(connection, expression):
         (f"struct_insert({FILE}, extra := 1)", "struct_insert"),
         (f"struct_concat({FILE}, struct_pack(extra := 1))", "struct_concat"),
         (f"struct_concat(struct_pack(extra := 1), {FILE})", "struct_concat"),
-        (f"struct_values({FILE})", "struct_values"),
     ],
 )
 def test_file_rejects_struct_alias_stripping_bypasses(connection, expression, function_name):
     with pytest.raises(vane.BinderException, match=rf"{function_name} does not support FILE values"):
         connection.execute(f"SELECT {expression}").fetchone()
+
+
+def test_file_does_not_shadow_struct_values_null_binding(connection):
+    with pytest.raises(vane.BinderException):
+        connection.execute(f"SELECT struct_values({FILE})").fetchone()
+
+    assert connection.execute("SELECT struct_values(NULL)").fetchone() == (None,)
 
 
 @pytest.mark.parametrize(
@@ -1359,3 +1379,131 @@ def test_file_type_round_trips_through_storage(tmp_path: Path):
         rows = connection.execute("SELECT typeof(value), value.url FROM files ORDER BY value IS NULL").fetchall()
 
     assert rows == [("FILE", "s3://bucket/missing.bin"), ("FILE", None)]
+
+
+def test_file_type_round_trips_through_parquet(connection, tmp_path: Path):
+    parquet_path = tmp_path / "files.parquet"
+    connection.execute(
+        f"""
+        COPY (
+            SELECT
+                {FILE} AS direct,
+                struct_pack(value := {FILE}) AS nested,
+                struct_pack(file_values := [{FILE}]) AS deeply_nested,
+                [{FILE}] AS files,
+                array_value({FILE}) AS fixed_files,
+                MAP {{'value': {FILE}}} AS file_map,
+                {{
+                    'url': 'ordinary',
+                    'content_type': NULL::VARCHAR,
+                    'position': NULL::BIGINT,
+                    'size': NULL::BIGINT,
+                    'checksum': NULL::VARCHAR
+                }} AS ordinary,
+                CAST(union_value(f := {FILE}) AS UNION(f FILE, n BIGINT)) AS choice
+        ) TO '{parquet_path}' (FORMAT PARQUET)
+        """
+    )
+
+    row = connection.execute(
+        f"""
+        SELECT
+            typeof(direct),
+            typeof(nested.value),
+            typeof(deeply_nested.file_values[1]),
+            typeof(files[1]),
+            typeof(fixed_files[1]),
+            typeof(map_extract_value(file_map, 'value')),
+            typeof(ordinary) <> 'FILE',
+            union_tag(choice),
+            typeof(choice.f),
+            direct.url,
+            (deeply_nested.file_values[1]).url,
+            (map_extract_value(file_map, 'value')).url,
+            choice.f.url
+        FROM read_parquet('{parquet_path}')
+        """
+    ).fetchone()
+
+    assert row == (
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        True,
+        "f",
+        "FILE",
+        "s3://bucket/missing.bin",
+        "s3://bucket/missing.bin",
+        "s3://bucket/missing.bin",
+        "s3://bucket/missing.bin",
+    )
+
+
+def test_file_type_survives_parquet_database_export_import(connection, tmp_path: Path):
+    export_path = tmp_path / "file_export"
+    connection.execute(
+        """
+        CREATE TABLE exported_files(
+            id INTEGER,
+            direct FILE,
+            nested STRUCT(value FILE),
+            deeply_nested STRUCT(file_values FILE[]),
+            files FILE[],
+            fixed_files FILE[1],
+            file_map MAP(VARCHAR, FILE),
+            choice UNION(f FILE, n BIGINT)
+        )
+        """
+    )
+    connection.execute(
+        f"""
+        INSERT INTO exported_files VALUES (
+            1,
+            {FILE},
+            struct_pack(value := {FILE}),
+            struct_pack(file_values := [{FILE}]),
+            [{FILE}],
+            array_value({FILE}),
+            MAP {{'value': {FILE}}},
+            CAST(union_value(f := {FILE}) AS UNION(f FILE, n BIGINT))
+        )
+        """
+    )
+
+    connection.execute(f"EXPORT DATABASE '{export_path}' (FORMAT PARQUET)")
+    connection.execute("DROP TABLE exported_files")
+    connection.execute(f"IMPORT DATABASE '{export_path}'")
+
+    row = connection.execute(
+        """
+        SELECT
+            typeof(direct),
+            typeof(nested.value),
+            typeof(deeply_nested.file_values[1]),
+            typeof(files[1]),
+            typeof(fixed_files[1]),
+            typeof(map_extract_value(file_map, 'value')),
+            typeof(choice.f),
+            direct.url,
+            (deeply_nested.file_values[1]).url,
+            (map_extract_value(file_map, 'value')).url,
+            choice.f.url
+        FROM exported_files
+        """
+    ).fetchone()
+    assert row == (
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        "FILE",
+        "s3://bucket/missing.bin",
+        "s3://bucket/missing.bin",
+        "s3://bucket/missing.bin",
+        "s3://bucket/missing.bin",
+    )

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -116,6 +116,81 @@ def test_nested_file_casts_allow_only_null_introduction(connection):
     assert row == ("FILE", True, "FILE", True)
 
 
+def test_file_union_casts_preserve_file_members(connection):
+    row = connection.execute(
+        f"""
+        SELECT union_tag(value), typeof(value.f), (value.f).url, value.n
+        FROM (
+            SELECT CAST(
+                union_value(f := {FILE})
+                AS UNION(f FILE, n BIGINT)
+            ) AS value
+        )
+        """
+    ).fetchone()
+
+    assert row == ("f", "FILE", "s3://bucket/missing.bin", None)
+
+
+def test_file_union_all_resolves_a_file_preserving_common_type(connection):
+    rows = connection.execute(
+        f"""
+        SELECT union_tag(value), typeof(value.f), (value.f).url, value.n
+        FROM (
+            SELECT union_value(f := {FILE}) AS value
+            UNION ALL
+            SELECT CAST(
+                42::BIGINT
+                AS UNION(f FILE, n BIGINT)
+            ) AS value
+        )
+        ORDER BY union_tag(value)
+        """
+    ).fetchall()
+
+    assert rows == [
+        ("f", "FILE", "s3://bucket/missing.bin", None),
+        ("n", "FILE", None, 42),
+    ]
+
+
+def test_file_implicit_cast_reporting_obeys_file_identity_rules(connection):
+    row = connection.execute(
+        f"""
+        SELECT
+            can_cast_implicitly(
+                {FILE},
+                NULL::STRUCT(
+                    url VARCHAR,
+                    content_type VARCHAR,
+                    position BIGINT,
+                    size BIGINT,
+                    checksum VARCHAR
+                )
+            ),
+            can_cast_implicitly(
+                union_value(f := {FILE}),
+                NULL::UNION(f FILE, n BIGINT)
+            ),
+            can_cast_implicitly(
+                union_value(f := {FILE}),
+                NULL::UNION(
+                    f STRUCT(
+                        url VARCHAR,
+                        content_type VARCHAR,
+                        position BIGINT,
+                        size BIGINT,
+                        checksum VARCHAR
+                    ),
+                    n BIGINT
+                )
+            )
+        """
+    ).fetchone()
+
+    assert row == (False, True, False)
+
+
 def test_file_comparison_uses_fieldwise_sql_three_value_logic(connection):
     row = connection.execute(
         f"""

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -85,6 +85,37 @@ def test_file_alias_survives_unrelated_nested_null_resolution(connection):
     assert row == ("FILE", "s3://bucket/missing.bin", None)
 
 
+def test_file_alias_survives_unrelated_recursive_type_replacement(connection):
+    row = connection.execute(
+        f"""
+        SELECT typeof(value.file), typeof(value.number), value.file.url, value.number
+        FROM (
+            SELECT replace_type(
+                struct_pack(file := {FILE}, number := 1::INTEGER),
+                NULL::INTEGER,
+                NULL::BIGINT
+            ) AS value
+        )
+        """
+    ).fetchone()
+
+    assert row == ("FILE", "BIGINT", "s3://bucket/missing.bin", 1)
+
+
+def test_nested_file_casts_allow_only_null_introduction(connection):
+    row = connection.execute(
+        """
+        SELECT
+            typeof(CAST([NULL] AS FILE[])[1]),
+            CAST([NULL] AS FILE[])[1] IS NULL,
+            typeof(CAST(struct_pack(number := 1) AS STRUCT(number INTEGER, file FILE)).file),
+            CAST(struct_pack(number := 1) AS STRUCT(number INTEGER, file FILE)).file IS NULL
+        """
+    ).fetchone()
+
+    assert row == ("FILE", True, "FILE", True)
+
+
 def test_file_comparison_uses_fieldwise_sql_three_value_logic(connection):
     row = connection.execute(
         f"""
@@ -205,6 +236,47 @@ def test_file_comparison_propagates_stored_root_nulls(connection):
     assert rows == [(True, False), (None, None)]
 
 
+def test_file_stored_root_null_masks_hidden_children_and_comparisons(tmp_path: Path):
+    database = tmp_path / "hidden-file-children.db"
+    stored_file = "file('x', 'application/octet-stream', 0, 0, 'sha256:abcdef')"
+
+    with vane.connect(str(database)) as connection:
+        connection.execute("CREATE TABLE files(value FILE)")
+        connection.execute(
+            f"""
+            INSERT INTO files
+            SELECT constant_or_null({stored_file}, marker)
+            FROM (VALUES (NULL::INTEGER)) AS input(marker)
+            """
+        )
+
+    with vane.connect(str(database)) as connection:
+        row = connection.execute(
+            f"""
+            SELECT
+                value IS NULL,
+                value.url,
+                value.content_type,
+                value.position,
+                value.size,
+                value.checksum,
+                struct_extract_at(value, 1),
+                value.url IS NULL,
+                value = {stored_file},
+                {stored_file} = value,
+                value != {stored_file},
+                {stored_file} != value
+            FROM files
+            """
+        ).fetchone()
+
+    assert row == (True, None, None, None, None, None, None, True, None, None, None, None)
+
+    with vane.connect(str(database)) as connection:
+        assert connection.execute("SELECT count(*) FROM files WHERE value.url = 'x'").fetchone() == (0,)
+        assert connection.execute("SELECT count(*) FROM files WHERE value.url IS NULL").fetchone() == (1,)
+
+
 def test_file_comparison_cannot_be_shadowed(connection):
     connection.execute("CREATE MACRO __vane_file_equal(left_value, right_value) AS TRUE")
 
@@ -259,11 +331,11 @@ def test_file_rejects_nested_list_search_comparison_bypasses(connection):
 @pytest.mark.parametrize(
     "expression",
     [
-        f"map_contains(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
-        f"map_extract(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
-        f"element_at(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
-        f"map_extract_value(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
-        f"map([{FILE_WITH_NULL_METADATA}], [1])[{FILE_WITH_NULL_METADATA}]",
+        f"map_contains(value, {FILE_WITH_NULL_METADATA}) FROM (VALUES (NULL::MAP(FILE, INTEGER))) input(value)",
+        f"map_extract(value, {FILE_WITH_NULL_METADATA}) FROM (VALUES (NULL::MAP(FILE, INTEGER))) input(value)",
+        f"element_at(value, {FILE_WITH_NULL_METADATA}) FROM (VALUES (NULL::MAP(FILE, INTEGER))) input(value)",
+        f"map_extract_value(value, {FILE_WITH_NULL_METADATA}) FROM (VALUES (NULL::MAP(FILE, INTEGER))) input(value)",
+        f"value[{FILE_WITH_NULL_METADATA}] FROM (VALUES (NULL::MAP(FILE, INTEGER))) input(value)",
         f"list_has_any([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
         f"array_has_any([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
         f"[{FILE_WITH_NULL_METADATA}] && [{FILE_WITH_NULL_METADATA}]",
@@ -281,6 +353,55 @@ def test_file_rejects_nested_list_search_comparison_bypasses(connection):
 )
 def test_file_rejects_collection_search_comparison_bypasses(connection, expression):
     with pytest.raises(vane.BinderException, match="Collection search functions do not support FILE"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        f"list_distinct([{FILE_WITH_NULL_METADATA}, {FILE_WITH_NULL_METADATA}])",
+        f"array_distinct([{FILE_WITH_NULL_METADATA}, {FILE_WITH_NULL_METADATA}])",
+        f"list_unique([{FILE_WITH_NULL_METADATA}, {FILE_WITH_NULL_METADATA}])",
+        f"array_unique([{FILE_WITH_NULL_METADATA}, {FILE_WITH_NULL_METADATA}])",
+        (
+            "list_distinct(["
+            f"struct_pack(value := {FILE_WITH_NULL_METADATA}), "
+            f"struct_pack(value := {FILE_WITH_NULL_METADATA})"
+            "])"
+        ),
+    ],
+)
+def test_file_rejects_list_hash_comparison_bypasses(connection, expression):
+    with pytest.raises(vane.BinderException, match="does not support FILE values"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize(
+    ("expression", "message"),
+    [
+        (
+            f"map([{FILE_WITH_NULL_METADATA}, {FILE_WITH_NULL_METADATA}], [1, 2])",
+            "map does not support FILE keys",
+        ),
+        (
+            "map(["
+            f"struct_pack(value := {FILE_WITH_NULL_METADATA}), "
+            f"struct_pack(value := {FILE_WITH_NULL_METADATA})"
+            "], [1, 2])",
+            "map does not support FILE keys",
+        ),
+        (
+            f"map_from_entries([row({FILE_WITH_NULL_METADATA}, 1), row({FILE_WITH_NULL_METADATA}, 2)])",
+            "map_from_entries does not support FILE keys",
+        ),
+        (
+            f"map_from_entries(array_value(row({FILE_WITH_NULL_METADATA}, 1), row({FILE_WITH_NULL_METADATA}, 2)))",
+            "map_from_entries does not support FILE keys",
+        ),
+    ],
+)
+def test_file_rejects_map_key_hash_comparison_bypasses(connection, expression, message):
+    with pytest.raises(vane.BinderException, match=message):
         connection.execute(f"SELECT {expression}").fetchone()
 
 
@@ -310,29 +431,42 @@ def test_file_remains_usable_as_a_map_value(connection):
         "s3://bucket/missing.bin",
     )
 
+    row = connection.execute(
+        f"""
+        SELECT
+            typeof(map_from_entries([row('key', {FILE})])['key']),
+            (map_from_entries([row('key', {FILE})])['key']).url
+        """
+    ).fetchone()
+    assert row == ("FILE", "s3://bucket/missing.bin")
+
 
 @pytest.mark.parametrize(
-    "key",
+    "key_type",
     [
-        FILE_WITH_NULL_METADATA,
-        f"struct_pack(value := {FILE_WITH_NULL_METADATA})",
+        "FILE",
+        "STRUCT(value FILE)",
     ],
 )
-def test_file_rejects_map_concat_keys(connection, key):
+def test_file_rejects_map_concat_keys(connection, key_type):
     with pytest.raises(vane.BinderException, match="MAP_CONCAT does not support FILE map keys"):
-        connection.execute(f"SELECT map_concat(map([{key}], [1]), map([{key}], [2]))").fetchone()
+        connection.execute(
+            f"SELECT map_concat(NULL::MAP({key_type}, INTEGER), NULL::MAP({key_type}, INTEGER))"
+        ).fetchone()
 
 
 @pytest.mark.parametrize(
-    "key",
+    ("key", "key_type"),
     [
-        FILE_WITH_NULL_METADATA,
-        f"struct_pack(value := {FILE_WITH_NULL_METADATA})",
+        (FILE_WITH_NULL_METADATA, "FILE"),
+        (f"struct_pack(value := {FILE_WITH_NULL_METADATA})", "STRUCT(value FILE)"),
     ],
 )
-def test_file_rejects_switch_keys(connection, key):
+def test_file_rejects_switch_keys(connection, key, key_type):
     with pytest.raises(vane.BinderException, match="SWITCH does not support FILE map keys"):
-        connection.execute(f"SELECT switch({key}, map([{key}], [1]))").fetchone()
+        connection.execute(
+            f"SELECT switch({key}, value) FROM (VALUES (NULL::MAP({key_type}, INTEGER))) input(value)"
+        ).fetchone()
 
 
 @pytest.mark.parametrize(
@@ -402,6 +536,7 @@ def test_file_rejects_min_max_bypasses(connection, aggregate):
         "histogram(value, [value])",
         "histogram_exact(value, [value])",
         "histogram(struct_pack(value := value))",
+        "is_histogram_other_bin(value)",
     ],
 )
 def test_file_rejects_other_ordering_aggregate_bypasses(connection, aggregate):
@@ -430,6 +565,13 @@ def test_file_remains_usable_as_an_arg_min_result(connection):
         "CAST(ROW('x', NULL, NULL, NULL, NULL) AS FILE)",
         f"CAST({FILE} AS STRUCT(url VARCHAR, content_type VARCHAR, position BIGINT, size BIGINT, checksum VARCHAR))",
         f"CAST({FILE} AS VARCHAR)",
+        f"CAST([{FILE}] AS STRUCT(url VARCHAR, content_type VARCHAR, position BIGINT, size BIGINT, checksum VARCHAR)[])",
+        f"CAST([{FILE}] AS VARCHAR)",
+        "CAST([ROW('x', NULL, NULL, NULL, NULL)] AS FILE[])",
+        (
+            f"CAST(struct_pack(value := {FILE}) AS STRUCT(value STRUCT("
+            "url VARCHAR, content_type VARCHAR, position BIGINT, size BIGINT, checksum VARCHAR)))"
+        ),
     ],
 )
 def test_file_rejects_casts_that_bypass_the_constructor(connection, expression):
@@ -489,6 +631,200 @@ def test_file_rejects_casts_that_bypass_the_constructor(connection, expression):
 def test_file_rejects_struct_remapping_bypasses(connection, expression):
     with pytest.raises(vane.BinderException, match="remap_struct does not support FILE"):
         connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize(
+    ("expression", "function_name"),
+    [
+        (f"struct_update({FILE}, url := 'other')", "struct_update"),
+        (f"struct_insert({FILE}, extra := 1)", "struct_insert"),
+        (f"struct_concat({FILE}, struct_pack(extra := 1))", "struct_concat"),
+        (f"struct_concat(struct_pack(extra := 1), {FILE})", "struct_concat"),
+        (f"struct_values({FILE})", "struct_values"),
+    ],
+)
+def test_file_rejects_struct_alias_stripping_bypasses(connection, expression, function_name):
+    with pytest.raises(vane.BinderException, match=rf"{function_name} does not support FILE values"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "json_transform('{}', '\"FILE\"')",
+        "json_transform('{}', '{\"value\":\"FILE\"}')",
+    ],
+)
+def test_file_rejects_dynamic_type_materialization_bypasses(connection, expression):
+    with pytest.raises(vane.BinderException, match="does not support FILE"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+def test_file_rejects_json_scan_materialization_bypass(connection, tmp_path: Path):
+    source = tmp_path / "file.json"
+    source.write_text('{"value":{"url":"hidden"}}')
+
+    with pytest.raises(vane.BinderException, match="read_json does not support FILE column types"):
+        connection.execute(f"SELECT * FROM read_json('{source}', columns={{value: 'FILE'}})").fetchall()
+
+    connection.execute("CREATE TABLE json_files(value FILE)")
+    with pytest.raises(vane.BinderException, match="COPY FROM JSON does not support FILE column types"):
+        connection.execute(f"COPY json_files FROM '{source}' (FORMAT JSON)")
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        f"SELECT DISTINCT value FROM (VALUES ({FILE_WITH_NULL_METADATA})) AS input(value)",
+        f"SELECT DISTINCT struct_pack(value := value) FROM (VALUES ({FILE})) AS input(value)",
+        f"SELECT DISTINCT ON (value) value FROM (VALUES ({FILE})) AS input(value)",
+        f"SELECT count(*) FROM (VALUES ({FILE})) AS input(value) GROUP BY value",
+        f"SELECT count(*) FROM (VALUES ({FILE})) AS input(value) GROUP BY struct_pack(value := value)",
+        f"SELECT value FROM (VALUES ({FILE})) AS input(value) GROUP BY ALL",
+        f"SELECT {FILE_WITH_NULL_METADATA} UNION SELECT {FILE_WITH_NULL_METADATA}",
+        f"SELECT {FILE_WITH_NULL_METADATA} INTERSECT SELECT {FILE_WITH_NULL_METADATA}",
+        f"SELECT {FILE_WITH_NULL_METADATA} INTERSECT ALL SELECT {FILE_WITH_NULL_METADATA}",
+        f"SELECT {FILE_WITH_NULL_METADATA} EXCEPT SELECT {FILE_WITH_NULL_METADATA}",
+        f"SELECT {FILE_WITH_NULL_METADATA} EXCEPT ALL SELECT {FILE_WITH_NULL_METADATA}",
+        (f"SELECT row_number() OVER (PARTITION BY value) FROM (VALUES ({FILE_WITH_NULL_METADATA})) AS input(value)"),
+        (f"SELECT row_number() OVER (PARTITION BY struct_pack(value := value)) FROM (VALUES ({FILE})) AS input(value)"),
+        f"SELECT count(DISTINCT value) FROM (VALUES ({FILE})) AS input(value)",
+        f"SELECT count(DISTINCT value) OVER () FROM (VALUES ({FILE})) AS input(value)",
+        f"PIVOT (SELECT {FILE} AS key, 1 AS value) ON key IN (NULL::FILE) USING sum(value)",
+        (
+            "WITH RECURSIVE input(value, depth) AS ("
+            f"SELECT {FILE}, 0 "
+            "UNION "
+            "SELECT value, depth + 1 FROM input WHERE depth < 0"
+            ") SELECT * FROM input"
+        ),
+        (
+            "WITH RECURSIVE input(value, depth) USING KEY (value) AS ("
+            f"SELECT {FILE}, 0 "
+            "UNION ALL "
+            "SELECT value, depth + 1 FROM input WHERE depth < 0"
+            ") SELECT * FROM input"
+        ),
+        (
+            f"SELECT 1 = ANY (SELECT 1 WHERE outer_input.value.url IS NOT NULL) "
+            f"FROM (VALUES ({FILE})) AS outer_input(value)"
+        ),
+    ],
+)
+def test_file_rejects_query_hash_comparison_bypasses(connection, query):
+    with pytest.raises(vane.BinderException, match=r"(?:does|do) not support FILE values"):
+        connection.execute(query).fetchall()
+
+
+@pytest.mark.parametrize("value", [FILE, f"struct_pack(value := {FILE})"])
+def test_file_rejects_relation_hash_comparison_bypasses(connection, value):
+    relation = connection.sql(f"SELECT {value} AS value")
+
+    with pytest.raises(vane.BinderException, match="DISTINCT does not support FILE values"):
+        relation.local_exchange(1).distinct().fetchall()
+
+    with pytest.raises(vane.BinderException, match="Repartition keys do not support FILE values"):
+        relation.repartition(2, "value").fetchall()
+
+
+@pytest.mark.parametrize("value", [FILE, f"struct_pack(value := {FILE})"])
+def test_file_rejects_copy_partition_hash_comparison_bypasses(connection, tmp_path: Path, value):
+    destination = tmp_path / "partitioned"
+
+    with pytest.raises(vane.BinderException, match="PARTITION_BY does not support FILE values"):
+        connection.execute(
+            f"COPY (SELECT {value} AS value, 1 AS payload) TO '{destination}' (FORMAT CSV, PARTITION_BY (value))"
+        )
+
+
+def test_file_remains_usable_outside_query_hash_keys(connection):
+    rows = connection.execute(
+        f"""
+        SELECT 1 AS key, {FILE} AS value
+        UNION ALL
+        SELECT 2 AS key, file('other', NULL, NULL, NULL, NULL) AS value
+        """
+    ).fetchall()
+    assert [row[1]["url"] for row in rows] == ["s3://bucket/missing.bin", "other"]
+
+    row = connection.execute(
+        f"""
+        SELECT DISTINCT ON (key) key, value
+        FROM (VALUES (1, {FILE}), (1, {FILE})) AS input(key, value)
+        ORDER BY key
+        """
+    ).fetchone()
+    assert row[0] == 1
+    assert row[1]["url"] == "s3://bucket/missing.bin"
+
+    row = connection.execute(
+        f"""
+        SELECT key, typeof(any_value(value)), any_value(value)
+        FROM (VALUES (1, {FILE}), (1, {FILE})) AS input(key, value)
+        GROUP BY key
+        """
+    ).fetchone()
+    assert row[:2] == (1, "FILE")
+    assert row[2]["url"] == "s3://bucket/missing.bin"
+
+    rows = connection.execute(
+        f"""
+        WITH RECURSIVE files(depth, value) AS (
+            SELECT 0, {FILE}
+            UNION ALL
+            SELECT depth + 1, value FROM files WHERE depth < 1
+        )
+        SELECT depth, value FROM files ORDER BY depth
+        """
+    ).fetchall()
+    assert [row[0] for row in rows] == [0, 1]
+    assert [row[1]["url"] for row in rows] == ["s3://bucket/missing.bin"] * 2
+
+    rows = connection.execute(
+        f"""
+        SELECT (SELECT outer_input.value.url)
+        FROM (VALUES ({FILE}), ({FILE})) AS outer_input(value)
+        """
+    ).fetchall()
+    assert rows == [("s3://bucket/missing.bin",)] * 2
+
+
+def test_file_array_alias_survives_tuple_collection_payloads(connection):
+    rows = connection.execute(
+        f"""
+        SELECT key, typeof(files[1]), files[1].url
+        FROM (
+            VALUES
+                (2, array_value(file('other', NULL, NULL, NULL, NULL))),
+                (1, array_value({FILE}))
+        ) AS input(key, files)
+        ORDER BY key
+        """
+    ).fetchall()
+
+    assert rows == [
+        (1, "FILE", "s3://bucket/missing.bin"),
+        (2, "FILE", "other"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "hash(value)",
+        "hash(struct_pack(value := value))",
+        "approx_count_distinct(value)",
+        "mode(value)",
+        "entropy(value)",
+        "approx_top_k(value, 2)",
+        "list_approx_count_distinct([value, value])",
+        "list_mode([value, value])",
+        "list_entropy([value, value])",
+    ],
+)
+def test_file_rejects_explicit_hash_consumers(connection, expression):
+    with pytest.raises(vane.BinderException, match="does not support FILE values"):
+        connection.execute(f"SELECT {expression} FROM (VALUES ({FILE_WITH_NULL_METADATA})) AS input(value)").fetchone()
 
 
 @pytest.mark.parametrize("column_type", ["FILE", "FILE[]", "STRUCT(value FILE)"])

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -130,6 +130,41 @@ def test_file_comparison_keeps_three_value_logic_in_joins(connection):
     assert count == 1
 
 
+def test_file_equality_remains_a_hash_join_condition(connection):
+    plan = connection.execute(
+        f"""
+        EXPLAIN
+        SELECT *
+        FROM (VALUES ({FILE}), ({FILE_WITH_NULL_METADATA})) AS left_side(value)
+        JOIN (VALUES ({FILE}), ({FILE_WITH_NULL_METADATA})) AS right_side(value)
+          ON left_side.value = right_side.value
+        """
+    ).fetchone()[1]
+
+    assert "HASH_JOIN" in plan
+    assert "BLOCKWISE_NL_JOIN" not in plan
+
+
+def test_file_comparison_supports_scalar_subqueries(connection):
+    assert connection.execute(f"SELECT (SELECT {FILE}) = {FILE}, (SELECT {FILE}) != {FILE}").fetchone() == (
+        True,
+        False,
+    )
+
+
+def test_file_comparison_does_not_duplicate_volatile_operands(connection):
+    connection.execute("CREATE SEQUENCE file_comparison_sequence START 1")
+
+    assert connection.execute(
+        """
+        SELECT
+            file(nextval('file_comparison_sequence')::VARCHAR, NULL, NULL, NULL, NULL)
+            = file(nextval('file_comparison_sequence')::VARCHAR, NULL, NULL, NULL, NULL)
+        """
+    ).fetchone() == (False,)
+    assert connection.execute("SELECT currval('file_comparison_sequence')").fetchone() == (2,)
+
+
 def test_file_comparison_propagates_stored_root_nulls(connection):
     connection.execute("CREATE TEMP TABLE file_values(value FILE)")
     connection.execute(f"INSERT INTO file_values VALUES ({FILE}), (NULL)")
@@ -186,14 +221,154 @@ def test_file_rejects_unsupported_comparisons(connection, predicate):
     ],
 )
 def test_file_rejects_list_search_comparison_bypasses(connection, function_name):
-    with pytest.raises(vane.BinderException, match="List search functions do not support FILE"):
+    with pytest.raises(vane.BinderException, match="Collection search functions do not support FILE"):
         connection.execute(f"SELECT {function_name}([{FILE}], {FILE})").fetchone()
 
 
 def test_file_rejects_nested_list_search_comparison_bypasses(connection):
     value = f"struct_pack(value := {FILE})"
-    with pytest.raises(vane.BinderException, match="List search functions do not support FILE"):
+    with pytest.raises(vane.BinderException, match="Collection search functions do not support FILE"):
         connection.execute(f"SELECT list_contains([{value}], {value})").fetchone()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        f"map_contains(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
+        f"map_extract(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
+        f"element_at(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
+        f"map_extract_value(map([{FILE_WITH_NULL_METADATA}], [1]), {FILE_WITH_NULL_METADATA})",
+        f"map([{FILE_WITH_NULL_METADATA}], [1])[{FILE_WITH_NULL_METADATA}]",
+        f"list_has_any([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
+        f"array_has_any([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
+        f"[{FILE_WITH_NULL_METADATA}] && [{FILE_WITH_NULL_METADATA}]",
+        f"list_has_all([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
+        f"array_has_all([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
+        f"[{FILE_WITH_NULL_METADATA}] @> [{FILE_WITH_NULL_METADATA}]",
+        f"[{FILE_WITH_NULL_METADATA}] <@ [{FILE_WITH_NULL_METADATA}]",
+        f"list_intersect([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
+        f"array_intersect([{FILE_WITH_NULL_METADATA}], [{FILE_WITH_NULL_METADATA}])",
+        f"struct_contains(row({FILE_WITH_NULL_METADATA}), {FILE_WITH_NULL_METADATA})",
+        f"struct_has(row({FILE_WITH_NULL_METADATA}), {FILE_WITH_NULL_METADATA})",
+        f"struct_position(row({FILE_WITH_NULL_METADATA}), {FILE_WITH_NULL_METADATA})",
+        f"struct_indexof(row({FILE_WITH_NULL_METADATA}), {FILE_WITH_NULL_METADATA})",
+    ],
+)
+def test_file_rejects_collection_search_comparison_bypasses(connection, expression):
+    with pytest.raises(vane.BinderException, match="Collection search functions do not support FILE"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+def test_file_remains_usable_as_a_map_value(connection):
+    row = connection.execute(
+        f"""
+        WITH input(value) AS (VALUES (map(['key'], [{FILE}])))
+        SELECT
+            map_contains(value, 'key'),
+            typeof(map_extract_value(value, 'key')),
+            (map_extract_value(value, 'key')).url,
+            typeof(map_extract(value, 'key')[1]),
+            (map_extract(value, 'key')[1]).url,
+            typeof(value['key']),
+            (value['key']).url
+        FROM input
+        """
+    ).fetchone()
+
+    assert row == (
+        True,
+        "FILE",
+        "s3://bucket/missing.bin",
+        "FILE",
+        "s3://bucket/missing.bin",
+        "FILE",
+        "s3://bucket/missing.bin",
+    )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        f"SELECT value FROM (VALUES ({FILE})) AS input(value) ORDER BY value",
+        f"SELECT value FROM (VALUES ({FILE})) AS input(value) ORDER BY struct_pack(value := value)",
+        f"SELECT list(value ORDER BY value) FROM (VALUES ({FILE})) AS input(value)",
+        f"SELECT percentile_disc(0.5) WITHIN GROUP (ORDER BY value) FROM (VALUES ({FILE})) AS input(value)",
+        f"SELECT row_number() OVER (ORDER BY value) FROM (VALUES ({FILE})) AS input(value)",
+        f"SELECT first_value(value ORDER BY value) OVER () FROM (VALUES ({FILE})) AS input(value)",
+    ],
+)
+def test_file_rejects_ordering_bypasses(connection, query):
+    with pytest.raises(
+        vane.BinderException,
+        match=r"(?:ORDER BY does not|ordering functions do not) support FILE values",
+    ):
+        connection.execute(query).fetchall()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        f"list_sort([{FILE}])",
+        f"array_sort([{FILE}])",
+        f"list_reverse_sort([{FILE}])",
+        f"array_reverse_sort([{FILE}])",
+        f"list_grade_up([{FILE}])",
+        f"list_sort([struct_pack(value := {FILE})])",
+        f"least({FILE}, {FILE})",
+        f"greatest({FILE}, {FILE})",
+        f"create_sort_key({FILE}, 'ASC NULLS LAST')",
+    ],
+)
+def test_file_rejects_generic_ordering_functions(connection, expression):
+    with pytest.raises(vane.BinderException, match="support FILE values"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize(
+    "aggregate",
+    [
+        "min(value)",
+        "max(value)",
+        "min(value, 1)",
+        "max(value, 1)",
+        "min(struct_pack(value := value))",
+        "max(struct_pack(value := value))",
+    ],
+)
+def test_file_rejects_min_max_bypasses(connection, aggregate):
+    with pytest.raises(vane.BinderException, match="does not support FILE values"):
+        connection.execute(f"SELECT {aggregate} FROM (VALUES ({FILE})) AS input(value)").fetchone()
+
+
+@pytest.mark.parametrize(
+    "aggregate",
+    [
+        "arg_min(1, value)",
+        "arg_max(1, value)",
+        "arg_min(1, value, 1)",
+        "arg_max(1, value, 1)",
+        "median(value)",
+        "quantile_disc(value, 0.5)",
+    ],
+)
+def test_file_rejects_other_ordering_aggregate_bypasses(connection, aggregate):
+    with pytest.raises(vane.BinderException, match="support FILE values"):
+        connection.execute(f"SELECT {aggregate} FROM (VALUES ({FILE})) AS input(value)").fetchone()
+
+
+def test_file_remains_usable_as_an_arg_min_result(connection):
+    row = connection.execute(
+        f"""
+        SELECT typeof(arg_min(value, key)), (arg_min(value, key)).url
+        FROM (
+            VALUES
+                (2, {FILE}),
+                (1, file('other', NULL, NULL, NULL, NULL))
+        ) AS input(key, value)
+        """
+    ).fetchone()
+
+    assert row == ("FILE", "other")
 
 
 @pytest.mark.parametrize(
@@ -334,6 +509,95 @@ def test_typed_null_file_is_supported(connection):
         "FILE",
         True,
     )
+
+
+def test_file_type_round_trips_through_arrow(connection):
+    pytest.importorskip("pyarrow")
+
+    arrow_table = connection.sql(
+        f"""
+        SELECT 0 AS row_id, {FILE} AS value, struct_pack(value := {FILE}) AS nested
+        UNION ALL
+        SELECT 1 AS row_id, NULL::FILE AS value, struct_pack(value := NULL::FILE) AS nested
+        """
+    ).to_arrow_table()
+    extension_name = b"ARROW:extension:name"
+    assert arrow_table.schema.field("value").metadata[extension_name] == b"vane.file"
+    assert arrow_table.schema.field("nested").type.field("value").metadata[extension_name] == b"vane.file"
+
+    rows = (
+        connection.from_arrow(arrow_table)
+        .project("row_id, typeof(value), typeof(nested.value), value.url, nested.value.url")
+        .order("row_id")
+        .fetchall()
+    )
+    assert rows == [
+        (0, "FILE", "FILE", "s3://bucket/missing.bin", "s3://bucket/missing.bin"),
+        (1, "FILE", "FILE", None, None),
+    ]
+
+
+def test_file_type_rejects_invalid_arrow_values(connection):
+    pa = pytest.importorskip("pyarrow")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+    file_field = pa.field(
+        "value",
+        file_storage_type,
+        metadata={
+            b"ARROW:extension:name": b"vane.file",
+            b"ARROW:extension:metadata": b"",
+        },
+    )
+    invalid_file = pa.array(
+        [
+            {
+                "url": None,
+                "content_type": None,
+                "position": None,
+                "size": None,
+                "checksum": None,
+            }
+        ],
+        type=file_storage_type,
+    )
+    arrow_table = pa.Table.from_arrays([invalid_file], schema=pa.schema([file_field]))
+
+    with pytest.raises(vane.InvalidInputException, match="Arrow FILE url cannot be NULL"):
+        connection.from_arrow(arrow_table).fetchall()
+
+
+def test_file_type_round_trips_through_local_exchange(connection):
+    pytest.importorskip("pyarrow")
+
+    relation = connection.sql(
+        """
+        SELECT
+            i,
+            file('object-' || i, NULL, NULL, NULL, NULL) AS value,
+            struct_pack(value := file('nested-' || i, NULL, NULL, NULL, NULL)) AS nested
+        FROM range(2) AS input(i)
+        """
+    )
+    rows = (
+        relation.local_exchange(1)
+        .project("i, typeof(value), typeof(nested.value), value.url, nested.value.url")
+        .order("i")
+        .fetchall()
+    )
+
+    assert rows == [
+        (0, "FILE", "FILE", "object-0", "nested-0"),
+        (1, "FILE", "FILE", "object-1", "nested-1"),
+    ]
 
 
 def test_file_type_round_trips_through_storage(tmp_path: Path):

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -7,7 +7,6 @@ import pytest
 
 import vane
 
-
 FILE = "file('s3://bucket/missing.bin', 'application/octet-stream', 10, 20, 'sha256:abcdef')"
 FILE_WITH_NULL_METADATA = "file('s3://bucket/missing.bin', NULL, NULL, NULL, NULL)"
 
@@ -170,6 +169,31 @@ def test_file_comparison_cannot_be_shadowed(connection):
 def test_file_rejects_unsupported_comparisons(connection, predicate):
     with pytest.raises(vane.BinderException):
         connection.execute(f"SELECT {predicate}").fetchone()
+
+
+@pytest.mark.parametrize(
+    "function_name",
+    [
+        "list_contains",
+        "array_contains",
+        "list_has",
+        "array_has",
+        "contains",
+        "list_position",
+        "list_indexof",
+        "array_position",
+        "array_indexof",
+    ],
+)
+def test_file_rejects_list_search_comparison_bypasses(connection, function_name):
+    with pytest.raises(vane.BinderException, match="List search functions do not support FILE"):
+        connection.execute(f"SELECT {function_name}([{FILE}], {FILE})").fetchone()
+
+
+def test_file_rejects_nested_list_search_comparison_bypasses(connection):
+    value = f"struct_pack(value := {FILE})"
+    with pytest.raises(vane.BinderException, match="List search functions do not support FILE"):
+        connection.execute(f"SELECT list_contains([{value}], {value})").fetchone()
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -35,6 +35,26 @@ def test_file_constructor_is_pure_and_exposes_canonical_fields(connection):
     )
 
 
+def test_file_supports_all_struct_extraction_forms(connection):
+    rows = connection.execute(
+        f"""
+        SELECT
+            struct_extract(value, 'url'),
+            struct_extract(value, 1),
+            struct_extract_at(value, 1),
+            array_extract(value, 'url'),
+            array_extract(value, 1),
+            value['url'],
+            value[1]
+        FROM (VALUES ({FILE}), (NULL::FILE)) AS input(value)
+        ORDER BY value IS NULL
+        """
+    ).fetchall()
+
+    url = "s3://bucket/missing.bin"
+    assert rows == [(url, url, url, url, url, url, url), (None, None, None, None, None, None, None)]
+
+
 @pytest.mark.parametrize(
     ("expression", "message"),
     [
@@ -1078,6 +1098,63 @@ def test_file_type_rejects_invalid_arrow_values(connection):
 
     with pytest.raises(vane.InvalidInputException, match="Arrow FILE url cannot be NULL"):
         connection.from_arrow(arrow_table).fetchall()
+
+
+def test_file_type_arrow_dictionary_validates_only_referenced_values(connection):
+    pa = pytest.importorskip("pyarrow")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+
+    class FileExtensionType(pa.ExtensionType):
+        def __init__(self):
+            pa.ExtensionType.__init__(self, file_storage_type, "vane.file")
+
+        def __arrow_ext_serialize__(self):
+            return b""
+
+        @classmethod
+        def __arrow_ext_deserialize__(cls, storage_type, serialized):
+            return cls()
+
+    file_values = FileExtensionType().wrap_array(
+        pa.array(
+            [
+                {
+                    "url": "active",
+                    "content_type": None,
+                    "position": None,
+                    "size": None,
+                    "checksum": None,
+                },
+                {
+                    "url": None,
+                    "content_type": None,
+                    "position": None,
+                    "size": None,
+                    "checksum": None,
+                },
+            ],
+            type=file_storage_type,
+        )
+    )
+
+    unreferenced_invalid = pa.DictionaryArray.from_arrays(pa.array([0], type=pa.int8()), file_values)
+    rows = (
+        connection.from_arrow(pa.table({"value": unreferenced_invalid})).project("typeof(value), value.url").fetchall()
+    )
+    assert rows == [("FILE", "active")]
+
+    referenced_invalid = pa.DictionaryArray.from_arrays(pa.array([1], type=pa.int8()), file_values)
+    with pytest.raises(vane.InvalidInputException, match="Arrow FILE url cannot be NULL"):
+        connection.from_arrow(pa.table({"value": referenced_invalid})).fetchall()
 
 
 def test_file_type_arrow_ignores_inactive_sparse_union_slots(connection):

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -152,6 +152,31 @@ def test_file_comparison_supports_scalar_subqueries(connection):
     )
 
 
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        (
+            "file('A', 'application/octet-stream', 0, 1, 'sha256:abcdef')",
+            "file('a', 'application/octet-stream', 0, 1, 'sha256:abcdef')",
+        ),
+        (
+            "file('x', 'TEXT/PLAIN', 0, 1, 'sha256:abcdef')",
+            "file('x', 'text/plain', 0, 1, 'sha256:abcdef')",
+        ),
+        (
+            "file('x', 'application/octet-stream', 0, 1, 'sha256:ABCDEF')",
+            "file('x', 'application/octet-stream', 0, 1, 'sha256:abcdef')",
+        ),
+    ],
+)
+def test_file_comparison_uses_binary_string_semantics(connection, left, right):
+    connection.execute("SET default_collation = 'nocase'")
+
+    assert connection.execute(
+        f"SELECT {left} = {right}, (SELECT {left}) = {right}, {left} != {right}, (SELECT {left}) != {right}"
+    ).fetchone() == (False, False, True, True)
+
+
 def test_file_comparison_does_not_duplicate_volatile_operands(connection):
     connection.execute("CREATE SEQUENCE file_comparison_sequence START 1")
 
@@ -284,6 +309,30 @@ def test_file_remains_usable_as_a_map_value(connection):
         "FILE",
         "s3://bucket/missing.bin",
     )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        FILE_WITH_NULL_METADATA,
+        f"struct_pack(value := {FILE_WITH_NULL_METADATA})",
+    ],
+)
+def test_file_rejects_map_concat_keys(connection, key):
+    with pytest.raises(vane.BinderException, match="MAP_CONCAT does not support FILE map keys"):
+        connection.execute(f"SELECT map_concat(map([{key}], [1]), map([{key}], [2]))").fetchone()
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        FILE_WITH_NULL_METADATA,
+        f"struct_pack(value := {FILE_WITH_NULL_METADATA})",
+    ],
+)
+def test_file_rejects_switch_keys(connection, key):
+    with pytest.raises(vane.BinderException, match="SWITCH does not support FILE map keys"):
+        connection.execute(f"SELECT switch({key}, map([{key}], [1]))").fetchone()
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -349,6 +349,10 @@ def test_file_rejects_min_max_bypasses(connection, aggregate):
         "arg_max(1, value, 1)",
         "median(value)",
         "quantile_disc(value, 0.5)",
+        "histogram(value)",
+        "histogram(value, [value])",
+        "histogram_exact(value, [value])",
+        "histogram(struct_pack(value := value))",
     ],
 )
 def test_file_rejects_other_ordering_aggregate_bypasses(connection, aggregate):

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -69,6 +69,13 @@ def test_file_extract_overloads_preserve_untyped_null_binding(connection):
     assert row == (None, None, None, None)
 
 
+def test_file_null_extract_overload_does_not_shadow_string_extract(connection):
+    assert connection.execute("SELECT array_extract('1234', '2')").fetchone() == ("2",)
+
+    with pytest.raises(vane.ConversionException, match="Could not convert string 'c' to INT64"):
+        connection.execute("SELECT array_extract('1234', 'c')").fetchone()
+
+
 @pytest.mark.parametrize(
     ("expression", "message"),
     [

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -1344,6 +1344,83 @@ def test_file_type_arrow_list_view_validates_sparse_child_span(connection):
     assert rows == [("FILE", "first"), ("FILE", "last")]
 
 
+def test_file_type_arrow_list_view_ignores_offsets_of_null_rows(connection):
+    pa = pytest.importorskip("pyarrow")
+    if not hasattr(pa, "ListViewArray"):
+        pytest.skip("The PyArrow version does not support ListViewArray")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+    file_field = pa.field(
+        "item",
+        file_storage_type,
+        metadata={
+            b"ARROW:extension:name": b"vane.file",
+            b"ARROW:extension:metadata": b"",
+        },
+    )
+    list_type = pa.list_view(file_field)
+    list_values = pa.ListViewArray.from_arrays(
+        offsets=pa.array([0, 100], type=pa.int32()),
+        sizes=pa.array([1, 1], type=pa.int32()),
+        values=pa.array(
+            [
+                {
+                    "url": "active",
+                    "content_type": None,
+                    "position": None,
+                    "size": None,
+                    "checksum": None,
+                }
+            ],
+            type=file_storage_type,
+        ),
+        type=list_type,
+        mask=pa.array([False, True]),
+    )
+    arrow_table = pa.Table.from_arrays([list_values], schema=pa.schema([pa.field("value", list_type)]))
+
+    rows = connection.from_arrow(arrow_table).project("value IS NULL, typeof(value[1]), (value[1]).url").fetchall()
+    assert rows == [
+        (False, "FILE", "active"),
+        (True, "FILE", None),
+    ]
+
+    nested_list_values = pa.ListViewArray.from_arrays(
+        offsets=pa.array([0, 100], type=pa.int32()),
+        sizes=pa.array([1, 1], type=pa.int32()),
+        values=list_values.values,
+        type=list_type,
+    )
+    parent_type = pa.struct([pa.field("items", list_type)])
+    parent_values = pa.StructArray.from_arrays(
+        [nested_list_values],
+        fields=list(parent_type),
+        mask=pa.array([False, True]),
+    )
+    parent_table = pa.Table.from_arrays(
+        [parent_values],
+        schema=pa.schema([pa.field("value", parent_type)]),
+    )
+
+    rows = (
+        connection.from_arrow(parent_table)
+        .project("value IS NULL, typeof(value.items[1]), (value.items[1]).url")
+        .fetchall()
+    )
+    assert rows == [
+        (False, "FILE", "active"),
+        (True, "FILE", None),
+    ]
+
+
 def test_file_type_round_trips_through_local_exchange(connection):
     pytest.importorskip("pyarrow")
 

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+import vane
+
+
+FILE = "file('s3://bucket/missing.bin', 'application/octet-stream', 10, 20, 'sha256:abcdef')"
+FILE_WITH_NULL_METADATA = "file('s3://bucket/missing.bin', NULL, NULL, NULL, NULL)"
+
+
+@pytest.fixture
+def connection():
+    with vane.connect() as conn:
+        yield conn
+
+
+def test_file_constructor_is_pure_and_exposes_canonical_fields(connection):
+    row = connection.execute(
+        f"""
+        SELECT typeof(value), value.url, value.content_type, value.position, value.size, value.checksum
+        FROM (SELECT {FILE} AS value)
+        """
+    ).fetchone()
+
+    assert row == (
+        "FILE",
+        "s3://bucket/missing.bin",
+        "application/octet-stream",
+        10,
+        20,
+        "sha256:abcdef",
+    )
+
+
+@pytest.mark.parametrize(
+    ("expression", "message"),
+    [
+        ("file(NULL, NULL, NULL, NULL, NULL)", "url cannot be NULL"),
+        ("file('x', NULL, 0, NULL, NULL)", "position and size"),
+        ("file('x', NULL, NULL, 0, NULL)", "position and size"),
+        ("file('x', NULL, -1, 0, NULL)", "non-negative"),
+        ("file('x', NULL, 0, -1, NULL)", "non-negative"),
+        ("file('x', NULL, 9223372036854775807, 1, NULL)", "exceeds BIGINT"),
+        ("file('x', NULL, NULL, NULL, 'sha256')", "<algorithm>:<digest>"),
+        ("file('x', NULL, NULL, NULL, ':abcdef')", "<algorithm>:<digest>"),
+        ("file('x', NULL, NULL, NULL, 'sha256:')", "<algorithm>:<digest>"),
+        ("file('x', NULL, NULL, NULL, 'sha256:abc:def')", "<algorithm>:<digest>"),
+    ],
+)
+def test_file_constructor_rejects_invalid_values(connection, expression, message):
+    with pytest.raises(vane.InvalidInputException, match=message):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+def test_file_constructor_accepts_zero_length_ranges(connection):
+    assert connection.execute("SELECT file('x', NULL, 0, 0, NULL).size").fetchone() == (0,)
+
+
+def test_file_constructor_supports_vectorized_inputs(connection):
+    rows = connection.execute(
+        """
+        SELECT value.url, value.position, value.size
+        FROM (
+            SELECT file('object-' || i, NULL, i, i + 1, NULL) AS value
+            FROM range(3) AS input(i)
+        )
+        ORDER BY value.position
+        """
+    ).fetchall()
+
+    assert rows == [("object-0", 0, 1), ("object-1", 1, 2), ("object-2", 2, 3)]
+
+
+def test_file_alias_survives_unrelated_nested_null_resolution(connection):
+    row = connection.execute(
+        f"""
+        SELECT typeof(value.file), value.file.url, value.missing
+        FROM (SELECT struct_pack(file := {FILE}, missing := NULL) AS value)
+        """
+    ).fetchone()
+
+    assert row == ("FILE", "s3://bucket/missing.bin", None)
+
+
+def test_file_comparison_uses_fieldwise_sql_three_value_logic(connection):
+    row = connection.execute(
+        f"""
+        SELECT
+            {FILE} = {FILE},
+            {FILE} != {FILE},
+            {FILE_WITH_NULL_METADATA} = {FILE_WITH_NULL_METADATA},
+            {FILE_WITH_NULL_METADATA} != {FILE_WITH_NULL_METADATA},
+            {FILE_WITH_NULL_METADATA} = file('other', NULL, NULL, NULL, NULL),
+            {FILE_WITH_NULL_METADATA} != file('other', NULL, NULL, NULL, NULL),
+            CAST(NULL AS FILE) = {FILE},
+            CAST(NULL AS FILE) != {FILE}
+        """
+    ).fetchone()
+
+    assert row == (True, False, None, None, False, True, None, None)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        "file('other', 'application/octet-stream', 10, 20, 'sha256:abcdef')",
+        "file('s3://bucket/missing.bin', 'text/plain', 10, 20, 'sha256:abcdef')",
+        "file('s3://bucket/missing.bin', 'application/octet-stream', 11, 20, 'sha256:abcdef')",
+        "file('s3://bucket/missing.bin', 'application/octet-stream', 10, 21, 'sha256:abcdef')",
+        "file('s3://bucket/missing.bin', 'application/octet-stream', 10, 20, 'sha256:fedcba')",
+    ],
+)
+def test_file_comparison_includes_every_field(connection, other):
+    assert connection.execute(f"SELECT {FILE} = {other}, {FILE} != {other}").fetchone() == (False, True)
+
+
+def test_file_comparison_keeps_three_value_logic_in_joins(connection):
+    count = connection.execute(
+        f"""
+        SELECT count(*)
+        FROM (VALUES ({FILE}), ({FILE_WITH_NULL_METADATA})) AS left_side(value)
+        JOIN (VALUES ({FILE}), ({FILE_WITH_NULL_METADATA})) AS right_side(value)
+          ON left_side.value = right_side.value
+        """
+    ).fetchone()[0]
+
+    assert count == 1
+
+
+def test_file_comparison_propagates_stored_root_nulls(connection):
+    connection.execute("CREATE TEMP TABLE file_values(value FILE)")
+    connection.execute(f"INSERT INTO file_values VALUES ({FILE}), (NULL)")
+
+    rows = connection.execute(
+        f"""
+        SELECT value = {FILE}, value != {FILE}
+        FROM file_values
+        ORDER BY value IS NULL
+        """
+    ).fetchall()
+
+    assert rows == [(True, False), (None, None)]
+
+
+def test_file_comparison_cannot_be_shadowed(connection):
+    connection.execute("CREATE MACRO __vane_file_equal(left_value, right_value) AS TRUE")
+
+    assert connection.execute(f"SELECT {FILE_WITH_NULL_METADATA} = {FILE_WITH_NULL_METADATA}").fetchone() == (None,)
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        f"{FILE} = ROW('x', NULL, NULL, NULL, NULL)",
+        f"{FILE} != 's3://bucket/missing.bin'",
+        f"{FILE} < {FILE}",
+        f"{FILE} IS DISTINCT FROM {FILE}",
+        f"{FILE} IN ({FILE})",
+        f"{FILE} IN (SELECT {FILE})",
+        f"{FILE} BETWEEN {FILE} AND {FILE}",
+        f"[{FILE}] = [{FILE}]",
+        f"struct_pack(value := {FILE}) = struct_pack(value := {FILE})",
+        f"[{FILE}] IN (SELECT [{FILE}])",
+    ],
+)
+def test_file_rejects_unsupported_comparisons(connection, predicate):
+    with pytest.raises(vane.BinderException):
+        connection.execute(f"SELECT {predicate}").fetchone()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "CAST(ROW('x', NULL, NULL, NULL, NULL) AS FILE)",
+        f"CAST({FILE} AS STRUCT(url VARCHAR, content_type VARCHAR, position BIGINT, size BIGINT, checksum VARCHAR))",
+        f"CAST({FILE} AS VARCHAR)",
+    ],
+)
+def test_file_rejects_casts_that_bypass_the_constructor(connection, expression):
+    with pytest.raises(vane.BinderException):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        """
+        remap_struct(
+            {
+                'url': NULL::VARCHAR,
+                'content_type': NULL::VARCHAR,
+                'position': 0::BIGINT,
+                'size': NULL::BIGINT,
+                'checksum': NULL::VARCHAR
+            },
+            NULL::FILE,
+            NULL,
+            NULL
+        )
+        """,
+        f"""
+        remap_struct(
+            {FILE},
+            NULL::STRUCT(
+                url VARCHAR,
+                content_type VARCHAR,
+                position BIGINT,
+                size BIGINT,
+                checksum VARCHAR
+            ),
+            NULL,
+            NULL
+        )
+        """,
+        f"""
+        remap_struct(
+            {{'unused': 1}},
+            NULL::STRUCT(
+                value STRUCT(
+                    url VARCHAR,
+                    content_type VARCHAR,
+                    position BIGINT,
+                    size BIGINT,
+                    checksum VARCHAR
+                )
+            ),
+            NULL,
+            {{'value': {FILE}}}
+        )
+        """,
+    ],
+)
+def test_file_rejects_struct_remapping_bypasses(connection, expression):
+    with pytest.raises(vane.BinderException, match="remap_struct does not support FILE"):
+        connection.execute(f"SELECT {expression}").fetchone()
+
+
+@pytest.mark.parametrize("column_type", ["FILE", "FILE[]", "STRUCT(value FILE)"])
+def test_file_rejects_untyped_parameters_that_bypass_the_constructor(connection, column_type):
+    with pytest.raises(vane.BinderException, match=r"construct it with file\(\.\.\.\)"):
+        connection.execute(f"PREPARE file_parameter AS SELECT CAST($1 AS {column_type})")
+
+
+def test_file_output_is_rejected_by_expression_udfs_until_file_materialization_is_supported(connection):
+    @vane.func(return_dtype="FILE")
+    def make_file(value):
+        return value
+
+    relation = connection.sql("SELECT 1 AS value")
+    with pytest.raises(vane.InvalidInputException, match="FILE inputs and outputs are not supported"):
+        relation.select(make_file(vane.col("value"))).fetchall()
+
+
+def test_file_input_is_rejected_by_expression_udfs_until_file_materialization_is_supported(connection):
+    @vane.func(return_dtype="VARCHAR")
+    def consume_file(value):
+        return str(value)
+
+    relation = connection.sql(f"SELECT {FILE} AS value")
+    with pytest.raises(vane.BinderException, match="FILE inputs and outputs are not supported"):
+        relation.select(consume_file(vane.col("value"))).fetchall()
+
+
+def test_file_output_is_rejected_by_attached_python_udfs(connection):
+    with pytest.raises(vane.InvalidInputException, match="FILE inputs and outputs are not supported"):
+        vane.attach_function(
+            lambda: None,
+            alias="file_output_udf",
+            connection=connection,
+            parameters=[],
+            return_dtype="FILE",
+        )
+
+
+def test_file_input_is_rejected_by_attached_python_udfs(connection):
+    vane.attach_function(
+        lambda value: str(value),
+        alias="file_input_udf",
+        connection=connection,
+        parameters=["FILE"],
+        return_dtype="VARCHAR",
+    )
+
+    with pytest.raises(vane.BinderException, match="FILE inputs and outputs are not supported"):
+        connection.execute(f"SELECT file_input_udf({FILE})").fetchone()
+
+
+def test_file_only_compares_with_the_same_logical_type(connection):
+    connection.execute(
+        """
+        CREATE TYPE other_file AS STRUCT(
+            url VARCHAR,
+            content_type VARCHAR,
+            position BIGINT,
+            size BIGINT,
+            checksum VARCHAR
+        )
+        """
+    )
+    with pytest.raises(vane.BinderException):
+        connection.execute(f"SELECT {FILE} = CAST(ROW('x', NULL, NULL, NULL, NULL) AS other_file)").fetchone()
+
+
+def test_typed_null_file_is_supported(connection):
+    assert connection.execute("SELECT typeof(CAST(NULL AS FILE)), CAST(NULL AS FILE) IS NULL").fetchone() == (
+        "FILE",
+        True,
+    )
+
+
+def test_file_type_round_trips_through_storage(tmp_path: Path):
+    database = tmp_path / "files.db"
+    with vane.connect(str(database)) as connection:
+        connection.execute("CREATE TABLE files(value FILE)")
+        connection.execute(f"INSERT INTO files VALUES ({FILE}), (NULL)")
+
+    with vane.connect(str(database)) as connection:
+        rows = connection.execute("SELECT typeof(value), value.url FROM files ORDER BY value IS NULL").fetchall()
+
+    assert rows == [("FILE", "s3://bucket/missing.bin"), ("FILE", None)]

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -1080,6 +1080,126 @@ def test_file_type_rejects_invalid_arrow_values(connection):
         connection.from_arrow(arrow_table).fetchall()
 
 
+def test_file_type_arrow_ignores_inactive_sparse_union_slots(connection):
+    pa = pytest.importorskip("pyarrow")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+    file_field = pa.field(
+        "f",
+        file_storage_type,
+        metadata={
+            b"ARROW:extension:name": b"vane.file",
+            b"ARROW:extension:metadata": b"",
+        },
+    )
+    file_values = pa.array(
+        [
+            {
+                "url": None,
+                "content_type": None,
+                "position": 0,
+                "size": None,
+                "checksum": None,
+            },
+            {
+                "url": "active",
+                "content_type": None,
+                "position": None,
+                "size": None,
+                "checksum": None,
+            },
+        ],
+        type=file_storage_type,
+    )
+    union_type = pa.sparse_union([file_field, pa.field("n", pa.int64())], type_codes=[0, 1])
+    union_values = pa.UnionArray.from_sparse(
+        pa.array([1, 0], type=pa.int8()),
+        [file_values, pa.array([7, 8], type=pa.int64())],
+        field_names=["f", "n"],
+        type_codes=[0, 1],
+    )
+    arrow_table = pa.Table.from_arrays(
+        [union_values],
+        schema=pa.schema([pa.field("value", union_type)]),
+    )
+
+    rows = (
+        connection.from_arrow(arrow_table)
+        .project("union_tag(value), typeof(value.f), (value.f).url, value.n")
+        .fetchall()
+    )
+    assert rows == [
+        ("n", "FILE", None, 7),
+        ("f", "FILE", "active", None),
+    ]
+
+
+def test_file_type_arrow_ignores_children_of_null_lists(connection):
+    pa = pytest.importorskip("pyarrow")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+    file_field = pa.field(
+        "item",
+        file_storage_type,
+        metadata={
+            b"ARROW:extension:name": b"vane.file",
+            b"ARROW:extension:metadata": b"",
+        },
+    )
+    file_values = pa.array(
+        [
+            {
+                "url": None,
+                "content_type": None,
+                "position": None,
+                "size": None,
+                "checksum": None,
+            },
+            {
+                "url": "active",
+                "content_type": None,
+                "position": None,
+                "size": None,
+                "checksum": None,
+            },
+        ],
+        type=file_storage_type,
+    )
+    list_type = pa.list_(file_field)
+    list_values = pa.ListArray.from_arrays(
+        pa.array([0, 1, 2], type=pa.int32()),
+        file_values,
+        type=list_type,
+        mask=pa.array([True, False]),
+    )
+    arrow_table = pa.Table.from_arrays(
+        [list_values],
+        schema=pa.schema([pa.field("value", list_type)]),
+    )
+
+    rows = connection.from_arrow(arrow_table).project("value IS NULL, typeof(value[1]), (value[1]).url").fetchall()
+    assert rows == [
+        (True, "FILE", None),
+        (False, "FILE", "active"),
+    ]
+
+
 def test_file_type_round_trips_through_local_exchange(connection):
     pytest.importorskip("pyarrow")
 

--- a/tests/fast/test_file_type.py
+++ b/tests/fast/test_file_type.py
@@ -590,6 +590,47 @@ def test_file_type_round_trips_through_arrow(connection):
     ]
 
 
+def test_file_type_arrow_parent_null_hides_child_values(connection):
+    pa = pytest.importorskip("pyarrow")
+
+    file_storage_type = pa.struct(
+        [
+            pa.field("url", pa.string()),
+            pa.field("content_type", pa.string()),
+            pa.field("position", pa.int64()),
+            pa.field("size", pa.int64()),
+            pa.field("checksum", pa.string()),
+        ]
+    )
+    hidden_file = pa.StructArray.from_arrays(
+        [
+            pa.array(["hidden-url"]),
+            pa.array(["application/hidden"]),
+            pa.array([1], type=pa.int64()),
+            pa.array([2], type=pa.int64()),
+            pa.array(["sha256:hidden"]),
+        ],
+        type=file_storage_type,
+        mask=pa.array([True]),
+    )
+    file_field = pa.field(
+        "value",
+        file_storage_type,
+        metadata={
+            b"ARROW:extension:name": b"vane.file",
+            b"ARROW:extension:metadata": b"",
+        },
+    )
+    arrow_table = pa.Table.from_arrays([hidden_file], schema=pa.schema([file_field]))
+
+    row = (
+        connection.from_arrow(arrow_table)
+        .project("value IS NULL, value.url, value.content_type, value.position, value.size, value.checksum")
+        .fetchone()
+    )
+    assert row == (True, None, None, None, None, None)
+
+
 def test_file_type_rejects_invalid_arrow_values(connection):
     pa = pytest.importorskip("pyarrow")
 


### PR DESCRIPTION
## Summary

- Add the first C++/SQL `FILE` core as a canonical DuckDB `STRUCT` alias with `url`, `content_type`, `position`, `size`, and `checksum` fields.
- Register a pure `file(...)` constructor that performs no I/O and enforces non-NULL URLs, paired non-negative byte ranges, range overflow safety, and `<algorithm>:<digest>` checksum syntax.
- Preserve FILE identity through storage, field access, recursive type replacement, nested casts, Arrow/Flight exchanges, Parquet COPY round trips, and Parquet `EXPORT DATABASE` / `IMPORT DATABASE`, including nested STRUCT, LIST, MAP, ARRAY element, and UNION positions.
- Validate FILE-bearing values at query-parameter, bound-constant, Appender, C API, Arrow import and every shared Arrow chunk-export boundary (including legacy C APIs), Parquet reader/writer, scalar-expression, native table-function, aggregate, and window result boundaries, including functions registered directly through `ExtensionLoader`.
- Bound sparse Arrow ListView conversion by valid logical rows only, including rows hidden by a NULL enclosing parent, so unreachable offset/size slots cannot expand the child scan window.
- Keep fieldwise SQL three-valued `=` / `!=` visible to hash-join planning while rejecting generic struct mutation, reconstruction, ordering, hash/distinct, map-key, repartition, JSON materialization, and current Python UDF paths that could bypass FILE semantics.
- Preserve existing untyped-NULL binding for DuckDB struct extraction functions while keeping exact-NULL overloads out of ordinary string-literal overload resolution.
- This remains the focused alias-core PR: it adds no compatibility fallback or implicit STRUCT conversion. Python FILE materialization and validated UDF input/output support will follow separately.

## Related issue

close: #660

## Documentation impact

- [ ] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [x] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Document the complete FILE API after the remaining Python value, I/O, metadata, and UDF layers land.

## Validation

- `scripts/format workspace --changed`
- `git diff --check`
- Release incremental install with `SKBUILD_BUILD_DIR="$PWD/build/python-release"`, `SKBUILD_CMAKE_BUILD_TYPE=Release`, `CMAKE_BUILD_PARALLEL_LEVEL=16`, and `uv pip install . --no-build-isolation`
- `scripts/run_installed_pytest.sh tests/fast/test_file_type.py -q` (`196 passed`)
- `build/native-cxx20/test/unittest 'test/issues/general/test_2416.test'` (`44 assertions in 1 test case`)
- `build/native-cxx20/test/unittest '[file],[capi][arrow]'` (`10,244 assertions in 11 test cases`)
- Full native suite (`1,109,419 assertions in 4,573 executed test cases`; `371 skipped`)
- `scripts/run_release_tests.sh` (`551 passed, 4 skipped, 17 deselected`; Real-Ray shard: `13 passed, 559 deselected`)
- Two consecutive clean static code-review passes after the final correction

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
