### PR TITLE
[feat](file) Add lightweight DuckDB FILE alias core

### DIFF
--- a/external/duckdb/src/common/types.cpp
+++ b/external/duckdb/src/common/types.cpp
@@ -1683,6 +1683,37 @@ LogicalType LogicalType::STRUCT(child_list_t<LogicalType> children) {
 	return LogicalType(LogicalTypeId::STRUCT, std::move(info));
 }
 
+LogicalType FileLogicalType::Create() {
+	child_list_t<LogicalType> children;
+	children.reserve(FIELD_COUNT);
+	children.emplace_back("url", LogicalType::VARCHAR);
+	children.emplace_back("content_type", LogicalType::VARCHAR);
+	children.emplace_back("position", LogicalType::BIGINT);
+	children.emplace_back("size", LogicalType::BIGINT);
+	children.emplace_back("checksum", LogicalType::VARCHAR);
+
+	auto result = LogicalType::STRUCT(std::move(children));
+	result.SetAlias(TYPE_NAME);
+	return result;
+}
+
+bool FileLogicalType::IsFile(const LogicalType &type) {
+	if (type.id() != LogicalTypeId::STRUCT || !type.AuxInfo() ||
+	    type.AuxInfo()->type != ExtraTypeInfoType::STRUCT_TYPE_INFO || !type.HasAlias() ||
+	    type.GetAlias() != TYPE_NAME) {
+		return false;
+	}
+	auto &children = StructType::GetChildTypes(type);
+	if (children.size() != FIELD_COUNT) {
+		return false;
+	}
+	return children[URL].first == "url" && children[URL].second == LogicalType::VARCHAR &&
+	       children[CONTENT_TYPE].first == "content_type" && children[CONTENT_TYPE].second == LogicalType::VARCHAR &&
+	       children[POSITION].first == "position" && children[POSITION].second == LogicalType::BIGINT &&
+	       children[SIZE].first == "size" && children[SIZE].second == LogicalType::BIGINT &&
+	       children[CHECKSUM].first == "checksum" && children[CHECKSUM].second == LogicalType::VARCHAR;
+}
+
 LogicalType LogicalType::AGGREGATE_STATE(aggregate_state_t state_type) { // NOLINT
 	auto info = make_shared_ptr<AggregateStateTypeInfo>(std::move(state_type));
 	return LogicalType(LogicalTypeId::AGGREGATE_STATE, std::move(info));

--- a/external/duckdb/src/function/function.cpp
+++ b/external/duckdb/src/function/function.cpp
@@ -9,6 +9,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/function/built_in_functions.hpp"
+#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table/datasource_scan.hpp"
@@ -17,6 +18,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/main/extension_entries.hpp"
 #include "duckdb/execution/operator/projection/physical_udf_inout.hpp"
+#include "duckdb/parser/parsed_data/create_type_info.hpp"
 
 namespace duckdb {
 
@@ -101,6 +103,14 @@ string BaseScalarFunction::ToString() const {
 
 // add your initializer for new functions here
 void BuiltinFunctions::Initialize() {
+	CreateTypeInfo file_type_info(FileLogicalType::TYPE_NAME, FileLogicalType::Create());
+	file_type_info.internal = true;
+	file_type_info.temporary = true;
+	catalog.CreateType(transaction, file_type_info);
+	for (auto &function : FileFunctions::GetFunctions()) {
+		AddFunction(std::move(function));
+	}
+
 	RegisterTableScanFunctions();
 	RegisterSQLiteFunctions();
 	RegisterReadFunctions();

--- a/external/duckdb/src/function/scalar/CMakeLists.txt
+++ b/external/duckdb/src/function/scalar/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library_unity(
   OBJECT
   compressed_materialization_utils.cpp
   create_sort_key.cpp
+  file.cpp
   strftime_format.cpp
   nested_functions.cpp
   pragma_functions.cpp

--- a/external/duckdb/src/function/scalar/file.cpp
+++ b/external/duckdb/src/function/scalar/file.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar/file.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "duckdb/function/scalar/file_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static void ValidateFileFields(bool url_is_valid, bool position_is_valid, int64_t position, bool size_is_valid,
+                               int64_t size, const string *checksum) {
+	if (!url_is_valid) {
+		throw InvalidInputException("file() url cannot be NULL");
+	}
+	if (position_is_valid != size_is_valid) {
+		throw InvalidInputException("file() position and size must either both be NULL or both be non-NULL");
+	}
+	if (position_is_valid) {
+		if (position < 0 || size < 0) {
+			throw InvalidInputException("file() position and size must be non-negative");
+		}
+		if (position > NumericLimits<int64_t>::Maximum() - size) {
+			throw InvalidInputException("file() byte range exceeds BIGINT");
+		}
+	}
+	if (checksum) {
+		auto separator = checksum->find(':');
+		if (separator == string::npos || separator == 0 || separator + 1 == checksum->size() ||
+		    checksum->find(':', separator + 1) != string::npos) {
+			throw InvalidInputException("file() checksum must have the form <algorithm>:<digest>");
+		}
+	}
+}
+
+static void ValidateFileArguments(DataChunk &args) {
+	UnifiedVectorFormat url_data;
+	UnifiedVectorFormat position_data;
+	UnifiedVectorFormat size_data;
+	UnifiedVectorFormat checksum_data;
+	args.data[FileLogicalType::URL].ToUnifiedFormat(args.size(), url_data);
+	args.data[FileLogicalType::POSITION].ToUnifiedFormat(args.size(), position_data);
+	args.data[FileLogicalType::SIZE].ToUnifiedFormat(args.size(), size_data);
+	args.data[FileLogicalType::CHECKSUM].ToUnifiedFormat(args.size(), checksum_data);
+
+	auto positions = UnifiedVectorFormat::GetData<int64_t>(position_data);
+	auto sizes = UnifiedVectorFormat::GetData<int64_t>(size_data);
+	auto checksums = UnifiedVectorFormat::GetData<string_t>(checksum_data);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto url_index = url_data.sel->get_index(row);
+		auto position_index = position_data.sel->get_index(row);
+		auto size_index = size_data.sel->get_index(row);
+		auto checksum_index = checksum_data.sel->get_index(row);
+		auto position_is_valid = position_data.validity.RowIsValid(position_index);
+		auto size_is_valid = size_data.validity.RowIsValid(size_index);
+		auto position = position_is_valid ? positions[position_index] : 0;
+		auto size = size_is_valid ? sizes[size_index] : 0;
+
+		string checksum;
+		const string *checksum_ptr = nullptr;
+		if (checksum_data.validity.RowIsValid(checksum_index)) {
+			checksum = checksums[checksum_index].GetString();
+			checksum_ptr = &checksum;
+		}
+		ValidateFileFields(url_data.validity.RowIsValid(url_index), position_is_valid, position, size_is_valid, size,
+		                   checksum_ptr);
+	}
+}
+
+static void FileConstructorFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	D_ASSERT(args.ColumnCount() == FileLogicalType::FIELD_COUNT);
+	ValidateFileArguments(args);
+
+	bool all_constant = true;
+	auto &children = StructVector::GetEntries(result);
+	for (idx_t index = 0; index < args.ColumnCount(); index++) {
+		if (args.data[index].GetVectorType() != VectorType::CONSTANT_VECTOR) {
+			all_constant = false;
+		}
+		children[index]->Reference(args.data[index]);
+	}
+	result.SetVectorType(all_constant ? VectorType::CONSTANT_VECTOR : VectorType::FLAT_VECTOR);
+	result.Verify(args.size());
+}
+
+template <bool NEGATE>
+static void FileComparisonFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	D_ASSERT(args.ColumnCount() == 2);
+	auto &left_children = StructVector::GetEntries(args.data[0]);
+	auto &right_children = StructVector::GetEntries(args.data[1]);
+	D_ASSERT(left_children.size() == FileLogicalType::FIELD_COUNT);
+	D_ASSERT(right_children.size() == FileLogicalType::FIELD_COUNT);
+
+	for (idx_t index = 0; index < FileLogicalType::FIELD_COUNT; index++) {
+		Vector field_equal(LogicalType::BOOLEAN);
+		VectorOperations::Equals(*left_children[index], *right_children[index], field_equal, args.size());
+		if (index == 0) {
+			result.Reference(field_equal);
+		} else {
+			Vector conjunction(LogicalType::BOOLEAN);
+			VectorOperations::And(field_equal, result, conjunction, args.size());
+			result.Reference(conjunction);
+		}
+	}
+
+	if (NEGATE) {
+		Vector negated_result(LogicalType::BOOLEAN);
+		VectorOperations::Not(result, negated_result, args.size());
+		result.Reference(negated_result);
+	}
+
+	UnifiedVectorFormat left_data;
+	UnifiedVectorFormat right_data;
+	args.data[0].ToUnifiedFormat(args.size(), left_data);
+	args.data[1].ToUnifiedFormat(args.size(), right_data);
+	if (!left_data.validity.AllValid() || !right_data.validity.AllValid()) {
+		result.Flatten(args.size());
+		auto &result_validity = FlatVector::Validity(result);
+		for (idx_t row = 0; row < args.size(); row++) {
+			auto left_index = left_data.sel->get_index(row);
+			auto right_index = right_data.sel->get_index(row);
+			if (!left_data.validity.RowIsValid(left_index) || !right_data.validity.RowIsValid(right_index)) {
+				result_validity.SetInvalid(row);
+			}
+		}
+	}
+}
+
+static ScalarFunction GetFileConstructor() {
+	vector<LogicalType> arguments {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::BIGINT,
+	                               LogicalType::VARCHAR};
+	ScalarFunction function("file", std::move(arguments), FileLogicalType::Create(), FileConstructorFunction);
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	function.SetFallible();
+	return function;
+}
+
+template <bool NEGATE>
+static ScalarFunction GetFileComparison() {
+	auto file_type = FileLogicalType::Create();
+	auto name = NEGATE ? FileLogicalType::NOT_EQUAL_FUNCTION_NAME : FileLogicalType::EQUAL_FUNCTION_NAME;
+	return ScalarFunction(name, {file_type, file_type}, LogicalType::BOOLEAN, FileComparisonFunction<NEGATE>);
+}
+
+} // namespace
+
+vector<ScalarFunction> FileFunctions::GetFunctions() {
+	vector<ScalarFunction> result;
+	result.push_back(GetFileConstructor());
+	result.push_back(GetFileComparison<false>());
+	result.push_back(GetFileComparison<true>());
+	return result;
+}
+
+} // namespace duckdb

--- a/external/duckdb/src/function/scalar/struct/struct_extract.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_extract.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
@@ -167,6 +173,9 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 	ScalarFunctionSet struct_extract_set("struct_extract");
 	struct_extract_set.AddFunction(GetKeyExtractFunction());
 	struct_extract_set.AddFunction(GetIndexExtractFunction());
+	auto file_key_extract = GetKeyExtractFunction();
+	file_key_extract.arguments[0] = FileLogicalType::Create();
+	struct_extract_set.AddFunction(std::move(file_key_extract));
 	return struct_extract_set;
 }
 

--- a/external/duckdb/src/include/duckdb/common/types.hpp
+++ b/external/duckdb/src/include/duckdb/common/types.hpp
@@ -514,6 +514,25 @@ struct StructType {
 	DUCKDB_API static bool IsUnnamed(const LogicalType &type);
 };
 
+struct FileLogicalType {
+	//! FILE is intentionally a named STRUCT representation. Generic nested operations retain STRUCT semantics.
+	static constexpr const char *TYPE_NAME = "FILE";
+	static constexpr const char *EQUAL_FUNCTION_NAME = "__vane_file_equal";
+	static constexpr const char *NOT_EQUAL_FUNCTION_NAME = "__vane_file_not_equal";
+
+	enum FieldIndex : idx_t {
+		URL = 0,
+		CONTENT_TYPE = 1,
+		POSITION = 2,
+		SIZE = 3,
+		CHECKSUM = 4,
+		FIELD_COUNT = 5,
+	};
+
+	DUCKDB_API static LogicalType Create();
+	DUCKDB_API static bool IsFile(const LogicalType &type);
+};
+
 struct MapType {
 	DUCKDB_API static const LogicalType &KeyType(const LogicalType &type);
 	DUCKDB_API static const LogicalType &ValueType(const LogicalType &type);

--- a/external/duckdb/src/include/duckdb/function/scalar/file_functions.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar/file_functions.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// duckdb/function/scalar/file_functions.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+struct FileFunctions {
+	static vector<ScalarFunction> GetFunctions();
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_comparison_expression.cpp
@@ -1,4 +1,12 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/parser/expression/comparison_expression.hpp"
+#include "duckdb/parser/expression/bound_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -61,6 +69,23 @@ static bool SwitchVarcharComparison(const LogicalType &type) {
 bool BoundComparisonExpression::TryBindComparison(ClientContext &context, const LogicalType &left_type,
                                                   const LogicalType &right_type, LogicalType &result_type,
                                                   ExpressionType comparison_type) {
+	const auto left_is_file = FileLogicalType::IsFile(left_type);
+	const auto right_is_file = FileLogicalType::IsFile(right_type);
+	if (left_is_file || right_is_file) {
+		if (comparison_type != ExpressionType::COMPARE_EQUAL && comparison_type != ExpressionType::COMPARE_NOTEQUAL) {
+			return false;
+		}
+		if ((!left_is_file && left_type.id() != LogicalTypeId::SQLNULL) ||
+		    (!right_is_file && right_type.id() != LogicalTypeId::SQLNULL)) {
+			return false;
+		}
+		if (left_is_file && right_is_file && left_type != right_type) {
+			return false;
+		}
+		result_type = left_is_file ? left_type : right_type;
+		return true;
+	}
+
 	LogicalType res;
 	bool is_equality;
 	switch (comparison_type) {
@@ -176,6 +201,21 @@ BindResult ExpressionBinder::BindExpression(ComparisonExpression &expr, idx_t de
 		return BindResult(BinderException(expr,
 		                                  "Cannot compare values of type %s and type %s - an explicit cast is required",
 		                                  left_sql_type.ToString(), right_sql_type.ToString()));
+	}
+	if (FileLogicalType::IsFile(input_type)) {
+		left = BoundCastExpression::AddCastToType(context, std::move(left), input_type);
+		right = BoundCastExpression::AddCastToType(context, std::move(right), input_type);
+
+		vector<unique_ptr<ParsedExpression>> children;
+		children.push_back(make_uniq<BoundExpression>(std::move(left)));
+		children.push_back(make_uniq<BoundExpression>(std::move(right)));
+		auto function_name = expr.GetExpressionType() == ExpressionType::COMPARE_EQUAL
+		                         ? FileLogicalType::EQUAL_FUNCTION_NAME
+		                         : FileLogicalType::NOT_EQUAL_FUNCTION_NAME;
+		unique_ptr<ParsedExpression> function =
+		    make_uniq<FunctionExpression>(SYSTEM_CATALOG, DEFAULT_SCHEMA, function_name, std::move(children));
+		function->SetQueryLocation(expr.GetQueryLocation());
+		return BindExpression(function, depth);
 	}
 	// add casts (if necessary)
 	left = BoundCastExpression::AddCastToType(context, std::move(left), input_type,

--- a/external/duckdb/test/sql/types/alias/test_file_alias.test
+++ b/external/duckdb/test/sql/types/alias/test_file_alias.test
@@ -1,0 +1,131 @@
+# name: test/sql/types/alias/test_file_alias.test
+# description: Test the lightweight FILE struct alias and its pure constructor
+# group: [file]
+
+statement ok
+PRAGMA enable_verification
+
+query TTTIIT
+SELECT typeof(value), value.url, value.content_type, value.position, value.size, value.checksum
+FROM (
+	SELECT file(
+		's3://bucket/missing.bin',
+		'application/octet-stream',
+		10,
+		20,
+		'sha256:abcdef'
+	) AS value
+)
+----
+FILE	s3://bucket/missing.bin	application/octet-stream	10	20	sha256:abcdef
+
+query TII rowsort
+SELECT value.url, value.position, value.size
+FROM (
+	SELECT file('object-' || i, NULL, i, i + 1, NULL) AS value
+	FROM range(3) AS input(i)
+)
+----
+object-0	0	1
+object-1	1	2
+object-2	2	3
+
+statement error
+SELECT file(NULL, NULL, NULL, NULL, NULL)
+----
+<REGEX>:.*url cannot be NULL.*
+
+statement error
+SELECT file('x', NULL, 0, NULL, NULL)
+----
+<REGEX>:.*position and size must either both be NULL or both be non-NULL.*
+
+statement error
+SELECT file('x', NULL, NULL, 0, NULL)
+----
+<REGEX>:.*position and size must either both be NULL or both be non-NULL.*
+
+statement error
+SELECT file('x', NULL, -1, 0, NULL)
+----
+<REGEX>:.*position and size must be non-negative.*
+
+statement error
+SELECT file('x', NULL, 9223372036854775807, 1, NULL)
+----
+<REGEX>:.*byte range exceeds BIGINT.*
+
+statement error
+SELECT file('x', NULL, NULL, NULL, 'sha256')
+----
+<REGEX>:.*checksum must have the form <algorithm>:<digest>.*
+
+query I
+SELECT file('x', NULL, 0, 0, NULL).size
+----
+0
+
+query IIIIIIII
+SELECT
+	complete = complete,
+	complete != complete,
+	partial = partial,
+	partial != partial,
+	partial = other,
+	partial != other,
+	NULL::FILE = complete,
+	NULL::FILE != complete
+FROM (
+	SELECT
+		file('x', 'application/octet-stream', 10, 20, 'sha256:abcdef') AS complete,
+		file('x', NULL, NULL, NULL, NULL) AS partial,
+		file('other', NULL, NULL, NULL, NULL) AS other
+)
+----
+true	false	NULL	NULL	false	true	NULL	NULL
+
+query IIIII
+SELECT
+	value = file('other', 'application/octet-stream', 10, 20, 'sha256:abcdef'),
+	value = file('x', 'text/plain', 10, 20, 'sha256:abcdef'),
+	value = file('x', 'application/octet-stream', 11, 20, 'sha256:abcdef'),
+	value = file('x', 'application/octet-stream', 10, 21, 'sha256:abcdef'),
+	value = file('x', 'application/octet-stream', 10, 20, 'sha256:fedcba')
+FROM (
+	SELECT file('x', 'application/octet-stream', 10, 20, 'sha256:abcdef') AS value
+)
+----
+false	false	false	false	false
+
+statement error
+SELECT file('x', NULL, NULL, NULL, NULL) < file('x', NULL, NULL, NULL, NULL)
+----
+<REGEX>:.*Cannot compare values of type FILE.*
+
+statement error
+SELECT file('x', NULL, NULL, NULL, NULL) = ROW('x', NULL, NULL, NULL, NULL)
+----
+<REGEX>:.*Cannot compare values of type FILE.*
+
+# Generic nested operations intentionally use the underlying STRUCT behavior.
+query II
+SELECT list_contains([value], value), hash(value) IS NOT NULL
+FROM (SELECT file('x', 'text/plain', 0, 1, 'sha256:a') AS value)
+----
+true	true
+
+statement ok
+CREATE TABLE file_values(value FILE)
+
+statement ok
+INSERT INTO file_values VALUES
+	(file('stored', 'text/plain', 0, 0, 'sha256:a')),
+	(NULL)
+
+query TT
+SELECT typeof(value), value.url
+FROM file_values
+ORDER BY value IS NULL
+----
+FILE	stored
+FILE	NULL

--- a/external/duckdb/test/sql/types/alias/test_file_alias.test
+++ b/external/duckdb/test/sql/types/alias/test_file_alias.test
@@ -1,6 +1,6 @@
 # name: test/sql/types/alias/test_file_alias.test
 # description: Test the lightweight FILE struct alias and its pure constructor
-# group: [file]
+# group: [alias]
 
 statement ok
 PRAGMA enable_verification


### PR DESCRIPTION
## Summary

- Register `FILE(url VARCHAR, content_type VARCHAR, position BIGINT, size BIGINT, checksum VARCHAR)` as a canonical DuckDB `STRUCT` alias that persists through table storage and database reopen.
- Add the pure, vectorized five-argument `file(...)` constructor with URL, byte-range, overflow, and checksum validation; construction performs no I/O.
- Add named field access plus direct same-`FILE` `=` and `!=` with fieldwise SQL three-valued logic.
- Keep generic nested operations on the underlying `STRUCT` semantics. This PR intentionally adds no global collection, cast, Arrow/Parquet, Appender, or UDF guards and no compatibility fallback; downstream I/O and UDF work will validate at their consumer boundaries.

This replaces the invasive guarded-alias approach with a focused engine foundation that follows DuckDB's alias model. A future native `LogicalTypeId::FILE` remains possible if stronger nominal behavior becomes necessary.

## Related issue

close: #660

Parent roadmap: #659

Supersedes #658.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This is the internal C++/SQL foundation; end-user documentation belongs with the public File APIs tracked by #659.

## Validation

- Two consecutive clean code-review passes after the final fix, followed by an additional final diff audit.
- `scripts/format duckdb --changed --check`
- `clang-format --dry-run --Werror` for the new DuckDB C++ files.
- `pre-commit run --from-ref upstream/main --to-ref HEAD`
- Incremental Release install with `CMAKE_BUILD_PARALLEL_LEVEL=20`.
- `build/native-cxx20/test/unittest "test/sql/types/alias/test_file_alias.test"` — 46 assertions passed.
- `scripts/run_release_tests.sh` — 551 passed / 4 skipped in the non-Ray shard; 13 passed in the real-Ray shard.
- Persistent database close/reopen smoke test covering `typeof`, named field access, and `FILE` equality.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
