### PR TITLE
[fix](ray) Execute portable table-function sources

### DIFF
--- a/external/duckdb/extension/json/json_functions/json_table_in_out.cpp
+++ b/external/duckdb/extension/json/json_functions/json_table_in_out.cpp
@@ -379,6 +379,13 @@ virtual_column_map_t GetJSONTableInOutVirtualColumns(ClientContext &, optional_p
 	return result;
 }
 
+static void JSONTableInOutSerialize(Serializer &, const optional_ptr<FunctionData>, const TableFunction &) {
+}
+
+static unique_ptr<FunctionData> JSONTableInOutDeserialize(Deserializer &, TableFunction &) {
+	return nullptr;
+}
+
 template <JSONTableInOutType TYPE>
 TableFunction GetJSONTableInOutFunction(const LogicalType &input_type, const bool &has_path_param) {
 	vector<LogicalType> arguments = {input_type};
@@ -388,6 +395,10 @@ TableFunction GetJSONTableInOutFunction(const LogicalType &input_type, const boo
 	TableFunction function(arguments, nullptr, JSONTableInOutBind, JSONTableInOutInitGlobal, JSONTableInOutInitLocal);
 	function.in_out_function = JSONTableInOutFunction<TYPE>;
 	function.get_virtual_columns = GetJSONTableInOutVirtualColumns;
+	function.serialize = JSONTableInOutSerialize;
+	function.deserialize = JSONTableInOutDeserialize;
+	function.SetDistributedScanCallbacks(
+	    MakeDistributedSingletonSourceCallbacks(TableFunctionDistributedBindDataMode::OPTIONAL));
 	function.projection_pushdown = true;
 	return function;
 }

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_scan.cpp
@@ -72,8 +72,8 @@ std::vector<uint64_t> GetFileSizesFromDB(const std::vector<OpenFileInfo> &files,
 }
 
 TableFunctionDistributedScanInput MakeDistributedScanInput(const PhysicalTableScan &scan) {
-	return TableFunctionDistributedScanInput(*scan.bind_data, scan.column_ids, scan.projection_ids,
-	                                         scan.table_filters.get(), scan.estimated_cardinality);
+	return TableFunctionDistributedScanInput(scan.bind_data.get(), scan.parameters, scan.column_ids,
+	                                         scan.projection_ids, scan.table_filters.get(), scan.estimated_cardinality);
 }
 
 vector<ScanSplit> MakeExtensionScanSplits(const PhysicalTableScan &scan, const DuckDBExecutionConfig &exec_cfg,
@@ -85,6 +85,9 @@ vector<ScanSplit> MakeExtensionScanSplits(const PhysicalTableScan &scan, const D
 	}
 	const auto &callbacks = scan.function.GetDistributedScanCallbacks();
 	callbacks.Validate(scan.function);
+	if (!scan.bind_data && callbacks.bind_data_mode == TableFunctionDistributedBindDataMode::REQUIRED) {
+		throw SerializationException("Distributed table function '%s' requires bind data", scan.function.name);
+	}
 	const auto &capability = callbacks.GetCapability();
 	if (!db) {
 		throw InvalidInputException("Distributed extension scan '%s' requires a DatabaseInstance for capability "
@@ -126,9 +129,6 @@ DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
 	unique_ptr<FunctionData> bind_data;
 	TableFunction function = scan.function;
 	if (scan.function.HasDistributedScanCallbacks()) {
-		if (!scan.bind_data) {
-			throw SerializationException("Distributed table function '%s' requires bind data", scan.function.name);
-		}
 		if (!scan.function.HasSerializationCallbacks()) {
 			throw SerializationException("Distributed table function '%s' requires complete serialize and deserialize "
 			                             "callbacks; worker rebind is not supported",
@@ -136,8 +136,11 @@ DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
 		}
 		const auto &callbacks = scan.function.GetDistributedScanCallbacks();
 		callbacks.Validate(scan.function);
+		if (!scan.bind_data && callbacks.bind_data_mode == TableFunctionDistributedBindDataMode::REQUIRED) {
+			throw SerializationException("Distributed table function '%s' requires bind data", scan.function.name);
+		}
 		bind_data = callbacks.create_worker_bind(MakeDistributedScanInput(scan));
-		if (!bind_data) {
+		if (!bind_data && callbacks.bind_data_mode == TableFunctionDistributedBindDataMode::REQUIRED) {
 			throw InvalidInputException("Distributed table function '%s' returned null from create_worker_bind",
 			                            scan.function.name);
 		}
@@ -178,13 +181,13 @@ DuckPhysicalPlanRef MakeTableScanPlan(const PhysicalTableScan &scan) {
 
 vector<ScanSplit> MakeTableScanSplits(const PhysicalTableScan &scan, const DuckDBExecutionConfig &exec_cfg,
                                       const shared_ptr<DatabaseInstance> &db) {
+	if (scan.function.HasDistributedScanCallbacks()) {
+		return MakeExtensionScanSplits(scan, exec_cfg, db);
+	}
 	if (!scan.bind_data) {
 		throw NotImplementedException("Distributed execution does not support table function \"%s\": bind data is "
 		                              "missing",
 		                              scan.function.name);
-	}
-	if (scan.function.HasDistributedScanCallbacks()) {
-		return MakeExtensionScanSplits(scan, exec_cfg, db);
 	}
 
 	vector<OpenFileInfo> files;

--- a/external/duckdb/src/execution/distributed/plan/scan_split.cpp
+++ b/external/duckdb/src/execution/distributed/plan/scan_split.cpp
@@ -366,6 +366,10 @@ static bool ApplyExtensionScanSplits(PhysicalTableScan &scan, const ScanSplitBat
 	}
 	const auto &callbacks = scan.function.GetDistributedScanCallbacks();
 	callbacks.Validate(scan.function);
+	if (!scan.bind_data && callbacks.bind_data_mode == TableFunctionDistributedBindDataMode::REQUIRED) {
+		SetApplyError(error, "distributed table function requires worker bind data: " + scan.function.name);
+		return false;
+	}
 	const auto &capability = callbacks.GetCapability();
 	const auto &first_split = batch.splits[0];
 	if (first_split.extension_capability != capability) {
@@ -393,7 +397,7 @@ static bool ApplyExtensionScanSplits(PhysicalTableScan &scan, const ScanSplitBat
 		assigned.estimated_bytes = split.estimated_bytes;
 		assigned_splits.push_back(std::move(assigned));
 	}
-	callbacks.apply_splits(*scan.bind_data, assigned_splits);
+	callbacks.apply_splits(scan.bind_data.get(), assigned_splits);
 	scan.extra_info.total_files = optional_idx(assigned_splits.size());
 	scan.extra_info.filtered_files = optional_idx(assigned_splits.size());
 	scan.distributed_scan_splits_applied = true;
@@ -415,12 +419,6 @@ static bool ApplyScanSplitBatchesToOperator(PhysicalOperator &op, const ScanSpli
 			auto it = batches.find(node_id);
 			if (it == batches.end()) {
 				stats.missing_batch++;
-			} else if (!scan.bind_data) {
-				matched_batches.insert(node_id);
-				stats.missing_bind++;
-				stats.invalid_assignment++;
-				SetApplyError(error,
-				              "scan split batch assigned to table function with null bind data: " + scan.function.name);
 			} else {
 				matched_batches.insert(node_id);
 				const auto &batch = *it->second;
@@ -432,6 +430,11 @@ static bool ApplyScanSplitBatchesToOperator(PhysicalOperator &op, const ScanSpli
 						stats.non_multi_bind++;
 						stats.invalid_assignment++;
 					}
+				} else if (!scan.bind_data) {
+					stats.missing_bind++;
+					stats.invalid_assignment++;
+					SetApplyError(error, "scan split batch assigned to table function with null bind data: " +
+					                         scan.function.name);
 				} else if (scan.function.HasDistributedScanCallbacks()) {
 					SetApplyError(error,
 					              "file scan split assigned to extension table function '" + scan.function.name + "'");
@@ -926,18 +929,17 @@ bool ApplyFteScanSourceQueuesToOperator(PhysicalOperator &op,
 					}
 					return false;
 				}
-				if (!scan.bind_data) {
-					if (error) {
-						*error = "FTE scan source queue target has null bind_data for scan_node_id=" +
-						         std::to_string(node_id);
-					}
-					return false;
-				}
 				if (scan.function.HasDistributedScanCallbacks()) {
 					if (!ApplyFteExtensionScanSplits(scan, entry->second, extension_batch_cache, error)) {
 						return false;
 					}
 					applied++;
+				} else if (!scan.bind_data) {
+					if (error) {
+						*error = "FTE scan source queue target has null bind_data for scan_node_id=" +
+						         std::to_string(node_id);
+					}
+					return false;
 				} else if (auto *multi_bind = dynamic_cast<MultiFileBindData *>(scan.bind_data.get())) {
 					auto cached_file_list = dynamic_file_list_cache.find(entry->second.get());
 					if (cached_file_list == dynamic_file_list_cache.end()) {

--- a/external/duckdb/src/execution/distributed/plan/scan_split.cpp
+++ b/external/duckdb/src/execution/distributed/plan/scan_split.cpp
@@ -401,6 +401,7 @@ static bool ApplyExtensionScanSplits(PhysicalTableScan &scan, const ScanSplitBat
 	scan.extra_info.total_files = optional_idx(assigned_splits.size());
 	scan.extra_info.filtered_files = optional_idx(assigned_splits.size());
 	scan.distributed_scan_splits_applied = true;
+	scan.distributed_scan_empty = batch.splits[0].empty;
 	return true;
 }
 

--- a/external/duckdb/src/execution/operator/scan/physical_table_scan.cpp
+++ b/external/duckdb/src/execution/operator/scan/physical_table_scan.cpp
@@ -41,6 +41,10 @@ class TableScanGlobalSourceState : public GlobalSourceState {
 public:
 	TableScanGlobalSourceState(ClientContext &context, const PhysicalTableScan &op) {
 		physical_table_scan_execution_strategy = Settings::Get<DebugPhysicalTableScanExecutionStrategySetting>(context);
+		if (op.distributed_scan_empty) {
+			max_threads = 1;
+			return;
+		}
 
 		if (op.dynamic_filters && op.dynamic_filters->HasFilters()) {
 			table_filters = op.dynamic_filters->GetFinalTableFilters(op, op.table_filters.get());
@@ -92,6 +96,9 @@ class TableScanLocalSourceState : public LocalSourceState {
 public:
 	TableScanLocalSourceState(ExecutionContext &context, TableScanGlobalSourceState &gstate,
 	                          const PhysicalTableScan &op) {
+		if (op.distributed_scan_empty) {
+			return;
+		}
 		if (op.function.init_local) {
 			TableFunctionInitInput input(op.bind_data.get(), op.column_ids, op.projection_ids,
 			                             gstate.GetTableFilters(op), op.extra_info.sample_options, &op);
@@ -168,6 +175,10 @@ static void ValidateAsyncStrategyResult(const PhysicalTableScanExecutionStrategy
 
 SourceResultType PhysicalTableScan::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                     OperatorSourceInput &input) const {
+	if (distributed_scan_empty) {
+		chunk.SetCardinality(0);
+		return SourceResultType::FINISHED;
+	}
 	D_ASSERT(!column_ids.empty());
 	auto &g_state = input.global_state.Cast<TableScanGlobalSourceState>();
 	auto &l_state = input.local_state.Cast<TableScanLocalSourceState>();
@@ -242,6 +253,11 @@ SourceResultType PhysicalTableScan::GetDataInternal(ExecutionContext &context, D
 }
 
 ProgressData PhysicalTableScan::GetProgress(ClientContext &context, GlobalSourceState &gstate_p) const {
+	if (distributed_scan_empty) {
+		ProgressData res;
+		res.SetInvalid();
+		return res;
+	}
 	auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();
 	ProgressData res;
 	if (function.table_scan_progress) {
@@ -262,7 +278,7 @@ ProgressData PhysicalTableScan::GetProgress(ClientContext &context, GlobalSource
 }
 
 bool PhysicalTableScan::SupportsPartitioning(const OperatorPartitionInfo &partition_info) const {
-	if (!function.get_partition_data) {
+	if (distributed_scan_empty || !function.get_partition_data) {
 		return false;
 	}
 	// FIXME: actually check if partition info is supported
@@ -410,7 +426,7 @@ bool PhysicalTableScan::Equals(const PhysicalOperator &other_p) const {
 }
 
 bool PhysicalTableScan::ParallelSource() const {
-	if (!function.function) {
+	if (distributed_scan_empty || !function.function) {
 		// table in-out functions cannot be executed in parallel as part of a PhysicalTableScan
 		// since they have only a single input row
 		return false;
@@ -420,7 +436,7 @@ bool PhysicalTableScan::ParallelSource() const {
 
 InsertionOrderPreservingMap<string> PhysicalTableScan::ExtraSourceParams(GlobalSourceState &gstate_p,
                                                                          LocalSourceState &lstate) const {
-	if (!function.dynamic_to_string) {
+	if (distributed_scan_empty || !function.dynamic_to_string) {
 		return InsertionOrderPreservingMap<string>();
 	}
 	auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();
@@ -432,7 +448,7 @@ InsertionOrderPreservingMap<string> PhysicalTableScan::ExtraSourceParams(GlobalS
 
 void PhysicalTableScan::GetMetrics(ClientContext &context, GlobalSourceState &gstate_p, LocalSourceState &lstate,
                                    const profiler_settings_t &requested_metrics, profiler_metrics_t &metrics) const {
-	if (!function.get_metrics && !function.rows_scanned) {
+	if (distributed_scan_empty || (!function.get_metrics && !function.rows_scanned)) {
 		return;
 	}
 	auto &gstate = gstate_p.Cast<TableScanGlobalSourceState>();

--- a/external/duckdb/src/function/table/datasource_scan.cpp
+++ b/external/duckdb/src/function/table/datasource_scan.cpp
@@ -34,7 +34,10 @@ static datasource_produce_stream_t RequireProduceStream(datasource_produce_strea
 
 static vector<DistributedScanSplit>
 DataSourcePlanDistributedScanSplits(const TableFunctionDistributedScanPlanningInput &input) {
-	auto &bind_data = input.bind_data.Cast<DataSourceScanBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed datasource scan requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<DataSourceScanBindData>();
 	vector<DistributedScanSplit> splits;
 	splits.reserve(bind_data.pickled_tasks.size());
 	for (idx_t task_index = 0; task_index < bind_data.pickled_tasks.size(); task_index++) {
@@ -47,7 +50,10 @@ DataSourcePlanDistributedScanSplits(const TableFunctionDistributedScanPlanningIn
 }
 
 static unique_ptr<FunctionData> DataSourceCreateDistributedWorkerBind(const TableFunctionDistributedScanInput &input) {
-	auto &source_bind = input.bind_data.Cast<DataSourceScanBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed datasource scan requires bind data");
+	}
+	auto &source_bind = input.bind_data->Cast<DataSourceScanBindData>();
 	auto worker_bind = make_uniq<DataSourceScanBindData>();
 	worker_bind->pickled_source = source_bind.pickled_source;
 	worker_bind->query_id = source_bind.query_id;
@@ -67,9 +73,12 @@ static bool IsCanonicalDataSourceSplitId(const string &split_id) {
 	return true;
 }
 
-static void DataSourceApplyDistributedSplits(FunctionData &worker_bind_data,
+static void DataSourceApplyDistributedSplits(optional_ptr<FunctionData> worker_bind_data,
                                              const vector<DistributedScanSplit> &splits) {
-	auto &bind_data = worker_bind_data.Cast<DataSourceScanBindData>();
+	if (!worker_bind_data) {
+		throw InvalidInputException("distributed datasource scan requires worker bind data");
+	}
+	auto &bind_data = worker_bind_data->Cast<DataSourceScanBindData>();
 	vector<string> validated_tasks;
 	validated_tasks.reserve(splits.size());
 	for (const auto &split : splits) {

--- a/external/duckdb/src/function/table/range.cpp
+++ b/external/duckdb/src/function/table/range.cpp
@@ -187,8 +187,8 @@ vector<DistributedSequenceSplit> DecodeDistributedSequenceSplits(const vector<Di
 	return result;
 }
 
-static bool DistributedSequenceSplitsEqual(const vector<DistributedSequenceSplit> &left,
-                                           const vector<DistributedSequenceSplit> &right) {
+bool DistributedSequenceSplitsEqual(const vector<DistributedSequenceSplit> &left,
+                                    const vector<DistributedSequenceSplit> &right) {
 	if (left.size() != right.size()) {
 		return false;
 	}
@@ -519,7 +519,10 @@ static unique_ptr<FunctionData> RangeFunctionDeserialize(Deserializer &deseriali
 
 static vector<DistributedScanSplit>
 PlanDistributedIntegerRange(const TableFunctionDistributedScanPlanningInput &input) {
-	auto &bind_data = input.bind_data.Cast<RangeFunctionBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed integer range requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<RangeFunctionBindData>();
 	if (!bind_data.has_parameters) {
 		throw InvalidInputException("distributed integer range requires scalar bound parameters");
 	}
@@ -528,7 +531,10 @@ PlanDistributedIntegerRange(const TableFunctionDistributedScanPlanningInput &inp
 
 static unique_ptr<FunctionData>
 CreateDistributedIntegerRangeWorkerBind(const TableFunctionDistributedScanInput &input) {
-	auto &source_bind = input.bind_data.Cast<RangeFunctionBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed integer range requires bind data");
+	}
+	auto &source_bind = input.bind_data->Cast<RangeFunctionBindData>();
 	if (!source_bind.has_parameters) {
 		throw InvalidInputException("distributed integer range requires scalar bound parameters");
 	}
@@ -538,9 +544,12 @@ CreateDistributedIntegerRangeWorkerBind(const TableFunctionDistributedScanInput 
 	return std::move(result);
 }
 
-static void ApplyDistributedIntegerRangeSplits(FunctionData &worker_bind_data,
+static void ApplyDistributedIntegerRangeSplits(optional_ptr<FunctionData> worker_bind_data,
                                                const vector<DistributedScanSplit> &splits) {
-	auto &bind_data = worker_bind_data.Cast<RangeFunctionBindData>();
+	if (!worker_bind_data) {
+		throw InvalidInputException("distributed integer range requires worker bind data");
+	}
+	auto &bind_data = worker_bind_data->Cast<RangeFunctionBindData>();
 	if (!bind_data.distributed || !bind_data.has_parameters) {
 		throw InvalidInputException("distributed integer range splits require a worker bind");
 	}
@@ -881,7 +890,10 @@ static unique_ptr<FunctionData> RangeDateTimeDeserialize(Deserializer &deseriali
 
 static vector<DistributedScanSplit>
 PlanDistributedDateTimeRange(const TableFunctionDistributedScanPlanningInput &input) {
-	auto &bind_data = input.bind_data.Cast<RangeDateTimeBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed timestamp range requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<RangeDateTimeBindData>();
 	if (!bind_data.has_parameters) {
 		throw InvalidInputException("distributed timestamp range requires scalar bound parameters");
 	}
@@ -890,7 +902,10 @@ PlanDistributedDateTimeRange(const TableFunctionDistributedScanPlanningInput &in
 
 static unique_ptr<FunctionData>
 CreateDistributedDateTimeRangeWorkerBind(const TableFunctionDistributedScanInput &input) {
-	auto &source_bind = input.bind_data.Cast<RangeDateTimeBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed timestamp range requires bind data");
+	}
+	auto &source_bind = input.bind_data->Cast<RangeDateTimeBindData>();
 	if (!source_bind.has_parameters) {
 		throw InvalidInputException("distributed timestamp range requires scalar bound parameters");
 	}
@@ -900,9 +915,12 @@ CreateDistributedDateTimeRangeWorkerBind(const TableFunctionDistributedScanInput
 	return std::move(result);
 }
 
-static void ApplyDistributedDateTimeRangeSplits(FunctionData &worker_bind_data,
+static void ApplyDistributedDateTimeRangeSplits(optional_ptr<FunctionData> worker_bind_data,
                                                 const vector<DistributedScanSplit> &splits) {
-	auto &bind_data = worker_bind_data.Cast<RangeDateTimeBindData>();
+	if (!worker_bind_data) {
+		throw InvalidInputException("distributed timestamp range requires worker bind data");
+	}
+	auto &bind_data = worker_bind_data->Cast<RangeDateTimeBindData>();
 	if (!bind_data.distributed || !bind_data.has_parameters) {
 		throw InvalidInputException("distributed timestamp range splits require a worker bind");
 	}

--- a/external/duckdb/src/function/table/read_csv.cpp
+++ b/external/duckdb/src/function/table/read_csv.cpp
@@ -551,7 +551,10 @@ static string DistributedCSVSplitId(const DistributedCSVSplitPayload &payload) {
 }
 
 static const MultiFileBindData &GetCSVDistributedBind(const TableFunctionDistributedScanInput &input) {
-	auto &bind_data = input.bind_data.Cast<MultiFileBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("Distributed CSV scan requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<MultiFileBindData>();
 	if (!bind_data.bind_data || !bind_data.file_list || !bind_data.multi_file_reader || !bind_data.interface) {
 		throw InvalidInputException("Distributed CSV scan requires complete multi-file bind data");
 	}
@@ -832,8 +835,12 @@ static unique_ptr<FunctionData> CreateDistributedCSVWorkerBind(const TableFuncti
 	return std::move(result);
 }
 
-static void ApplyDistributedCSVSplits(FunctionData &worker_bind_data, const vector<DistributedScanSplit> &splits) {
-	auto &worker = worker_bind_data.Cast<MultiFileBindData>();
+static void ApplyDistributedCSVSplits(optional_ptr<FunctionData> worker_bind_data,
+                                      const vector<DistributedScanSplit> &splits) {
+	if (!worker_bind_data) {
+		throw InvalidInputException("Distributed CSV splits require worker bind data");
+	}
+	auto &worker = worker_bind_data->Cast<MultiFileBindData>();
 	if (!worker.bind_data || !worker.file_list || !worker.multi_file_reader || !worker.interface) {
 		throw InvalidInputException("Distributed CSV splits require complete worker bind data");
 	}

--- a/external/duckdb/src/function/table/repeat.cpp
+++ b/external/duckdb/src/function/table/repeat.cpp
@@ -1,20 +1,39 @@
 #include "duckdb/function/table/range.hpp"
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/function/table/distributed_sequence.hpp"
 
 namespace duckdb {
 
 struct RepeatFunctionData : public TableFunctionData {
+	RepeatFunctionData() = default;
+
 	RepeatFunctionData(Value value, idx_t target_count) : value(std::move(value)), target_count(target_count) {
 	}
 
 	Value value;
-	idx_t target_count;
+	idx_t target_count = 0;
+	bool distributed = false;
+	vector<DistributedSequenceSplit> sequence_splits;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<RepeatFunctionData>(*this);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto other = dynamic_cast<const RepeatFunctionData *>(&other_p);
+		return other && column_ids == other->column_ids && value.type() == other->value.type() &&
+		       Value::NotDistinctFrom(value, other->value) && target_count == other->target_count &&
+		       distributed == other->distributed &&
+		       DistributedSequenceSplitsEqual(sequence_splits, other->sequence_splits);
+	}
 };
 
 struct RepeatOperatorData : public GlobalTableFunctionState {
-	RepeatOperatorData() : current_count(0) {
-	}
-	idx_t current_count;
+	idx_t current_count = 0;
+	idx_t sequence_split_index = 0;
+	idx_t sequence_split_row = 0;
 };
 
 static unique_ptr<FunctionData> RepeatBind(ClientContext &context, TableFunctionBindInput &input,
@@ -41,10 +60,26 @@ static void RepeatFunction(ClientContext &context, TableFunctionInput &data_p, D
 	auto &bind_data = data_p.bind_data->Cast<RepeatFunctionData>();
 	auto &state = data_p.global_state->Cast<RepeatOperatorData>();
 
-	idx_t remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
+	idx_t remaining;
+	if (bind_data.distributed) {
+		while (state.sequence_split_index < bind_data.sequence_splits.size() &&
+		       state.sequence_split_row == bind_data.sequence_splits[state.sequence_split_index].row_count) {
+			state.sequence_split_index++;
+			state.sequence_split_row = 0;
+		}
+		if (state.sequence_split_index == bind_data.sequence_splits.size()) {
+			output.SetCardinality(0);
+			return;
+		}
+		auto &sequence_split = bind_data.sequence_splits[state.sequence_split_index];
+		remaining = MinValue<idx_t>(sequence_split.row_count - state.sequence_split_row, STANDARD_VECTOR_SIZE);
+		state.sequence_split_row += remaining;
+	} else {
+		remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
+		state.current_count += remaining;
+	}
 	output.data[0].Reference(bind_data.value);
 	output.SetCardinality(remaining);
-	state.current_count += remaining;
 }
 
 static unique_ptr<NodeStatistics> RepeatCardinality(ClientContext &context, const FunctionData *bind_data_p) {
@@ -52,10 +87,88 @@ static unique_ptr<NodeStatistics> RepeatCardinality(ClientContext &context, cons
 	return make_uniq<NodeStatistics>(bind_data.target_count, bind_data.target_count);
 }
 
-void RepeatTableFunction::RegisterFunction(BuiltinFunctions &set) {
+static void RepeatSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                            const TableFunction &) {
+	if (!bind_data_p) {
+		throw SerializationException("repeat requires bind data");
+	}
+	auto &bind_data = bind_data_p->Cast<RepeatFunctionData>();
+	serializer.WriteProperty(101, "value", bind_data.value);
+	serializer.WriteProperty(102, "target_count", NumericCast<int64_t>(bind_data.target_count));
+	serializer.WriteProperty(103, "distributed", bind_data.distributed);
+}
+
+static unique_ptr<FunctionData> RepeatDeserialize(Deserializer &deserializer, TableFunction &) {
+	auto result = make_uniq<RepeatFunctionData>();
+	result->value = deserializer.ReadProperty<Value>(101, "value");
+	auto target_count = deserializer.ReadProperty<int64_t>(102, "target_count");
+	if (target_count < 0) {
+		throw SerializationException("serialized repeat has a negative target count");
+	}
+	result->target_count = NumericCast<idx_t>(target_count);
+	result->distributed = deserializer.ReadProperty<bool>(103, "distributed");
+	return std::move(result);
+}
+
+static vector<DistributedScanSplit> PlanDistributedRepeat(const TableFunctionDistributedScanPlanningInput &input) {
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed repeat requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<RepeatFunctionData>();
+	auto result = PlanDistributedSequenceSplits(bind_data.target_count, true, input.target_split_count);
+	// The repeated value can be an arbitrarily large nested value. Preserve the
+	// exact row estimate, but do not reuse the sequence helper's BIGINT byte
+	// estimate as if every output row were eight bytes.
+	for (auto &split : result) {
+		split.estimated_bytes = optional_idx();
+	}
+	return result;
+}
+
+static unique_ptr<FunctionData> CreateDistributedRepeatWorkerBind(const TableFunctionDistributedScanInput &input) {
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed repeat requires bind data");
+	}
+	auto result = make_uniq<RepeatFunctionData>(input.bind_data->Cast<RepeatFunctionData>());
+	result->distributed = true;
+	result->sequence_splits.clear();
+	return std::move(result);
+}
+
+static void ApplyDistributedRepeatSplits(optional_ptr<FunctionData> worker_bind_data,
+                                         const vector<DistributedScanSplit> &splits) {
+	if (!worker_bind_data) {
+		throw InvalidInputException("distributed repeat requires worker bind data");
+	}
+	auto &bind_data = worker_bind_data->Cast<RepeatFunctionData>();
+	if (!bind_data.distributed) {
+		throw InvalidInputException("distributed repeat splits require a worker bind");
+	}
+	bind_data.sequence_splits = DecodeDistributedSequenceSplits(splits, bind_data.target_count, true);
+}
+
+static TableFunctionDistributedScanCallbacks RepeatDistributedCallbacks() {
+	TableFunctionDistributedScanCallbacks callbacks;
+	callbacks.protocol_version = DISTRIBUTED_SEQUENCE_PROTOCOL_VERSION;
+	callbacks.split_codec = {DISTRIBUTED_SEQUENCE_SPLIT_CODEC, DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION};
+	callbacks.plan_splits = PlanDistributedRepeat;
+	callbacks.create_worker_bind = CreateDistributedRepeatWorkerBind;
+	callbacks.apply_splits = ApplyDistributedRepeatSplits;
+	return callbacks;
+}
+
+TableFunction RepeatTableFunction::GetFunction() {
 	TableFunction repeat("repeat", {LogicalType::ANY, LogicalType::BIGINT}, RepeatFunction, RepeatBind, RepeatInit);
 	repeat.cardinality = RepeatCardinality;
-	set.AddFunction(repeat);
+	repeat.serialize = RepeatSerialize;
+	repeat.deserialize = RepeatDeserialize;
+	repeat.SetDistributedScanCallbacks(RepeatDistributedCallbacks());
+	repeat.BindDistributedScanCapability("vane_core");
+	return repeat;
+}
+
+void RepeatTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(GetFunction());
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/repeat_row.cpp
+++ b/external/duckdb/src/function/table/repeat_row.cpp
@@ -1,21 +1,48 @@
 #include "duckdb/function/table/range.hpp"
 #include "duckdb/common/algorithm.hpp"
+#include "duckdb/common/serializer/deserializer.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
+#include "duckdb/function/table/distributed_sequence.hpp"
 
 namespace duckdb {
 
 struct RepeatRowFunctionData : public TableFunctionData {
+	RepeatRowFunctionData() = default;
+
 	RepeatRowFunctionData(vector<Value> values, idx_t target_count)
 	    : values(std::move(values)), target_count(target_count) {
 	}
 
-	const vector<Value> values;
-	idx_t target_count;
+	vector<Value> values;
+	idx_t target_count = 0;
+	bool distributed = false;
+	vector<DistributedSequenceSplit> sequence_splits;
+
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<RepeatRowFunctionData>(*this);
+	}
+
+	bool Equals(const FunctionData &other_p) const override {
+		auto other = dynamic_cast<const RepeatRowFunctionData *>(&other_p);
+		if (!other || column_ids != other->column_ids || values.size() != other->values.size() ||
+		    target_count != other->target_count || distributed != other->distributed ||
+		    !DistributedSequenceSplitsEqual(sequence_splits, other->sequence_splits)) {
+			return false;
+		}
+		for (idx_t value_index = 0; value_index < values.size(); value_index++) {
+			if (values[value_index].type() != other->values[value_index].type() ||
+			    !Value::NotDistinctFrom(values[value_index], other->values[value_index])) {
+				return false;
+			}
+		}
+		return true;
+	}
 };
 
 struct RepeatRowOperatorData : public GlobalTableFunctionState {
-	RepeatRowOperatorData() : current_count(0) {
-	}
-	idx_t current_count;
+	idx_t current_count = 0;
+	idx_t sequence_split_index = 0;
+	idx_t sequence_split_row = 0;
 };
 
 static unique_ptr<FunctionData> RepeatRowBind(ClientContext &context, TableFunctionBindInput &input,
@@ -43,12 +70,28 @@ static void RepeatRowFunction(ClientContext &context, TableFunctionInput &data_p
 	auto &bind_data = data_p.bind_data->Cast<RepeatRowFunctionData>();
 	auto &state = data_p.global_state->Cast<RepeatRowOperatorData>();
 
-	idx_t remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
+	idx_t remaining;
+	if (bind_data.distributed) {
+		while (state.sequence_split_index < bind_data.sequence_splits.size() &&
+		       state.sequence_split_row == bind_data.sequence_splits[state.sequence_split_index].row_count) {
+			state.sequence_split_index++;
+			state.sequence_split_row = 0;
+		}
+		if (state.sequence_split_index == bind_data.sequence_splits.size()) {
+			output.SetCardinality(0);
+			return;
+		}
+		auto &sequence_split = bind_data.sequence_splits[state.sequence_split_index];
+		remaining = MinValue<idx_t>(sequence_split.row_count - state.sequence_split_row, STANDARD_VECTOR_SIZE);
+		state.sequence_split_row += remaining;
+	} else {
+		remaining = MinValue<idx_t>(bind_data.target_count - state.current_count, STANDARD_VECTOR_SIZE);
+		state.current_count += remaining;
+	}
 	for (idx_t val_idx = 0; val_idx < bind_data.values.size(); val_idx++) {
 		output.data[val_idx].Reference(bind_data.values[val_idx]);
 	}
 	output.SetCardinality(remaining);
-	state.current_count += remaining;
 }
 
 static unique_ptr<NodeStatistics> RepeatRowCardinality(ClientContext &context, const FunctionData *bind_data_p) {
@@ -56,12 +99,92 @@ static unique_ptr<NodeStatistics> RepeatRowCardinality(ClientContext &context, c
 	return make_uniq<NodeStatistics>(bind_data.target_count, bind_data.target_count);
 }
 
-void RepeatRowTableFunction::RegisterFunction(BuiltinFunctions &set) {
+static void RepeatRowSerialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                               const TableFunction &) {
+	if (!bind_data_p) {
+		throw SerializationException("repeat_row requires bind data");
+	}
+	auto &bind_data = bind_data_p->Cast<RepeatRowFunctionData>();
+	serializer.WriteProperty(101, "values", bind_data.values);
+	serializer.WriteProperty(102, "target_count", NumericCast<int64_t>(bind_data.target_count));
+	serializer.WriteProperty(103, "distributed", bind_data.distributed);
+}
+
+static unique_ptr<FunctionData> RepeatRowDeserialize(Deserializer &deserializer, TableFunction &) {
+	auto result = make_uniq<RepeatRowFunctionData>();
+	result->values = deserializer.ReadProperty<vector<Value>>(101, "values");
+	auto target_count = deserializer.ReadProperty<int64_t>(102, "target_count");
+	if (target_count < 0) {
+		throw SerializationException("serialized repeat_row has a negative target count");
+	}
+	result->target_count = NumericCast<idx_t>(target_count);
+	result->distributed = deserializer.ReadProperty<bool>(103, "distributed");
+	if (result->values.empty()) {
+		throw SerializationException("serialized repeat_row has no values");
+	}
+	return std::move(result);
+}
+
+static vector<DistributedScanSplit> PlanDistributedRepeatRow(const TableFunctionDistributedScanPlanningInput &input) {
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed repeat_row requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<RepeatRowFunctionData>();
+	auto result = PlanDistributedSequenceSplits(bind_data.target_count, true, input.target_split_count);
+	// Row width depends on every (possibly nested) repeated value. Keep the
+	// exact cardinality while leaving byte size unknown to the scheduler.
+	for (auto &split : result) {
+		split.estimated_bytes = optional_idx();
+	}
+	return result;
+}
+
+static unique_ptr<FunctionData> CreateDistributedRepeatRowWorkerBind(const TableFunctionDistributedScanInput &input) {
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed repeat_row requires bind data");
+	}
+	auto result = make_uniq<RepeatRowFunctionData>(input.bind_data->Cast<RepeatRowFunctionData>());
+	result->distributed = true;
+	result->sequence_splits.clear();
+	return std::move(result);
+}
+
+static void ApplyDistributedRepeatRowSplits(optional_ptr<FunctionData> worker_bind_data,
+                                            const vector<DistributedScanSplit> &splits) {
+	if (!worker_bind_data) {
+		throw InvalidInputException("distributed repeat_row requires worker bind data");
+	}
+	auto &bind_data = worker_bind_data->Cast<RepeatRowFunctionData>();
+	if (!bind_data.distributed) {
+		throw InvalidInputException("distributed repeat_row splits require a worker bind");
+	}
+	bind_data.sequence_splits = DecodeDistributedSequenceSplits(splits, bind_data.target_count, true);
+}
+
+static TableFunctionDistributedScanCallbacks RepeatRowDistributedCallbacks() {
+	TableFunctionDistributedScanCallbacks callbacks;
+	callbacks.protocol_version = DISTRIBUTED_SEQUENCE_PROTOCOL_VERSION;
+	callbacks.split_codec = {DISTRIBUTED_SEQUENCE_SPLIT_CODEC, DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION};
+	callbacks.plan_splits = PlanDistributedRepeatRow;
+	callbacks.create_worker_bind = CreateDistributedRepeatRowWorkerBind;
+	callbacks.apply_splits = ApplyDistributedRepeatRowSplits;
+	return callbacks;
+}
+
+TableFunction RepeatRowTableFunction::GetFunction() {
 	TableFunction repeat_row("repeat_row", {}, RepeatRowFunction, RepeatRowBind, RepeatRowInit);
 	repeat_row.varargs = LogicalType::ANY;
 	repeat_row.named_parameters["num_rows"] = LogicalType::BIGINT;
 	repeat_row.cardinality = RepeatRowCardinality;
-	set.AddFunction(repeat_row);
+	repeat_row.serialize = RepeatRowSerialize;
+	repeat_row.deserialize = RepeatRowDeserialize;
+	repeat_row.SetDistributedScanCallbacks(RepeatRowDistributedCallbacks());
+	repeat_row.BindDistributedScanCapability("vane_core");
+	return repeat_row;
+}
+
+void RepeatRowTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(GetFunction());
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/unnest.cpp
+++ b/external/duckdb/src/function/table/unnest.cpp
@@ -100,12 +100,18 @@ static unique_ptr<FunctionData> UnnestDeserialize(Deserializer &deserializer, Ta
 	return make_uniq<UnnestBindData>(std::move(input_type));
 }
 
-void UnnestTableFunction::RegisterFunction(BuiltinFunctions &set) {
+TableFunction UnnestTableFunction::GetFunction() {
 	TableFunction unnest_function("unnest", {LogicalType::ANY}, nullptr, UnnestBind, UnnestInit, UnnestLocalInit);
 	unnest_function.in_out_function = UnnestFunction;
 	unnest_function.serialize = UnnestSerialize;
 	unnest_function.deserialize = UnnestDeserialize;
-	set.AddFunction(unnest_function);
+	unnest_function.SetDistributedScanCallbacks(MakeDistributedSingletonSourceCallbacks());
+	unnest_function.BindDistributedScanCapability("vane_core");
+	return unnest_function;
+}
+
+void UnnestTableFunction::RegisterFunction(BuiltinFunctions &set) {
+	set.AddFunction(GetFunction());
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table_function.cpp
+++ b/external/duckdb/src/function/table_function.cpp
@@ -68,6 +68,9 @@ unique_ptr<FunctionData> CreateDistributedSingletonWorkerBind(const TableFunctio
 }
 
 void ApplyDistributedSingletonSource(optional_ptr<FunctionData>, const vector<DistributedScanSplit> &splits) {
+	if (splits.empty()) {
+		return;
+	}
 	if (splits.size() != 1) {
 		throw InvalidInputException("distributed singleton source requires exactly one assigned split");
 	}

--- a/external/duckdb/src/function/table_function.cpp
+++ b/external/duckdb/src/function/table_function.cpp
@@ -48,6 +48,51 @@ DistributedScanSplit DistributedScanSplit::Deserialize(Deserializer &deserialize
 	return result;
 }
 
+namespace {
+
+vector<DistributedScanSplit> PlanDistributedSingletonSource(const TableFunctionDistributedScanPlanningInput &input) {
+	DistributedScanSplit split;
+	split.split_id = "0";
+	if (input.estimated_cardinality != DConstants::INVALID_INDEX) {
+		split.estimated_cardinality = optional_idx(input.estimated_cardinality);
+	}
+	split.Validate();
+	return {std::move(split)};
+}
+
+unique_ptr<FunctionData> CreateDistributedSingletonWorkerBind(const TableFunctionDistributedScanInput &input) {
+	if (!input.bind_data) {
+		return nullptr;
+	}
+	return input.bind_data->Copy();
+}
+
+void ApplyDistributedSingletonSource(optional_ptr<FunctionData>, const vector<DistributedScanSplit> &splits) {
+	if (splits.size() != 1) {
+		throw InvalidInputException("distributed singleton source requires exactly one assigned split");
+	}
+	const auto &split = splits[0];
+	split.Validate();
+	if (split.split_id != "0" || !split.payload.empty()) {
+		throw InvalidInputException("distributed singleton source received an invalid split");
+	}
+}
+
+} // namespace
+
+TableFunctionDistributedScanCallbacks
+MakeDistributedSingletonSourceCallbacks(TableFunctionDistributedBindDataMode bind_data_mode) {
+	TableFunctionDistributedScanCallbacks callbacks;
+	callbacks.protocol_version = DISTRIBUTED_SINGLETON_SOURCE_PROTOCOL_VERSION;
+	callbacks.split_codec = {DISTRIBUTED_SINGLETON_SOURCE_SPLIT_CODEC,
+	                         DISTRIBUTED_SINGLETON_SOURCE_SPLIT_CODEC_VERSION};
+	callbacks.bind_data_mode = bind_data_mode;
+	callbacks.plan_splits = PlanDistributedSingletonSource;
+	callbacks.create_worker_bind = CreateDistributedSingletonWorkerBind;
+	callbacks.apply_splits = ApplyDistributedSingletonSource;
+	return callbacks;
+}
+
 TableFunction::TableFunction(string name, const vector<LogicalType> &arguments, table_function_t function_,
                              table_function_bind_t bind, table_function_init_global_t init_global,
                              table_function_init_local_t init_local)
@@ -132,6 +177,14 @@ void TableFunctionDistributedScanCallbacks::ValidateDefinition(const string &fun
 		throw InvalidInputException(
 		    "Distributed scan protocol version for table function '%s' must be greater than zero", function_name);
 	}
+	switch (bind_data_mode) {
+	case TableFunctionDistributedBindDataMode::REQUIRED:
+	case TableFunctionDistributedBindDataMode::OPTIONAL:
+		break;
+	default:
+		throw InvalidInputException("Distributed scan callbacks for table function '%s' have an invalid bind-data mode",
+		                            function_name);
+	}
 	split_codec.Validate("Distributed scan split codec for table function '" + function_name + "'");
 }
 
@@ -182,8 +235,9 @@ const DistributedExtensionCapabilityReference &TableFunctionDistributedScanCallb
 
 bool TableFunctionDistributedScanCallbacks::operator==(const TableFunctionDistributedScanCallbacks &other) const {
 	return protocol_version == other.protocol_version && capability == other.capability &&
-	       split_codec == other.split_codec && plan_splits == other.plan_splits &&
-	       create_worker_bind == other.create_worker_bind && apply_splits == other.apply_splits;
+	       split_codec == other.split_codec && bind_data_mode == other.bind_data_mode &&
+	       plan_splits == other.plan_splits && create_worker_bind == other.create_worker_bind &&
+	       apply_splits == other.apply_splits;
 }
 
 void TableFunction::SetDistributedScanCallbacks(TableFunctionDistributedScanCallbacks callbacks) {

--- a/external/duckdb/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/scan/physical_table_scan.hpp
@@ -62,6 +62,9 @@ public:
 	//! leaves this false; explicit static or FTE split injection sets it before
 	//! executor initialization. Coordinator bind state is never a fallback.
 	bool distributed_scan_splits_applied = false;
+	//! Runtime-only execution fence for an explicit empty extension assignment.
+	//! This may only be true after distributed_scan_splits_applied is set.
+	bool distributed_scan_empty = false;
 	//! Contains a reference to dynamically generated table filters (through e.g. a join up in the tree)
 	shared_ptr<DynamicTableFilterSet> dynamic_filters;
 	//! Virtual columns

--- a/external/duckdb/src/include/duckdb/function/distributed_table_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/distributed_table_function.hpp
@@ -99,7 +99,9 @@ typedef unique_ptr<FunctionData> (*table_function_create_distributed_worker_bind
     const TableFunctionDistributedScanInput &input);
 
 //! Decode and install the assigned opaque splits into a deserialized worker
-//! bind object. An empty vector must install an empty scan.
+//! bind object. An empty vector is an explicit empty assignment: the callback
+//! must clear retained assignment state, and the runtime suppresses execution
+//! after the callback returns.
 typedef void (*table_function_apply_distributed_scan_splits_t)(optional_ptr<FunctionData> worker_bind_data,
                                                                const vector<DistributedScanSplit> &splits);
 

--- a/external/duckdb/src/include/duckdb/function/distributed_table_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/distributed_table_function.hpp
@@ -25,6 +25,15 @@ class FileSystem;
 class TableFilterSet;
 class TableFunction;
 
+static constexpr idx_t DISTRIBUTED_SINGLETON_SOURCE_PROTOCOL_VERSION = 1;
+static constexpr idx_t DISTRIBUTED_SINGLETON_SOURCE_SPLIT_CODEC_VERSION = 1;
+static constexpr const char *DISTRIBUTED_SINGLETON_SOURCE_SPLIT_CODEC = "vane.singleton-source-split";
+
+//! Whether a distributed table-function contract requires a FunctionData
+//! object. Some table-in/out functions carry their complete portable state in
+//! scalar parameters and legitimately bind to nullptr.
+enum class TableFunctionDistributedBindDataMode : uint8_t { REQUIRED = 0, OPTIONAL = 1 };
+
 //! Stable catalog identity for one table-function overload. This uses the
 //! declared argument and varargs types rather than bind-time concrete types.
 DUCKDB_API string GetDistributedTableFunctionSignature(const string &function_name,
@@ -47,14 +56,15 @@ struct DistributedScanSplit {
 //! Physical scan information available while an extension creates its split
 //! envelopes or constructs a worker bind.
 struct TableFunctionDistributedScanInput {
-	TableFunctionDistributedScanInput(const FunctionData &bind_data_p, const vector<ColumnIndex> &column_ids_p,
-	                                  const vector<idx_t> &projection_ids_p,
+	TableFunctionDistributedScanInput(optional_ptr<const FunctionData> bind_data_p, const vector<Value> &parameters_p,
+	                                  const vector<ColumnIndex> &column_ids_p, const vector<idx_t> &projection_ids_p,
 	                                  optional_ptr<const TableFilterSet> table_filters_p, idx_t estimated_cardinality_p)
-	    : bind_data(bind_data_p), column_ids(column_ids_p), projection_ids(projection_ids_p),
+	    : bind_data(bind_data_p), parameters(parameters_p), column_ids(column_ids_p), projection_ids(projection_ids_p),
 	      table_filters(table_filters_p), estimated_cardinality(estimated_cardinality_p) {
 	}
 
-	const FunctionData &bind_data;
+	optional_ptr<const FunctionData> bind_data;
+	const vector<Value> &parameters;
 	const vector<ColumnIndex> &column_ids;
 	const vector<idx_t> &projection_ids;
 	optional_ptr<const TableFilterSet> table_filters;
@@ -90,7 +100,7 @@ typedef unique_ptr<FunctionData> (*table_function_create_distributed_worker_bind
 
 //! Decode and install the assigned opaque splits into a deserialized worker
 //! bind object. An empty vector must install an empty scan.
-typedef void (*table_function_apply_distributed_scan_splits_t)(FunctionData &worker_bind_data,
+typedef void (*table_function_apply_distributed_scan_splits_t)(optional_ptr<FunctionData> worker_bind_data,
                                                                const vector<DistributedScanSplit> &splits);
 
 //! Complete distributed scan contract attached to a TableFunction. Extension
@@ -102,6 +112,7 @@ typedef void (*table_function_apply_distributed_scan_splits_t)(FunctionData &wor
 struct TableFunctionDistributedScanCallbacks {
 	idx_t protocol_version = 0;
 	DistributedPayloadCodec split_codec;
+	TableFunctionDistributedBindDataMode bind_data_mode = TableFunctionDistributedBindDataMode::REQUIRED;
 	table_function_plan_distributed_scan_splits_t plan_splits = nullptr;
 	table_function_create_distributed_worker_bind_t create_worker_bind = nullptr;
 	table_function_apply_distributed_scan_splits_t apply_splits = nullptr;
@@ -115,5 +126,12 @@ struct TableFunctionDistributedScanCallbacks {
 private:
 	DistributedExtensionCapabilityReference capability;
 };
+
+//! Construct the explicit one-work-unit protocol used by portable scalar
+//! sources that are replayable on a worker but are not independently
+//! partitionable. The scalar parameters remain part of PhysicalTableScan serde;
+//! the singleton split controls exactly-once scheduler assignment.
+DUCKDB_API TableFunctionDistributedScanCallbacks MakeDistributedSingletonSourceCallbacks(
+    TableFunctionDistributedBindDataMode bind_data_mode = TableFunctionDistributedBindDataMode::REQUIRED);
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/function/table/distributed_sequence.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/distributed_sequence.hpp
@@ -39,6 +39,9 @@ DUCKDB_API vector<DistributedScanSplit> PlanDistributedSequenceSplits(idx_t card
 DUCKDB_API vector<DistributedSequenceSplit> DecodeDistributedSequenceSplits(const vector<DistributedScanSplit> &splits,
                                                                             idx_t cardinality, bool exact_count);
 
+DUCKDB_API bool DistributedSequenceSplitsEqual(const vector<DistributedSequenceSplit> &left,
+                                               const vector<DistributedSequenceSplit> &right);
+
 //! Exact arithmetic shared by indexable BIGINT and TIMESTAMP sequences.
 DUCKDB_API idx_t ComputeDistributedSequenceCardinality(int64_t start, int64_t end, int64_t increment, bool inclusive);
 DUCKDB_API int64_t GetDistributedSequenceValue(int64_t start, int64_t increment, idx_t row_offset);

--- a/external/duckdb/src/include/duckdb/function/table/range.hpp
+++ b/external/duckdb/src/include/duckdb/function/table/range.hpp
@@ -30,14 +30,17 @@ struct RangeTableFunction {
 };
 
 struct RepeatTableFunction {
+	static TableFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
 struct RepeatRowTableFunction {
+	static TableFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 
 struct UnnestTableFunction {
+	static TableFunction GetFunction();
 	static void RegisterFunction(BuiltinFunctions &set);
 };
 

--- a/external/duckdb/src/main/database.cpp
+++ b/external/duckdb/src/main/database.cpp
@@ -365,6 +365,9 @@ void DatabaseInstance::Initialize(const char *database_path, DBConfig *user_conf
 	for (const auto &function : ReadCSVTableFunction::GetFunctions()) {
 		add_core_table_function(function);
 	}
+	add_core_table_function(RepeatTableFunction::GetFunction());
+	add_core_table_function(RepeatRowTableFunction::GetFunction());
+	add_core_table_function(UnnestTableFunction::GetFunction());
 	distributed_extension_manager->RegisterExtension(core_manifest);
 
 	// initialize the secret manager

--- a/external/duckdb/test/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/test/execution/distributed/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_EXECUTION_DISTRIBUTED_SOURCES
     test_copy_finalize.cpp
     test_distributed_extension_manager.cpp
     test_distributed_csv.cpp
+    test_distributed_portable_sources.cpp
     test_distributed_range.cpp
     test_distributed_test_extension.cpp
     test_execute_plan.cpp

--- a/external/duckdb/test/execution/distributed/test_distributed_extension_manager.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_extension_manager.cpp
@@ -118,11 +118,12 @@ static vector<DistributedScanSplit> DistributedOverloadPlan(const TableFunctionD
 }
 
 static unique_ptr<FunctionData> DistributedOverloadCreateWorkerBind(const TableFunctionDistributedScanInput &input) {
-	input.bind_data.Cast<DistributedOverloadBindData>();
+	REQUIRE(input.bind_data);
+	input.bind_data->Cast<DistributedOverloadBindData>();
 	return make_uniq<DistributedOverloadBindData>();
 }
 
-static void DistributedOverloadApply(FunctionData &, const vector<DistributedScanSplit> &) {
+static void DistributedOverloadApply(optional_ptr<FunctionData>, const vector<DistributedScanSplit> &) {
 }
 
 static void DistributedOverloadSerialize(Serializer &serializer, const optional_ptr<FunctionData>,

--- a/external/duckdb/test/execution/distributed/test_distributed_portable_sources.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_portable_sources.cpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "catch.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/pipeline_node/translator_scan.hpp"
+#include "duckdb/execution/distributed/plan/fte_split_queue.hpp"
+#include "duckdb/execution/distributed/plan/scan_split.hpp"
+#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
+#include "duckdb/execution/physical_plan.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/function/distributed_table_function.hpp"
+#include "duckdb/function/table/distributed_sequence.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+
+using namespace duckdb;
+
+namespace {
+
+struct PlannedPortableSource {
+	distributed::DuckPhysicalPlanRef worker_plan;
+	vector<distributed::ScanSplit> splits;
+};
+
+static distributed::ScanSplitBatch MakePortableSourceSplitBatch(vector<distributed::ScanSplit> splits) {
+	distributed::ScanSplitBatch result;
+	result.splits = std::move(splits);
+	result.Validate();
+	return result;
+}
+
+static distributed::ScanSplitBatch MakePortableSourceSplitBatch(const distributed::ScanSplit &split) {
+	return MakePortableSourceSplitBatch(vector<distributed::ScanSplit> {split});
+}
+
+static PlannedPortableSource PlanPortableSource(DuckDB &db, Connection &connection, const string &query,
+                                                idx_t worker_slots) {
+	auto logical_plan = connection.ExtractPlan(query);
+	REQUIRE(logical_plan != nullptr);
+	PhysicalPlanGenerator generator(*connection.context);
+	auto generated_plan = generator.Plan(std::move(logical_plan));
+	REQUIRE(generated_plan != nullptr);
+	REQUIRE(generated_plan->Root().type == PhysicalOperatorType::TABLE_SCAN);
+	auto &coordinator_scan = generated_plan->Root().Cast<PhysicalTableScan>();
+	REQUIRE(coordinator_scan.function.HasDistributedScanCallbacks());
+
+	distributed::DuckDBExecutionConfig config;
+	config.set_distributed_worker_slots(worker_slots);
+	PlannedPortableSource result;
+	result.worker_plan = distributed::MakeTableScanPlan(coordinator_scan);
+	result.splits = distributed::MakeTableScanSplits(coordinator_scan, config, db.instance);
+	return result;
+}
+
+static vector<vector<Value>> ExecutePortableAssignment(Connection &connection,
+                                                       const distributed::DuckPhysicalPlanRef &worker_plan,
+                                                       const distributed::ScanSplitBatch &batch, idx_t scan_node_id) {
+	auto execution_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	auto &scan = distributed::ClonePhysicalPlanRootIntoPlanOrThrow(
+	                 worker_plan, *execution_plan, "distributed_portable_source", connection.context.get())
+	                 .Cast<PhysicalTableScan>();
+	scan.extra_info.scan_node_id = optional_idx(scan_node_id);
+	scan.extra_info.scan_group_id = optional_idx(scan_node_id);
+	execution_plan->SetRoot(scan);
+
+	unordered_map<idx_t, distributed::ScanSplitBatch> assignments;
+	assignments.emplace(scan_node_id, batch);
+	string apply_error;
+	REQUIRE(distributed::ApplyScanSplitBatchesToPlan(*execution_plan, assignments, &apply_error));
+	REQUIRE(apply_error.empty());
+	REQUIRE(distributed::ValidateDistributedScanSplitsApplied(*execution_plan));
+
+	auto prepared = make_shared_ptr<PreparedStatementData>(StatementType::SELECT_STATEMENT);
+	prepared->names = scan.names;
+	prepared->types = scan.GetTypes();
+	prepared->properties.return_type = StatementReturnType::QUERY_RESULT;
+	prepared->output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+	prepared->memory_type = QueryResultMemoryType::IN_MEMORY;
+	prepared->physical_plan = std::move(execution_plan);
+	PendingQueryParameters parameters;
+	auto pending = connection.context->PendingQueryPreparedStatementNoRebind("test:distributed_portable_source",
+	                                                                         prepared, parameters);
+	REQUIRE(pending != nullptr);
+	REQUIRE_FALSE(pending->HasError());
+	auto query_result = pending->Execute();
+	REQUIRE(query_result != nullptr);
+	REQUIRE_NO_FAIL(*query_result);
+	auto materialized = dynamic_cast<MaterializedQueryResult *>(query_result.get());
+	REQUIRE(materialized != nullptr);
+	vector<vector<Value>> result;
+	result.reserve(materialized->RowCount());
+	for (idx_t row_index = 0; row_index < materialized->RowCount(); row_index++) {
+		vector<Value> row;
+		row.reserve(materialized->ColumnCount());
+		for (idx_t column_index = 0; column_index < materialized->ColumnCount(); column_index++) {
+			row.push_back(materialized->GetValue(column_index, row_index));
+		}
+		result.push_back(std::move(row));
+	}
+	return result;
+}
+
+static vector<vector<Value>> ExecutePortableAssignment(Connection &connection,
+                                                       const distributed::DuckPhysicalPlanRef &worker_plan,
+                                                       const distributed::ScanSplit &split, idx_t scan_node_id) {
+	return ExecutePortableAssignment(connection, worker_plan, MakePortableSourceSplitBatch(split), scan_node_id);
+}
+
+} // namespace
+
+TEST_CASE("Distributed repeat plans exact sequence splits", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanPortableSource(db, connection, "SELECT * FROM repeat(NULL::INTEGER, 10)", 4);
+	REQUIRE(planned.splits.size() == 4);
+
+	idx_t row_count = 0;
+	idx_t planned_cardinality = 0;
+	for (idx_t split_index = 0; split_index < planned.splits.size(); split_index++) {
+		const auto &split = planned.splits[split_index];
+		REQUIRE(split.kind == distributed::ScanSplitKind::EXTENSION);
+		REQUIRE_FALSE(split.empty);
+		REQUIRE(split.split_id == std::to_string(split_index));
+		REQUIRE(split.split_codec.name == DISTRIBUTED_SEQUENCE_SPLIT_CODEC);
+		REQUIRE(split.split_codec.version == DISTRIBUTED_SEQUENCE_SPLIT_CODEC_VERSION);
+		REQUIRE(split.estimated_cardinality.IsValid());
+		REQUIRE_FALSE(split.estimated_bytes.IsValid());
+		planned_cardinality += split.estimated_cardinality.GetIndex();
+		auto rows = ExecutePortableAssignment(connection, planned.worker_plan, split, 100 + split_index);
+		row_count += rows.size();
+		for (const auto &row : rows) {
+			REQUIRE(row.size() == 1);
+			REQUIRE(row[0].IsNull());
+		}
+	}
+	REQUIRE(planned_cardinality == 10);
+	REQUIRE(row_count == 10);
+
+	auto non_contiguous = MakePortableSourceSplitBatch(planned.splits[0]);
+	non_contiguous.Merge(MakePortableSourceSplitBatch(planned.splits[2]));
+	REQUIRE(ExecutePortableAssignment(connection, planned.worker_plan, non_contiguous, 200).size() == 5);
+}
+
+TEST_CASE("Distributed repeat_row preserves typed values across grouped splits", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned =
+	    PlanPortableSource(db, connection, "SELECT * FROM repeat_row(42, NULL::VARCHAR, [1, 2], num_rows=7)", 3);
+	REQUIRE(planned.splits.size() == 3);
+
+	auto assignment = MakePortableSourceSplitBatch(planned.splits[0]);
+	assignment.Merge(MakePortableSourceSplitBatch(planned.splits[2]));
+	assignment.Merge(MakePortableSourceSplitBatch(planned.splits[1]));
+	auto rows = ExecutePortableAssignment(connection, planned.worker_plan, assignment, 300);
+	REQUIRE(rows.size() == 7);
+	for (const auto &row : rows) {
+		REQUIRE(row.size() == 3);
+		REQUIRE(row[0].GetValue<int32_t>() == 42);
+		REQUIRE(row[1].IsNull());
+		REQUIRE(row[2].ToString() == "[1, 2]");
+	}
+}
+
+TEST_CASE("Distributed repeat installs an explicit empty assignment", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanPortableSource(db, connection, "SELECT * FROM repeat('unused', 0)", 8);
+	REQUIRE(planned.splits.size() == 1);
+	REQUIRE(planned.splits[0].empty);
+	REQUIRE(ExecutePortableAssignment(connection, planned.worker_plan, planned.splits[0], 400).empty());
+}
+
+TEST_CASE("Distributed standalone unnest uses one scheduler-owned source split", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanPortableSource(db, connection, "SELECT * FROM unnest([1, NULL, 3])", 8);
+	REQUIRE(planned.splits.size() == 1);
+	const auto &split = planned.splits[0];
+	REQUIRE(split.kind == distributed::ScanSplitKind::EXTENSION);
+	REQUIRE_FALSE(split.empty);
+	REQUIRE(split.split_id == "0");
+	REQUIRE(split.extension_payload.empty());
+	REQUIRE(split.split_codec.name == DISTRIBUTED_SINGLETON_SOURCE_SPLIT_CODEC);
+	REQUIRE(split.split_codec.version == DISTRIBUTED_SINGLETON_SOURCE_SPLIT_CODEC_VERSION);
+
+	auto rows = ExecutePortableAssignment(connection, planned.worker_plan, split, 500);
+	REQUIRE(rows.size() == 3);
+	REQUIRE(rows[0][0].GetValue<int32_t>() == 1);
+	REQUIRE(rows[1][0].IsNull());
+	REQUIRE(rows[2][0].GetValue<int32_t>() == 3);
+
+	auto empty = PlanPortableSource(db, connection, "SELECT * FROM unnest([]::INTEGER[])", 8);
+	REQUIRE(empty.splits.size() == 1);
+	REQUIRE_FALSE(empty.splits[0].empty);
+	REQUIRE(ExecutePortableAssignment(connection, empty.worker_plan, empty.splits[0], 501).empty());
+}
+
+TEST_CASE("Distributed singleton source rejects malformed assignments", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanPortableSource(db, connection, "SELECT * FROM unnest([1])", 1);
+	auto malformed = planned.splits[0];
+	malformed.split_id = "1";
+
+	auto execution_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());
+	auto &scan = distributed::ClonePhysicalPlanRootIntoPlanOrThrow(
+	                 planned.worker_plan, *execution_plan, "distributed_singleton_malformed", connection.context.get())
+	                 .Cast<PhysicalTableScan>();
+	scan.extra_info.scan_node_id = optional_idx(600);
+	scan.extra_info.scan_group_id = optional_idx(600);
+	execution_plan->SetRoot(scan);
+	unordered_map<idx_t, distributed::ScanSplitBatch> assignments;
+	assignments.emplace(600, MakePortableSourceSplitBatch(malformed));
+	string apply_error;
+	REQUIRE_THROWS_WITH(distributed::ApplyScanSplitBatchesToPlan(*execution_plan, assignments, &apply_error),
+	                    Catch::Matchers::Contains("invalid split"));
+}
+
+TEST_CASE("Distributed optional-bind singleton accepts static and FTE assignments", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanPortableSource(db, connection, "SELECT * FROM unnest([1])", 1);
+	REQUIRE(planned.splits.size() == 1);
+	auto split_batch = MakePortableSourceSplitBatch(planned.splits[0]);
+
+	auto make_nullable_plan = [&](idx_t scan_node_id) {
+		auto plan = distributed::ClonePhysicalPlanOrThrow(planned.worker_plan, "distributed_optional_bind_singleton",
+		                                                  connection.context.get());
+		auto &scan = plan->Root().Cast<PhysicalTableScan>();
+		auto callbacks = scan.function.GetDistributedScanCallbacks();
+		callbacks.bind_data_mode = TableFunctionDistributedBindDataMode::OPTIONAL;
+		scan.function.SetDistributedScanCallbacks(std::move(callbacks));
+		scan.bind_data.reset();
+		scan.extra_info.scan_node_id = optional_idx(scan_node_id);
+		scan.extra_info.scan_group_id = optional_idx(scan_node_id);
+		return plan;
+	};
+
+	auto static_plan = make_nullable_plan(700);
+	unordered_map<idx_t, distributed::ScanSplitBatch> static_assignments;
+	static_assignments.emplace(700, split_batch);
+	string static_error;
+	REQUIRE(distributed::ApplyScanSplitBatchesToPlan(*static_plan, static_assignments, &static_error));
+	REQUIRE(static_error.empty());
+	REQUIRE(static_plan->Root().Cast<PhysicalTableScan>().distributed_scan_splits_applied);
+
+	auto fte_plan = make_nullable_plan(701);
+	auto queue = std::make_shared<distributed::FteSplitQueue>();
+	queue->AddSplit(distributed::TaskInput::make_scan_split_batch(split_batch.SerializeToBytes()));
+	queue->NoMoreSplits();
+	unordered_map<idx_t, std::shared_ptr<distributed::FteSplitQueue>> queues;
+	queues.emplace(701, std::move(queue));
+	string fte_error;
+	REQUIRE(distributed::ApplyFteScanSourceQueuesToPlan(*fte_plan, queues, &fte_error));
+	REQUIRE(fte_error.empty());
+	REQUIRE(fte_plan->Root().Cast<PhysicalTableScan>().distributed_scan_splits_applied);
+}

--- a/external/duckdb/test/execution/distributed/test_distributed_portable_sources.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_portable_sources.cpp
@@ -199,6 +199,16 @@ TEST_CASE("Distributed standalone unnest uses one scheduler-owned source split",
 	REQUIRE(ExecutePortableAssignment(connection, empty.worker_plan, empty.splits[0], 501).empty());
 }
 
+TEST_CASE("Distributed singleton source installs an explicit empty assignment", "[distributed][portable_source]") {
+	DuckDB db(nullptr);
+	Connection connection(db);
+	auto planned = PlanPortableSource(db, connection, "SELECT * FROM unnest([1, 2, 3])", 1);
+	REQUIRE(planned.splits.size() == 1);
+	auto explicit_empty =
+	    distributed::ScanSplit::EmptyExtension(planned.splits[0].extension_capability, planned.splits[0].split_codec);
+	REQUIRE(ExecutePortableAssignment(connection, planned.worker_plan, explicit_empty, 550).empty());
+}
+
 TEST_CASE("Distributed singleton source rejects malformed assignments", "[distributed][portable_source]") {
 	DuckDB db(nullptr);
 	Connection connection(db);

--- a/external/duckdb/test/execution/distributed/test_distributed_test_extension.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_test_extension.cpp
@@ -358,7 +358,10 @@ static unique_ptr<FunctionData> DistributedTestScanDeserialize(Deserializer &des
 
 static unique_ptr<FunctionData> DistributedTestCreateWorkerBind(const TableFunctionDistributedScanInput &input) {
 	distributed_test_create_worker_bind_calls++;
-	auto &source_bind = input.bind_data.Cast<DistributedTestScanBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed test scan requires bind data");
+	}
+	auto &source_bind = input.bind_data->Cast<DistributedTestScanBindData>();
 	auto worker_bind = make_uniq<DistributedTestScanBindData>();
 	worker_bind->requested_unit_count = source_bind.requested_unit_count;
 	return std::move(worker_bind);
@@ -366,7 +369,10 @@ static unique_ptr<FunctionData> DistributedTestCreateWorkerBind(const TableFunct
 
 static vector<DistributedScanSplit> DistributedTestPlanSplits(const TableFunctionDistributedScanPlanningInput &input) {
 	distributed_test_last_target_split_count = input.target_split_count;
-	auto &bind_data = input.bind_data.Cast<DistributedTestScanBindData>();
+	if (!input.bind_data) {
+		throw InvalidInputException("distributed test scan requires bind data");
+	}
+	auto &bind_data = input.bind_data->Cast<DistributedTestScanBindData>();
 	vector<DistributedScanSplit> result;
 	result.reserve(bind_data.units.size());
 	for (const auto &unit : bind_data.units) {
@@ -386,8 +392,12 @@ static vector<DistributedScanSplit> DistributedTestPlanSplits(const TableFunctio
 	return result;
 }
 
-static void DistributedTestApplySplits(FunctionData &worker_bind_data, const vector<DistributedScanSplit> &splits) {
-	auto &bind_data = worker_bind_data.Cast<DistributedTestScanBindData>();
+static void DistributedTestApplySplits(optional_ptr<FunctionData> worker_bind_data,
+                                       const vector<DistributedScanSplit> &splits) {
+	if (!worker_bind_data) {
+		throw InvalidInputException("distributed test scan requires worker bind data");
+	}
+	auto &bind_data = worker_bind_data->Cast<DistributedTestScanBindData>();
 	vector<DistributedTestSourceUnit> assigned_units;
 	assigned_units.reserve(splits.size());
 	for (const auto &split : splits) {
@@ -519,6 +529,11 @@ TEST_CASE("Distributed synthetic extension transports file splits with an explic
 	incomplete_callbacks.create_worker_bind = nullptr;
 	REQUIRE_THROWS_WITH(incomplete_function.SetDistributedScanCallbacks(std::move(incomplete_callbacks)),
 	                    Catch::Matchers::Contains("create_worker_bind"));
+	auto invalid_bind_mode_function = DistributedTestScanFunction();
+	auto invalid_bind_mode_callbacks = invalid_bind_mode_function.GetDistributedScanCallbacks();
+	invalid_bind_mode_callbacks.bind_data_mode = static_cast<TableFunctionDistributedBindDataMode>(255);
+	REQUIRE_THROWS_WITH(invalid_bind_mode_function.SetDistributedScanCallbacks(std::move(invalid_bind_mode_callbacks)),
+	                    Catch::Matchers::Contains("invalid bind-data mode"));
 
 	DuckDB coordinator_db(nullptr);
 	coordinator_db.LoadStaticExtension<DistributedTestExtension>();

--- a/external/duckdb/test/execution/distributed/test_distributed_test_extension.cpp
+++ b/external/duckdb/test/execution/distributed/test_distributed_test_extension.cpp
@@ -617,8 +617,9 @@ TEST_CASE("Distributed synthetic extension transports file splits with an explic
 	auto empty_worker_plan = CloneAndApply(worker, empty_planned.worker_plan, empty_roundtrip, 8);
 	string empty_assignment_error;
 	REQUIRE(distributed::ValidateDistributedScanSplitsApplied(*empty_worker_plan, &empty_assignment_error));
-	auto &empty_bind =
-	    empty_worker_plan->Root().Cast<PhysicalTableScan>().bind_data->Cast<DistributedTestScanBindData>();
+	auto &empty_worker_scan = empty_worker_plan->Root().Cast<PhysicalTableScan>();
+	REQUIRE(empty_worker_scan.distributed_scan_empty);
+	auto &empty_bind = empty_worker_scan.bind_data->Cast<DistributedTestScanBindData>();
 	REQUIRE(empty_bind.units.empty());
 
 	auto missing_fte_batch_plan = distributed::ClonePhysicalPlanOrThrow(
@@ -647,6 +648,7 @@ TEST_CASE("Distributed synthetic extension transports file splits with an explic
 	string empty_fte_error;
 	REQUIRE(distributed::ApplyFteScanSourceQueuesToPlan(*empty_fte_plan, empty_fte_queues, &empty_fte_error));
 	REQUIRE(empty_fte_scan.distributed_scan_splits_applied);
+	REQUIRE(empty_fte_scan.distributed_scan_empty);
 	REQUIRE(empty_fte_scan.bind_data->Cast<DistributedTestScanBindData>().units.empty());
 
 	auto duplicate_fte_plan = make_uniq<PhysicalPlan>(Allocator::DefaultAllocator());

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -787,6 +787,14 @@ def test_connection_snapshot_captures_exact_extension_contract():
     assert isinstance(snapshot["extensions"], list)
     assert all(set(extension) >= {"name", "version"} for extension in snapshot["extensions"])
     assert snapshot["distributed_extension_contracts"] == [
+        "json{table_function:json_each(JSON)@1,"
+        "table_function:json_each(JSON, VARCHAR)@1,"
+        "table_function:json_each(VARCHAR)@1,"
+        "table_function:json_each(VARCHAR, VARCHAR)@1,"
+        "table_function:json_tree(JSON)@1,"
+        "table_function:json_tree(JSON, VARCHAR)@1,"
+        "table_function:json_tree(VARCHAR)@1,"
+        "table_function:json_tree(VARCHAR, VARCHAR)@1}",
         "vane_core{table_function:datasource_scan(POINTER, POINTER, BLOB, BLOB[])@1,"
         "table_function:generate_series(BIGINT)@1,"
         "table_function:generate_series(BIGINT, BIGINT)@1,"
@@ -799,7 +807,10 @@ def test_connection_snapshot_captures_exact_extension_contract():
         "table_function:read_csv(VARCHAR)@1,"
         "table_function:read_csv(VARCHAR[])@1,"
         "table_function:read_csv_auto(VARCHAR)@1,"
-        "table_function:read_csv_auto(VARCHAR[])@1}",
+        "table_function:read_csv_auto(VARCHAR[])@1,"
+        "table_function:repeat(ANY, BIGINT)@1,"
+        "table_function:repeat_row([ANY...])@1,"
+        "table_function:unnest(ANY)@1}",
     ]
 
 

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -600,6 +600,83 @@ def test_ray_range_and_generate_series_distributed(ray_runner, duckdb_conn, monk
             raise AssertionError(f"{case_label}: distributed execution failed") from exc
 
 
+def test_ray_repeat_sources_use_exact_sequence_splits(ray_runner, duckdb_conn, monkeypatch):
+    monkeypatch.setenv("VANE_RAY_SCAN_SPLIT_MIN_COUNT", "4")
+    cases = [
+        (
+            "SELECT value FROM repeat(NULL::INTEGER, 17) AS t(value)",
+            "test_ray_e2e: distributed repeat source",
+        ),
+        (
+            """
+                SELECT id, label, payload
+                FROM repeat_row(
+                    42,
+                    NULL::VARCHAR,
+                    [1, NULL, 3],
+                    num_rows=11
+                ) AS t(id, label, payload)
+            """,
+            "test_ray_e2e: distributed repeat_row source",
+        ),
+    ]
+    for sql, label in cases:
+        relation = duckdb_conn.sql(sql)
+        _, num_parts = _get_distributed_plan_info(relation, label)
+        assert num_parts is not None and num_parts >= 4
+        _run_query_case(duckdb_conn, ray_runner, sql, label)
+
+    empty_sql = "SELECT value FROM repeat('unused', 0) AS t(value)"
+    empty_parts = _run_iter_tables(ray_runner, duckdb_conn.sql(empty_sql), "test_ray_e2e: empty repeat source")
+    assert empty_parts == []
+
+
+def test_ray_singleton_table_inout_sources_run_exactly_once(ray_runner, duckdb_conn):
+    duckdb_conn.execute("LOAD json")
+    cases = [
+        (
+            "SELECT value, ordinality FROM unnest([10, NULL, 30]) WITH ORDINALITY AS t(value, ordinality)",
+            "test_ray_e2e: singleton unnest source",
+        ),
+        (
+            "SELECT key, value, type, atom, id, parent, fullkey, path, rowid, json, root "
+            'FROM json_each(\'{"a": 1, "b": [2, null]}\')',
+            "test_ray_e2e: singleton json_each source",
+        ),
+        (
+            "SELECT key, value, type, atom, id, parent, fullkey, path, rowid, json, root "
+            "FROM json_tree('{\"a\": 1, \"b\": [2, null]}', '$.b')",
+            "test_ray_e2e: singleton json_tree source with path",
+        ),
+    ]
+    for sql, label in cases:
+        relation = duckdb_conn.sql(sql)
+        _, num_parts = _get_distributed_plan_info(relation, label)
+        assert num_parts == 1
+        _run_query_case(duckdb_conn, ray_runner, sql, label, ordered=True)
+
+    empty_sql = "SELECT * FROM unnest([]::INTEGER[])"
+    empty_relation = duckdb_conn.sql(empty_sql)
+    _, num_parts = _get_distributed_plan_info(empty_relation, "test_ray_e2e: empty singleton unnest")
+    assert num_parts == 1
+    assert _run_iter_tables(ray_runner, empty_relation, "test_ray_e2e: empty singleton unnest") == []
+
+
+def test_ray_correlated_unnest_remains_input_driven(ray_runner, duckdb_conn):
+    sql = """
+        SELECT id, value
+        FROM (VALUES (1, [10, 11]), (2, [20])) AS input(id, values),
+             LATERAL unnest(values) AS expanded(value)
+    """
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        "test_ray_e2e: correlated unnest remains input driven",
+        require_any=["UNNEST", "INOUT_FUNCTION", "DELIM_JOIN"],
+    )
+
+
 @pytest.mark.gpu
 def test_ray_vllm_distributed(ray_runner, duckdb_conn):
     from vane.ai.providers.vllm import _build_native_vllm_options_argument


### PR DESCRIPTION
## Summary

- extend the distributed table-function contract with explicit required/optional bind-data semantics and scalar scan parameters
- add a reusable singleton-source split protocol for portable, non-partitionable scalar sources
- distribute `repeat` and `repeat_row` with exact sequence splits and portable bind serialization
- execute standalone `unnest`, `json_each`, and `json_tree` exactly once through Ray, while leaving correlated UNNEST input-driven
- publish the new core/JSON capabilities and cover static assignment, FTE assignment, malformed splits, serde, empty inputs, and Ray execution

The native callback ABI is intentionally updated without a compatibility shim or fallback path. True data-owning parallelism for standalone UNNEST is tracked separately in #666.

## Related issue

close: #654

Follow-up: #666

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change makes previously rejected SQL forms follow the existing Ray runner contract; it does not add a new user-facing API.

## Validation

- `scripts/format workspace --from-ref upstream/main --check`
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Release wheel build/install with `CMAKE_BUILD_PARALLEL_LEVEL=16`, `VANE_NATIVE_BUILD_JOBS=16`, and `uv pip install . --no-build-isolation`
- `scripts/run_native_tests.sh "[distributed][portable_source],[distributed][csv]"` — 14 test cases, 795 assertions
- `scripts/run_native_tests.sh "[distributed]"` — 246 test cases, 9899 assertions
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e.py::test_ray_repeat_sources_use_exact_sequence_splits tests/fast/test_ray_e2e.py::test_ray_singleton_table_inout_sources_run_exactly_once tests/fast/test_ray_e2e.py::test_ray_correlated_unnest_remains_input_driven` — 3 passed on a local CPU Ray cluster
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e_serialization.py::test_single_csv_file_uses_explicit_byte_ranges_through_real_ray` — 1 passed
- `scripts/run_installed_pytest.sh tests/fast/test_ray_connection_snapshot.py::test_connection_snapshot_captures_exact_extension_contract` — 1 passed
- `scripts/run_release_tests.sh` — 555 non-Ray tests and 13 real-Ray tests passed; 17/559 tests deselected by the release shards

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.