### PR TITLE
[fix](distributed) Handle virtual object-store prefixes during cleanup

### DIFF
--- a/external/duckdb/src/common/file_system.cpp
+++ b/external/duckdb/src/common/file_system.cpp
@@ -740,6 +740,10 @@ bool FileSystem::IsLocalFileSystem() const {
 	return false;
 }
 
+bool FileSystem::HasDirectorySemantics(const string &, optional_ptr<FileOpener>) {
+	return IsLocalFileSystem();
+}
+
 bool FileSystem::OnDiskFile(FileHandle &handle) {
 	throw NotImplementedException("%s: OnDiskFile is not implemented!", GetName());
 }

--- a/external/duckdb/src/common/virtual_file_system.cpp
+++ b/external/duckdb/src/common/virtual_file_system.cpp
@@ -332,6 +332,10 @@ std::string VirtualFileSystem::GetName() const {
 	return "VirtualFileSystem";
 }
 
+bool VirtualFileSystem::HasDirectorySemantics(const string &path, optional_ptr<FileOpener> opener) {
+	return FindFileSystem(path, opener).HasDirectorySemantics(path, opener);
+}
+
 bool VirtualFileSystem::SubSystemIsDisabled(const string &name) {
 	auto registry = file_system_registry.atomic_load();
 	auto &disabled_file_systems = registry->disabled_file_systems;

--- a/external/duckdb/src/include/duckdb/common/file_system.hpp
+++ b/external/duckdb/src/include/duckdb/common/file_system.hpp
@@ -302,6 +302,8 @@ public:
 
 	//! Whether this is a LocalFileSystem instance.
 	DUCKDB_API virtual bool IsLocalFileSystem() const;
+	//! Whether the filesystem handling this path has concrete directory entries rather than key-prefix semantics.
+	DUCKDB_API virtual bool HasDirectorySemantics(const string &path, optional_ptr<FileOpener> opener = nullptr);
 
 	//! Return the name of the filesytem. Used for forming diagnosis messages.
 	DUCKDB_API virtual std::string GetName() const = 0;

--- a/external/duckdb/src/include/duckdb/common/opener_file_system.hpp
+++ b/external/duckdb/src/include/duckdb/common/opener_file_system.hpp
@@ -186,6 +186,12 @@ public:
 		return "OpenerFileSystem - " + GetFileSystem().GetName();
 	}
 
+	bool HasDirectorySemantics(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		VerifyNoOpener(opener);
+		VerifyCanAccessDirectory(path);
+		return GetFileSystem().HasDirectorySemantics(path, GetOpener());
+	}
+
 	void RegisterSubSystem(unique_ptr<FileSystem> sub_fs) override {
 		GetFileSystem().RegisterSubSystem(std::move(sub_fs));
 	}

--- a/external/duckdb/src/include/duckdb/common/virtual_file_system.hpp
+++ b/external/duckdb/src/include/duckdb/common/virtual_file_system.hpp
@@ -63,6 +63,7 @@ public:
 	FileSystem &GetDefaultFileSystem();
 
 	std::string GetName() const override;
+	bool HasDirectorySemantics(const string &path, optional_ptr<FileOpener> opener = nullptr) override;
 
 	void SetDisabledFileSystems(const vector<string> &names) override;
 	bool SubSystemIsDisabled(const string &name) override;

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -1241,6 +1241,7 @@ inline bool DistributedCopyMayUseDirectTargetLayout(FileSystem &fs, const std::s
 inline DuckDBResult<DistributedCopyPrefixCleanupResult>
 CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
                              const std::string &remove_last = std::string()) {
+	const bool has_directory_semantics = !FileSystem::IsRemoteFile(prefix);
 	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, prefix);
 	if (files_res.is_err()) {
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(files_res.error());
@@ -1262,7 +1263,8 @@ CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
 	}
 
 	DistributedCopyPrefixCleanupResult result;
-	result.existed = !files.empty() || !remove_last.empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix);
+	result.existed = !files.empty() || !remove_last.empty() ||
+	                 (has_directory_semantics && DistributedCopyDirectoryExistsNoThrow(fs, prefix));
 	auto remove_res = RemoveDistributedCopyFiles(fs, files);
 	if (remove_res.is_err()) {
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(remove_res.error());
@@ -1313,7 +1315,13 @@ CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
 		}
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(remaining_res.error());
 	}
-	if (!remaining_res.value().empty() || DistributedCopyDirectoryExistsNoThrow(fs, prefix)) {
+	// Object stores have no real directories. Their filesystem adapters can
+	// report a prefix as a directory even after its final object was removed.
+	// For remote paths, the authoritative cleanup condition is therefore an
+	// empty object listing. Local filesystems retain the stricter directory
+	// removal check.
+	if (!remaining_res.value().empty() ||
+	    (has_directory_semantics && DistributedCopyDirectoryExistsNoThrow(fs, prefix))) {
 		auto cleanup_error = directory_removal_error.empty()
 		                         ? "distributed COPY prefix still exists after cleanup: " + prefix
 		                         : directory_removal_error;

--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -1241,7 +1241,7 @@ inline bool DistributedCopyMayUseDirectTargetLayout(FileSystem &fs, const std::s
 inline DuckDBResult<DistributedCopyPrefixCleanupResult>
 CleanupDistributedCopyPrefix(FileSystem &fs, const std::string &prefix,
                              const std::string &remove_last = std::string()) {
-	const bool has_directory_semantics = !FileSystem::IsRemoteFile(prefix);
+	const bool has_directory_semantics = fs.HasDirectorySemantics(prefix);
 	auto files_res = ListDistributedCopyFilesUnderPrefix(fs, prefix);
 	if (files_res.is_err()) {
 		return DuckDBResult<DistributedCopyPrefixCleanupResult>::err(files_res.error());

--- a/external/duckdb/src/include/duckdb/storage/caching_file_system_wrapper.hpp
+++ b/external/duckdb/src/include/duckdb/storage/caching_file_system_wrapper.hpp
@@ -58,6 +58,7 @@ public:
 	DUCKDB_API ~CachingFileSystemWrapper() override;
 
 	DUCKDB_API std::string GetName() const override;
+	DUCKDB_API bool HasDirectorySemantics(const string &path, optional_ptr<FileOpener> opener = nullptr) override;
 
 	DUCKDB_API unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
 	                                           optional_ptr<FileOpener> opener = nullptr) override;

--- a/external/duckdb/src/storage/caching_file_system_wrapper.cpp
+++ b/external/duckdb/src/storage/caching_file_system_wrapper.cpp
@@ -81,6 +81,10 @@ std::string CachingFileSystemWrapper::GetName() const {
 	return "CachingFileSystemWrapper";
 }
 
+bool CachingFileSystemWrapper::HasDirectorySemantics(const string &path, optional_ptr<FileOpener> opener) {
+	return underlying_file_system.HasDirectorySemantics(path, opener);
+}
+
 //===----------------------------------------------------------------------===//
 // Write Operations (Not Supported - Read-Only Filesystem)
 //===----------------------------------------------------------------------===//

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -175,7 +175,8 @@ private:
 
 class MappedRemoteFileSystem : public LocalFileSystem {
 public:
-	explicit MappedRemoteFileSystem(string local_root) : local_root(std::move(local_root)) {
+	explicit MappedRemoteFileSystem(string local_root, string remote_prefix = "s3://bucket")
+	    : local_root(std::move(local_root)), remote_prefix(std::move(remote_prefix)) {
 	}
 
 	unique_ptr<FileHandle> OpenFile(const string &path, FileOpenFlags flags,
@@ -223,6 +224,14 @@ public:
 		return backing_fs.TryRemoveFile(MapPath(path), opener);
 	}
 
+	bool CanHandleFile(const string &path) override {
+		return StringUtil::StartsWith(path, remote_prefix);
+	}
+
+	bool IsLocalFileSystem() const override {
+		return false;
+	}
+
 	void FailRemovalOf(string path) {
 		failed_removal_path = std::move(path);
 		fail_removal = true;
@@ -236,9 +245,14 @@ public:
 		return "MappedRemoteFileSystem";
 	}
 
+protected:
+	bool ListFilesExtended(const string &path, const std::function<void(OpenFileInfo &info)> &callback,
+	                       optional_ptr<FileOpener> opener) override {
+		return backing_fs.ListFiles(MapPath(path), callback, opener);
+	}
+
 private:
 	string MapPath(const string &path) const {
-		const string remote_prefix = "s3://bucket";
 		if (!StringUtil::StartsWith(path, remote_prefix)) {
 			throw InternalException("unexpected mapped remote path: " + path);
 		}
@@ -247,14 +261,16 @@ private:
 
 	LocalFileSystem backing_fs;
 	string local_root;
+	string remote_prefix;
 	string failed_removal_path;
 	bool fail_removal = false;
 };
 
 class PhantomRemoteDirectoryFileSystem : public MappedRemoteFileSystem {
 public:
-	PhantomRemoteDirectoryFileSystem(string local_root, string phantom_directory)
-	    : MappedRemoteFileSystem(std::move(local_root)), phantom_directory(std::move(phantom_directory)) {
+	PhantomRemoteDirectoryFileSystem(string local_root, string remote_prefix, string phantom_directory)
+	    : MappedRemoteFileSystem(std::move(local_root), std::move(remote_prefix)),
+	      phantom_directory(std::move(phantom_directory)) {
 	}
 
 	bool DirectoryExists(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
@@ -1048,22 +1064,29 @@ TEST_CASE("Expired direct-target cleanup accepts a missing legacy run prefix",
 TEST_CASE("Direct-target cleanup ignores phantom remote directories",
           "[distributed][copy][lifecycle][object-storage]") {
 	CopyFinalizeTestDirectory test_dir("copy_finalize_phantom_remote_directory");
-	const string base_path = "s3://bucket/out";
+	const string remote_prefix = "custom-object://bucket";
+	const string base_path = remote_prefix + "/out";
 	const string run_id = "run-direct-target";
 	auto run_prefix = BuildCopyDirectWriteRunDirectory(base_path, run_id, "/");
-	PhantomRemoteDirectoryFileSystem fs(test_dir.fs.JoinPath(test_dir.path, "remote"), run_prefix);
+	VirtualFileSystem fs;
+	fs.RegisterSubSystem(make_uniq<PhantomRemoteDirectoryFileSystem>(test_dir.fs.JoinPath(test_dir.path, "remote"),
+	                                                                 remote_prefix, run_prefix));
+	REQUIRE_FALSE(FileSystem::IsRemoteFile(base_path));
+	REQUIRE_FALSE(fs.HasDirectorySemantics(run_prefix));
 
 	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id, 1).is_ok());
 	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_failed", "part.parquet");
 	WriteTestFile(fs, data_file, "stale");
-	REQUIRE(fs.DirectoryExists(run_prefix));
+	REQUIRE(fs.DirectoryExists(run_prefix, nullptr));
 
 	auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, base_path, run_id);
 
+	auto cleanup_error = cleanup_res.is_err() ? cleanup_res.error().what() : string();
+	INFO(cleanup_error);
 	REQUIRE(cleanup_res.is_ok());
-	REQUIRE_FALSE(fs.FileExists(data_file));
+	REQUIRE_FALSE(fs.FileExists(data_file, nullptr));
 	auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
-	REQUIRE_FALSE(fs.FileExists(paths.lifecycle_path));
+	REQUIRE_FALSE(fs.FileExists(paths.lifecycle_path, nullptr));
 }
 
 TEST_CASE("Direct-write cleanup keeps lifecycle registration until metadata cleanup finishes",

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -251,6 +251,30 @@ private:
 	bool fail_removal = false;
 };
 
+class PhantomRemoteDirectoryFileSystem : public MappedRemoteFileSystem {
+public:
+	PhantomRemoteDirectoryFileSystem(string local_root, string phantom_directory)
+	    : MappedRemoteFileSystem(std::move(local_root)), phantom_directory(std::move(phantom_directory)) {
+	}
+
+	bool DirectoryExists(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == phantom_directory) {
+			return true;
+		}
+		return MappedRemoteFileSystem::DirectoryExists(path, opener);
+	}
+
+	void RemoveDirectory(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == phantom_directory) {
+			return;
+		}
+		MappedRemoteFileSystem::RemoveDirectory(path, opener);
+	}
+
+private:
+	string phantom_directory;
+};
+
 class WindowsPathFileSystem : public LocalFileSystem {
 public:
 	string PathSeparator(const string &) override {
@@ -1019,6 +1043,27 @@ TEST_CASE("Expired direct-target cleanup accepts a missing legacy run prefix",
 	REQUIRE_FALSE(local_fs.FileExists(data_file));
 	auto paths = BuildDistributedCopyFinalizeCommitPaths(local_fs, base_path, run_id);
 	REQUIRE_FALSE(local_fs.FileExists(paths.lifecycle_path));
+}
+
+TEST_CASE("Direct-target cleanup ignores phantom remote directories",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_phantom_remote_directory");
+	const string base_path = "s3://bucket/out";
+	const string run_id = "run-direct-target";
+	auto run_prefix = BuildCopyDirectWriteRunDirectory(base_path, run_id, "/");
+	PhantomRemoteDirectoryFileSystem fs(test_dir.fs.JoinPath(test_dir.path, "remote"), run_prefix);
+
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id, 1).is_ok());
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_failed", "part.parquet");
+	WriteTestFile(fs, data_file, "stale");
+	REQUIRE(fs.DirectoryExists(run_prefix));
+
+	auto cleanup_res = CleanupDistributedCopyUncommittedDirectWriteRun(fs, base_path, run_id);
+
+	REQUIRE(cleanup_res.is_ok());
+	REQUIRE_FALSE(fs.FileExists(data_file));
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(fs, base_path, run_id);
+	REQUIRE_FALSE(fs.FileExists(paths.lifecycle_path));
 }
 
 TEST_CASE("Direct-write cleanup keeps lifecycle registration until metadata cleanup finishes",

--- a/src/vane_py/include/vane_python/pyfilesystem.hpp
+++ b/src/vane_py/include/vane_python/pyfilesystem.hpp
@@ -53,12 +53,13 @@ class PythonFilesystem : public FileSystem {
 private:
 	const vector<string> protocols;
 	AbstractFileSystem filesystem;
+	const bool directory_semantics;
 	std::string DecodeFlags(FileOpenFlags flags);
 	bool Exists(const string &filename, const char *func_name) const;
 
 public:
-	explicit PythonFilesystem(vector<string> protocols, AbstractFileSystem filesystem)
-	    : protocols(std::move(protocols)), filesystem(std::move(filesystem)) {
+	explicit PythonFilesystem(vector<string> protocols, AbstractFileSystem filesystem, bool directory_semantics)
+	    : protocols(std::move(protocols)), filesystem(std::move(filesystem)), directory_semantics(directory_semantics) {
 	}
 	~PythonFilesystem() override;
 
@@ -88,6 +89,9 @@ public:
 
 	bool IsManuallySet() override {
 		return true;
+	}
+	bool HasDirectorySemantics(const string &, optional_ptr<FileOpener> = nullptr) override {
+		return directory_semantics;
 	}
 
 	bool OnDiskFile(FileHandle &handle) override {

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -844,7 +844,19 @@ void DuckDBPyConnection::RegisterFilesystem(AbstractFileSystem filesystem) {
 		}
 	}
 
-	fs.RegisterSubSystem(make_uniq<PythonFilesystem>(std::move(protocols), std::move(filesystem)));
+	// fsspec does not expose a general capability that distinguishes concrete
+	// directories from object-store prefixes. Its LocalFileSystem hierarchy has
+	// concrete directory semantics; other hierarchical implementations can opt
+	// in explicitly without relying on protocol-name heuristics.
+	bool directory_semantics;
+	if (py::hasattr(filesystem, "vane_directory_semantics")) {
+		directory_semantics = py::bool_(filesystem.attr("vane_directory_semantics"));
+	} else {
+		auto local_filesystem = py::module::import("fsspec.implementations.local").attr("LocalFileSystem");
+		directory_semantics = py::isinstance(filesystem, local_filesystem);
+	}
+
+	fs.RegisterSubSystem(make_uniq<PythonFilesystem>(std::move(protocols), std::move(filesystem), directory_semantics));
 }
 
 py::list DuckDBPyConnection::ListFilesystems() {

--- a/src/vane_py/pyfilesystem.cpp
+++ b/src/vane_py/pyfilesystem.cpp
@@ -233,7 +233,7 @@ bool PythonFilesystem::ListFiles(const string &directory, const std::function<vo
 	PythonGILWrapper gil;
 	bool nonempty = false;
 
-	for (auto item : filesystem.attr("ls")(py::str(directory))) {
+	for (auto item : filesystem.attr("ls")(py::str(directory), py::arg("detail") = true)) {
 		bool is_dir = py::cast<std::string>(item["type"]) == "directory";
 		callback(py::str(item["name"]), is_dir);
 		nonempty = true;

--- a/tests/fast/test_ray_cpp_bindings.py
+++ b/tests/fast/test_ray_cpp_bindings.py
@@ -2631,6 +2631,62 @@ def test_copy_direct_write_lifecycle_cleanup_once_uses_connection_filesystem():
     assert not filesystem.exists(data_path)
 
 
+def test_copy_direct_write_lifecycle_cleanup_preserves_registered_local_directory_error(tmp_path, monkeypatch):
+    fsspec = pytest.importorskip("fsspec", minversion="2022.11.0")
+    filesystem = fsspec.filesystem("file", skip_instance_cache=True)
+    base = tmp_path / "registered_local_cleanup"
+    base_path = f"file://{base.as_posix()}"
+    run_id = "run-local-directory-error"
+    run_dir = base / f"_vane_direct_write_{run_id}"
+    data_file = run_dir / "w_failed" / "part.parquet"
+    lifecycle_file = base.parent / f"{base.name}.duckdb_commit" / run_id / "lifecycle.txt"
+    data_file.parent.mkdir(parents=True)
+    data_file.write_bytes(b"stale")
+    lifecycle_file.parent.mkdir(parents=True)
+    lifecycle_file.write_text(
+        textwrap.dedent(
+            f"""\
+            version=2
+            mode=direct_write
+            base_path={base_path}
+            worker_base_path={base_path}
+            run_id={run_id}
+            created_epoch_ms=1000
+            direct_write_run_dir={base_path}/_vane_direct_write_{run_id}
+            """
+        )
+    )
+
+    original_rm = filesystem.rm
+
+    def fail_run_directory_removal(path, recursive=False, **kwargs):
+        stripped_path = filesystem._strip_protocol(path).rstrip("/")
+        if recursive and stripped_path == run_dir.as_posix():
+            raise PermissionError("injected registered-local directory removal failure")
+        return original_rm(path, recursive=recursive, **kwargs)
+
+    monkeypatch.setattr(filesystem, "rm", fail_run_directory_removal)
+    conn = vane.connect()
+    try:
+        conn.register_filesystem(filesystem)
+        result = vane.ray_cxx.cleanup_expired_copy_direct_write_runs(
+            base_path,
+            min_age_ms=5_000,
+            now_epoch_ms=10_000,
+            conn=conn,
+        )
+    finally:
+        conn.close()
+
+    assert result["scanned_runs"] == 1
+    assert result["cleaned_runs"] == 0
+    assert result["errors"] == 1
+    assert "injected registered-local directory removal failure" in result["error_messages"][0]
+    assert not data_file.exists()
+    assert run_dir.exists()
+    assert lifecycle_file.exists()
+
+
 def test_copy_direct_write_lifecycle_cleanup_releases_gil_before_connection_lock():
     pytest.importorskip("fsspec", minversion="2022.11.0")
     script = textwrap.dedent(


### PR DESCRIPTION
## Summary

Treat an empty object listing as the authoritative result when cleaning a
distributed COPY prefix on remote object storage. Object-store filesystem
adapters can continue reporting a virtual directory after its final object is
removed; treating that report as a cleanup failure prevents the direct-target
cleanup path from removing data artifacts and lifecycle metadata.

Local filesystem cleanup remains strict: a real directory that still exists
after removal continues to fail closed. A regression test covers the remote
phantom-directory behavior while the existing local directory-removal test
guards the local contract.

## Related issue

N/A — small, self-contained lifecycle cleanup fix discovered by the
distributed Iceberg CTAS failure-cleanup integration test.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/run_native_tests.sh "Direct-target cleanup ignores phantom remote directories"`
  - 1 test case, 6 assertions passed
- `build/native-cxx20/test/unittest "Direct-write cleanup restores lifecycle when directory removal fails"`
  - 1 test case, 14 assertions passed
- `scripts/format duckdb --changed`
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (No new dependencies or copied assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
