### PR TITLE
[feat](milvus) Add a keyed-upsert DataSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,31 @@ For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/da
 
 Follow the [Quickstart guide](https://vane.astrovela.ai/docs/data/quickstart/quickstart) to build and run your first Vane pipeline.
 
+### Milvus full-row upserts
+
+Install the optional client with `pip install vane-ai[milvus]`. `MilvusSink`
+performs immediate, replay-safe full-row upserts for collections whose primary
+key is an explicit `INT64` or `VARCHAR` field; AutoID and dynamic-field
+collections are rejected. A failed distributed operation can leave batches
+visible, so it is not an atomic or exactly-once transaction.
+
+```python
+from vane import EnvironmentSecret, MilvusSink
+
+sink = MilvusSink(
+    "documents",
+    uri="https://milvus.example:19530",
+    primary_key="id",
+    token=EnvironmentSecret("MILVUS_TOKEN"),
+)
+summary = relation.write_datasink(sink)
+```
+
+Every input field must map to a collection field (use `field_mapping` when
+names differ), and all required collection fields must be included. Only
+ordinary override-mode upserts are submitted; partial updates and array
+operations are not part of this adapter.
+
 ### Execution Policy
 
 Vane uses the Ray runner by default. If no runner is configured, executing a lazy relation through consumers such as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ Issues = "https://github.com/AstroVela/vane/issues"
 Changelog = "https://github.com/AstroVela/vane/releases"
 
 [project.optional-dependencies]
+milvus = ["pymilvus>=2.5.18,<2.6"]
 openai = ["openai>=1.66.0", "tiktoken"] # floor adds the Responses API used by the default Prompt path
 anthropic = ["anthropic>=0.117.0"] # floor matches the Messages.create option surface validated in vane/ai/providers/anthropic.py
 google = ["google-genai>=1.22.0"] # floor adds GenerateContentConfig.response_json_schema
@@ -225,6 +226,7 @@ include = [
     "/tests/ray_test_profile.py",
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",
+    "/tests/fast/test_milvus_datasink.py",
     "/tests/fast/test_package_metadata.py",
     "/tests/fast/test_ray_test_profile.py",
     "/tests/fast/test_transformers_provider_security.py",

--- a/tests/fast/test_milvus_datasink.py
+++ b/tests/fast/test_milvus_datasink.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pyarrow as pa
+import pytest
+
+import vane.datasink.milvus as milvus
+from vane import EnvironmentSecret, MilvusSink
+from vane.datasink import WriteContext
+
+
+def _schema(*, auto_id: bool = False, dynamic: bool = False, primary_type: int = 5) -> dict[str, object]:
+    return {
+        "auto_id": auto_id,
+        "enable_dynamic_field": dynamic,
+        "fields": [
+            {"name": "id", "type": primary_type, "is_primary": True, "nullable": False, "params": {}},
+            {"name": "embedding", "type": 101, "nullable": False, "params": {"dim": 3}},
+            {"name": "title", "type": 21, "nullable": False, "params": {"max_length": 16}},
+        ],
+    }
+
+
+class _Client:
+    schema: Mapping[str, object] = _schema()
+    instances: list["_Client"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.upserts: list[dict[str, object]] = []
+        self.closed = False
+        type(self).instances.append(self)
+
+    def describe_collection(self, **kwargs: object) -> Mapping[str, object]:
+        assert kwargs == {"collection_name": "items", "timeout": 5.0}
+        return self.schema
+
+    def upsert(self, **kwargs: object) -> Mapping[str, int]:
+        self.upserts.append(kwargs)
+        return {"upsert_count": len(kwargs["data"])}
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _fake_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    _Client.schema = _schema()
+    _Client.instances = []
+    monkeypatch.setattr(milvus, "_load_milvus_client", lambda: _Client)
+
+
+def _arrow_schema() -> pa.Schema:
+    return pa.schema([("id", pa.int64()), ("embedding", pa.list_(pa.float32())), ("title", pa.string())])
+
+
+def _sink(**kwargs: object) -> MilvusSink:
+    options: dict[str, object] = {
+        "uri": "http://milvus:19530",
+        "primary_key": "id",
+        "timeout": 5,
+    }
+    options.update(kwargs)
+    return MilvusSink("items", **options)  # type: ignore[arg-type]
+
+
+def _worker(**kwargs: object):
+    return _sink(**kwargs).bind(_arrow_schema()).open_worker(WriteContext("test-op"))
+
+
+def _table(
+    *, ids: list[int] | None = None, vectors: list[list[float]] | None = None, titles: list[str] | None = None
+) -> pa.Table:
+    return pa.table(
+        {
+            "id": ids or [1, 2],
+            "embedding": vectors or [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+            "title": titles or ["one", "two"],
+        },
+        schema=_arrow_schema(),
+    )
+
+
+def test_milvus_sink_binds_explicit_primary_key_and_writes_override_upserts() -> None:
+    worker = _worker()
+
+    result = worker.write(_table())
+
+    assert result.rows_received == result.rows_affected == 2
+    assert result.metadata == {"provider": "milvus", "collection": "items"}
+    client = _Client.instances[0]
+    assert client.kwargs == {"uri": "http://milvus:19530"}
+    assert len(client.upserts) == 1
+    assert client.upserts[0]["collection_name"] == "items"
+    assert client.upserts[0]["timeout"] == 5.0
+    assert client.upserts[0]["data"] == [
+        {"id": 1, "embedding": pytest.approx([0.1, 0.2, 0.3]), "title": "one"},
+        {"id": 2, "embedding": pytest.approx([0.4, 0.5, 0.6]), "title": "two"},
+    ]
+    worker.close()
+    assert client.closed
+
+
+@pytest.mark.parametrize(
+    ("schema", "message"),
+    [
+        (_schema(auto_id=True), "auto_id disabled"),
+        (_schema(dynamic=True), "dynamic fields"),
+        (_schema(primary_type=4), "INT64 or VARCHAR"),
+        ({**_schema(), "fields": _schema()["fields"][1:]}, "primary key does not match"),
+    ],
+)
+def test_milvus_sink_rejects_unsafe_or_invalid_collection_schema(schema: Mapping[str, object], message: str) -> None:
+    _Client.schema = schema
+
+    with pytest.raises(ValueError, match=message):
+        _worker()
+    assert _Client.instances[0].closed
+
+
+def test_milvus_sink_rejects_missing_required_and_unknown_fields() -> None:
+    schema = _schema()
+    schema["fields"] = [*schema["fields"], {"name": "required", "type": 5, "nullable": False, "params": {}}]
+    _Client.schema = schema
+    with pytest.raises(ValueError, match="missing required"):
+        _worker()
+
+    _Client.schema = _schema()
+    sink = _sink(field_mapping={"title": "missing"})
+    with pytest.raises(ValueError, match="absent"):
+        sink.bind(_arrow_schema()).open_worker(WriteContext("test-op"))
+
+
+def test_milvus_sink_validates_arrow_schema_mapping_and_primary_key() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        _sink(primary_key="missing").bind(_arrow_schema())
+    with pytest.raises(ValueError, match="int64 or string"):
+        _sink(primary_key="embedding").bind(_arrow_schema())
+    with pytest.raises(ValueError, match="unique"):
+        _sink(field_mapping={"id": "id", "title": "id"}).bind(_arrow_schema())
+    with pytest.raises(ValueError, match="does not support"):
+        _sink().bind(pa.schema([("id", pa.int64()), ("embedding", pa.list_(pa.float64())), ("title", pa.string())]))
+    with pytest.raises(ValueError, match="must not contain credentials"):
+        MilvusSink("items", uri="https://user:secret@milvus.example", primary_key="id")
+
+
+def test_milvus_sink_validates_collection_field_types_and_vector_dimensions() -> None:
+    schema = _schema()
+    schema["fields"][1]["type"] = 100
+    _Client.schema = schema
+    with pytest.raises(ValueError, match="does not match Arrow"):
+        _worker()
+
+    _Client.schema = _schema()
+    worker = _worker()
+    with pytest.raises(ValueError, match="invalid dimension"):
+        worker.write(_table(vectors=[[0.1, 0.2], [0.3, 0.4]]))
+
+
+def test_milvus_sink_enforces_batch_and_value_limits_before_sdk_submission() -> None:
+    worker = _worker(max_batch_rows=1)
+    with pytest.raises(ValueError, match="max_batch_rows"):
+        worker.write(_table())
+    assert not _Client.instances[0].upserts
+
+    worker = _worker(max_batch_bytes=1)
+    with pytest.raises(ValueError, match="max_batch_bytes"):
+        worker.write(_table())
+    assert not _Client.instances[1].upserts
+
+    worker = _worker()
+    with pytest.raises(ValueError, match="max_length"):
+        worker.write(_table(titles=["x" * 17, "two"]))
+    assert not _Client.instances[2].upserts
+
+    worker = _worker()
+    with pytest.raises(ValueError, match="max_length"):
+        worker.write(_table(titles=["你" * 6, "two"]))
+    assert not _Client.instances[3].upserts
+
+    worker = _worker()
+    with pytest.raises(ValueError, match="invalid value"):
+        worker.write(_table(vectors=[[0.1, float("nan"), 0.3], [0.4, 0.5, 0.6]]))
+    assert not _Client.instances[4].upserts
+
+
+def test_milvus_sink_resolves_token_only_on_worker_and_redacts_plan(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MILVUS_TOKEN", "super-secret")
+    sink = _sink(token=EnvironmentSecret("MILVUS_TOKEN"), database="default")
+    bound = sink.bind(_arrow_schema())
+    assert "super-secret" not in repr(sink)
+    worker = bound.open_worker(WriteContext("test-op"))
+    assert _Client.instances[0].kwargs == {
+        "uri": "http://milvus:19530",
+        "token": "super-secret",
+        "db_name": "default",
+    }
+    worker.abort(RuntimeError("planned"))
+    assert _Client.instances[0].closed
+
+
+def test_milvus_sink_rejects_plaintext_tokens_and_invalid_provider_result() -> None:
+    with pytest.raises(TypeError, match="EnvironmentSecret"):
+        _sink(token="secret")  # type: ignore[arg-type]
+
+    worker = _worker()
+    _Client.instances[0].upsert = lambda **kwargs: {"upsert_count": 1}  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="affected-row count"):
+        worker.write(_table())
+
+
+def test_milvus_sink_rejects_nonfinite_timeout_and_mismatched_batches() -> None:
+    with pytest.raises(ValueError, match="timeout"):
+        _sink(timeout=float("nan"))
+
+    worker = _worker()
+    with pytest.raises(ValueError, match="bound input schema"):
+        worker.write(pa.table({"id": [1], "embedding": [[0.1, 0.2, 0.3]], "other": ["x"]}))

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -211,6 +211,7 @@ from vane.datasink import (
     WriteSummary,
     write_datasink,
 )
+from vane.datasink.milvus import MilvusSink
 from vane.value.constant import (
     BinaryValue,
     BitValue,
@@ -340,6 +341,7 @@ __all__: list[str] = [
     "DataSinkExecutionOptions",
     "DataSinkWorker",
     "DataSinkWriteError",
+    "MilvusSink",
     "DatabaseError",
     "DATETIME",
     "DateValue",

--- a/vane/datasink/milvus.py
+++ b/vane/datasink/milvus.py
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replay-safe, full-row Milvus upserts for :mod:`vane.datasink`.
+
+Install with ``pip install vane-ai[milvus]``.  This adapter intentionally
+supports only collections with an explicit INT64 or VARCHAR primary key and
+ordinary override-mode upserts.  A failed distributed operation can therefore
+leave some batches visible; it is not an atomic transaction.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+import pyarrow as pa
+
+from vane.datasink import (
+    BoundKeyedUpsertSink,
+    DataSink,
+    DataSinkCapabilities,
+    DataSinkExecutionOptions,
+    DataSinkWorker,
+    EnvironmentSecret,
+    WriteContext,
+    WriteResult,
+)
+
+_INT64 = 5
+_VARCHAR = 21
+_FLOAT_VECTOR = 101
+_TYPE_NAMES = {
+    1: "BOOL",
+    2: "INT8",
+    3: "INT16",
+    4: "INT32",
+    5: "INT64",
+    10: "FLOAT",
+    11: "DOUBLE",
+    21: "VARCHAR",
+    101: "FLOAT_VECTOR",
+}
+
+
+def _require_text(name: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    value = value.strip()
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _optional_text(name: str, value: object | None) -> str | None:
+    if value is None:
+        return None
+    return _require_text(name, value)
+
+
+def _uri(value: object) -> str:
+    uri = _require_text("uri", value)
+    parsed = urlsplit(uri)
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("uri must not contain credentials; use token=EnvironmentSecret(...) instead")
+    return uri
+
+
+def _positive_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a positive integer")
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _milvus_type(field: Mapping[str, Any]) -> int:
+    value = field.get("type")
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Milvus field {field.get('name')!r} has an invalid type")
+    return value
+
+
+def _arrow_milvus_type(field: pa.Field) -> int:
+    data_type = field.type
+    if pa.types.is_boolean(data_type):
+        return 1
+    if pa.types.is_int8(data_type):
+        return 2
+    if pa.types.is_int16(data_type):
+        return 3
+    if pa.types.is_int32(data_type):
+        return 4
+    if pa.types.is_int64(data_type):
+        return _INT64
+    if pa.types.is_float32(data_type):
+        return 10
+    if pa.types.is_float64(data_type):
+        return 11
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return _VARCHAR
+    if (
+        pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type)
+    ) and pa.types.is_float32(data_type.value_type):
+        return _FLOAT_VECTOR
+    raise ValueError(f"MilvusSink does not support Arrow field {field.name!r} with type {data_type}")
+
+
+def _field_dimension(field: Mapping[str, Any]) -> int:
+    params = field.get("params", {})
+    if not isinstance(params, Mapping):
+        raise ValueError(f"Milvus vector field {field.get('name')!r} has invalid params")
+    return _positive_int(f"Milvus vector field {field.get('name')!r} dim", params.get("dim"))
+
+
+def _field_max_length(field: Mapping[str, Any]) -> int:
+    params = field.get("params", {})
+    if not isinstance(params, Mapping):
+        raise ValueError(f"Milvus VARCHAR field {field.get('name')!r} has invalid params")
+    return _positive_int(f"Milvus VARCHAR field {field.get('name')!r} max_length", params.get("max_length"))
+
+
+def _load_milvus_client() -> type[Any]:
+    try:
+        from pymilvus import MilvusClient  # type: ignore[import-not-found]
+    except ImportError as error:
+        raise ImportError("MilvusSink requires pymilvus; install vane-ai[milvus]") from error
+    return MilvusClient
+
+
+@dataclass(frozen=True)
+class _FieldBinding:
+    source_name: str
+    target_name: str
+    arrow_type: pa.DataType
+
+
+class MilvusSink(DataSink):
+    """Write a relation into one Milvus collection using full-row upserts.
+
+    ``token`` accepts only :class:`EnvironmentSecret`, keeping credential values
+    out of serialized plans.  ``field_mapping`` maps input relation columns to
+    collection fields; without it, names must match exactly.
+    """
+
+    def __init__(
+        self,
+        collection_name: str,
+        *,
+        uri: str,
+        primary_key: str,
+        token: EnvironmentSecret | None = None,
+        database: str | None = None,
+        field_mapping: Mapping[str, str] | None = None,
+        worker_count: int = 1,
+        max_batch_rows: int = 1_000,
+        max_batch_bytes: int = 16 * 1024 * 1024,
+        timeout: float | None = None,
+    ) -> None:
+        self.collection_name = _require_text("collection_name", collection_name)
+        self.uri = _uri(uri)
+        self.primary_key = _require_text("primary_key", primary_key)
+        if token is not None and not isinstance(token, EnvironmentSecret):
+            raise TypeError("token must be an EnvironmentSecret or None")
+        self.token = token
+        self.database = _optional_text("database", database)
+        self.worker_count = _positive_int("worker_count", worker_count)
+        self.max_batch_rows = _positive_int("max_batch_rows", max_batch_rows)
+        self.max_batch_bytes = _positive_int("max_batch_bytes", max_batch_bytes)
+        if timeout is not None and (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or not math.isfinite(timeout)
+            or timeout <= 0
+        ):
+            raise ValueError("timeout must be a positive number or None")
+        self.timeout = None if timeout is None else float(timeout)
+        mapping = dict(field_mapping or {})
+        for source, target in mapping.items():
+            _require_text("field_mapping source", source)
+            _require_text("field_mapping target", target)
+        if len(set(mapping.values())) != len(mapping):
+            raise ValueError("field_mapping values must be unique")
+        self.field_mapping = mapping
+
+    def bind(self, schema: pa.Schema) -> BoundKeyedUpsertSink:
+        if not isinstance(schema, pa.Schema):
+            raise TypeError("schema must be pyarrow.Schema")
+        source_names = set(schema.names)
+        unknown_sources = set(self.field_mapping).difference(source_names)
+        if unknown_sources:
+            raise ValueError(f"field_mapping contains unknown input columns: {sorted(unknown_sources)!r}")
+        bindings = tuple(
+            _FieldBinding(field.name, self.field_mapping.get(field.name, field.name), field.type) for field in schema
+        )
+        if len({binding.target_name for binding in bindings}) != len(bindings):
+            raise ValueError("field_mapping must produce unique collection field names")
+        primary_sources = [binding.source_name for binding in bindings if binding.target_name == self.primary_key]
+        if len(primary_sources) != 1:
+            raise ValueError("primary_key must map from exactly one input column")
+        primary_field = schema.field(primary_sources[0])
+        if _arrow_milvus_type(primary_field) not in {_INT64, _VARCHAR}:
+            raise ValueError("Milvus primary_key input column must be Arrow int64 or string")
+        for field in schema:
+            _arrow_milvus_type(field)
+        return _BoundMilvusSink(self, bindings, primary_sources[0])
+
+
+class _BoundMilvusSink(BoundKeyedUpsertSink):
+    def __init__(self, sink: MilvusSink, bindings: tuple[_FieldBinding, ...], key_column: str) -> None:
+        self._sink = sink
+        self._bindings = bindings
+        self._key_column = key_column
+
+    @property
+    def capabilities(self) -> DataSinkCapabilities:
+        from vane.datasink import CommitProtocol, RetryMode
+
+        return DataSinkCapabilities(CommitProtocol.IMMEDIATE, RetryMode.IDEMPOTENT)
+
+    @property
+    def execution_options(self) -> DataSinkExecutionOptions:
+        return DataSinkExecutionOptions(
+            worker_count=self._sink.worker_count,
+            batch_size=self._sink.max_batch_rows,
+            target_max_batch_bytes=self._sink.max_batch_bytes,
+        )
+
+    @property
+    def key_columns(self) -> Sequence[str]:
+        return (self._key_column,)
+
+    def open_worker(self, context: WriteContext) -> DataSinkWorker:
+        return _MilvusWorker(self._sink, self._bindings)
+
+
+class _MilvusWorker(DataSinkWorker):
+    def __init__(self, sink: MilvusSink, bindings: tuple[_FieldBinding, ...]) -> None:
+        client_kwargs: dict[str, Any] = {"uri": sink.uri}
+        if sink.token is not None:
+            client_kwargs["token"] = sink.token.resolve()
+        if sink.database is not None:
+            client_kwargs["db_name"] = sink.database
+        self._sink = sink
+        self._bindings = bindings
+        self._client = _load_milvus_client()(**client_kwargs)
+        self._closed = False
+        try:
+            self._fields = self._validate_collection()
+        except BaseException:
+            self.close()
+            raise
+
+    def _validate_collection(self) -> Mapping[str, Mapping[str, Any]]:
+        description = self._client.describe_collection(
+            collection_name=self._sink.collection_name, timeout=self._sink.timeout
+        )
+        if not isinstance(description, Mapping):
+            raise ValueError("Milvus describe_collection returned an invalid schema")
+        if description.get("auto_id") is not False:
+            raise ValueError("MilvusSink requires a collection with auto_id disabled")
+        raw_fields = description.get("fields")
+        if not isinstance(raw_fields, list):
+            raise ValueError("Milvus describe_collection returned no fields")
+        fields: dict[str, Mapping[str, Any]] = {}
+        for raw_field in raw_fields:
+            if not isinstance(raw_field, Mapping) or not isinstance(raw_field.get("name"), str):
+                raise ValueError("Milvus describe_collection returned an invalid field")
+            if raw_field["name"] in fields:
+                raise ValueError(f"Milvus describe_collection returned duplicate field {raw_field['name']!r}")
+            fields[raw_field["name"]] = raw_field
+        primary = [field for field in fields.values() if field.get("is_primary") is True]
+        if len(primary) != 1 or primary[0].get("name") != self._sink.primary_key:
+            raise ValueError("Milvus collection primary key does not match MilvusSink.primary_key")
+        if _milvus_type(primary[0]) not in {_INT64, _VARCHAR}:
+            raise ValueError("Milvus collection primary key must be INT64 or VARCHAR")
+        bound_targets = {binding.target_name for binding in self._bindings}
+        unknown = bound_targets.difference(fields)
+        if unknown:
+            raise ValueError(f"input fields are absent from Milvus collection: {sorted(unknown)!r}")
+        if description.get("enable_dynamic_field") is True:
+            raise ValueError("MilvusSink does not support collections with dynamic fields enabled")
+        missing_required = [
+            name
+            for name, field in fields.items()
+            if name not in bound_targets and field.get("nullable") is not True and "default_value" not in field
+        ]
+        if missing_required:
+            raise ValueError(f"input is missing required Milvus fields: {sorted(missing_required)!r}")
+        for binding in self._bindings:
+            remote = fields[binding.target_name]
+            expected_type = _arrow_milvus_type(pa.field(binding.source_name, binding.arrow_type))
+            actual_type = _milvus_type(remote)
+            if expected_type != actual_type:
+                raise ValueError(
+                    f"Milvus field {binding.target_name!r} type {_TYPE_NAMES.get(actual_type, actual_type)} "
+                    f"does not match Arrow field {binding.source_name!r}"
+                )
+            if actual_type == _FLOAT_VECTOR:
+                _field_dimension(remote)
+            if actual_type == _VARCHAR:
+                _field_max_length(remote)
+        return fields
+
+    def _records(self, table: pa.Table) -> list[dict[str, Any]]:
+        if not isinstance(table, pa.Table):
+            raise TypeError(f"MilvusSink expected pyarrow.Table, got {type(table).__name__}")
+        expected_names = tuple(binding.source_name for binding in self._bindings)
+        if tuple(table.column_names) != expected_names:
+            raise ValueError("Milvus batch schema does not match the bound input schema")
+        for binding in self._bindings:
+            if table.schema.field(binding.source_name).type != binding.arrow_type:
+                raise ValueError("Milvus batch schema does not match the bound input schema")
+        if table.num_rows > self._sink.max_batch_rows:
+            raise ValueError("Milvus batch exceeds max_batch_rows")
+        if table.nbytes > self._sink.max_batch_bytes:
+            raise ValueError("Milvus batch exceeds max_batch_bytes")
+        records: list[dict[str, Any]] = []
+        for row in table.to_pylist():
+            record: dict[str, Any] = {}
+            for binding in self._bindings:
+                value = row[binding.source_name]
+                remote = self._fields[binding.target_name]
+                if value is None and remote.get("nullable") is not True:
+                    raise ValueError(f"Milvus field {binding.target_name!r} is not nullable")
+                if value is not None and _milvus_type(remote) == _VARCHAR:
+                    if len(value.encode("utf-8")) > _field_max_length(remote):
+                        raise ValueError(f"Milvus field {binding.target_name!r} exceeds max_length")
+                if value is not None and _milvus_type(remote) == _FLOAT_VECTOR:
+                    if not isinstance(value, list) or len(value) != _field_dimension(remote):
+                        raise ValueError(f"Milvus vector field {binding.target_name!r} has an invalid dimension")
+                    if any(
+                        isinstance(element, bool)
+                        or not isinstance(element, (int, float))
+                        or not math.isfinite(float(element))
+                        for element in value
+                    ):
+                        raise ValueError(f"Milvus vector field {binding.target_name!r} contains an invalid value")
+                record[binding.target_name] = value
+            records.append(record)
+        return records
+
+    def write(self, table: pa.Table) -> WriteResult:
+        records = self._records(table)
+        response = self._client.upsert(
+            collection_name=self._sink.collection_name,
+            data=records,
+            timeout=self._sink.timeout,
+        )
+        count = response.get("upsert_count") if isinstance(response, Mapping) else None
+        if isinstance(count, bool) or not isinstance(count, int) or count != table.num_rows:
+            raise RuntimeError("Milvus upsert returned an invalid affected-row count")
+        return WriteResult(
+            rows_received=table.num_rows,
+            rows_affected=count,
+            bytes_received=table.nbytes,
+            metadata={"provider": "milvus", "collection": self._sink.collection_name},
+        )
+
+    def abort(self, error: BaseException) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._client.close()
+            self._closed = True
+
+
+__all__ = ["MilvusSink"]


### PR DESCRIPTION
## Summary

- Add an optional `pymilvus` dependency and `MilvusSink` for immediate, replay-safe distributed full-row upserts.
- Require explicit INT64 or VARCHAR primary keys, reject AutoID and dynamic-field collections, and validate collection/Arrow schemas, vectors, UTF-8 VARCHAR limits, batch limits, and provider result counts before accepting writes.
- Keep credentials out of serialized plans with `EnvironmentSecret`, document the constrained contract, and add SDK-mocked coverage.

## Related issue

close: #649

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

README documents installation, the relation-to-collection usage, and the replay/visibility limitations.

## Validation

- `uv tool run pre-commit run --files README.md pyproject.toml vane/__init__.py vane/datasink/milvus.py tests/fast/test_milvus_datasink.py` — passed (ruff, format, mypy, and repository hooks).
- `tests/fast/test_milvus_datasink.py` — 12 passed, using the #652 native module with the branch Python sources; no live Milvus service was used.
- Attempted `uv pip install . --no-build-isolation` with the Release incremental build directory. The worktree environment lacks a coherent vcpkg toolchain configuration: direct CMake discovery cannot find Arrow; the prefix-only wheel builds but loads against an incompatible system OpenSSL (`SSL_get0_group_name`).
- Attempted release non-Ray suite once. It stopped in pre-existing `tests/fast/test_datasink.py` local-fast cases in that temporary mixed native environment, before the real-Ray phase; this adapter has no native changes.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.