### PR TITLE
[refactor](file) Move SQL registration into extension

### DIFF
--- a/cmake/duckdb_loader.cmake
+++ b/cmake/duckdb_loader.cmake
@@ -42,7 +42,8 @@ _duckdb_set_default(DUCKDB_SOURCE_PATH
                     "${CMAKE_CURRENT_SOURCE_DIR}/external/duckdb")
 
 # Extension list - commonly used extensions for Python
-_duckdb_set_default(BUILD_EXTENSIONS "core_functions;parquet;icu;json;httpfs")
+_duckdb_set_default(BUILD_EXTENSIONS
+                    "core_functions;file;parquet;icu;json;httpfs")
 
 # Core build options - disable unnecessary components for Python builds
 _duckdb_set_default(BUILD_SHELL OFF)

--- a/external/duckdb/extension/extension_config.cmake
+++ b/external/duckdb/extension/extension_config.cmake
@@ -9,4 +9,5 @@
 
 # these extensions are loaded by default on every build as they are an essential part of DuckDB
 duckdb_extension_load(core_functions)
+duckdb_extension_load(file)
 duckdb_extension_load(parquet)

--- a/external/duckdb/extension/file/CMakeLists.txt
+++ b/external/duckdb/extension/file/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5...3.29)
+
+project(FileExtension)
+
+include_directories(include)
+
+set(FILE_EXTENSION_FILES file_extension.cpp file_functions.cpp)
+
+build_static_extension(file ${FILE_EXTENSION_FILES})
+set(PARAMETERS "-warnings")
+build_loadable_extension(file ${PARAMETERS} ${FILE_EXTENSION_FILES})
+
+install(
+  TARGETS file_extension
+  EXPORT "${DUCKDB_EXPORT_SET}"
+  LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+  ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")

--- a/external/duckdb/extension/file/file_extension.cpp
+++ b/external/duckdb/extension/file/file_extension.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "file_extension.hpp"
+
+#include "file_functions.hpp"
+
+#include "duckdb/function/scalar/nested_functions.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+static void LoadInternal(ExtensionLoader &loader) {
+	loader.RegisterType(FileLogicalType::TYPE_NAME, FileLogicalType::Create());
+
+	for (auto &function : FileFunctions::GetFunctions()) {
+		loader.RegisterFunction(std::move(function));
+	}
+
+	auto file_key_extract = GetKeyExtractFunction();
+	file_key_extract.arguments[0] = FileLogicalType::Create();
+	loader.RegisterFunction(std::move(file_key_extract));
+}
+
+void FileExtension::Load(ExtensionLoader &loader) {
+	LoadInternal(loader);
+}
+
+std::string FileExtension::Name() {
+	return "file";
+}
+
+std::string FileExtension::Version() const {
+#ifdef EXT_VERSION_FILE
+	return EXT_VERSION_FILE;
+#else
+	return "";
+#endif
+}
+
+} // namespace duckdb
+
+extern "C" {
+
+DUCKDB_CPP_EXTENSION_ENTRY(file, loader) {
+	duckdb::LoadInternal(loader);
+}
+}

--- a/external/duckdb/extension/file/file_functions.cpp
+++ b/external/duckdb/extension/file/file_functions.cpp
@@ -4,11 +4,11 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/function/scalar/file.cpp
+// file_functions.cpp
 //
 //===----------------------------------------------------------------------===//
 
-#include "duckdb/function/scalar/file_functions.hpp"
+#include "file_functions.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"

--- a/external/duckdb/extension/file/include/file_extension.hpp
+++ b/external/duckdb/extension/file/include/file_extension.hpp
@@ -4,18 +4,21 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// duckdb/function/scalar/file_functions.hpp
+// file_extension.hpp
 //
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include "duckdb/function/scalar_function.hpp"
+#include "duckdb.hpp"
 
 namespace duckdb {
 
-struct FileFunctions {
-	static vector<ScalarFunction> GetFunctions();
+class FileExtension : public Extension {
+public:
+	void Load(ExtensionLoader &loader) override;
+	std::string Name() override;
+	std::string Version() const override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/extension/file/include/file_functions.hpp
+++ b/external/duckdb/extension/file/include/file_functions.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_functions.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+struct FileFunctions {
+	static vector<ScalarFunction> GetFunctions();
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/function/function.cpp
+++ b/external/duckdb/src/function/function.cpp
@@ -9,7 +9,6 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/hash.hpp"
 #include "duckdb/function/built_in_functions.hpp"
-#include "duckdb/function/scalar/file_functions.hpp"
 #include "duckdb/function/scalar/string_functions.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/function/table/datasource_scan.hpp"
@@ -18,7 +17,6 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/main/extension_entries.hpp"
 #include "duckdb/execution/operator/projection/physical_udf_inout.hpp"
-#include "duckdb/parser/parsed_data/create_type_info.hpp"
 
 namespace duckdb {
 
@@ -103,14 +101,6 @@ string BaseScalarFunction::ToString() const {
 
 // add your initializer for new functions here
 void BuiltinFunctions::Initialize() {
-	CreateTypeInfo file_type_info(FileLogicalType::TYPE_NAME, FileLogicalType::Create());
-	file_type_info.internal = true;
-	file_type_info.temporary = true;
-	catalog.CreateType(transaction, file_type_info);
-	for (auto &function : FileFunctions::GetFunctions()) {
-		AddFunction(std::move(function));
-	}
-
 	RegisterTableScanFunctions();
 	RegisterSQLiteFunctions();
 	RegisterReadFunctions();

--- a/external/duckdb/src/function/scalar/CMakeLists.txt
+++ b/external/duckdb/src/function/scalar/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library_unity(
   OBJECT
   compressed_materialization_utils.cpp
   create_sort_key.cpp
-  file.cpp
   strftime_format.cpp
   nested_functions.cpp
   pragma_functions.cpp

--- a/external/duckdb/src/function/scalar/struct/struct_extract.cpp
+++ b/external/duckdb/src/function/scalar/struct/struct_extract.cpp
@@ -1,9 +1,3 @@
-// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
-// SPDX-FileCopyrightText: 2026 Vane contributors
-// SPDX-License-Identifier: MIT
-//
-// Modified by Vane contributors.
-
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/scalar/struct_functions.hpp"
@@ -173,9 +167,6 @@ ScalarFunctionSet StructExtractFun::GetFunctions() {
 	ScalarFunctionSet struct_extract_set("struct_extract");
 	struct_extract_set.AddFunction(GetKeyExtractFunction());
 	struct_extract_set.AddFunction(GetIndexExtractFunction());
-	auto file_key_extract = GetKeyExtractFunction();
-	file_key_extract.arguments[0] = FileLogicalType::Create();
-	struct_extract_set.AddFunction(std::move(file_key_extract));
 	return struct_extract_set;
 }
 

--- a/external/duckdb/src/include/duckdb/function/scalar/nested_functions.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar/nested_functions.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -82,7 +88,7 @@ struct HistogramAggState {
 	MAP_TYPE *hist;
 };
 
-ScalarFunction GetKeyExtractFunction();
+DUCKDB_API ScalarFunction GetKeyExtractFunction();
 ScalarFunction GetIndexExtractFunction();
 ScalarFunction GetExtractAtFunction();
 

--- a/external/duckdb/test/sql/file/test_file_alias.test
+++ b/external/duckdb/test/sql/file/test_file_alias.test
@@ -1,6 +1,15 @@
-# name: test/sql/types/alias/test_file_alias.test
-# description: Test the lightweight FILE struct alias and its pure constructor
-# group: [alias]
+# name: test/sql/file/test_file_alias.test
+# description: Test the extension-owned FILE struct alias and its pure constructor
+# group: [file]
+
+require file
+
+load __TEST_DIR__/file.db
+
+query I
+SELECT count(*) FROM duckdb_extensions() WHERE extension_name = 'file' AND loaded
+----
+1
 
 statement ok
 PRAGMA enable_verification
@@ -121,6 +130,16 @@ statement ok
 INSERT INTO file_values VALUES
 	(file('stored', 'text/plain', 0, 0, 'sha256:a')),
 	(NULL)
+
+query TT
+SELECT typeof(value), value.url
+FROM file_values
+ORDER BY value IS NULL
+----
+FILE	stored
+FILE	NULL
+
+restart
 
 query TT
 SELECT typeof(value), value.url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ exclude = [
 ]
 
 [tool.scikit-build.cmake.define]
-BUILD_EXTENSIONS = "core_functions;json;parquet;icu;httpfs"
+BUILD_EXTENSIONS = "core_functions;file;json;parquet;icu;httpfs"
 
 # Override: if COVERAGE is set then:
 # - we create a RelWithDebInfo build
@@ -288,6 +288,7 @@ include = [
     "external/duckdb/extension/generated_extension_loader.cpp.in",
     "external/duckdb/extension/loader/**",
     "external/duckdb/extension/core_functions/**",
+    "external/duckdb/extension/file/**",
     "external/duckdb/extension/icu/**",
     "external/duckdb/third_party/jemalloc/**",
     "external/duckdb/extension/json/**",

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -392,7 +392,7 @@ def test_release_runtime_is_self_contained_by_default():
         ).fetchall()
     }
 
-    expected_extensions = {"core_functions", "httpfs", "icu", "json", "parquet"}
+    expected_extensions = {"core_functions", "file", "httpfs", "icu", "json", "parquet"}
 
     assert settings == {
         "allow_unsigned_extensions": "false",


### PR DESCRIPTION
## Summary

- Move FILE SQL type registration, the pure constructor/comparison functions, and the field-extraction overload from the DuckDB core initializer into an in-tree `file` extension.
- Link and load `file` by default in native and Python builds, while also providing a loadable extension target.
- Preserve the existing FILE SQL behavior and no-I/O guarantees; add explicit extension-load and database-restart coverage.
- Export `GetKeyExtractFunction()` as the minimal core boundary needed by the loadable extension.

## Related issue

close: #680

Parent tracking issue: #659

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This is an internal registration/packaging refactor; the SQL surface and semantics are unchanged.

## Validation

Linux x86_64, GCC 13.3, Python 3.12; native and wheel builds used 20 compile jobs.

- `scripts/format workspace --changed --check`
- `VANE_NATIVE_BUILD_JOBS=20 scripts/run_native_tests.sh "test/sql/file/test_file_alias.test"` — 1 case, 51 assertions passed
- `build/native-cxx20/test/unittest` — 4,588 cases and 1,109,117 assertions passed; 371 environment-gated tests skipped
- `cmake --build build/native-cxx20 --target file_loadable_extension --parallel 20`
- `CMAKE_BUILD_PARALLEL_LEVEL=20 SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `scripts/run_installed_pytest.sh tests/fast/test_package_metadata.py` — 27 passed
- `scripts/run_release_tests.sh` — 669 non-Ray and 14 shared-Ray tests passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
