### PR TITLE
[feat](file) Add SQL file execution capabilities

### DIFF
--- a/external/duckdb/extension/file/CMakeLists.txt
+++ b/external/duckdb/extension/file/CMakeLists.txt
@@ -4,11 +4,14 @@ project(FileExtension)
 
 include_directories(include)
 
-set(FILE_EXTENSION_FILES file_extension.cpp file_functions.cpp)
+set(FILE_EXTENSION_FILES
+    file_extension.cpp file_functions.cpp file_metadata_functions.cpp
+    file_mime_type.cpp file_resolver.cpp file_value.cpp)
 
 build_static_extension(file ${FILE_EXTENSION_FILES})
 set(PARAMETERS "-warnings")
 build_loadable_extension(file ${PARAMETERS} ${FILE_EXTENSION_FILES})
+target_link_libraries(file_loadable_extension duckdb_mbedtls)
 
 install(
   TARGETS file_extension

--- a/external/duckdb/extension/file/README.md
+++ b/external/duckdb/extension/file/README.md
@@ -1,0 +1,102 @@
+# FILE SQL extension
+
+`FILE` is a governed, read-only reference. The extension never copies resolved
+credentials into its five persisted fields. Functions that access storage open
+the URL at execution time through the current `ClientContext` file opener, so
+connector selection, Secret scope matching, retries, and credential refresh
+remain connector-owned.
+
+## Metadata contract
+
+`file_stat(file)` returns this connector-neutral struct:
+
+```sql
+STRUCT(
+    url VARCHAR,
+    object_size UBIGINT,
+    last_modified TIMESTAMP,
+    version VARCHAR,
+    etag VARCHAR,
+    content_type VARCHAR
+)
+```
+
+- `object_size` is the backing object's size, not a ranged FILE's logical
+  size. `file_size(file)` returns the logical size and can therefore use a
+  declared range without I/O.
+- `last_modified`, `version`, `etag`, and `content_type` are nullable. Values
+  exposed by a connector are returned when available and may become stale
+  after the call. Local files do not synthesize a provider version. A MIME type
+  inferred from a URL suffix is a hint. Content sniffing is requested
+  explicitly with `file_mime_type(file, 'content')` or used after metadata by
+  `'auto'`. Provider ETags remain ETags; they are never promoted to checksums or
+  versions.
+- `to_file(path)` opens the object and returns the complete logical view as
+  `position = 0, size = object_size`. `try_to_file` returns NULL for storage,
+  network, permission, configuration, or missing-connector failures.
+- `file_exists` returns false for a missing object, a non-file object, or a
+  declared range outside the backing object. It returns NULL when access cannot
+  be determined because of permission, network, configuration, or connector
+  failures.
+
+`file_enrich(file, fields)` accepts `size`, `content_type`, and `checksum`.
+Missing content types use connector metadata, then a recognized URL suffix,
+and otherwise sniff exactly the FILE's logical byte window. Missing checksums
+are computed as lowercase SHA-256 over that same window. Enrichment never
+overwrites an already populated field.
+
+## Identity contract
+
+Identity functions do not perform I/O:
+
+- `file_same_location` compares URL and logical range. Whole-object versus
+  explicit-range references are indeterminate (NULL), even when the explicit
+  range may cover the whole object.
+- `file_locator_id` is
+  `file-locator-v1:sha256:<hex>`. The digest covers the byte string
+  `vane:file-locator:v1`, a NUL separator, the URL length as an unsigned
+  64-bit big-endian integer, the URL bytes, a whole/range marker, and—when
+  ranged—the position and size as unsigned 64-bit big-endian integers.
+- `file_same_content` first proves inequality from two known different logical
+  sizes, treats two known zero-length views as equal, and otherwise compares
+  checksum digests only when their case-insensitive algorithm names match.
+  Insufficient or incomparable evidence returns NULL.
+- `file_content_id` is `file-content-v1:empty` for a known empty view,
+  `file-content-v1:checksum:<lowercase-algorithm>:<digest>` when a checksum is
+  present, and NULL without content evidence. Digest bytes remain opaque and
+  case-sensitive.
+
+## I/O boundary
+
+Every storage-facing function validates the exact FILE alias, non-NULL and
+NUL-free URL, paired and non-negative range, range overflow, and checksum token
+before opening a connector. Reads prefer the positional FileSystem API and fall
+back to seek plus bounded sequential reads for connectors without positional
+reads. Both paths reject a short object and never expose bytes outside the
+declared `[position, position + size)` window.
+
+Content MIME detection is a bounded, best-effort magic-byte hint, not format
+validation. It reads through the 4 KiB boundary plus the eight-byte HDF5
+signature first; strong prefix evidence avoids any additional HDF5 I/O. The
+built-in rules cover common PNG, JPEG, GIF, WebP, ISO-BMFF, MP3, WAV, Ogg, MPEG,
+HDF5, PDF, ZIP, and HTML content. Unknown content returns `NULL`. If the prefix
+is inconclusive, HDF5 additionally probes the remaining legal power-of-two
+user-block offsets with one eight-byte logical-range read per offset, so
+detection remains logarithmic in the FILE view size. Decoders and downstream
+providers remain responsible for validating content before consuming it.
+
+Resolver opens carry DuckDB's nonblocking flag so native local special files
+can be rejected from the opened handle without a check/open race. Registered
+Python filesystems do not yet implement that open contract and fail before
+performing I/O; their provider-specific execution support is intentionally
+deferred.
+
+## Distributed boundary
+
+Ray plan admission rejects storage-facing FILE scalars (`to_file`,
+`try_to_file`, `file_enrich`, `file_size`, `file_exists`, `file_stat`, and the
+two-argument `file_mime_type`) until workers have an explicit connector,
+credential, path-resolution, and refresh contract. Connection-scoped DuckDB
+Secrets are not serialized to workers. I/O-free FILE construction, field and
+path access, one-argument metadata MIME lookup, comparison, and identity
+functions remain distributable.

--- a/external/duckdb/extension/file/file_extension.cpp
+++ b/external/duckdb/extension/file/file_extension.cpp
@@ -4,6 +4,7 @@
 #include "file_extension.hpp"
 
 #include "file_functions.hpp"
+#include "file_metadata_functions.hpp"
 
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
@@ -14,6 +15,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	loader.RegisterType(FileLogicalType::TYPE_NAME, FileLogicalType::Create());
 
 	for (auto &function : FileFunctions::GetFunctions()) {
+		loader.RegisterFunction(std::move(function));
+	}
+	for (auto &function : FileMetadataFunctions::GetFunctions()) {
 		loader.RegisterFunction(std::move(function));
 	}
 

--- a/external/duckdb/extension/file/file_functions.cpp
+++ b/external/duckdb/extension/file/file_functions.cpp
@@ -9,40 +9,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "file_functions.hpp"
+#include "file_value.hpp"
 
-#include "duckdb/common/exception.hpp"
-#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
 namespace duckdb {
 
 namespace {
-
-static void ValidateFileFields(bool url_is_valid, bool position_is_valid, int64_t position, bool size_is_valid,
-                               int64_t size, const string *checksum) {
-	if (!url_is_valid) {
-		throw InvalidInputException("file() url cannot be NULL");
-	}
-	if (position_is_valid != size_is_valid) {
-		throw InvalidInputException("file() position and size must either both be NULL or both be non-NULL");
-	}
-	if (position_is_valid) {
-		if (position < 0 || size < 0) {
-			throw InvalidInputException("file() position and size must be non-negative");
-		}
-		if (position > NumericLimits<int64_t>::Maximum() - size) {
-			throw InvalidInputException("file() byte range exceeds BIGINT");
-		}
-	}
-	if (checksum) {
-		auto separator = checksum->find(':');
-		if (separator == string::npos || separator == 0 || separator + 1 == checksum->size() ||
-		    checksum->find(':', separator + 1) != string::npos) {
-			throw InvalidInputException("file() checksum must have the form <algorithm>:<digest>");
-		}
-	}
-}
 
 static void ValidateFileArguments(DataChunk &args) {
 	UnifiedVectorFormat url_data;
@@ -57,15 +31,22 @@ static void ValidateFileArguments(DataChunk &args) {
 	auto positions = UnifiedVectorFormat::GetData<int64_t>(position_data);
 	auto sizes = UnifiedVectorFormat::GetData<int64_t>(size_data);
 	auto checksums = UnifiedVectorFormat::GetData<string_t>(checksum_data);
+	auto urls = UnifiedVectorFormat::GetData<string_t>(url_data);
 	for (idx_t row = 0; row < args.size(); row++) {
 		auto url_index = url_data.sel->get_index(row);
 		auto position_index = position_data.sel->get_index(row);
 		auto size_index = size_data.sel->get_index(row);
 		auto checksum_index = checksum_data.sel->get_index(row);
-		auto position_is_valid = position_data.validity.RowIsValid(position_index);
-		auto size_is_valid = size_data.validity.RowIsValid(size_index);
-		auto position = position_is_valid ? positions[position_index] : 0;
-		auto size = size_is_valid ? sizes[size_index] : 0;
+		auto has_position = position_data.validity.RowIsValid(position_index);
+		auto has_size = size_data.validity.RowIsValid(size_index);
+		auto position = has_position ? positions[position_index] : 0;
+		auto size = has_size ? sizes[size_index] : 0;
+		string url;
+		const string *url_ptr = nullptr;
+		if (url_data.validity.RowIsValid(url_index)) {
+			url = urls[url_index].GetString();
+			url_ptr = &url;
+		}
 
 		string checksum;
 		const string *checksum_ptr = nullptr;
@@ -73,8 +54,7 @@ static void ValidateFileArguments(DataChunk &args) {
 			checksum = checksums[checksum_index].GetString();
 			checksum_ptr = &checksum;
 		}
-		ValidateFileFields(url_data.validity.RowIsValid(url_index), position_is_valid, position, size_is_valid, size,
-		                   checksum_ptr);
+		FileReference::ValidateFields(url_ptr, has_position, position, has_size, size, checksum_ptr, "file");
 	}
 }
 

--- a/external/duckdb/extension/file/file_metadata_functions.cpp
+++ b/external/duckdb/extension/file/file_metadata_functions.cpp
@@ -1,0 +1,426 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_metadata_functions.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "file_metadata_functions.hpp"
+
+#include "file_mime_type.hpp"
+#include "file_resolver.hpp"
+#include "file_value.hpp"
+
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#include <cerrno>
+
+namespace duckdb {
+
+namespace {
+
+static Value NullValue(const LogicalType &type) {
+	return Value(type);
+}
+
+static bool TryGetFile(DataChunk &args, idx_t argument, idx_t row, const string &function_name, FileReference &result) {
+	auto value = args.data[argument].GetValue(row);
+	if (value.IsNull()) {
+		return false;
+	}
+	result = FileReference::FromValue(value, function_name);
+	return true;
+}
+
+static bool IsRecoverableAccessError(const ErrorData &error) {
+	switch (error.Type()) {
+	case ExceptionType::IO:
+	case ExceptionType::HTTP:
+	case ExceptionType::NETWORK:
+	case ExceptionType::CONNECTION:
+	case ExceptionType::PERMISSION:
+	case ExceptionType::MISSING_EXTENSION:
+	case ExceptionType::AUTOLOAD:
+	case ExceptionType::INVALID_CONFIGURATION:
+	case ExceptionType::NOT_IMPLEMENTED:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static bool IsNotFoundError(const ErrorData &error) {
+	auto status = error.ExtraInfo().find("status_code");
+	if (status != error.ExtraInfo().end() && (status->second == "404" || status->second == "410")) {
+		return true;
+	}
+	auto error_number = error.ExtraInfo().find("errno");
+	return error_number != error.ExtraInfo().end() &&
+	       (error_number->second == std::to_string(ENOENT) || error_number->second == std::to_string(ENOTDIR));
+}
+
+static bool IsNotRegularFileError(const ErrorData &error) {
+	auto file_kind = error.ExtraInfo().find("file_kind");
+	return file_kind != error.ExtraInfo().end() && file_kind->second == "not_regular";
+}
+
+static bool IsFileRangeOutOfBoundsError(const ErrorData &error) {
+	auto file_range = error.ExtraInfo().find("file_range");
+	return file_range != error.ExtraInfo().end() && file_range->second == "out_of_bounds";
+}
+
+static FileReference ToFileReference(ClientContext &context, const string &path) {
+	FileReference result;
+	result.url = path;
+	auto resolved = ResolvedFile::Open(context, result);
+	result.has_range = true;
+	result.position = 0;
+	result.size = NumericCast<int64_t>(resolved->ObjectSize());
+	result.has_content_type = resolved->MimeTypeFromResolvedMetadata(result.content_type);
+	result.Validate("to_file");
+	return result;
+}
+
+template <bool TRY>
+static void ToFileFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto path_value = args.data[0].GetValue(row);
+		if (path_value.IsNull()) {
+			result.SetValue(row, NullValue(FileLogicalType::Create()));
+			continue;
+		}
+		try {
+			result.SetValue(row, ToFileReference(state.GetContext(), path_value.GetValue<string>()).ToValue());
+		} catch (const std::exception &exception) {
+			if (!TRY) {
+				throw;
+			}
+			ErrorData error(exception);
+			if (!IsRecoverableAccessError(error)) {
+				throw;
+			}
+			result.SetValue(row, NullValue(FileLogicalType::Create()));
+		}
+	}
+}
+
+static void FilePathFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_path", file)) {
+			result.SetValue(row, NullValue(LogicalType::VARCHAR));
+			continue;
+		}
+		result.SetValue(row, Value(file.url));
+	}
+}
+
+static void FileSizeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_size", file)) {
+			result.SetValue(row, NullValue(LogicalType::UBIGINT));
+			continue;
+		}
+		auto size = file.has_range ? NumericCast<uint64_t>(file.size)
+		                           : ResolvedFile::Open(state.GetContext(), file)->LogicalSize();
+		result.SetValue(row, Value::UBIGINT(size));
+	}
+}
+
+static void FileExistsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_exists", file)) {
+			result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+			continue;
+		}
+		try {
+			ResolvedFile::Open(state.GetContext(), file);
+			result.SetValue(row, Value::BOOLEAN(true));
+		} catch (const std::exception &exception) {
+			ErrorData error(exception);
+			if (IsNotFoundError(error) || IsNotRegularFileError(error) || IsFileRangeOutOfBoundsError(error)) {
+				result.SetValue(row, Value::BOOLEAN(false));
+			} else if (IsRecoverableAccessError(error)) {
+				result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+			} else {
+				throw;
+			}
+		}
+	}
+}
+
+static void FileStatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_stat", file)) {
+			result.SetValue(row, NullValue(FileStatValue::Type()));
+			continue;
+		}
+		result.SetValue(row, ResolvedFile::Open(state.GetContext(), file)->Stat().ToValue());
+	}
+}
+
+enum class MimeDetectionMode : uint8_t { METADATA, CONTENT, AUTO };
+
+static MimeDetectionMode ParseMimeDetectionMode(const Value &value) {
+	auto mode = StringUtil::Lower(value.GetValue<string>());
+	if (mode == "metadata") {
+		return MimeDetectionMode::METADATA;
+	}
+	if (mode == "content") {
+		return MimeDetectionMode::CONTENT;
+	}
+	if (mode == "auto") {
+		return MimeDetectionMode::AUTO;
+	}
+	throw InvalidInputException("file_mime_type() detect must be 'metadata', 'content', or 'auto'");
+}
+
+static void FileMimeTypeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_mime_type", file)) {
+			result.SetValue(row, NullValue(LogicalType::VARCHAR));
+			continue;
+		}
+		MimeDetectionMode mode = MimeDetectionMode::METADATA;
+		if (args.ColumnCount() == 2) {
+			auto detect = args.data[1].GetValue(row);
+			if (detect.IsNull()) {
+				result.SetValue(row, NullValue(LogicalType::VARCHAR));
+				continue;
+			}
+			mode = ParseMimeDetectionMode(detect);
+		}
+
+		string mime_type;
+		bool detected = false;
+		if (mode == MimeDetectionMode::METADATA) {
+			if (file.has_content_type) {
+				mime_type = file.content_type;
+				detected = true;
+			} else {
+				detected = FileMimeType::FromPath(file.url, mime_type);
+			}
+		} else if (mode == MimeDetectionMode::AUTO && file.has_content_type) {
+			mime_type = file.content_type;
+			detected = true;
+		}
+		if (!detected && mode != MimeDetectionMode::METADATA) {
+			auto resolved = ResolvedFile::Open(state.GetContext(), file);
+			if (mode == MimeDetectionMode::AUTO) {
+				detected = resolved->MimeTypeFromResolvedMetadata(mime_type);
+			}
+			if (!detected) {
+				detected = resolved->GuessMimeType(mime_type);
+			}
+		}
+		result.SetValue(row, detected ? Value(mime_type) : NullValue(LogicalType::VARCHAR));
+	}
+}
+
+static void GuessMimeTypeFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto bytes = args.data[0].GetValue(row);
+		if (bytes.IsNull()) {
+			result.SetValue(row, NullValue(LogicalType::VARCHAR));
+			continue;
+		}
+		auto &data = StringValue::Get(bytes);
+		string mime_type;
+		auto detected = FileMimeType::FromBytes(const_data_ptr_cast(data.data()), data.size(), mime_type, true);
+		result.SetValue(row, detected ? Value(mime_type) : NullValue(LogicalType::VARCHAR));
+	}
+}
+
+static void FileEnrichFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		auto fields_value = args.data[1].GetValue(row);
+		if (!TryGetFile(args, 0, row, "file_enrich", file) || fields_value.IsNull()) {
+			result.SetValue(row, NullValue(FileLogicalType::Create()));
+			continue;
+		}
+		bool enrich_size = false;
+		bool enrich_content_type = false;
+		bool enrich_checksum = false;
+		for (const auto &field_value : ListValue::GetChildren(fields_value)) {
+			if (field_value.IsNull()) {
+				throw InvalidInputException("file_enrich() fields cannot contain NULL");
+			}
+			auto field = StringUtil::Lower(field_value.GetValue<string>());
+			if (field == "size") {
+				enrich_size = true;
+			} else if (field == "content_type") {
+				enrich_content_type = true;
+			} else if (field == "checksum") {
+				enrich_checksum = true;
+			} else {
+				throw InvalidInputException("file_enrich() field '%s' is not supported", field);
+			}
+		}
+
+		unique_ptr<ResolvedFile> resolved;
+		auto resolve = [&]() -> ResolvedFile & {
+			if (!resolved) {
+				resolved = ResolvedFile::Open(state.GetContext(), file);
+			}
+			return *resolved;
+		};
+		if (enrich_size && !file.has_range) {
+			auto object_size = resolve().ObjectSize();
+			file.has_range = true;
+			file.position = 0;
+			file.size = NumericCast<int64_t>(object_size);
+		}
+		if (enrich_content_type && !file.has_content_type) {
+			file.has_content_type = resolve().MimeTypeFromResolvedMetadata(file.content_type);
+			if (!file.has_content_type) {
+				file.has_content_type = resolve().GuessMimeType(file.content_type);
+			}
+		}
+		if (enrich_checksum && !file.has_checksum) {
+			auto checksum = resolve().Sha256();
+			file.has_checksum = true;
+			file.checksum = "sha256:" + checksum;
+		}
+		result.SetValue(row, file.ToValue());
+	}
+}
+
+static void FileSameLocationFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference left;
+		FileReference right;
+		if (!TryGetFile(args, 0, row, "file_same_location", left) ||
+		    !TryGetFile(args, 1, row, "file_same_location", right)) {
+			result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+			continue;
+		}
+		if (left.url != right.url) {
+			result.SetValue(row, Value::BOOLEAN(false));
+		} else if (!left.has_range && !right.has_range) {
+			result.SetValue(row, Value::BOOLEAN(true));
+		} else if (left.has_range != right.has_range) {
+			result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+		} else {
+			result.SetValue(row, Value::BOOLEAN(left.position == right.position && left.size == right.size));
+		}
+	}
+}
+
+static void FileSameContentFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference left;
+		FileReference right;
+		if (!TryGetFile(args, 0, row, "file_same_content", left) ||
+		    !TryGetFile(args, 1, row, "file_same_content", right)) {
+			result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+			continue;
+		}
+		if (left.has_range && right.has_range && left.size != right.size) {
+			result.SetValue(row, Value::BOOLEAN(false));
+			continue;
+		}
+		if (left.has_range && right.has_range && left.size == 0) {
+			result.SetValue(row, Value::BOOLEAN(true));
+			continue;
+		}
+		if (!left.has_checksum || !right.has_checksum) {
+			result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+			continue;
+		}
+		auto left_separator = left.checksum.find(':');
+		auto right_separator = right.checksum.find(':');
+		auto left_algorithm = StringUtil::Lower(left.checksum.substr(0, left_separator));
+		auto right_algorithm = StringUtil::Lower(right.checksum.substr(0, right_separator));
+		if (left_algorithm != right_algorithm) {
+			result.SetValue(row, NullValue(LogicalType::BOOLEAN));
+			continue;
+		}
+		result.SetValue(row, Value::BOOLEAN(left.checksum.substr(left_separator + 1) ==
+		                                    right.checksum.substr(right_separator + 1)));
+	}
+}
+
+static void FileLocatorIdFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_locator_id", file)) {
+			result.SetValue(row, NullValue(LogicalType::VARCHAR));
+			continue;
+		}
+		result.SetValue(row, Value(FileIdentity::LocatorId(file)));
+	}
+}
+
+static void FileContentIdFunction(DataChunk &args, ExpressionState &, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		FileReference file;
+		if (!TryGetFile(args, 0, row, "file_content_id", file)) {
+			result.SetValue(row, NullValue(LogicalType::VARCHAR));
+			continue;
+		}
+		result.SetValue(row, FileIdentity::ContentId(file));
+	}
+}
+
+static ScalarFunction MakeScalarFunction(const string &name, vector<LogicalType> arguments, LogicalType return_type,
+                                         scalar_function_t function, bool accesses_storage = false) {
+	ScalarFunction result(name, std::move(arguments), std::move(return_type), std::move(function));
+	result.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	result.SetFallible();
+	if (accesses_storage) {
+		result.SetStability(FunctionStability::VOLATILE);
+	}
+	return result;
+}
+
+} // namespace
+
+vector<ScalarFunction> FileMetadataFunctions::GetFunctions() {
+	auto file_type = FileLogicalType::Create();
+	vector<ScalarFunction> result;
+	result.push_back(MakeScalarFunction("to_file", {LogicalType::VARCHAR}, file_type, ToFileFunction<false>, true));
+	result.push_back(MakeScalarFunction("try_to_file", {LogicalType::VARCHAR}, file_type, ToFileFunction<true>, true));
+	result.push_back(MakeScalarFunction("file_enrich", {file_type, LogicalType::LIST(LogicalType::VARCHAR)}, file_type,
+	                                    FileEnrichFunction, true));
+	result.push_back(MakeScalarFunction("file_path", {file_type}, LogicalType::VARCHAR, FilePathFunction));
+	result.push_back(MakeScalarFunction("file_size", {file_type}, LogicalType::UBIGINT, FileSizeFunction, true));
+	result.push_back(MakeScalarFunction("file_exists", {file_type}, LogicalType::BOOLEAN, FileExistsFunction, true));
+	result.push_back(MakeScalarFunction("file_stat", {file_type}, FileStatValue::Type(), FileStatFunction, true));
+	result.push_back(MakeScalarFunction("file_mime_type", {file_type}, LogicalType::VARCHAR, FileMimeTypeFunction));
+	result.push_back(MakeScalarFunction("file_mime_type", {file_type, LogicalType::VARCHAR}, LogicalType::VARCHAR,
+	                                    FileMimeTypeFunction, true));
+	result.push_back(
+	    MakeScalarFunction("guess_mime_type", {LogicalType::BLOB}, LogicalType::VARCHAR, GuessMimeTypeFunction));
+	result.push_back(MakeScalarFunction("file_same_location", {file_type, file_type}, LogicalType::BOOLEAN,
+	                                    FileSameLocationFunction));
+	result.push_back(
+	    MakeScalarFunction("file_same_content", {file_type, file_type}, LogicalType::BOOLEAN, FileSameContentFunction));
+	result.push_back(MakeScalarFunction("file_locator_id", {file_type}, LogicalType::VARCHAR, FileLocatorIdFunction));
+	result.push_back(MakeScalarFunction("file_content_id", {file_type}, LogicalType::VARCHAR, FileContentIdFunction));
+	return result;
+}
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/file_mime_type.cpp
+++ b/external/duckdb/extension/file/file_mime_type.cpp
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_mime_type.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "file_mime_type.hpp"
+
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/string_util.hpp"
+
+#include <cstring>
+
+namespace duckdb {
+
+namespace {
+
+struct ExtensionMimeType {
+	const char *extension;
+	const char *mime_type;
+};
+
+struct IsoBmffMimeCandidate {
+	const char *mime_type = nullptr;
+	uint8_t priority = 0;
+};
+
+static bool HasBytes(const_data_ptr_t data, idx_t size, idx_t offset, const char *expected, idx_t expected_size) {
+	return offset <= size && expected_size <= size - offset && memcmp(data + offset, expected, expected_size) == 0;
+}
+
+static bool SetMimeType(string &result, const char *mime_type) {
+	result = mime_type;
+	return true;
+}
+
+static uint16_t ReadLittleEndianUInt16(const_data_ptr_t data) {
+	return static_cast<uint16_t>(data[0]) | (static_cast<uint16_t>(data[1]) << 8);
+}
+
+static uint32_t ReadLittleEndianUInt32(const_data_ptr_t data) {
+	return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
+	       (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
+}
+
+static uint32_t ReadBigEndianUInt32(const_data_ptr_t data) {
+	return (static_cast<uint32_t>(data[0]) << 24) | (static_cast<uint32_t>(data[1]) << 16) |
+	       (static_cast<uint32_t>(data[2]) << 8) | static_cast<uint32_t>(data[3]);
+}
+
+static uint64_t ReadBigEndianUInt64(const_data_ptr_t data) {
+	return (static_cast<uint64_t>(ReadBigEndianUInt32(data)) << 32) | ReadBigEndianUInt32(data + 4);
+}
+
+static bool IsGifHeader(const_data_ptr_t data, idx_t size) {
+	static constexpr idx_t LOGICAL_SCREEN_DESCRIPTOR_END = 13;
+	return size >= LOGICAL_SCREEN_DESCRIPTOR_END &&
+	       (HasBytes(data, size, 0, "GIF87a", 6) || HasBytes(data, size, 0, "GIF89a", 6)) &&
+	       ReadLittleEndianUInt16(data + 6) != 0 && ReadLittleEndianUInt16(data + 8) != 0;
+}
+
+static bool IsRiffForm(const_data_ptr_t data, idx_t size, const char *form_type, uint32_t minimum_payload_size = 4) {
+	return size >= 12 && HasBytes(data, size, 0, "RIFF", 4) &&
+	       ReadLittleEndianUInt32(data + 4) >= minimum_payload_size && HasBytes(data, size, 8, form_type, 4);
+}
+
+static bool IsWebpHeader(const_data_ptr_t data, idx_t size) {
+	return size >= 16 && IsRiffForm(data, size, "WEBP", 12) &&
+	       (HasBytes(data, size, 12, "VP8 ", 4) || HasBytes(data, size, 12, "VP8L", 4) ||
+	        HasBytes(data, size, 12, "VP8X", 4));
+}
+
+static bool IsOggPageHeader(const_data_ptr_t data, idx_t size) {
+	static constexpr idx_t FIXED_HEADER_SIZE = 27;
+	if (size < FIXED_HEADER_SIZE || !HasBytes(data, size, 0, "OggS", 4) || data[4] != 0 || (data[5] & 0xf8) != 0) {
+		return false;
+	}
+	return data[26] <= size - FIXED_HEADER_SIZE;
+}
+
+static bool IsMpegAudioFrameHeader(const_data_ptr_t data, idx_t size) {
+	if (size < 4 || data[0] != 0xff || (data[1] & 0xe0) != 0xe0) {
+		return false;
+	}
+	auto version = (data[1] >> 3) & 0x03;
+	auto layer = (data[1] >> 1) & 0x03;
+	auto bitrate = (data[2] >> 4) & 0x0f;
+	auto sample_rate = (data[2] >> 2) & 0x03;
+	auto emphasis = data[3] & 0x03;
+	return version != 0x01 && layer != 0x00 && bitrate != 0x00 && bitrate != 0x0f && sample_rate != 0x03 &&
+	       emphasis != 0x02;
+}
+
+static bool IsId3v2Header(const_data_ptr_t data, idx_t size, bool complete_input) {
+	if (size < 10 || !HasBytes(data, size, 0, "ID3", 3)) {
+		return false;
+	}
+	auto major_version = data[3];
+	auto revision = data[4];
+	auto flags = data[5];
+	if (major_version < 2 || major_version > 4 || revision == 0xff) {
+		return false;
+	}
+
+	static constexpr uint8_t RESERVED_FLAGS[] = {0, 0, 0x3f, 0x1f, 0x0f};
+	if ((flags & RESERVED_FLAGS[major_version]) != 0) {
+		return false;
+	}
+
+	uint64_t payload_size = 0;
+	for (idx_t offset = 6; offset < 10; offset++) {
+		if ((data[offset] & 0x80) != 0) {
+			return false;
+		}
+		payload_size = (payload_size << 7) | data[offset];
+	}
+	if (payload_size == 0) {
+		return false;
+	}
+	auto footer_size = major_version == 4 && (flags & 0x10) != 0 ? 10 : 0;
+	return !complete_input || payload_size + footer_size <= size - 10;
+}
+
+static bool IsPdfHeader(const_data_ptr_t data, idx_t size) {
+	return size >= 8 && HasBytes(data, size, 0, "%PDF-", 5) && data[5] >= '0' && data[5] <= '9' && data[6] == '.' &&
+	       data[7] >= '0' && data[7] <= '9';
+}
+
+static bool IsZipHeader(const_data_ptr_t data, idx_t size) {
+	if (HasBytes(data, size, 0, "PK\x03\x04", 4)) {
+		return size >= 30;
+	}
+	if (HasBytes(data, size, 0, "PK\x05\x06", 4)) {
+		return size >= 22;
+	}
+	return size >= 12 && HasBytes(data, size, 0, "PK\x07\x08", 4) && HasBytes(data, size, 8, "PK\x03\x04", 4);
+}
+
+static IsoBmffMimeCandidate MimeCandidateFromIsoBmffBrand(const_data_ptr_t brand) {
+	if (HasBytes(brand, 4, 0, "avif", 4)) {
+		return {"image/avif", 3};
+	}
+	if (HasBytes(brand, 4, 0, "avis", 4)) {
+		return {"image/avif-sequence", 3};
+	}
+	if (HasBytes(brand, 4, 0, "heic", 4) || HasBytes(brand, 4, 0, "heix", 4) || HasBytes(brand, 4, 0, "hevc", 4) ||
+	    HasBytes(brand, 4, 0, "hevx", 4)) {
+		return {"image/heic", 3};
+	}
+	if (HasBytes(brand, 4, 0, "mif1", 4)) {
+		return {"image/heif", 2};
+	}
+	if (HasBytes(brand, 4, 0, "msf1", 4)) {
+		return {"image/heif-sequence", 2};
+	}
+	if (HasBytes(brand, 4, 0, "M4A ", 4) || HasBytes(brand, 4, 0, "M4B ", 4)) {
+		return {"audio/mp4", 3};
+	}
+	if (HasBytes(brand, 4, 0, "qt  ", 4)) {
+		return {"video/quicktime", 3};
+	}
+	return {};
+}
+
+static void ConsiderIsoBmffBrand(const_data_ptr_t brand, IsoBmffMimeCandidate &best_candidate) {
+	auto candidate = MimeCandidateFromIsoBmffBrand(brand);
+	// The first equally specific brand wins. A concrete compatible brand still
+	// overrides a generic HEIF brand such as mif1 or msf1.
+	if (candidate.priority > best_candidate.priority) {
+		best_candidate = candidate;
+	}
+}
+
+static bool MimeTypeFromIsoBmff(const_data_ptr_t data, idx_t size, string &result) {
+	if (size < 16 || !HasBytes(data, size, 4, "ftyp", 4)) {
+		return false;
+	}
+
+	uint64_t box_size = ReadBigEndianUInt32(data);
+	idx_t brand_offset = 8;
+	idx_t compatible_brand_offset = 16;
+	if (box_size == 1) {
+		if (size < 24) {
+			return false;
+		}
+		box_size = ReadBigEndianUInt64(data + 8);
+		brand_offset = 16;
+		compatible_brand_offset = 24;
+	} else if (box_size == 0) {
+		box_size = size;
+	}
+	if (box_size < compatible_brand_offset || (box_size - compatible_brand_offset) % 4 != 0) {
+		return false;
+	}
+
+	IsoBmffMimeCandidate best_candidate;
+	ConsiderIsoBmffBrand(data + brand_offset, best_candidate);
+	auto available_box_size = NumericCast<idx_t>(MinValue<uint64_t>(box_size, size));
+	for (idx_t offset = compatible_brand_offset; offset + 4 <= available_box_size; offset += 4) {
+		ConsiderIsoBmffBrand(data + offset, best_candidate);
+	}
+	// Daft treats an otherwise unknown ftyp box as MP4. Keep that best-effort
+	// fallback after Vane's image/audio-specific routing has inspected all
+	// available compatible brands.
+	return SetMimeType(result, best_candidate.mime_type ? best_candidate.mime_type : "video/mp4");
+}
+
+static bool IsHtmlPrefix(const_data_ptr_t data, idx_t size) {
+	return HasBytes(data, size, 0, "<!DOCTYPE", 9) || HasBytes(data, size, 0, "<html", 5) ||
+	       HasBytes(data, size, 0, "<HTML", 5);
+}
+
+static bool IsUriStyleLocator(const string &path) {
+	auto separator = path.find("://");
+	if (separator == string::npos || separator == 0 || !StringUtil::CharacterIsAlpha(path[0])) {
+		return false;
+	}
+#ifdef _WIN32
+	if (separator == 1) {
+		return false;
+	}
+#endif
+	for (idx_t index = 1; index < separator; index++) {
+		auto character = path[index];
+		if (!StringUtil::CharacterIsAlpha(character) && !StringUtil::CharacterIsDigit(character) && character != '+' &&
+		    character != '-' && character != '.') {
+			return false;
+		}
+	}
+	return StringUtil::Lower(path.substr(0, separator)) != "file";
+}
+
+static string ExtensionFromPath(const string &path) {
+	auto is_uri = IsUriStyleLocator(path);
+	auto scheme_separator = is_uri ? path.find("://") : string::npos;
+	auto scheme = is_uri ? StringUtil::Lower(path.substr(0, scheme_separator)) : string();
+	auto delimiter = is_uri ? path.find_first_of("?#", scheme_separator + 3) : string::npos;
+	if (delimiter != string::npos && scheme != "http" && scheme != "https") {
+		return string();
+	}
+	auto clean_path = path.substr(0, delimiter);
+	if (is_uri && clean_path.find('/', scheme_separator + 3) == string::npos) {
+		return string();
+	}
+	auto slash = clean_path.find_last_of("/\\");
+	auto dot = clean_path.find_last_of('.');
+	if (dot == string::npos || (slash != string::npos && dot < slash) || dot + 1 == clean_path.size()) {
+		return string();
+	}
+	return StringUtil::Lower(clean_path.substr(dot + 1));
+}
+
+} // namespace
+
+bool FileMimeType::FromPath(const string &path, string &result) {
+	static constexpr ExtensionMimeType MAPPINGS[] = {
+	    {"txt", "text/plain"},
+	    {"text", "text/plain"},
+	    {"log", "text/plain"},
+	    {"csv", "text/csv"},
+	    {"tsv", "text/tab-separated-values"},
+	    {"md", "text/markdown"},
+	    {"html", "text/html"},
+	    {"htm", "text/html"},
+	    {"json", "application/json"},
+	    {"jsonl", "application/x-ndjson"},
+	    {"ndjson", "application/x-ndjson"},
+	    {"xml", "application/xml"},
+	    {"pdf", "application/pdf"},
+	    {"zip", "application/zip"},
+	    {"gz", "application/gzip"},
+	    {"gzip", "application/gzip"},
+	    {"png", "image/png"},
+	    {"jpg", "image/jpeg"},
+	    {"jpeg", "image/jpeg"},
+	    {"gif", "image/gif"},
+	    {"webp", "image/webp"},
+	    {"bmp", "image/bmp"},
+	    {"tif", "image/tiff"},
+	    {"tiff", "image/tiff"},
+	    {"avif", "image/avif"},
+	    {"avifs", "image/avif-sequence"},
+	    {"heic", "image/heic"},
+	    {"heif", "image/heif"},
+	    {"heifs", "image/heif-sequence"},
+	    {"mp3", "audio/mpeg"},
+	    {"wav", "audio/wav"},
+	    {"flac", "audio/flac"},
+	    {"aac", "audio/aac"},
+	    {"ogg", "audio/ogg"},
+	    {"oga", "audio/ogg"},
+	    {"opus", "audio/ogg"},
+	    {"m4a", "audio/mp4"},
+	    {"mp4", "video/mp4"},
+	    {"m4v", "video/mp4"},
+	    {"mov", "video/quicktime"},
+	    {"webm", "video/webm"},
+	    {"mkv", "video/x-matroska"},
+	    {"avi", "video/x-msvideo"},
+	    {"h5", "application/vnd.hdfgroup.hdf5"},
+	    {"hdf5", "application/vnd.hdfgroup.hdf5"},
+	    {"he5", "application/vnd.hdfgroup.hdf5"},
+	};
+	auto extension = ExtensionFromPath(path);
+	for (auto &mapping : MAPPINGS) {
+		if (extension == mapping.extension) {
+			return SetMimeType(result, mapping.mime_type);
+		}
+	}
+	return false;
+}
+
+bool FileMimeType::IsHdf5Signature(const_data_ptr_t data, idx_t size) {
+	static constexpr char HDF5[] = "\x89HDF\r\n\x1a\n";
+	return HasBytes(data, size, 0, HDF5, sizeof(HDF5) - 1);
+}
+
+bool FileMimeType::FromBytes(const_data_ptr_t data, idx_t size, string &result, bool complete_input) {
+	// This is deliberately a bounded, best-effort magic-byte sniffer, not a
+	// decoder or a structural validator. Consumers must validate the file when
+	// they decode it. The compact rule set follows Daft's file MIME semantics,
+	// with Vane-specific ISO-BMFF routing and HDF5 user-block support.
+	static constexpr char PNG[] = "\x89PNG\r\n\x1a\n";
+	if (HasBytes(data, size, 0, PNG, sizeof(PNG) - 1)) {
+		return SetMimeType(result, "image/png");
+	}
+	if (size >= 3 && data[0] == 0xff && data[1] == 0xd8 && data[2] == 0xff) {
+		return SetMimeType(result, "image/jpeg");
+	}
+	if (IsGifHeader(data, size)) {
+		return SetMimeType(result, "image/gif");
+	}
+	if (IsWebpHeader(data, size)) {
+		return SetMimeType(result, "image/webp");
+	}
+	if (MimeTypeFromIsoBmff(data, size, result)) {
+		return true;
+	}
+	if (IsId3v2Header(data, size, complete_input) || IsMpegAudioFrameHeader(data, size)) {
+		return SetMimeType(result, "audio/mpeg");
+	}
+	if (IsRiffForm(data, size, "WAVE")) {
+		return SetMimeType(result, "audio/wav");
+	}
+	if (IsOggPageHeader(data, size)) {
+		return SetMimeType(result, "audio/ogg");
+	}
+	if (HasBytes(data, size, 0, "\x00\x00\x01\xba", 4)) {
+		return SetMimeType(result, "video/mpeg");
+	}
+	static constexpr idx_t HDF5_SIGNATURE_SIZE = 8;
+	for (idx_t offset = 0; offset + HDF5_SIGNATURE_SIZE <= size; offset = offset == 0 ? 512 : offset * 2) {
+		if (IsHdf5Signature(data + offset, size - offset)) {
+			return SetMimeType(result, "application/vnd.hdfgroup.hdf5");
+		}
+		if (offset > size / 2) {
+			break;
+		}
+	}
+	if (IsPdfHeader(data, size)) {
+		return SetMimeType(result, "application/pdf");
+	}
+	if (IsZipHeader(data, size)) {
+		return SetMimeType(result, "application/zip");
+	}
+	if (IsHtmlPrefix(data, size)) {
+		return SetMimeType(result, "text/html");
+	}
+	return false;
+}
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/file_resolver.cpp
+++ b/external/duckdb/extension/file/file_resolver.cpp
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_resolver.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "file_resolver.hpp"
+
+#include "file_mime_type.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/opener_file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/timestamp.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "mbedtls_wrapper.hpp"
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
+
+namespace duckdb {
+
+namespace {
+
+static Value OptionalStringValue(bool has_value, const string &value) {
+	return has_value ? Value(value) : Value(LogicalType::VARCHAR);
+}
+
+#ifndef _WIN32
+static bool IsNativeLocalNonRegularPath(FileSystem &file_system, const string &path) {
+	auto scheme_separator = path.find("://");
+	if (scheme_separator != string::npos && !StringUtil::StartsWith(StringUtil::Lower(path), "file://")) {
+		return false;
+	}
+	auto local_path = file_system.ExpandPath(path);
+	struct stat status;
+	return stat(local_path.c_str(), &status) == 0 && !S_ISREG(status.st_mode);
+}
+#endif
+
+static bool TryGetMetadataString(const FileMetadata &metadata, const string &name, string &result) {
+	auto entry = metadata.extended_file_info.find(name);
+	if (entry == metadata.extended_file_info.end() || entry->second.IsNull() ||
+	    entry->second.type().id() == LogicalTypeId::BLOB) {
+		return false;
+	}
+	result = entry->second.DefaultCastAs(LogicalType::VARCHAR).GetValue<string>();
+	return !result.empty();
+}
+
+} // namespace
+
+LogicalType FileStatValue::Type() {
+	child_list_t<LogicalType> fields;
+	fields.emplace_back("url", LogicalType::VARCHAR);
+	fields.emplace_back("object_size", LogicalType::UBIGINT);
+	fields.emplace_back("last_modified", LogicalType::TIMESTAMP);
+	fields.emplace_back("version", LogicalType::VARCHAR);
+	fields.emplace_back("etag", LogicalType::VARCHAR);
+	fields.emplace_back("content_type", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(fields));
+}
+
+Value FileStatValue::ToValue() const {
+	vector<Value> fields;
+	fields.reserve(6);
+	fields.emplace_back(url);
+	fields.push_back(has_object_size ? Value::UBIGINT(object_size) : Value(LogicalType::UBIGINT));
+	fields.push_back(has_last_modified ? Value::TIMESTAMP(last_modified) : Value(LogicalType::TIMESTAMP));
+	fields.push_back(OptionalStringValue(has_version, version));
+	fields.push_back(OptionalStringValue(has_etag, etag));
+	fields.push_back(OptionalStringValue(has_content_type, content_type));
+	return Value::STRUCT(Type(), std::move(fields));
+}
+
+ResolvedFile::ResolvedFile(ClientContext &context_p, unique_ptr<FileHandle> handle_p, FileReference file_p,
+                           uint64_t object_size_p, uint64_t logical_position_p, uint64_t logical_size_p)
+    : context(context_p), handle(std::move(handle_p)), file(std::move(file_p)), object_size(object_size_p),
+      logical_position(logical_position_p), logical_size(logical_size_p) {
+}
+
+unique_ptr<ResolvedFile> ResolvedFile::Open(ClientContext &context, const FileReference &file) {
+	file.Validate("FILE resolver");
+	if (context.IsInterrupted()) {
+		throw InterruptException();
+	}
+	auto &file_system = FileSystem::GetFileSystem(context);
+#ifdef _WIN32
+	file_system.Cast<OpenerFileSystem>().VerifyCanAccessFile(file.url);
+	if (file_system.IsPipe(file.url)) {
+		throw IOException({{"file_kind", "not_regular"}}, "FILE resolver requires a regular file");
+	}
+#endif
+	auto flags = FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_PARALLEL_ACCESS | FileFlags::FILE_FLAGS_NONBLOCKING;
+	unique_ptr<FileHandle> handle;
+	try {
+		handle = file_system.OpenFile(file.url, flags);
+	} catch (const IOException &) {
+#ifndef _WIN32
+		if (IsNativeLocalNonRegularPath(file_system, file.url)) {
+			throw IOException({{"file_kind", "not_regular"}}, "FILE resolver requires a regular file");
+		}
+#endif
+		throw;
+	}
+	if (!handle) {
+		throw IOException("FILE resolver could not open the requested file");
+	}
+	auto file_type = handle->file_system.GetFileType(*handle);
+	// VirtualFileSystem wraps native FIFOs in PipeFileSystem, whose generic file type is INVALID.
+	// Consult the opened handle in that case so the wrapper cannot be mistaken for an untyped remote file.
+	if (file_type != FileType::FILE_TYPE_REGULAR && (file_type != FileType::FILE_TYPE_INVALID || handle->IsPipe())) {
+		throw IOException({{"file_kind", "not_regular"}}, "FILE resolver requires a regular file");
+	}
+	auto signed_object_size = handle->file_system.GetFileSize(*handle);
+	if (signed_object_size < 0) {
+		throw IOException("FILE resolver could not determine the object size");
+	}
+	auto object_size = NumericCast<uint64_t>(signed_object_size);
+	auto logical_position = file.has_range ? NumericCast<uint64_t>(file.position) : 0;
+	auto logical_size = file.has_range ? NumericCast<uint64_t>(file.size) : object_size;
+	if (logical_position > object_size || logical_size > object_size - logical_position) {
+		throw IOException({{"file_range", "out_of_bounds"}},
+		                  "FILE byte range [%d, %d) exceeds the backing object size %d", logical_position,
+		                  logical_position + logical_size, object_size);
+	}
+	return unique_ptr<ResolvedFile>(
+	    new ResolvedFile(context, std::move(handle), file, object_size, logical_position, logical_size));
+}
+
+uint64_t ResolvedFile::ObjectSize() const {
+	return object_size;
+}
+
+uint64_t ResolvedFile::LogicalSize() const {
+	return logical_size;
+}
+
+FileStatValue ResolvedFile::Stat() const {
+	FileStatValue result;
+	result.url = file.url;
+	result.has_object_size = true;
+	result.object_size = object_size;
+	auto is_local_file = handle->file_system.IsLocalFileSystem();
+	FileMetadata metadata;
+	bool has_metadata = false;
+
+	try {
+		metadata = handle->file_system.Stats(*handle);
+		has_metadata = true;
+	} catch (const NotImplementedException &) {
+	}
+
+	if (has_metadata) {
+		auto last_modified = metadata.last_modification_time;
+		if (Timestamp::IsFinite(last_modified)) {
+			result.has_last_modified = true;
+			result.last_modified = last_modified;
+		}
+		result.has_version = TryGetMetadataString(metadata, "version", result.version) ||
+		                     TryGetMetadataString(metadata, "version_id", result.version);
+		result.has_etag = TryGetMetadataString(metadata, "etag", result.etag);
+	}
+
+	if (!result.has_last_modified) {
+		try {
+			auto last_modified = handle->file_system.GetLastModifiedTime(*handle);
+			if (Timestamp::IsFinite(last_modified) && !(!is_local_file && last_modified == timestamp_t())) {
+				result.has_last_modified = true;
+				result.last_modified = last_modified;
+			}
+		} catch (const NotImplementedException &) {
+		}
+	}
+
+	if (!is_local_file && !result.has_version && !result.has_etag) {
+		try {
+			auto version_tag = handle->file_system.GetVersionTag(*handle);
+			if (!version_tag.empty()) {
+				result.has_etag = true;
+				result.etag = std::move(version_tag);
+			}
+		} catch (const NotImplementedException &) {
+		}
+	}
+
+	if (file.has_content_type) {
+		result.has_content_type = true;
+		result.content_type = file.content_type;
+	} else if (has_metadata && (TryGetMetadataString(metadata, "content_type", result.content_type) ||
+	                            TryGetMetadataString(metadata, "mime_type", result.content_type))) {
+		result.has_content_type = true;
+	} else {
+		result.has_content_type = FileMimeType::FromPath(file.url, result.content_type);
+	}
+	return result;
+}
+
+bool ResolvedFile::MimeTypeFromResolvedMetadata(string &result) const {
+	if (file.has_content_type) {
+		result = file.content_type;
+		return true;
+	}
+	try {
+		auto metadata = handle->file_system.Stats(*handle);
+		if (TryGetMetadataString(metadata, "content_type", result) ||
+		    TryGetMetadataString(metadata, "mime_type", result)) {
+			return true;
+		}
+	} catch (const NotImplementedException &) {
+	}
+	return FileMimeType::FromPath(file.url, result);
+}
+
+void ResolvedFile::ReadExact(data_ptr_t target, uint64_t size, uint64_t logical_offset) const {
+	if (logical_offset > logical_size || size > logical_size - logical_offset) {
+		throw OutOfRangeException("FILE read [%d, %d) exceeds the logical view size %d", logical_offset,
+		                          logical_offset + size, logical_size);
+	}
+	if (size == 0) {
+		return;
+	}
+	if (context.IsInterrupted()) {
+		throw InterruptException();
+	}
+	auto read_size = NumericCast<idx_t>(size);
+	auto absolute_offset = NumericCast<idx_t>(logical_position + logical_offset);
+	try {
+		handle->Read(QueryContext(context), target, read_size, absolute_offset);
+		if (context.IsInterrupted()) {
+			throw InterruptException();
+		}
+		return;
+	} catch (const NotImplementedException &) {
+		// Some registered file systems only implement seek plus sequential reads.
+	}
+
+	if (context.IsInterrupted()) {
+		throw InterruptException();
+	}
+	handle->Seek(absolute_offset);
+	idx_t total_read = 0;
+	while (total_read < read_size) {
+		if (context.IsInterrupted()) {
+			throw InterruptException();
+		}
+		auto remaining = read_size - total_read;
+		auto bytes_read = handle->Read(QueryContext(context), target + total_read, remaining);
+		if (bytes_read <= 0) {
+			throw IOException("FILE resolver encountered a short read: expected %d bytes, received %d", read_size,
+			                  total_read);
+		}
+		auto read_count = NumericCast<idx_t>(bytes_read);
+		if (read_count > remaining) {
+			throw IOException("FILE resolver received %d bytes after requesting at most %d", read_count, remaining);
+		}
+		total_read += read_count;
+	}
+}
+
+string ResolvedFile::Sha256() const {
+	duckdb_mbedtls::MbedTlsWrapper::SHA256State state;
+	static constexpr idx_t BUFFER_SIZE = 1024 * 1024;
+	vector<data_t> buffer(MinValue<uint64_t>(logical_size, BUFFER_SIZE));
+	uint64_t offset = 0;
+	while (offset < logical_size) {
+		if (context.IsInterrupted()) {
+			throw InterruptException();
+		}
+		auto next_size = MinValue<uint64_t>(logical_size - offset, buffer.size());
+		ReadExact(buffer.data(), next_size, offset);
+		if (context.IsInterrupted()) {
+			throw InterruptException();
+		}
+		state.AddBytes(buffer.data(), next_size);
+		offset += next_size;
+	}
+	string result(duckdb_mbedtls::MbedTlsWrapper::SHA256_HASH_LENGTH_TEXT, '\0');
+	state.FinishHex(&result[0]);
+	return result;
+}
+
+bool ResolvedFile::GuessMimeType(string &result, idx_t maximum_bytes) const {
+	auto probe_size = MinValue<uint64_t>(logical_size, maximum_bytes);
+	if (probe_size == 0) {
+		return false;
+	}
+	vector<data_t> prefix(NumericCast<idx_t>(probe_size));
+	ReadExact(prefix.data(), probe_size);
+	if (FileMimeType::FromBytes(prefix.data(), prefix.size(), result, probe_size == logical_size)) {
+		return true;
+	}
+
+	static constexpr idx_t HDF5_SIGNATURE_SIZE = 8;
+	vector<data_t> hdf5_signature(HDF5_SIGNATURE_SIZE);
+	for (uint64_t offset = 0; offset <= logical_size && HDF5_SIGNATURE_SIZE <= logical_size - offset;) {
+		// FromBytes already inspected every legal offset wholly contained in the
+		// prefix, so only the remaining offsets require another range read.
+		if (offset + HDF5_SIGNATURE_SIZE > prefix.size()) {
+			ReadExact(hdf5_signature.data(), HDF5_SIGNATURE_SIZE, offset);
+			if (FileMimeType::IsHdf5Signature(hdf5_signature.data(), hdf5_signature.size())) {
+				result = "application/vnd.hdfgroup.hdf5";
+				return true;
+			}
+		}
+		if (offset == 0) {
+			offset = 512;
+		} else {
+			if (offset > logical_size / 2) {
+				break;
+			}
+			offset *= 2;
+		}
+	}
+	return false;
+}
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/file_value.cpp
+++ b/external/duckdb/extension/file/file_value.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_value.cpp
+//
+//===----------------------------------------------------------------------===//
+
+#include "file_value.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "mbedtls_wrapper.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static Value OptionalStringValue(bool has_value, const string &value) {
+	return has_value ? Value(value) : Value(LogicalType::VARCHAR);
+}
+
+static Value OptionalBigintValue(bool has_value, int64_t value) {
+	return has_value ? Value::BIGINT(value) : Value(LogicalType::BIGINT);
+}
+
+static void AppendBigEndianUInt64(string &target, uint64_t value) {
+	for (idx_t byte_index = 0; byte_index < sizeof(uint64_t); byte_index++) {
+		auto shift = NumericCast<uint8_t>((sizeof(uint64_t) - byte_index - 1) * 8);
+		target.push_back(static_cast<char>((value >> shift) & 0xff));
+	}
+}
+
+static string Sha256Hex(const string &input) {
+	duckdb_mbedtls::MbedTlsWrapper::SHA256State state;
+	state.AddBytes(const_data_ptr_cast(input.data()), input.size());
+	string result(duckdb_mbedtls::MbedTlsWrapper::SHA256_HASH_LENGTH_TEXT, '\0');
+	state.FinishHex(&result[0]);
+	return result;
+}
+
+} // namespace
+
+FileReference FileReference::FromFields(const Value &url_value, const Value &content_type_value,
+                                        const Value &position_value, const Value &size_value,
+                                        const Value &checksum_value, const string &function_name) {
+	FileReference result;
+	string url;
+	const string *url_ptr = nullptr;
+	if (!url_value.IsNull()) {
+		url = url_value.GetValue<string>();
+		url_ptr = &url;
+	}
+	auto has_position = !position_value.IsNull();
+	auto has_size = !size_value.IsNull();
+	auto position = has_position ? position_value.GetValue<int64_t>() : 0;
+	auto size = has_size ? size_value.GetValue<int64_t>() : 0;
+	string checksum;
+	const string *checksum_ptr = nullptr;
+	if (!checksum_value.IsNull()) {
+		checksum = checksum_value.GetValue<string>();
+		checksum_ptr = &checksum;
+	}
+	ValidateFields(url_ptr, has_position, position, has_size, size, checksum_ptr, function_name);
+
+	result.url = std::move(url);
+	if (!content_type_value.IsNull()) {
+		result.has_content_type = true;
+		result.content_type = content_type_value.GetValue<string>();
+	}
+	if (has_position) {
+		result.has_range = true;
+		result.position = position;
+		result.size = size;
+	}
+	if (checksum_ptr) {
+		result.has_checksum = true;
+		result.checksum = std::move(checksum);
+	}
+	return result;
+}
+
+FileReference FileReference::FromValue(const Value &value, const string &function_name) {
+	if (value.IsNull()) {
+		throw InternalException("FileReference::FromValue called with NULL");
+	}
+	if (!FileLogicalType::IsFile(value.type())) {
+		throw InvalidInputException("%s() requires an exact FILE value", function_name);
+	}
+	const auto &children = StructValue::GetChildren(value);
+	if (children.size() != FileLogicalType::FIELD_COUNT) {
+		throw InvalidInputException("%s() received a malformed FILE value", function_name);
+	}
+	return FromFields(children[FileLogicalType::URL], children[FileLogicalType::CONTENT_TYPE],
+	                  children[FileLogicalType::POSITION], children[FileLogicalType::SIZE],
+	                  children[FileLogicalType::CHECKSUM], function_name);
+}
+
+void FileReference::ValidateFields(const string *url, bool has_position, int64_t position, bool has_size, int64_t size,
+                                   const string *checksum, const string &function_name) {
+	if (!url) {
+		throw InvalidInputException("%s() url cannot be NULL", function_name);
+	}
+	if (url->find('\0') != string::npos) {
+		throw InvalidInputException("%s() url cannot contain NUL bytes", function_name);
+	}
+	if (has_position != has_size) {
+		throw InvalidInputException("%s() position and size must either both be NULL or both be non-NULL",
+		                            function_name);
+	}
+	if (has_position && (position < 0 || size < 0)) {
+		throw InvalidInputException("%s() position and size must be non-negative", function_name);
+	}
+	if (has_position && position > NumericLimits<int64_t>::Maximum() - size) {
+		throw InvalidInputException("%s() byte range exceeds BIGINT", function_name);
+	}
+	if (checksum) {
+		auto separator = checksum->find(':');
+		if (checksum->find('\0') != string::npos || separator == string::npos || separator == 0 ||
+		    separator + 1 == checksum->size() || checksum->find(':', separator + 1) != string::npos) {
+			throw InvalidInputException("%s() checksum must have the form <algorithm>:<digest>", function_name);
+		}
+	}
+}
+
+void FileReference::Validate(const string &function_name) const {
+	ValidateFields(&url, has_range, position, has_range, size, has_checksum ? &checksum : nullptr, function_name);
+}
+
+Value FileReference::ToValue() const {
+	Validate("FILE output");
+	vector<Value> fields;
+	fields.reserve(FileLogicalType::FIELD_COUNT);
+	fields.emplace_back(url);
+	fields.push_back(OptionalStringValue(has_content_type, content_type));
+	fields.push_back(OptionalBigintValue(has_range, position));
+	fields.push_back(OptionalBigintValue(has_range, size));
+	fields.push_back(OptionalStringValue(has_checksum, checksum));
+	return Value::STRUCT(FileLogicalType::Create(), std::move(fields));
+}
+
+string FileIdentity::LocatorId(const FileReference &file) {
+	file.Validate("file_locator_id");
+	string canonical = "vane:file-locator:v1";
+	canonical.push_back('\0');
+	AppendBigEndianUInt64(canonical, file.url.size());
+	canonical.append(file.url);
+	canonical.push_back(file.has_range ? '\1' : '\0');
+	if (file.has_range) {
+		AppendBigEndianUInt64(canonical, NumericCast<uint64_t>(file.position));
+		AppendBigEndianUInt64(canonical, NumericCast<uint64_t>(file.size));
+	}
+	return "file-locator-v1:sha256:" + Sha256Hex(canonical);
+}
+
+string FileIdentity::NormalizeChecksum(const string &checksum) {
+	auto separator = checksum.find(':');
+	D_ASSERT(separator != string::npos);
+	return StringUtil::Lower(checksum.substr(0, separator)) + checksum.substr(separator);
+}
+
+Value FileIdentity::ContentId(const FileReference &file) {
+	file.Validate("file_content_id");
+	if (file.has_range && file.size == 0) {
+		return Value("file-content-v1:empty");
+	}
+	if (!file.has_checksum) {
+		return Value(LogicalType::VARCHAR);
+	}
+	return Value("file-content-v1:checksum:" + NormalizeChecksum(file.checksum));
+}
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/include/file_metadata_functions.hpp
+++ b/external/duckdb/extension/file/include/file_metadata_functions.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_metadata_functions.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+struct FileMetadataFunctions {
+	static vector<ScalarFunction> GetFunctions();
+};
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/include/file_mime_type.hpp
+++ b/external/duckdb/extension/file/include/file_mime_type.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_mime_type.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types.hpp"
+
+namespace duckdb {
+
+struct FileMimeType {
+	// MIME results are bounded best-effort routing hints, not file validation.
+	static bool FromPath(const string &path, string &result);
+	static bool FromBytes(const_data_ptr_t data, idx_t size, string &result, bool complete_input);
+	static bool IsHdf5Signature(const_data_ptr_t data, idx_t size);
+};
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/include/file_resolver.hpp
+++ b/external/duckdb/extension/file/include/file_resolver.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_resolver.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "file_value.hpp"
+
+#include "duckdb/common/file_system.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+
+struct FileStatValue {
+	string url;
+	uint64_t object_size = 0;
+	timestamp_t last_modified;
+	string version;
+	string etag;
+	string content_type;
+	bool has_object_size = false;
+	bool has_last_modified = false;
+	bool has_version = false;
+	bool has_etag = false;
+	bool has_content_type = false;
+
+	static LogicalType Type();
+	Value ToValue() const;
+};
+
+class ResolvedFile {
+public:
+	static unique_ptr<ResolvedFile> Open(ClientContext &context, const FileReference &file);
+
+	uint64_t ObjectSize() const;
+	uint64_t LogicalSize() const;
+	FileStatValue Stat() const;
+	bool MimeTypeFromResolvedMetadata(string &result) const;
+	void ReadExact(data_ptr_t target, uint64_t size, uint64_t logical_offset = 0) const;
+	string Sha256() const;
+	bool GuessMimeType(string &result, idx_t maximum_bytes = 4096 + 8) const;
+
+private:
+	ResolvedFile(ClientContext &context, unique_ptr<FileHandle> handle, FileReference file, uint64_t object_size,
+	             uint64_t logical_position, uint64_t logical_size);
+
+	ClientContext &context;
+	unique_ptr<FileHandle> handle;
+	FileReference file;
+	uint64_t object_size;
+	uint64_t logical_position;
+	uint64_t logical_size;
+};
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/include/file_value.hpp
+++ b/external/duckdb/extension/file/include/file_value.hpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// file_value.hpp
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/common/types/value.hpp"
+
+namespace duckdb {
+
+//! A validated, extension-owned view of the five fields in a FILE value.
+struct FileReference {
+	string url;
+	string content_type;
+	int64_t position = 0;
+	int64_t size = 0;
+	string checksum;
+	bool has_content_type = false;
+	bool has_range = false;
+	bool has_checksum = false;
+
+	static FileReference FromFields(const Value &url, const Value &content_type, const Value &position,
+	                                const Value &size, const Value &checksum, const string &function_name);
+	static FileReference FromValue(const Value &value, const string &function_name);
+	static void ValidateFields(const string *url, bool has_position, int64_t position, bool has_size, int64_t size,
+	                           const string *checksum, const string &function_name);
+
+	void Validate(const string &function_name) const;
+	Value ToValue() const;
+};
+
+struct FileIdentity {
+	static string LocatorId(const FileReference &file);
+	static string NormalizeChecksum(const string &checksum);
+	static Value ContentId(const FileReference &file);
+};
+
+} // namespace duckdb

--- a/external/duckdb/src/common/file_system.cpp
+++ b/external/duckdb/src/common/file_system.cpp
@@ -62,6 +62,7 @@ constexpr FileOpenFlags FileFlags::FILE_FLAGS_NULL_IF_EXISTS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_MULTI_CLIENT_ACCESS;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_DISABLE_LOGGING;
 constexpr FileOpenFlags FileFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
+constexpr FileOpenFlags FileFlags::FILE_FLAGS_NONBLOCKING;
 
 void FileOpenFlags::Verify() {
 #ifdef DEBUG

--- a/external/duckdb/src/common/local_file_system.cpp
+++ b/external/duckdb/src/common/local_file_system.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/logging/log_manager.hpp"
 #include "duckdb/common/multi_file/multi_file_list.hpp"
 
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <sys/stat.h>
@@ -356,6 +357,9 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 #else
 		open_flags |= O_DIRECT;
 #endif
+	}
+	if (flags.OpenNonBlocking()) {
+		open_flags |= O_NONBLOCK;
 	}
 
 	// Determine permissions
@@ -866,6 +870,24 @@ std::string LocalFileSystem::GetLastErrorAsString() {
 	return message;
 }
 
+static bool IsWindowsNotFoundError(DWORD error_code) {
+	return error_code == ERROR_FILE_NOT_FOUND || error_code == ERROR_PATH_NOT_FOUND ||
+	       error_code == ERROR_INVALID_DRIVE;
+}
+
+static unordered_map<string, string> WindowsErrorInfo(DWORD error_code) {
+	unordered_map<string, string> result;
+	result["windows_error"] = std::to_string(error_code);
+	if (IsWindowsNotFoundError(error_code)) {
+		result["errno"] = std::to_string(ENOENT);
+	} else if (error_code == ERROR_DIRECTORY) {
+		result["errno"] = std::to_string(ENOTDIR);
+	} else if (error_code == ERROR_ACCESS_DENIED) {
+		result["errno"] = std::to_string(EACCES);
+	}
+	return result;
+}
+
 static timestamp_t FiletimeToTimeStamp(FILETIME file_time) {
 	// https://stackoverflow.com/questions/29266743/what-is-dwlowdatetime-and-dwhighdatetime
 	ULARGE_INTEGER ul;
@@ -1076,19 +1098,26 @@ unique_ptr<FileHandle> LocalFileSystem::OpenFile(const string &path_p, FileOpenF
 	if (flags.DirectIO()) {
 		flags_and_attributes |= FILE_FLAG_NO_BUFFERING;
 	}
+	if (flags.OpenNonBlocking()) {
+		// This also lets the caller open a directory and reject it from the resulting handle type.
+		flags_and_attributes |= FILE_FLAG_BACKUP_SEMANTICS;
+	}
 	HANDLE hFile = CreateFileW(unicode_path.c_str(), desired_access, share_mode, NULL, creation_disposition,
 	                           flags_and_attributes, NULL);
 	if (hFile == INVALID_HANDLE_VALUE) {
-		if (flags.ReturnNullIfNotExists() && GetLastError() == ERROR_FILE_NOT_FOUND) {
+		auto error_code = GetLastError();
+		if (flags.ReturnNullIfNotExists() && IsWindowsNotFoundError(error_code)) {
 			return nullptr;
 		}
+		SetLastError(error_code);
 		auto error = LocalFileSystem::GetLastErrorAsString();
 
 		auto extended_error = AdditionalLockInfo(unicode_path);
 		if (!extended_error.empty()) {
 			extended_error = "\n" + extended_error;
 		}
-		throw IOException("Cannot open file \"%s\": %s%s", path.c_str(), error, extended_error);
+		throw IOException(WindowsErrorInfo(error_code), "Cannot open file \"%s\": %s%s", path.c_str(), error,
+		                  extended_error);
 	}
 	auto handle = make_uniq<WindowsFileHandle>(*this, path.c_str(), hFile, flags);
 	if (flags.OpenForAppending()) {

--- a/external/duckdb/src/include/duckdb/common/file_open_flags.hpp
+++ b/external/duckdb/src/include/duckdb/common/file_open_flags.hpp
@@ -32,6 +32,7 @@ public:
 	static constexpr idx_t FILE_FLAGS_MULTI_CLIENT_ACCESS = idx_t(1 << 11);
 	static constexpr idx_t FILE_FLAGS_DISABLE_LOGGING = idx_t(1 << 12);
 	static constexpr idx_t FILE_FLAGS_ENABLE_EXTENSION_INSTALL = idx_t(1 << 13);
+	static constexpr idx_t FILE_FLAGS_NONBLOCKING = idx_t(1 << 14);
 
 public:
 	FileOpenFlags() = default;
@@ -132,6 +133,9 @@ public:
 	inline bool EnableExtensionInstall() const {
 		return flags & FILE_FLAGS_ENABLE_EXTENSION_INSTALL;
 	}
+	inline bool OpenNonBlocking() const {
+		return flags & FILE_FLAGS_NONBLOCKING;
+	}
 	inline idx_t GetFlagsInternal() const {
 		return flags;
 	}
@@ -180,6 +184,8 @@ public:
 	//! Opened file is allowed to be a duckdb_extension
 	static constexpr FileOpenFlags FILE_FLAGS_ENABLE_EXTENSION_INSTALL =
 	    FileOpenFlags(FileOpenFlags::FILE_FLAGS_ENABLE_EXTENSION_INSTALL);
+	//! Open without waiting for a special-file peer. This has no effect on regular files.
+	static constexpr FileOpenFlags FILE_FLAGS_NONBLOCKING = FileOpenFlags(FileOpenFlags::FILE_FLAGS_NONBLOCKING);
 };
 
 } // namespace duckdb

--- a/external/duckdb/test/common/test_file_system.cpp
+++ b/external/duckdb/test/common/test_file_system.cpp
@@ -10,6 +10,7 @@
 #include "test_helpers.hpp"
 #if (!defined(_WIN32) && !defined(WIN32))
 #define TEST_HAVE_SYMLINK
+#include <sys/stat.h>
 #include <unistd.h>
 #else
 #include "duckdb/common/windows.hpp"
@@ -192,6 +193,31 @@ TEST_CASE("Test file operations", "[file_system]") {
 	handle.reset();
 	fs->RemoveFile(fname);
 }
+
+#if !defined(_WIN32) && !defined(WIN32)
+TEST_CASE("Nonblocking local opens do not wait for FIFO peers", "[file_system]") {
+	auto fs = FileSystem::CreateLocal();
+	auto fifo_path = TestCreatePath("nonblocking_open_fifo");
+	if (fs->IsPipe(fifo_path)) {
+		fs->RemoveFile(fifo_path);
+	}
+	REQUIRE(mkfifo(fifo_path.c_str(), 0600) == 0);
+
+	auto handle = fs->OpenFile(fifo_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NONBLOCKING);
+	REQUIRE(handle);
+	REQUIRE(fs->GetFileType(*handle) == FileType::FILE_TYPE_FIFO);
+	handle.reset();
+
+	auto virtual_fs = make_uniq<VirtualFileSystem>(FileSystem::CreateLocal());
+	auto wrapped_handle =
+	    virtual_fs->OpenFile(fifo_path, FileFlags::FILE_FLAGS_READ | FileFlags::FILE_FLAGS_NONBLOCKING |
+	                                        FileFlags::FILE_FLAGS_PARALLEL_ACCESS);
+	REQUIRE(wrapped_handle);
+	REQUIRE(wrapped_handle->IsPipe());
+	wrapped_handle.reset();
+	fs->RemoveFile(fifo_path);
+}
+#endif
 
 TEST_CASE("absolute paths", "[file_system]") {
 	duckdb::LocalFileSystem fs;

--- a/external/duckdb/test/sql/file/test_file_io.test
+++ b/external/duckdb/test/sql/file/test_file_io.test
@@ -1,0 +1,287 @@
+# name: test/sql/file/test_file_io.test
+# description: Test FILE execution-time metadata, content evidence, and identity
+# group: [file]
+
+require file
+
+statement ok
+PRAGMA enable_verification
+
+# Constructor fields and suffix metadata remain usable without opening the URL.
+query TI
+SELECT file_path(value), file_size(value)
+FROM (SELECT file('missing.txt', NULL, 7, 3, NULL) AS value)
+----
+missing.txt	3
+
+query T
+SELECT file_mime_type(file('missing.txt', NULL, NULL, NULL, NULL))
+----
+text/plain
+
+# Conversion opens the object and materializes the complete logical window.
+query TTIIT
+SELECT typeof(value), value.url, value.position, value.size, value.content_type
+FROM (SELECT to_file('test/sql/table_function/files/one.txt') AS value)
+----
+FILE	test/sql/table_function/files/one.txt	0	12	text/plain
+
+query I
+SELECT try_to_file('test/sql/table_function/files/does-not-exist') IS NULL
+----
+true
+
+statement error
+SELECT to_file('test/sql/table_function/files/does-not-exist')
+----
+<REGEX>:.*(Cannot open file|could not open).*
+
+query IIIII
+SELECT
+	file_exists(file('test/sql/table_function/files/one.txt', NULL, NULL, NULL, NULL)),
+	file_exists(file('test/sql/table_function/files/does-not-exist', NULL, NULL, NULL, NULL)),
+	file_exists(file('test/sql/table_function/files', NULL, NULL, NULL, NULL)),
+	file_exists(file('test/sql/table_function/files/one.txt', NULL, 12, 0, NULL)),
+	file_exists(file('test/sql/table_function/files/one.txt', NULL, 13, 0, NULL))
+----
+true	false	false	true	false
+
+query IIIII
+SELECT
+	file_stat(value).object_size,
+	file_stat(value).last_modified IS NOT NULL,
+	file_stat(value).version IS NULL,
+	file_stat(value).etag IS NULL,
+	file_stat(value).content_type = 'text/plain'
+FROM (SELECT file('test/sql/table_function/files/one.txt', NULL, 6, 5, NULL) AS value)
+----
+12	true	true	true	true
+
+# MIME sniffing reads only the declared logical view.
+query TTTTT
+SELECT
+	guess_mime_type(unhex('89504e470d0a1a0a')),
+	guess_mime_type(unhex('504b0304')),
+	file_mime_type(file('test/sql/table_function/files/four.blob', NULL, NULL, NULL, NULL), 'content'),
+	file_mime_type(file('test/sql/table_function/files/four.blob', NULL, 4, 8, NULL), 'content'),
+	file_mime_type(file('test/sql/table_function/files/one.txt', NULL, NULL, NULL, NULL), 'auto')
+----
+image/png	NULL	application/zip	NULL	text/plain
+
+# Content sniffing follows Daft's bounded best-effort contract. Unknown binary,
+# plain text, and structured text without a supported magic signature return NULL.
+query TTTT
+SELECT
+	guess_mime_type(unhex('0001')),
+	guess_mime_type('plain text'::BLOB),
+	guess_mime_type('{}'::BLOB),
+	guess_mime_type('GIF89a notes'::BLOB)
+----
+NULL	NULL	NULL	NULL
+
+query TTTTTT
+SELECT
+	guess_mime_type(unhex('89504e470d0a1a0a')),
+	guess_mime_type(unhex('ffd8ff')),
+	guess_mime_type(unhex('47494638396101000100000000')),
+	guess_mime_type(unhex('524946460c0000005745425056503820')),
+	guess_mime_type(unhex('255044462d312e37')),
+	guess_mime_type(unhex('504b03040a00' || repeat('00', 24)))
+----
+image/png	image/jpeg	image/gif	image/webp	application/pdf	application/zip
+
+query TTTTTTT
+SELECT
+	guess_mime_type(unhex('4944330400000000000b5449543200000001000000')),
+	guess_mime_type(unhex('fffb9064')),
+	guess_mime_type(unhex('524946460400000057415645')),
+	guess_mime_type(unhex('4f6767530000' || repeat('00', 21))),
+	guess_mime_type(unhex('000001ba')),
+	guess_mime_type('<html'::BLOB),
+	guess_mime_type(unhex('894844460d0a1a0a'))
+----
+audio/mpeg	audio/mpeg	audio/wav	audio/ogg	video/mpeg	text/html	application/vnd.hdfgroup.hdf5
+
+# ISO-BMFF inspects every available brand. Specific compatible brands override
+# generic container brands regardless of their order.
+query TTTTTT
+SELECT
+	guess_mime_type(unhex('00000010667479706d70343200000000')),
+	guess_mime_type(unhex('00000010667479707878787800000000')),
+	guess_mime_type(unhex('000000146674797069736f6d000000004d344120')),
+	guess_mime_type(unhex('00000014667479706d6966310000000061766966')),
+	guess_mime_type(unhex('00000014667479706d6966310000000068656963')),
+	guess_mime_type(unhex('00000011667479706d703432000000000000'))
+----
+video/mp4	video/mp4	audio/mp4	image/avif	image/heic	NULL
+
+# Suffix hints distinguish URI delimiters from literal local filename bytes.
+query TTTTT
+SELECT
+	file_mime_type(file('report.json?part', NULL, NULL, NULL, NULL)),
+	file_mime_type(file('https://example.test/report.json?part', NULL, NULL, NULL, NULL)),
+	file_mime_type(file('https://service.json', NULL, NULL, NULL, NULL)),
+	file_mime_type(file('s3://bucket/report.json?versionId=1', NULL, NULL, NULL, NULL)),
+	file_mime_type(file('file:///tmp/report.json?part', NULL, NULL, NULL, NULL))
+----
+NULL	application/json	NULL	NULL	NULL
+
+statement error
+SELECT file_mime_type(file('x', NULL, NULL, NULL, NULL), 'fallback')
+----
+<REGEX>:.*detect must be 'metadata', 'content', or 'auto'.*
+
+query TT
+SELECT
+	file_mime_type(file('missing.json', NULL, NULL, NULL, NULL), 'metadata'),
+	file_mime_type(file('missing.json', 'image/png', NULL, NULL, NULL), 'auto')
+----
+application/json	image/png
+
+statement error
+SELECT file_mime_type(file('missing.json', NULL, NULL, NULL, NULL), 'auto')
+----
+<REGEX>:.*(Cannot open file|could not open).*
+
+statement ok
+COPY (
+	SELECT repeat('x', 16384)::BLOB || unhex('894844460d0a1a0a')
+) TO '__TEST_DIR__/hdf5_user_block.bin' (FORMAT BLOB)
+
+query T
+SELECT file_mime_type(
+	file('__TEST_DIR__/hdf5_user_block.bin', NULL, NULL, NULL, NULL),
+	'content'
+)
+----
+application/vnd.hdfgroup.hdf5
+
+# Enrichment preserves the logical view and hashes exactly that view.
+query TTIIT
+SELECT typeof(value), value.content_type, value.position, value.size, value.checksum
+FROM (
+	SELECT file_enrich(
+		file('test/sql/table_function/files/one.txt', NULL, 6, 5, NULL),
+		['size', 'content_type', 'checksum']
+	) AS value
+)
+----
+FILE	text/plain	6	5	sha256:78ae647dc5544d227130a0682a51e30bc7777fbb6d8a8f17007463a3ecd1d524
+
+query IIT
+SELECT value.position, value.size, value.checksum
+FROM (
+	SELECT file_enrich(
+		file('test/sql/table_function/files/one.txt', NULL, NULL, NULL, NULL),
+		['size', 'checksum']
+	) AS value
+)
+----
+0	12	sha256:7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069
+
+query T
+SELECT file_enrich(
+	file('test/sql/table_function/files/one.txt', NULL, 12, 0, NULL),
+	['checksum']
+).checksum
+----
+sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+statement error
+SELECT file_enrich(file('test/sql/table_function/files/one.txt', NULL, 8, 8, NULL), ['checksum'])
+----
+<REGEX>:.*byte range.*exceeds the backing object size.*
+
+statement error
+SELECT file_enrich(file('x', NULL, NULL, NULL, NULL), ['etag'])
+----
+<REGEX>:.*field 'etag' is not supported.*
+
+statement error
+SELECT file_path(struct_pack(
+	url := NULL::VARCHAR,
+	content_type := NULL::VARCHAR,
+	"position" := NULL::BIGINT,
+	size := NULL::BIGINT,
+	checksum := NULL::VARCHAR
+)::FILE)
+----
+<REGEX>:.*url cannot be NULL.*
+
+statement error
+SELECT file('before' || chr(0) || 'after', NULL, NULL, NULL, NULL)
+----
+<REGEX>:.*url cannot contain NUL bytes.*
+
+statement error
+SELECT file_exists(struct_pack(
+	url := 'test/sql/table_function/files/one.txt',
+	content_type := NULL::VARCHAR,
+	"position" := 0::BIGINT,
+	size := NULL::BIGINT,
+	checksum := NULL::VARCHAR
+)::FILE)
+----
+<REGEX>:.*position and size must either both be NULL or both be non-NULL.*
+
+statement error
+SELECT file_stat(struct_pack(
+	url := 'test/sql/table_function/files/one.txt',
+	content_type := NULL::VARCHAR,
+	"position" := NULL::BIGINT,
+	size := NULL::BIGINT,
+	checksum := 'invalid'::VARCHAR
+)::FILE)
+----
+<REGEX>:.*checksum must have the form <algorithm>:<digest>.*
+
+statement error
+SELECT file_content_id(struct_pack(
+	url := 'x',
+	content_type := NULL::VARCHAR,
+	"position" := NULL::BIGINT,
+	size := NULL::BIGINT,
+	checksum := ('sha256:a' || chr(0) || 'b')::VARCHAR
+)::FILE)
+----
+<REGEX>:.*checksum must have the form <algorithm>:<digest>.*
+
+# Locator identity and content evidence are independent and I/O-free.
+query IIII
+SELECT
+	file_same_location(file('x', NULL, NULL, NULL, NULL), file('x', 'text/plain', NULL, NULL, NULL)),
+	file_same_location(file('x', NULL, 1, 2, NULL), file('x', NULL, 1, 2, NULL)),
+	file_same_location(file('x', NULL, 1, 2, NULL), file('x', NULL, 1, 3, NULL)),
+	file_same_location(file('x', NULL, NULL, NULL, NULL), file('x', NULL, 0, 3, NULL))
+----
+true	true	false	NULL
+
+query IIIIII
+SELECT
+	file_same_content(file('a', NULL, 0, 3, 'sha256:abc'), file('b', NULL, 7, 3, 'SHA256:abc')),
+	file_same_content(file('a', NULL, 0, 3, 'sha256:abc'), file('b', NULL, 7, 3, 'sha256:def')),
+	file_same_content(file('a', NULL, 0, 3, 'sha256:abc'), file('b', NULL, 7, 3, 'md5:def')),
+	file_same_content(file('a', NULL, 0, 3, NULL), file('b', NULL, 7, 4, NULL)),
+	file_same_content(file('a', NULL, 0, 0, NULL), file('b', NULL, 9, 0, NULL)),
+	file_same_content(file('a', NULL, NULL, NULL, NULL), file('b', NULL, NULL, NULL, NULL))
+----
+true	false	NULL	false	true	NULL
+
+query TTT
+SELECT
+	file_content_id(file('x', NULL, 0, 1, 'SHA256:AbC')),
+	file_content_id(file('x', NULL, 0, 0, NULL)),
+	file_content_id(file('x', NULL, NULL, NULL, NULL))
+----
+file-content-v1:checksum:sha256:AbC	file-content-v1:empty	NULL
+
+query TTII
+SELECT
+	file_locator_id(file('x', NULL, NULL, NULL, NULL)),
+	file_locator_id(file('x', NULL, 2, 3, NULL)),
+	file_locator_id(file('x', NULL, NULL, NULL, NULL)) =
+		file_locator_id(file('x', 'text/plain', NULL, NULL, 'sha256:any')),
+	file_locator_id(file('x', NULL, NULL, NULL, NULL)) !=
+		file_locator_id(file('x', NULL, 0, 1, NULL))
+----
+file-locator-v1:sha256:5b0c80f0d235a7012cd2e4fa9b1a50118ed42c184eb797c52986fc114bf8e144	file-locator-v1:sha256:4def93c927555f3931c34c6aefe0f0c709e90a6596bea35a644b65334ce05487	true	true

--- a/src/vane_py/pyfilesystem.cpp
+++ b/src/vane_py/pyfilesystem.cpp
@@ -74,6 +74,9 @@ string PythonFilesystem::DecodeFlags(FileOpenFlags flags) {
 
 unique_ptr<FileHandle> PythonFilesystem::OpenFile(const string &path, FileOpenFlags flags,
                                                   optional_ptr<FileOpener> opener) {
+	if (flags.OpenNonBlocking()) {
+		throw NotImplementedException("Nonblocking opens are not supported by registered Python filesystems");
+	}
 	PythonGILWrapper gil;
 
 	if (flags.Compression() != FileCompressionType::UNCOMPRESSED) {

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -126,6 +126,33 @@ struct PyLogicalPlan {
 	PyPhysicalPlanWrapper to_physical_plan(py::object conn_obj, py::object effective_session_config) const;
 };
 
+static bool IsStorageFacingFileScalar(const ScalarFunction &function) {
+	if (function.catalog_name != SYSTEM_CATALOG || function.schema_name != DEFAULT_SCHEMA ||
+	    function.GetStability() != FunctionStability::VOLATILE) {
+		return false;
+	}
+	// These are the FILE extension overloads registered with accesses_storage=true.
+	return function.name == "to_file" || function.name == "try_to_file" || function.name == "file_enrich" ||
+	       function.name == "file_size" || function.name == "file_exists" || function.name == "file_stat" ||
+	       function.name == "file_mime_type";
+}
+
+class DistributedFileScalarValidator final : public LogicalOperatorVisitor {
+public:
+	void VisitExpression(unique_ptr<Expression> *expression) override {
+		if ((*expression)->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
+			auto &function = (*expression)->Cast<BoundFunctionExpression>().function;
+			if (IsStorageFacingFileScalar(function)) {
+				throw InvalidInputException(
+				    "Ray distributed execution does not yet support storage-facing FILE function '%s'; "
+				    "worker-side FILE connector, credential, and path resolution is not available",
+				    function.name);
+			}
+		}
+		LogicalOperatorVisitor::VisitExpression(expression);
+	}
+};
+
 static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::Relation> &rel) {
 	if (!rel) {
 		throw duckdb::InternalException("Relation is null");
@@ -138,6 +165,7 @@ static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::
 		duckdb::Planner planner(*client_context);
 		planner.CreatePlan(std::move(relation_stmt));
 		auto logical_plan = std::move(planner.plan);
+		DistributedFileScalarValidator().VisitOperator(*logical_plan);
 
 		// NOTE: We intentionally do NOT run the Optimizer here.
 		// The unoptimized (bound) logical plan is serialized and sent to the Driver,

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -38,6 +38,8 @@
 #include <duckdb/execution/distributed/pipeline_node/vllm.hpp>
 #include <duckdb/execution/distributed/utils/channel.hpp>
 #include <duckdb/planner/planner.hpp>
+#include <duckdb/planner/logical_operator_visitor.hpp>
+#include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/limits.hpp>
 #include <duckdb/common/local_file_system.hpp>

--- a/tests/fast/test_filesystem.py
+++ b/tests/fast/test_filesystem.py
@@ -73,6 +73,26 @@ class TestPythonFilesystem:
 
         duckdb_cursor.unregister_filesystem("memory")
 
+    def test_file_resolver_fails_before_registered_python_io(
+        self,
+        duckdb_cursor: DuckDBPyConnection,
+        memory: fsspec.AbstractFileSystem,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        duckdb_cursor.register_filesystem(memory)
+
+        def unexpected_open(*_args, **_kwargs):
+            pytest.fail("FILE resolver attempted registered Python filesystem I/O")
+
+        monkeypatch.setattr(memory, "open", unexpected_open)
+        with pytest.raises(vane.NotImplementedException, match="Nonblocking opens are not supported"):
+            duckdb_cursor.execute("SELECT to_file('memory://integers.csv')")
+
+        assert duckdb_cursor.execute("SELECT try_to_file('memory://integers.csv') IS NULL").fetchone() == (True,)
+        assert duckdb_cursor.execute(
+            "SELECT file_exists(file('memory://integers.csv', NULL, NULL, NULL, NULL)) IS NULL"
+        ).fetchone() == (True,)
+
     def test_reject_abstract_filesystem(self, duckdb_cursor: DuckDBPyConnection):
         with pytest.raises(InvalidInputException):
             duckdb_cursor.register_filesystem(fsspec.AbstractFileSystem())

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -27,6 +27,77 @@ def _table_from_native_result(result):
     return pa.concat_tables(payloads)
 
 
+@pytest.mark.parametrize(
+    ("function_name", "expression"),
+    [
+        ("to_file", "to_file('file:///driver-only/value.bin')"),
+        ("try_to_file", "try_to_file('file:///driver-only/value.bin')"),
+        (
+            "file_enrich",
+            "file_enrich(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL), ['size'])",
+        ),
+        (
+            "file_size",
+            "file_size(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL))",
+        ),
+        (
+            "file_exists",
+            "file_exists(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL))",
+        ),
+        (
+            "file_stat",
+            "file_stat(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL))",
+        ),
+        (
+            "file_mime_type",
+            "file_mime_type(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL), 'content')",
+        ),
+    ],
+)
+def test_distributed_plan_rejects_storage_facing_file_scalars(function_name, expression):
+    ray_cxx = _require_ray_cxx()
+    connection = vane.connect()
+    try:
+        relation = connection.sql(f"SELECT {expression} FROM range(2)")
+        with pytest.raises(
+            ValueError,
+            match=rf"storage-facing FILE function '{function_name}'",
+        ):
+            ray_cxx.PyLogicalPlan.from_duckdb_relation(
+                relation,
+                f"storage-facing-file-{function_name}",
+            )
+    finally:
+        connection.close()
+
+
+def test_distributed_plan_allows_io_free_file_scalars():
+    ray_cxx = _require_ray_cxx()
+    connection = vane.connect()
+    try:
+        file_value = "file('file:///driver-only/value.txt', 'text/plain', 1, 2, 'sha256:abcd')"
+        relation = connection.sql(
+            f"""
+            SELECT
+                file_path({file_value}),
+                file_mime_type({file_value}),
+                guess_mime_type('GIF89a'::BLOB),
+                file_same_location({file_value}, {file_value}),
+                file_same_content({file_value}, {file_value}),
+                file_locator_id({file_value}),
+                file_content_id({file_value}),
+                {file_value} = {file_value}
+            FROM range(2)
+            """
+        )
+
+        plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "io-free-file-scalars")
+
+        assert plan is not None
+    finally:
+        connection.close()
+
+
 def test_logical_plan_captures_connection_scoped_vane_session(monkeypatch):
     ray_cxx = _require_ray_cxx()
 

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -35,6 +35,38 @@ def _collect_rows_from_parts(parts):
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")
 @pytest.mark.usefixtures("ray_local")
+def test_default_ray_rejects_file_io_for_driver_only_path(monkeypatch, tmp_path):
+    import fcntl
+    import os
+
+    payload = b"driver-only-payload"
+    payload_path = tmp_path / "driver-only.bin"
+    payload_path.write_bytes(payload)
+
+    connection = vane.connect()
+    try:
+        with payload_path.open("rb") as source:
+            descriptor = fcntl.fcntl(source.fileno(), fcntl.F_DUPFD_CLOEXEC, 512)
+            try:
+                driver_path = f"/proc/self/fd/{descriptor}"
+                assert connection.execute(f"SELECT file_size(try_to_file('{driver_path}'))").fetchone() == (
+                    len(payload),
+                )
+
+                monkeypatch.delenv("VANE_RUNNER", raising=False)
+                vane.teardown_runner()
+                relation = connection.sql(f"SELECT file_size(try_to_file('{driver_path}')) FROM range(2)")
+
+                with pytest.raises(ValueError, match="storage-facing FILE function"):
+                    relation.fetchall()
+            finally:
+                os.close(descriptor)
+    finally:
+        connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
 def test_run_simple_plan_on_ray_local():
     from vane import runners as _runners
 


### PR DESCRIPTION
## Summary

- add execution-time SQL support for `to_file`, `try_to_file`, `file_enrich`, `file_path`, `file_size`, `file_exists`, `file_stat`, `file_mime_type`, and `guess_mime_type`
- add pure identity/evidence functions `file_same_location`, `file_same_content`, `file_locator_id`, and `file_content_id`
- resolve each exact FILE value through the current `ClientContext`, keep credentials connector-owned, enforce paired non-negative byte ranges, and constrain content reads and SHA-256 enrichment to the declared logical window
- reject local special files without blocking or introducing a check/open race; registered Python filesystems fail before Python I/O until they implement the nonblocking open contract
- document the SQL metadata, identity, error, and I/O contracts and cover range validation, MIME detection, enrichment, identity, FIFO handling, and Python-filesystem fail-fast behavior

This PR intentionally excludes `list_files`, provider-specific registered Python filesystem execution, distributed/Ray integration, Python FILE values, and AI/UDF support. Those remain follow-up work after this scalar SQL execution contract is stable.

## Related issue

Part of #661
Part of #662

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The FILE SQL execution, metadata, identity, and I/O contracts are documented in `external/duckdb/extension/file/README.md`.

## Validation

- `scripts/format workspace --changed`
- `git diff --check`
- non-editable incremental Release install with `CMAKE_BUILD_PARALLEL_LEVEL=32`: `uv pip install . --no-build-isolation`
- native `unittest 'Nonblocking local opens do not wait for FIFO peers'` — 5 assertions passed
- native `unittest 'test/sql/file/test_file_alias.test'` — 51 assertions passed
- native `unittest 'test/sql/file/test_file_io.test'` — 128 assertions passed
- `scripts/run_installed_pytest.sh tests/fast/test_filesystem.py -q` — 17 passed, 1 optional loadable-extension test skipped

Validation ran on Linux x86-64 with Python 3.12 and a 32-job native build.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
