### PR TITLE
[feat](milvus) Add a keyed-upsert DataSink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,105 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  milvus-tests:
+    name: Milvus integration test
+    needs:
+      - changes
+      - native-fast-tests
+    if: needs.changes.outputs.run_full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      VANE_TEST_MILVUS_URI: http://127.0.0.1:19530
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download the built wheel
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ci-python-artifacts-3.12
+          path: dist
+
+      - name: Install the wheel and Milvus test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          wheel_path="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          test -n "$wheel_path"
+          python -m pip install --force-reinstall "${wheel_path}[milvus]" pytest
+          python -m pip check
+          python -c 'import pymilvus'
+
+      - name: Start Milvus standalone
+        run: |
+          milvus_runtime="$RUNNER_TEMP/vane-milvus"
+          mkdir -p "$milvus_runtime"
+          printf '%s\n' \
+            'listen-client-urls: http://0.0.0.0:2379' \
+            'advertise-client-urls: http://0.0.0.0:2379' \
+            'quota-backend-bytes: 4294967296' \
+            'auto-compaction-mode: revision' \
+            "auto-compaction-retention: '1000'" \
+            > "$milvus_runtime/embedEtcd.yaml"
+          printf '%s\n' '# Extra config to override default milvus.yaml' \
+            > "$milvus_runtime/user.yaml"
+          docker run --detach \
+            --name vane-milvus \
+            --security-opt seccomp=unconfined \
+            --env ETCD_USE_EMBED=true \
+            --env ETCD_DATA_DIR=/var/lib/milvus/etcd \
+            --env ETCD_CONFIG_PATH=/milvus/configs/embedEtcd.yaml \
+            --env COMMON_STORAGETYPE=local \
+            --env DEPLOY_MODE=STANDALONE \
+            --mount "type=bind,source=$milvus_runtime/embedEtcd.yaml,target=/milvus/configs/embedEtcd.yaml,readonly" \
+            --mount "type=bind,source=$milvus_runtime/user.yaml,target=/milvus/configs/user.yaml,readonly" \
+            --publish 127.0.0.1:19530:19530 \
+            --publish 127.0.0.1:9091:9091 \
+            milvusdb/milvus:v3.0.0@sha256:49371c30af46b1013e4d3e0b980e691d81376d69cdbe1b372725baf1d7255862 \
+            milvus run standalone
+
+      - name: Wait for Milvus to become healthy
+        run: |
+          for attempt in {1..90}; do
+            if curl --fail --silent http://127.0.0.1:9091/healthz > /dev/null; then
+              exit 0
+            fi
+            if [[ "$(docker inspect --format '{{.State.Status}}' vane-milvus)" != "running" ]]; then
+              echo "Milvus stopped before becoming healthy" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Milvus did not become healthy within 180 seconds" >&2
+          exit 1
+
+      - name: Run the live Milvus sink test
+        run: |
+          timeout --signal=INT --kill-after=30s 300s \
+            scripts/run_installed_pytest.sh \
+              -o addopts= \
+              -m external_service \
+              tests/fast/test_milvus_datasink.py
+
+      - name: Print Milvus logs on failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: docker logs vane-milvus
+
+      - name: Stop Milvus
+        if: ${{ always() }}
+        continue-on-error: true
+        run: docker rm --force vane-milvus
+
   ai-tests:
     name: AI tests
     needs:
@@ -481,6 +580,7 @@ jobs:
       - source-package
       - native-fast-tests
       - fast-tests
+      - milvus-tests
       - ai-tests
     runs-on: ubuntu-24.04
     steps:
@@ -489,6 +589,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           AI_TESTS_RESULT: ${{ needs.ai-tests.result }}
           FAST_TESTS_RESULT: ${{ needs.fast-tests.result }}
+          MILVUS_TESTS_RESULT: ${{ needs.milvus-tests.result }}
           RUN_FULL: ${{ needs.changes.outputs.run_full }}
           SOURCE_PACKAGE_RESULT: ${{ needs.source-package.result }}
           NATIVE_TESTS_RESULT: ${{ needs.native-fast-tests.result }}
@@ -514,8 +615,9 @@ jobs:
           if [[ "$SOURCE_PACKAGE_RESULT" != "$expected_result" ||
                 "$NATIVE_TESTS_RESULT" != "$expected_result" ||
                 "$FAST_TESTS_RESULT" != "$expected_result" ||
+                "$MILVUS_TESTS_RESULT" != "$expected_result" ||
                 "$AI_TESTS_RESULT" != "$expected_result" ]]; then
-            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT, ai-tests=$AI_TESTS_RESULT" >&2
+            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT, milvus-tests=$MILVUS_TESTS_RESULT, ai-tests=$AI_TESTS_RESULT" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ pip install 'vane-ai[vllm]'     # Native vLLM inference on Linux x86-64
 pip install 'vane-ai[sglang]'   # Native SGLang 0.5.17 inference on Linux x86-64
 pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
 pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
+pip install 'vane-ai[milvus]'   # distributed full-row Milvus upserts
 ```
 
 The SGLang extra follows SGLang 0.5.17's default CUDA 13 dependency set. Python package metadata cannot select a
@@ -125,6 +126,45 @@ For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/da
 ### Quick Start
 
 Follow the [Quickstart guide](https://vane.astrovela.ai/docs/data/quickstart/quickstart) to build and run your first Vane pipeline.
+
+### Milvus DataSink
+
+`MilvusSink` writes distributed relation batches with ordinary full-row
+override upserts. The collection must disable AutoID and dynamic fields, must
+not define collection functions, and must have one caller-assigned `INT64` or
+`VARCHAR` primary key. Every required collection field must be present; use
+`field_mapping` when relation and collection names differ. Partial updates,
+merge modes, and array append/remove operations are not exposed.
+
+Supported relation fields are Arrow booleans, signed 8/16/32/64-bit integers,
+32/64-bit floats, strings, and lists of 32-bit floats for `FLOAT_VECTOR`
+fields. `max_batch_rows` limits rows per worker call, while `max_batch_bytes`
+limits the Arrow buffer size before conversion to Milvus records.
+`uri` accepts a base HTTP(S) endpoint without embedded credentials or a
+database path; select a non-default database with `database=...`. Credential
+values must come from an `EnvironmentSecret` resolved on each worker.
+
+```python
+from vane import EnvironmentSecret, MilvusSink
+
+sink = MilvusSink(
+    "documents",
+    uri="https://milvus.example:19530",
+    primary_key="id",
+    token=EnvironmentSecret("MILVUS_TOKEN"),
+)
+summary = relation.write_datasink(sink)
+```
+
+The default `max_retries=0` disables Vane's full-operation replay after an
+unknown outcome; PyMilvus can still recover transport failures within an SDK
+call's configured timeout. If Vane retries are enabled, it replays the complete
+input with the same operation ID; the adapter replaces the same explicit
+primary keys, but concurrent external writers can still race. Successful
+batches are acknowledged and applied independently, so a failed operation can
+be partially applied. Vane does not provide an atomic transaction, rollback,
+or exactly-once delivery, and read visibility follows the consistency level
+used by Milvus readers.
 
 ### Execution Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ Issues = "https://github.com/AstroVela/vane/issues"
 Changelog = "https://github.com/AstroVela/vane/releases"
 
 [project.optional-dependencies]
+milvus = ["pymilvus>=3.0.1,<4"]
 openai = ["openai>=1.66.0", "tiktoken"] # floor adds the Responses API used by the default Prompt path
 anthropic = ["anthropic>=0.117.0"] # floor matches the Messages.create option surface validated in vane/ai/providers/anthropic.py
 google = ["google-genai>=1.22.0"] # floor adds GenerateContentConfig.response_json_schema
@@ -96,6 +97,7 @@ all = [ # Cloud providers and dataframe/filesystem integrations; local model run
     "pandas",  # used for pandas dataframes
     "adbc-driver-manager", # for the adbc driver
     "pillow>=10", # used for image inputs and video frames
+    "pymilvus>=3.0.1,<4", # Milvus DataSink
 ]
 
 ######################################################################################################
@@ -225,6 +227,7 @@ include = [
     "/tests/ray_test_profile.py",
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",
+    "/tests/fast/test_milvus_datasink.py",
     "/tests/fast/test_package_metadata.py",
     "/tests/fast/test_ray_test_profile.py",
     "/tests/fast/test_transformers_provider_security.py",

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -23,6 +23,7 @@ export VANE_FAST_TEST_ARTIFACT_MODE=1
 release_tests=(
   "$project_root/tests/fast/test_ai_release_contracts.py"
   "$project_root/tests/fast/test_datasink.py"
+  "$project_root/tests/fast/test_milvus_datasink.py"
   "$project_root/tests/fast/test_package_metadata.py"
   "$project_root/tests/fast/test_ray_test_profile.py"
   "$project_root/tests/fast/test_transformers_provider_security.py"

--- a/tests/fast/test_milvus_datasink.py
+++ b/tests/fast/test_milvus_datasink.py
@@ -1,0 +1,688 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import builtins
+import os
+import uuid
+from collections.abc import Mapping
+from copy import deepcopy
+from enum import IntEnum
+from typing import Any
+
+import cloudpickle
+import pyarrow as pa
+import pytest
+
+import vane
+import vane.datasink.milvus as milvus
+from vane import EnvironmentSecret, MilvusSink
+from vane.datasink import BoundKeyedUpsertSink, WriteContext
+
+_REAL_LOAD_MILVUS_SDK = milvus._load_milvus_sdk
+
+
+class _DataType(IntEnum):
+    BOOL = 1
+    INT8 = 2
+    INT16 = 3
+    INT32 = 4
+    INT64 = 5
+    FLOAT = 10
+    DOUBLE = 11
+    VARCHAR = 21
+    TEXT = 25
+    FLOAT_VECTOR = 101
+
+
+def _description(
+    *,
+    collection_name: str = "items",
+    auto_id: bool = False,
+    dynamic: bool = False,
+    functions: list[object] | None = None,
+    primary_type: _DataType = _DataType.INT64,
+    title_type: _DataType = _DataType.VARCHAR,
+) -> dict[str, object]:
+    title_params: dict[str, int] = {"max_length": 16} if title_type is _DataType.VARCHAR else {}
+    return {
+        "collection_name": collection_name,
+        "auto_id": auto_id,
+        "enable_dynamic_field": dynamic,
+        "functions": [] if functions is None else functions,
+        "fields": [
+            {
+                "name": "id",
+                "type": primary_type,
+                "is_primary": True,
+                "nullable": False,
+                "params": {"max_length": 32} if primary_type is _DataType.VARCHAR else {},
+            },
+            {
+                "name": "embedding",
+                "type": _DataType.FLOAT_VECTOR,
+                "nullable": False,
+                "params": {"dim": 3},
+            },
+            {
+                "name": "title",
+                "type": title_type,
+                "nullable": False,
+                "params": title_params,
+            },
+        ],
+    }
+
+
+_DEFAULT_RESPONSE = object()
+
+
+class _Client:
+    description: object = _description()
+    describe_error: BaseException | None = None
+    upsert_error: BaseException | None = None
+    close_error: BaseException | None = None
+    response: object = _DEFAULT_RESPONSE
+    instances: list[_Client] = []
+    store: dict[object, dict[str, object]] = {}
+
+    def __init__(self, **kwargs: object) -> None:
+        self.options = kwargs
+        self.describe_calls: list[dict[str, object]] = []
+        self.upsert_calls: list[dict[str, object]] = []
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    def describe_collection(self, **kwargs: object) -> object:
+        self.describe_calls.append(kwargs)
+        if self.describe_error is not None:
+            raise self.describe_error
+        return deepcopy(self.description)
+
+    def upsert(self, **kwargs: object) -> object:
+        self.upsert_calls.append(kwargs)
+        if self.upsert_error is not None:
+            raise self.upsert_error
+        records = kwargs["data"]
+        assert isinstance(records, list)
+        description = self.description
+        assert isinstance(description, Mapping)
+        fields = description["fields"]
+        assert isinstance(fields, list)
+        primary_names = [field["name"] for field in fields if isinstance(field, Mapping) and field.get("is_primary")]
+        assert len(primary_names) == 1
+        primary_name = primary_names[0]
+        for record in records:
+            assert isinstance(record, dict)
+            type(self).store[record[primary_name]] = deepcopy(record)
+        if self.response is _DEFAULT_RESPONSE:
+            return {"upsert_count": len(records), "ids": [record[primary_name] for record in records]}
+        return self.response
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+@pytest.fixture(autouse=True)
+def _fake_sdk(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    if request.node.get_closest_marker("external_service") is not None:
+        return
+    _Client.description = _description()
+    _Client.describe_error = None
+    _Client.upsert_error = None
+    _Client.close_error = None
+    _Client.response = _DEFAULT_RESPONSE
+    _Client.instances = []
+    _Client.store = {}
+    monkeypatch.setattr(milvus, "_load_milvus_sdk", lambda: (_Client, _DataType))
+
+
+def _arrow_schema(
+    *,
+    id_type: pa.DataType | None = None,
+    vector_type: pa.DataType | None = None,
+    title_type: pa.DataType | None = None,
+) -> pa.Schema:
+    return pa.schema(
+        [
+            ("id", pa.int64() if id_type is None else id_type),
+            ("embedding", pa.list_(pa.float32()) if vector_type is None else vector_type),
+            ("title", pa.string() if title_type is None else title_type),
+        ]
+    )
+
+
+def _sink(**kwargs: object) -> MilvusSink:
+    options: dict[str, object] = {
+        "uri": "https://milvus.example:19530",
+        "primary_key": "id",
+        "timeout": 5,
+    }
+    options.update(kwargs)
+    return MilvusSink("items", **options)  # type: ignore[arg-type]
+
+
+def _bound(**kwargs: object) -> BoundKeyedUpsertSink:
+    return _sink(**kwargs).bind(_arrow_schema())
+
+
+def _worker(**kwargs: object) -> Any:
+    return _bound(**kwargs).open_worker(WriteContext("milvus-test"))
+
+
+def _table(
+    *,
+    ids: list[int] | None = None,
+    vectors: list[list[float]] | None = None,
+    titles: list[str | None] | None = None,
+    schema: pa.Schema | None = None,
+) -> pa.Table:
+    return pa.table(
+        {
+            "id": [1, 2] if ids is None else ids,
+            "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] if vectors is None else vectors,
+            "title": ["one", "two"] if titles is None else titles,
+        },
+        schema=_arrow_schema() if schema is None else schema,
+    )
+
+
+def test_milvus_sink_is_public_without_importing_pymilvus() -> None:
+    assert vane.MilvusSink is MilvusSink
+    assert milvus.__all__ == ["MilvusSink"]
+
+
+def test_milvus_sink_reports_the_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def missing_pymilvus(name: str, *args: object, **kwargs: object) -> Any:
+        if name == "pymilvus":
+            raise ModuleNotFoundError("No module named 'pymilvus'", name="pymilvus")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_pymilvus)
+    with pytest.raises(ImportError, match=r"vane-ai\[milvus\]"):
+        _REAL_LOAD_MILVUS_SDK()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"collection_name": ""}, ValueError, "collection_name"),
+        ({"collection_name": " items"}, ValueError, "whitespace"),
+        ({"uri": "milvus.example:19530"}, ValueError, "HTTP or HTTPS"),
+        ({"uri": "https://milvus.example/database"}, ValueError, "database path"),
+        ({"uri": "https://milvus.example:not-a-port"}, ValueError, "valid HTTP or HTTPS"),
+        ({"uri": "https://user:secret@milvus.example"}, ValueError, "credentials"),
+        ({"uri": "https://milvus.example?token=secret"}, ValueError, "query parameters"),
+        ({"primary_key": ""}, ValueError, "primary_key"),
+        ({"token": "plain-text"}, TypeError, "EnvironmentSecret"),
+        ({"database": " "}, ValueError, "database"),
+        ({"worker_count": True}, TypeError, "worker_count"),
+        ({"worker_count": 0}, ValueError, "worker_count"),
+        ({"max_batch_rows": -1}, ValueError, "max_batch_rows"),
+        ({"max_batch_bytes": 1.5}, TypeError, "max_batch_bytes"),
+        ({"max_retries": True}, TypeError, "max_retries"),
+        ({"max_retries": -1}, ValueError, "max_retries"),
+        ({"timeout": None}, TypeError, "timeout"),
+        ({"timeout": float("inf")}, ValueError, "timeout"),
+        ({"field_mapping": []}, TypeError, "field_mapping"),
+        ({"field_mapping": {"id": "pk", "title": "pk"}}, ValueError, "targets"),
+    ],
+)
+def test_milvus_sink_validates_constructor(overrides: dict[str, object], error: type[Exception], message: str) -> None:
+    options: dict[str, object] = {
+        "collection_name": "items",
+        "uri": "https://milvus.example:19530",
+        "primary_key": "id",
+    }
+    options.update(overrides)
+    with pytest.raises(error, match=message):
+        MilvusSink(**options)  # type: ignore[arg-type]
+
+
+def test_milvus_sink_binds_key_mapping_and_execution_options() -> None:
+    sink = _sink(
+        primary_key="remote_id",
+        field_mapping={"id": "remote_id"},
+        worker_count=3,
+        max_batch_rows=17,
+        max_batch_bytes=2_048,
+        max_retries=2,
+    )
+    bound = sink.bind(_arrow_schema())
+
+    assert isinstance(bound, BoundKeyedUpsertSink)
+    assert tuple(bound.key_columns) == ("id",)
+    assert bound.execution_options.worker_count == 3
+    assert bound.execution_options.batch_size == 17
+    assert bound.execution_options.target_max_batch_bytes == 2_048
+    assert bound.execution_options.max_retries == 2
+
+
+def test_milvus_sink_writes_mapped_fields_with_a_varchar_primary_key() -> None:
+    description = _description(primary_type=_DataType.VARCHAR)
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    for field in fields:
+        assert isinstance(field, dict)
+        field["name"] = {"id": "remote_id", "embedding": "vector", "title": "text"}[field["name"]]
+    _Client.description = description
+    schema = _arrow_schema(id_type=pa.string())
+    sink = _sink(
+        primary_key="remote_id",
+        field_mapping={"id": "remote_id", "embedding": "vector", "title": "text"},
+    )
+    worker = sink.bind(schema).open_worker(WriteContext("mapped-varchar"))
+    table = pa.table(
+        {"id": ["a", "b"], "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], "title": ["one", "two"]},
+        schema=schema,
+    )
+
+    worker.write(table)
+
+    assert _Client.instances[0].upsert_calls[0]["data"] == [
+        {"remote_id": "a", "vector": pytest.approx([0.1, 0.2, 0.3]), "text": "one"},
+        {"remote_id": "b", "vector": pytest.approx([0.4, 0.5, 0.6]), "text": "two"},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("arrow_type", "remote_type", "value"),
+    [
+        (pa.bool_(), _DataType.BOOL, True),
+        (pa.int8(), _DataType.INT8, 8),
+        (pa.int16(), _DataType.INT16, 16),
+        (pa.int32(), _DataType.INT32, 32),
+        (pa.int64(), _DataType.INT64, 64),
+        (pa.float32(), _DataType.FLOAT, 1.25),
+        (pa.float64(), _DataType.DOUBLE, 2.5),
+        (pa.string(), _DataType.VARCHAR, "varchar"),
+        (pa.large_string(), _DataType.TEXT, "text"),
+    ],
+)
+def test_milvus_sink_supports_scalar_arrow_mappings(
+    arrow_type: pa.DataType,
+    remote_type: _DataType,
+    value: object,
+) -> None:
+    _Client.description = _description(title_type=remote_type)
+    schema = _arrow_schema(title_type=arrow_type)
+    worker = _sink().bind(schema).open_worker(WriteContext("scalar-mapping"))
+    table = pa.table(
+        {"id": [1], "embedding": [[0.1, 0.2, 0.3]], "title": [value]},
+        schema=schema,
+    )
+
+    result = worker.write(table)
+
+    assert result.rows_affected == 1
+
+
+def test_milvus_sink_rejects_invalid_bound_schema_and_mapping() -> None:
+    with pytest.raises(TypeError, match="pyarrow.Schema"):
+        _sink().bind(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="unique input column"):
+        _sink().bind(pa.schema([("id", pa.int64()), ("id", pa.int64())]))
+    with pytest.raises(ValueError, match="unknown input"):
+        _sink(field_mapping={"missing": "remote"}).bind(_arrow_schema())
+    with pytest.raises(ValueError, match="unique Milvus"):
+        _sink(field_mapping={"id": "title"}).bind(_arrow_schema())
+    with pytest.raises(ValueError, match="exactly one"):
+        _sink(primary_key="missing").bind(_arrow_schema())
+    with pytest.raises(ValueError, match="int64 or string"):
+        _sink(primary_key="embedding").bind(_arrow_schema())
+    with pytest.raises(ValueError, match="does not support"):
+        _sink().bind(_arrow_schema(vector_type=pa.list_(pa.float64())))
+
+
+def test_milvus_sink_defers_secret_resolution_and_sdk_import_to_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VANE_TEST_MILVUS_TOKEN", "worker-only-secret")
+    sink = _sink(token=EnvironmentSecret("VANE_TEST_MILVUS_TOKEN"), database="analytics")
+    serialized = cloudpickle.dumps(sink)
+    assert b"worker-only-secret" not in serialized
+
+    bound = sink.bind(_arrow_schema())
+    assert b"worker-only-secret" not in cloudpickle.dumps(bound)
+    assert not _Client.instances
+    worker = bound.open_worker(WriteContext("secret-test"))
+
+    assert _Client.instances[0].options == {
+        "uri": "https://milvus.example:19530",
+        "timeout": 5.0,
+        "dedicated": True,
+        "token": "worker-only-secret",
+        "db_name": "analytics",
+    }
+    worker.close()
+
+
+@pytest.mark.parametrize(
+    ("description", "message"),
+    [
+        (None, "invalid description"),
+        ({**_description(), "collection_name": "other"}, "different collection"),
+        (_description(auto_id=True), "AutoID"),
+        (_description(dynamic=True), "dynamic fields"),
+        (_description(functions=[{"name": "embed"}]), "collections with functions"),
+        ({**_description(), "functions": None}, "function metadata"),
+        ({**_description(), "fields": []}, "no fields"),
+    ],
+)
+def test_milvus_sink_rejects_unsupported_collection_contract(description: object, message: str) -> None:
+    _Client.description = description
+    with pytest.raises(ValueError, match=message):
+        _worker()
+    assert _Client.instances[0].close_calls == 1
+
+
+def test_milvus_sink_rejects_invalid_collection_fields_and_primary_key() -> None:
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    fields.append(deepcopy(fields[0]))
+    _Client.description = description
+    with pytest.raises(ValueError, match="duplicate field"):
+        _worker()
+
+    _Client.description = _description(primary_type=_DataType.INT32)
+    with pytest.raises(ValueError, match="INT64 or VARCHAR"):
+        _worker()
+
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[0], dict)
+    fields[0]["auto_id"] = True
+    _Client.description = description
+    with pytest.raises(ValueError, match="AutoID"):
+        _worker()
+
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[0], dict)
+    fields[0]["is_primary"] = False
+    _Client.description = description
+    with pytest.raises(ValueError, match="primary key does not match"):
+        _worker()
+
+
+def test_milvus_sink_validates_required_unknown_and_function_output_fields() -> None:
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    fields.append({"name": "required", "type": _DataType.INT64, "nullable": False, "params": {}})
+    _Client.description = description
+    with pytest.raises(ValueError, match="missing required"):
+        _worker()
+
+    _Client.description = _description()
+    with pytest.raises(ValueError, match="absent from"):
+        _sink(field_mapping={"title": "missing"}).bind(_arrow_schema()).open_worker(WriteContext("unknown"))
+
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[1], dict)
+    fields[1]["is_function_output"] = True
+    _Client.description = description
+    with pytest.raises(ValueError, match="function output"):
+        _worker()
+
+
+def test_milvus_sink_allows_omitted_nullable_and_defaulted_fields() -> None:
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    fields.extend(
+        [
+            {"name": "optional", "type": _DataType.INT64, "nullable": True, "params": {}},
+            {"name": "defaulted", "type": _DataType.INT64, "default_value": 7, "params": {}},
+        ]
+    )
+    _Client.description = description
+    worker = _worker()
+    worker.write(_table())
+    assert len(_Client.instances[0].upsert_calls) == 1
+
+
+def test_milvus_sink_validates_remote_types_and_parameters() -> None:
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[2], dict)
+    fields[2]["type"] = _DataType.INT64
+    _Client.description = description
+    with pytest.raises(ValueError, match="does not match Arrow"):
+        _worker()
+
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[2], dict)
+    fields[2]["params"] = {"max_length": 0}
+    _Client.description = description
+    with pytest.raises(ValueError, match="invalid max_length"):
+        _worker()
+
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[1], dict)
+    fields[1]["params"] = {"dim": "3"}
+    _Client.description = description
+    with pytest.raises(ValueError, match="invalid dim"):
+        _worker()
+
+
+def test_milvus_sink_accepts_text_fields_and_fixed_vector_dimensions() -> None:
+    _Client.description = _description(title_type=_DataType.TEXT)
+    worker = _sink().bind(_arrow_schema(vector_type=pa.list_(pa.float32(), 3))).open_worker(WriteContext("fixed"))
+    result = worker.write(_table(schema=_arrow_schema(vector_type=pa.list_(pa.float32(), 3))))
+    assert result.rows_affected == 2
+
+    with pytest.raises(ValueError, match="fixed dimension"):
+        _sink().bind(_arrow_schema(vector_type=pa.list_(pa.float32(), 2))).open_worker(WriteContext("bad-fixed"))
+
+
+def test_milvus_sink_validates_values_before_upsert() -> None:
+    worker = _worker()
+    with pytest.raises(ValueError, match="invalid dimension"):
+        worker.write(_table(vectors=[[0.1, 0.2], [0.3, 0.4]]))
+    with pytest.raises(ValueError, match="invalid value"):
+        worker.write(_table(vectors=[[0.1, float("nan"), 0.3], [0.4, 0.5, 0.6]]))
+    with pytest.raises(ValueError, match="max_length"):
+        worker.write(_table(titles=["你" * 6, "two"]))
+    with pytest.raises(ValueError, match="null"):
+        worker.write(_table(titles=[None, "two"]))
+    with pytest.raises(ValueError, match="null"):
+        worker.write(_table(ids=[None, 2]))  # type: ignore[list-item]
+    assert not _Client.instances[0].upsert_calls
+
+
+def test_milvus_sink_allows_null_for_nullable_or_defaulted_mapped_field() -> None:
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[2], dict)
+    fields[2]["nullable"] = True
+    _Client.description = description
+    worker = _worker()
+    worker.write(_table(titles=[None, "two"]))
+
+    description = _description()
+    fields = description["fields"]
+    assert isinstance(fields, list)
+    assert isinstance(fields[2], dict)
+    fields[2]["default_value"] = "untitled"
+    _Client.description = description
+    worker = _worker()
+    worker.write(_table(titles=[None, "two"]))
+
+
+def test_milvus_sink_enforces_batch_and_schema_limits_before_upsert() -> None:
+    worker = _worker(max_batch_rows=1)
+    with pytest.raises(ValueError, match="max_batch_rows"):
+        worker.write(_table())
+    assert not _Client.instances[0].upsert_calls
+
+    worker = _worker(max_batch_bytes=1)
+    with pytest.raises(ValueError, match="max_batch_bytes"):
+        worker.write(_table())
+    assert not _Client.instances[1].upsert_calls
+
+    worker = _worker()
+    bad_schema = pa.schema([("id", pa.int64()), ("embedding", pa.list_(pa.float32())), ("other", pa.string())])
+    with pytest.raises(ValueError, match="bound input schema"):
+        worker.write(pa.table({"id": [1], "embedding": [[0.1, 0.2, 0.3]], "other": ["x"]}, schema=bad_schema))
+    assert not _Client.instances[2].upsert_calls
+
+
+def test_milvus_sink_writes_override_upserts_and_returns_bounded_results() -> None:
+    worker = _worker()
+    table = _table()
+
+    first = worker.write(table)
+    second = worker.write(table)
+
+    assert first.rows_received == first.rows_affected == 2
+    assert first.bytes_received == table.nbytes
+    assert first.metadata == {"provider": "milvus", "collection": "items", "write_mode": "override"}
+    assert len(first.warnings) == 1
+    assert second.warnings == ()
+    client = _Client.instances[0]
+    assert client.describe_calls == [{"collection_name": "items", "timeout": 5.0}]
+    assert client.upsert_calls[0]["collection_name"] == "items"
+    assert client.upsert_calls[0]["timeout"] == 5.0
+    assert client.upsert_calls[0]["partial_update"] is False
+    assert client.upsert_calls[0]["data"] == [
+        {"id": 1, "embedding": pytest.approx([0.1, 0.2, 0.3]), "title": "one"},
+        {"id": 2, "embedding": pytest.approx([0.4, 0.5, 0.6]), "title": "two"},
+    ]
+
+
+def test_milvus_sink_validates_static_result_payload_before_upsert() -> None:
+    collection = "c" * (65 * 1024)
+    _Client.description = _description(collection_name=collection)
+    sink = MilvusSink(collection, uri="https://milvus.example:19530", primary_key="id")
+
+    with pytest.raises(ValueError, match="64 KiB"):
+        sink.bind(_arrow_schema()).open_worker(WriteContext("bounded-result"))
+
+    assert _Client.instances[0].close_calls == 1
+    assert not _Client.instances[0].upsert_calls
+
+
+@pytest.mark.parametrize(
+    "response",
+    [None, {}, {"upsert_count": True}, {"upsert_count": 1}, {"upsert_count": "2"}],
+)
+def test_milvus_sink_rejects_invalid_provider_results(response: object) -> None:
+    _Client.response = response
+    worker = _worker()
+    with pytest.raises(RuntimeError, match="affected-row count"):
+        worker.write(_table())
+
+
+def test_milvus_sink_propagates_provider_failures_and_closes_on_abort() -> None:
+    _Client.describe_error = RuntimeError("describe failed")
+    with pytest.raises(RuntimeError, match="describe failed"):
+        _worker()
+    assert _Client.instances[0].close_calls == 1
+
+    _Client.describe_error = None
+    worker = _worker()
+    _Client.upsert_error = TimeoutError("upsert timed out")
+    with pytest.raises(TimeoutError, match="upsert timed out"):
+        worker.write(_table())
+    worker.abort(TimeoutError("upsert timed out"))
+    assert _Client.instances[1].close_calls == 1
+    worker.close()
+    assert _Client.instances[1].close_calls == 1
+
+
+def test_milvus_sink_retains_client_ownership_when_close_fails() -> None:
+    worker = _worker()
+    _Client.close_error = RuntimeError("close failed")
+    with pytest.raises(RuntimeError, match="close failed"):
+        worker.close()
+    assert _Client.instances[0].close_calls == 1
+
+    _Client.close_error = None
+    worker.close()
+    assert _Client.instances[0].close_calls == 2
+
+
+def test_milvus_sink_replay_replaces_the_same_primary_keys() -> None:
+    table = _table()
+    first_worker = _bound(max_retries=1).open_worker(WriteContext("stable-operation"))
+    second_worker = _bound(max_retries=1).open_worker(WriteContext("stable-operation"))
+
+    first_worker.write(table)
+    snapshot = deepcopy(_Client.store)
+    second_worker.write(table)
+
+    assert _Client.store == snapshot
+    assert set(_Client.store) == {1, 2}
+    assert sum(len(client.upsert_calls) for client in _Client.instances) == 2
+
+
+@pytest.mark.external_service
+def test_milvus_sink_live_full_row_upsert() -> None:
+    uri = os.environ.get("VANE_TEST_MILVUS_URI")
+    if not uri:
+        pytest.skip("VANE_TEST_MILVUS_URI is required for the external Milvus test")
+    pymilvus = pytest.importorskip("pymilvus")
+    token_value = os.environ.get("VANE_TEST_MILVUS_TOKEN")
+    options: dict[str, object] = {"uri": uri, "timeout": 30.0, "dedicated": True}
+    if token_value is not None:
+        options["token"] = token_value
+    client = pymilvus.MilvusClient(**options)
+    collection = f"vane_sink_e2e_{uuid.uuid4().hex}"
+    collection_created = False
+    try:
+        schema = client.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field("id", pymilvus.DataType.INT64, is_primary=True)
+        schema.add_field("embedding", pymilvus.DataType.FLOAT_VECTOR, dim=2)
+        schema.add_field("title", pymilvus.DataType.VARCHAR, max_length=64)
+        index = client.prepare_index_params()
+        index.add_index("embedding", index_type="AUTOINDEX", metric_type="COSINE")
+        client.create_collection(
+            collection_name=collection,
+            schema=schema,
+            index_params=index,
+            consistency_level="Strong",
+            timeout=30.0,
+        )
+        collection_created = True
+        relation = vane.from_arrow(
+            pa.table(
+                {
+                    "id": [1, 2],
+                    "embedding": pa.array([[0.1, 0.2], [0.3, 0.4]], type=pa.list_(pa.float32(), 2)),
+                    "title": ["one", "two"],
+                }
+            )
+        )
+        token = EnvironmentSecret("VANE_TEST_MILVUS_TOKEN") if token_value is not None else None
+        summary = relation.write_datasink(
+            MilvusSink(collection, uri=uri, primary_key="id", token=token, timeout=30.0),
+            operation_id=f"milvus-live-{uuid.uuid4()}",
+        )
+        assert summary.rows_affected == 2
+        rows = client.query(
+            collection_name=collection, ids=[1, 2], output_fields=["id", "title"], consistency_level="Strong"
+        )
+        assert {row["id"]: row["title"] for row in rows} == {1: "one", 2: "two"}
+    finally:
+        try:
+            if collection_created:
+                client.drop_collection(collection_name=collection, timeout=30.0)
+        finally:
+            client.close()

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -208,6 +208,7 @@ from vane.datasink import (
     WriteSummary,
     write_datasink,
 )
+from vane.datasink.milvus import MilvusSink
 from vane.value.constant import (
     BinaryValue,
     BitValue,
@@ -369,6 +370,7 @@ __all__: list[str] = [
     "ListValue",
     "LongValue",
     "MapValue",
+    "MilvusSink",
     "NUMBER",
     "NotImplementedException",
     "NotSupportedError",

--- a/vane/datasink/milvus.py
+++ b/vane/datasink/milvus.py
@@ -1,0 +1,592 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed, full-row Milvus upserts.
+
+The adapter intentionally supports a narrow delivery contract: collections
+must use a caller-assigned INT64 or VARCHAR primary key, AutoID and dynamic
+fields must be disabled, and collection functions are not supported. Each
+successful worker batch has been acknowledged by Milvus, but batches are not a
+transaction and read visibility follows the consistency selected by Milvus
+readers.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from urllib.parse import urlsplit
+
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+from vane.datasink import (
+    BoundKeyedUpsertSink,
+    DataSink,
+    DataSinkExecutionOptions,
+    DataSinkWorker,
+    EnvironmentSecret,
+    WriteContext,
+    WriteResult,
+)
+
+_MAX_INT64 = (1 << 63) - 1
+_DEFAULT_MAX_BATCH_ROWS = 1_000
+_DEFAULT_MAX_BATCH_BYTES = 16 * 1024 * 1024
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_PARTIAL_VISIBILITY_WARNING = (
+    "Milvus applies worker batches independently; a later operation failure can leave this batch applied, "
+    "and query visibility follows the reader's Milvus consistency level"
+)
+
+
+def _name(name: str, value: object, *, optional: bool = False) -> str | None:
+    if value is None and optional:
+        return None
+    suffix = " or None" if optional else ""
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string{suffix}")
+    if not value or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    if value != value.strip() or "\x00" in value:
+        raise ValueError(f"{name} must not contain surrounding whitespace or NUL characters")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ValueError(f"{name} must contain valid UTF-8") from error
+    return value
+
+
+def _uri(value: object) -> str:
+    uri = _name("uri", value)
+    assert uri is not None
+    try:
+        parsed = urlsplit(uri)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as error:
+        raise ValueError("uri must be a valid HTTP or HTTPS Milvus endpoint") from error
+    if parsed.scheme not in {"http", "https"} or hostname is None:
+        raise ValueError("uri must be an absolute HTTP or HTTPS Milvus endpoint")
+    if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+        raise ValueError(
+            "uri must not contain credentials, query parameters, or fragments; use token=EnvironmentSecret(...)"
+        )
+    if parsed.path not in {"", "/"}:
+        raise ValueError("uri must not contain a database path; use database=... instead")
+    return uri
+
+
+def _positive_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a positive integer")
+    if value <= 0 or value > _MAX_INT64:
+        raise ValueError(f"{name} must be a positive signed 64-bit integer")
+    return value
+
+
+def _non_negative_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a non-negative integer")
+    if value < 0 or value > _MAX_INT64:
+        raise ValueError(f"{name} must be a non-negative signed 64-bit integer")
+    return value
+
+
+def _positive_number(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a positive number")
+    try:
+        normalized = float(value)
+    except OverflowError as error:
+        raise ValueError(f"{name} must be a finite positive number") from error
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise ValueError(f"{name} must be a finite positive number")
+    return normalized
+
+
+def _field_mapping(value: object) -> tuple[tuple[str, str], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise TypeError("field_mapping must be a mapping or None")
+    normalized: list[tuple[str, str]] = []
+    for source, target in value.items():
+        source_name = _name("field_mapping source", source)
+        target_name = _name("field_mapping target", target)
+        assert source_name is not None and target_name is not None
+        normalized.append((source_name, target_name))
+    sources = [source for source, _ in normalized]
+    targets = [target for _, target in normalized]
+    if len(set(sources)) != len(sources):
+        raise ValueError("field_mapping sources must be unique")
+    if len(set(targets)) != len(targets):
+        raise ValueError("field_mapping targets must be unique")
+    return tuple(normalized)
+
+
+class _ArrowKind(str, Enum):
+    BOOL = "BOOL"
+    INT8 = "INT8"
+    INT16 = "INT16"
+    INT32 = "INT32"
+    INT64 = "INT64"
+    FLOAT = "FLOAT"
+    DOUBLE = "DOUBLE"
+    STRING = "STRING"
+    FLOAT_VECTOR = "FLOAT_VECTOR"
+
+
+@dataclass(frozen=True)
+class _ArrowField:
+    source_name: str
+    target_name: str
+    data_type: pa.DataType
+    kind: _ArrowKind
+    fixed_dimension: int | None = None
+
+
+def _arrow_kind(field: pa.Field) -> tuple[_ArrowKind, int | None]:
+    data_type = field.type
+    if pa.types.is_boolean(data_type):
+        return _ArrowKind.BOOL, None
+    if pa.types.is_int8(data_type):
+        return _ArrowKind.INT8, None
+    if pa.types.is_int16(data_type):
+        return _ArrowKind.INT16, None
+    if pa.types.is_int32(data_type):
+        return _ArrowKind.INT32, None
+    if pa.types.is_int64(data_type):
+        return _ArrowKind.INT64, None
+    if pa.types.is_float32(data_type):
+        return _ArrowKind.FLOAT, None
+    if pa.types.is_float64(data_type):
+        return _ArrowKind.DOUBLE, None
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return _ArrowKind.STRING, None
+    if (
+        pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type)
+    ) and pa.types.is_float32(data_type.value_type):
+        dimension = data_type.list_size if pa.types.is_fixed_size_list(data_type) else None
+        if dimension is not None and dimension <= 0:
+            raise ValueError(f"Milvus FLOAT_VECTOR source field {field.name!r} must have a positive dimension")
+        return _ArrowKind.FLOAT_VECTOR, dimension
+    raise ValueError(f"MilvusSink does not support Arrow field {field.name!r} with type {data_type}")
+
+
+@dataclass(frozen=True)
+class _MilvusTypes:
+    bool: int
+    int8: int
+    int16: int
+    int32: int
+    int64: int
+    float: int
+    double: int
+    varchar: int
+    text: int
+    float_vector: int
+
+    @classmethod
+    def from_sdk(cls, data_type: Any) -> _MilvusTypes:
+        return cls(
+            bool=int(data_type.BOOL),
+            int8=int(data_type.INT8),
+            int16=int(data_type.INT16),
+            int32=int(data_type.INT32),
+            int64=int(data_type.INT64),
+            float=int(data_type.FLOAT),
+            double=int(data_type.DOUBLE),
+            varchar=int(data_type.VARCHAR),
+            text=int(data_type.TEXT),
+            float_vector=int(data_type.FLOAT_VECTOR),
+        )
+
+    def expected(self, kind: _ArrowKind) -> tuple[int, ...]:
+        if kind is _ArrowKind.STRING:
+            return (self.varchar, self.text)
+        return {
+            _ArrowKind.BOOL: (self.bool,),
+            _ArrowKind.INT8: (self.int8,),
+            _ArrowKind.INT16: (self.int16,),
+            _ArrowKind.INT32: (self.int32,),
+            _ArrowKind.INT64: (self.int64,),
+            _ArrowKind.FLOAT: (self.float,),
+            _ArrowKind.DOUBLE: (self.double,),
+            _ArrowKind.FLOAT_VECTOR: (self.float_vector,),
+        }[kind]
+
+    def label(self, value: int) -> str:
+        labels = {
+            self.bool: "BOOL",
+            self.int8: "INT8",
+            self.int16: "INT16",
+            self.int32: "INT32",
+            self.int64: "INT64",
+            self.float: "FLOAT",
+            self.double: "DOUBLE",
+            self.varchar: "VARCHAR",
+            self.text: "TEXT",
+            self.float_vector: "FLOAT_VECTOR",
+        }
+        return labels.get(value, f"type code {value}")
+
+
+def _load_milvus_sdk() -> tuple[type[Any], Any]:
+    try:
+        from pymilvus import DataType, MilvusClient  # type: ignore[import-not-found, import-untyped, unused-ignore]
+    except ModuleNotFoundError as error:
+        if error.name != "pymilvus":
+            raise
+        raise ImportError("MilvusSink requires PyMilvus; install vane-ai[milvus]") from error
+    return MilvusClient, DataType
+
+
+@dataclass(frozen=True)
+class _RemoteField:
+    data_type: int
+    nullable: bool
+    has_default: bool
+    max_length: int | None
+    dimension: int | None
+
+    @property
+    def accepts_null(self) -> bool:
+        return self.nullable or self.has_default
+
+
+def _remote_type(field: Mapping[str, Any]) -> int:
+    value = field.get("type")
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Milvus field {field.get('name')!r} has an invalid type")
+    return int(value)
+
+
+def _field_parameter(field: Mapping[str, Any], parameter: str) -> int:
+    params = field.get("params")
+    if not isinstance(params, Mapping):
+        raise ValueError(f"Milvus field {field.get('name')!r} has invalid parameters")
+    value = params.get(parameter)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"Milvus field {field.get('name')!r} has an invalid {parameter}")
+    return value
+
+
+class MilvusSink(DataSink):
+    """Write relation batches to one Milvus collection with override upserts.
+
+    ``field_mapping`` maps source relation columns to collection fields. The
+    primary key names a collection field and must map from exactly one source
+    column. ``token`` is resolved from the worker environment and is never
+    stored as plaintext in the serialized sink plan.
+
+    Framework retries are disabled unless ``max_retries`` is positive. A retry
+    replays the full input using the same Vane operation ID. Replaying a row
+    replaces the same Milvus primary key, but Vane does not coordinate with
+    concurrent external writers and does not provide exactly-once delivery.
+    """
+
+    def __init__(
+        self,
+        collection_name: str,
+        *,
+        uri: str,
+        primary_key: str,
+        token: EnvironmentSecret | None = None,
+        database: str | None = None,
+        field_mapping: Mapping[str, str] | None = None,
+        worker_count: int = 1,
+        max_batch_rows: int = _DEFAULT_MAX_BATCH_ROWS,
+        max_batch_bytes: int = _DEFAULT_MAX_BATCH_BYTES,
+        max_retries: int = 0,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        normalized_collection = _name("collection_name", collection_name)
+        normalized_primary_key = _name("primary_key", primary_key)
+        normalized_database = _name("database", database, optional=True)
+        assert normalized_collection is not None and normalized_primary_key is not None
+        if token is not None and not isinstance(token, EnvironmentSecret):
+            raise TypeError("token must be an EnvironmentSecret or None")
+        self.collection_name = normalized_collection
+        self.uri = _uri(uri)
+        self.primary_key = normalized_primary_key
+        self.database = normalized_database
+        self.worker_count = _positive_int("worker_count", worker_count)
+        self.max_batch_rows = _positive_int("max_batch_rows", max_batch_rows)
+        self.max_batch_bytes = _positive_int("max_batch_bytes", max_batch_bytes)
+        self.max_retries = _non_negative_int("max_retries", max_retries)
+        self.timeout = _positive_number("timeout", timeout)
+        self._token = token
+        self._field_mapping = _field_mapping(field_mapping)
+
+    def bind(self, schema: pa.Schema) -> BoundKeyedUpsertSink:
+        if not isinstance(schema, pa.Schema):
+            raise TypeError("schema must be pyarrow.Schema")
+        if len(set(schema.names)) != len(schema.names):
+            raise ValueError("MilvusSink requires unique input column names")
+        mapping = dict(self._field_mapping)
+        unknown_sources = set(mapping).difference(schema.names)
+        if unknown_sources:
+            raise ValueError(f"field_mapping contains unknown input columns: {sorted(unknown_sources)!r}")
+
+        fields: list[_ArrowField] = []
+        for field in schema:
+            kind, dimension = _arrow_kind(field)
+            fields.append(
+                _ArrowField(
+                    source_name=field.name,
+                    target_name=mapping.get(field.name, field.name),
+                    data_type=field.type,
+                    kind=kind,
+                    fixed_dimension=dimension,
+                )
+            )
+        if len({field.target_name for field in fields}) != len(fields):
+            raise ValueError("field_mapping must produce unique Milvus field names")
+        primary_sources = [field for field in fields if field.target_name == self.primary_key]
+        if len(primary_sources) != 1:
+            raise ValueError("primary_key must map from exactly one input column")
+        if primary_sources[0].kind not in {_ArrowKind.INT64, _ArrowKind.STRING}:
+            raise ValueError("Milvus primary key source must be Arrow int64 or string")
+        return _BoundMilvusSink(self, tuple(fields), primary_sources[0].source_name)
+
+
+class _BoundMilvusSink(BoundKeyedUpsertSink):
+    def __init__(self, sink: MilvusSink, fields: tuple[_ArrowField, ...], primary_source: str) -> None:
+        self._sink = sink
+        self._fields = fields
+        self._primary_source = primary_source
+
+    @property
+    def execution_options(self) -> DataSinkExecutionOptions:
+        return DataSinkExecutionOptions(
+            worker_count=self._sink.worker_count,
+            batch_size=self._sink.max_batch_rows,
+            target_max_batch_bytes=self._sink.max_batch_bytes,
+            max_retries=self._sink.max_retries,
+        )
+
+    @property
+    def key_columns(self) -> Sequence[str]:
+        return (self._primary_source,)
+
+    def open_worker(self, _context: WriteContext) -> DataSinkWorker:
+        return _MilvusWorker(self._sink, self._fields)
+
+
+class _MilvusWorker(DataSinkWorker):
+    def __init__(self, sink: MilvusSink, fields: tuple[_ArrowField, ...]) -> None:
+        client_type, data_type = _load_milvus_sdk()
+        self._types = _MilvusTypes.from_sdk(data_type)
+        client_options: dict[str, Any] = {
+            "uri": sink.uri,
+            "timeout": sink.timeout,
+            "dedicated": True,
+        }
+        if sink._token is not None:
+            client_options["token"] = sink._token.resolve()
+        if sink.database is not None:
+            client_options["db_name"] = sink.database
+        self._sink = sink
+        self._bindings = fields
+        self._client: Any | None = client_type(**client_options)
+        self._warning_pending = True
+        try:
+            self._remote_fields = self._validate_collection()
+            self._result_metadata = {
+                "provider": "milvus",
+                "collection": self._sink.collection_name,
+                "write_mode": "override",
+            }
+            # Validate all static result payloads before the first remote side
+            # effect, so an applied upsert cannot be followed by a local result
+            # serialization failure.
+            WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                metadata=self._result_metadata,
+                warnings=(_PARTIAL_VISIBILITY_WARNING,),
+            )
+        except BaseException as error:
+            try:
+                self.close()
+            except BaseException as close_error:
+                add_note = getattr(error, "add_note", None)
+                if callable(add_note):
+                    try:
+                        add_note(f"Milvus client cleanup also failed: {type(close_error).__name__}")
+                    except BaseException:
+                        pass
+            raise
+
+    def _client_or_raise(self) -> Any:
+        if self._client is None:
+            raise RuntimeError("MilvusSink worker is closed")
+        return self._client
+
+    def _validate_collection(self) -> Mapping[str, _RemoteField]:
+        description = self._client_or_raise().describe_collection(
+            collection_name=self._sink.collection_name,
+            timeout=self._sink.timeout,
+        )
+        if not isinstance(description, Mapping):
+            raise ValueError("Milvus describe_collection returned an invalid description")
+        if description.get("collection_name") != self._sink.collection_name:
+            raise ValueError("Milvus describe_collection returned a different collection")
+        if description.get("auto_id") is not False:
+            raise ValueError("MilvusSink requires AutoID to be disabled")
+        if description.get("enable_dynamic_field") is not False:
+            raise ValueError("MilvusSink requires dynamic fields to be disabled")
+        functions = description.get("functions")
+        if not isinstance(functions, list):
+            raise ValueError("Milvus describe_collection returned invalid function metadata")
+        if functions:
+            raise ValueError("MilvusSink does not support collections with functions")
+        raw_fields = description.get("fields")
+        if not isinstance(raw_fields, list) or not raw_fields:
+            raise ValueError("Milvus describe_collection returned no fields")
+
+        fields: dict[str, Mapping[str, Any]] = {}
+        for raw_field in raw_fields:
+            if not isinstance(raw_field, Mapping):
+                raise ValueError("Milvus describe_collection returned an invalid field")
+            field_name = raw_field.get("name")
+            if not isinstance(field_name, str) or not field_name:
+                raise ValueError("Milvus describe_collection returned an invalid field name")
+            if field_name in fields:
+                raise ValueError(f"Milvus describe_collection returned duplicate field {field_name!r}")
+            if raw_field.get("is_function_output") is True:
+                raise ValueError("MilvusSink does not support function output fields")
+            fields[field_name] = raw_field
+
+        primary_fields = [field for field in fields.values() if field.get("is_primary") is True]
+        if len(primary_fields) != 1 or primary_fields[0].get("name") != self._sink.primary_key:
+            raise ValueError("Milvus collection primary key does not match MilvusSink.primary_key")
+        primary_type = _remote_type(primary_fields[0])
+        if primary_type not in {self._types.int64, self._types.varchar}:
+            raise ValueError("Milvus collection primary key must be INT64 or VARCHAR")
+        if primary_fields[0].get("auto_id") is True:
+            raise ValueError("MilvusSink requires AutoID to be disabled")
+
+        target_names = {binding.target_name for binding in self._bindings}
+        unknown_targets = target_names.difference(fields)
+        if unknown_targets:
+            raise ValueError(f"input fields are absent from the Milvus collection: {sorted(unknown_targets)!r}")
+        missing_required = [
+            name
+            for name, field in fields.items()
+            if name not in target_names and field.get("nullable") is not True and field.get("default_value") is None
+        ]
+        if missing_required:
+            raise ValueError(f"input is missing required Milvus fields: {sorted(missing_required)!r}")
+
+        validated: dict[str, _RemoteField] = {}
+        for binding in self._bindings:
+            raw_field = fields[binding.target_name]
+            remote_type = _remote_type(raw_field)
+            if remote_type not in self._types.expected(binding.kind):
+                raise ValueError(
+                    f"Milvus field {binding.target_name!r} type {self._types.label(remote_type)} "
+                    f"does not match Arrow field {binding.source_name!r} type {binding.data_type}"
+                )
+            max_length = _field_parameter(raw_field, "max_length") if remote_type == self._types.varchar else None
+            dimension = _field_parameter(raw_field, "dim") if remote_type == self._types.float_vector else None
+            if binding.fixed_dimension is not None and dimension != binding.fixed_dimension:
+                raise ValueError(
+                    f"Milvus vector field {binding.target_name!r} dimension {dimension} "
+                    f"does not match Arrow fixed dimension {binding.fixed_dimension}"
+                )
+            validated[binding.target_name] = _RemoteField(
+                data_type=remote_type,
+                nullable=raw_field.get("nullable") is True,
+                has_default=raw_field.get("default_value") is not None,
+                max_length=max_length,
+                dimension=dimension,
+            )
+        return validated
+
+    def _records(self, table: pa.Table) -> tuple[list[dict[str, Any]], int, int]:
+        if not isinstance(table, pa.Table):
+            raise TypeError(f"MilvusSink expected pyarrow.Table, got {type(table).__name__}")
+        if len(table.schema) != len(self._bindings):
+            raise ValueError("Milvus batch schema does not match the bound input schema")
+        for index, binding in enumerate(self._bindings):
+            batch_field = table.schema.field(index)
+            if batch_field.name != binding.source_name or batch_field.type != binding.data_type:
+                raise ValueError("Milvus batch schema does not match the bound input schema")
+        row_count = table.num_rows
+        batch_bytes = table.nbytes
+        if row_count > self._sink.max_batch_rows:
+            raise ValueError("Milvus batch exceeds max_batch_rows")
+        if batch_bytes > self._sink.max_batch_bytes:
+            raise ValueError("Milvus batch exceeds max_batch_bytes")
+
+        records: list[dict[str, Any]] = []
+        for row in table.to_pylist():
+            record: dict[str, Any] = {}
+            for binding in self._bindings:
+                value = row[binding.source_name]
+                remote = self._remote_fields[binding.target_name]
+                if value is None:
+                    if binding.target_name == self._sink.primary_key or not remote.accepts_null:
+                        raise ValueError(f"Milvus field {binding.target_name!r} does not accept null values")
+                elif remote.data_type == self._types.varchar:
+                    try:
+                        encoded = value.encode("utf-8")
+                    except (AttributeError, UnicodeEncodeError) as error:
+                        raise ValueError(
+                            f"Milvus VARCHAR field {binding.target_name!r} contains invalid UTF-8"
+                        ) from error
+                    assert remote.max_length is not None
+                    if len(encoded) > remote.max_length:
+                        raise ValueError(f"Milvus VARCHAR field {binding.target_name!r} exceeds max_length")
+                elif remote.data_type == self._types.float_vector:
+                    assert remote.dimension is not None
+                    if not isinstance(value, list) or len(value) != remote.dimension:
+                        raise ValueError(f"Milvus vector field {binding.target_name!r} has an invalid dimension")
+                    if any(
+                        isinstance(element, bool)
+                        or not isinstance(element, (int, float))
+                        or not math.isfinite(float(element))
+                        for element in value
+                    ):
+                        raise ValueError(f"Milvus vector field {binding.target_name!r} contains an invalid value")
+                record[binding.target_name] = value
+            records.append(record)
+        return records, row_count, batch_bytes
+
+    def write(self, table: pa.Table) -> WriteResult:
+        records, row_count, batch_bytes = self._records(table)
+        response = self._client_or_raise().upsert(
+            collection_name=self._sink.collection_name,
+            data=records,
+            timeout=self._sink.timeout,
+            partial_update=False,
+        )
+        count = response.get("upsert_count") if isinstance(response, Mapping) else None
+        if isinstance(count, bool) or not isinstance(count, int) or count != row_count:
+            raise RuntimeError("Milvus upsert returned an invalid affected-row count")
+        warnings = (_PARTIAL_VISIBILITY_WARNING,) if self._warning_pending else ()
+        self._warning_pending = False
+        return WriteResult(
+            rows_received=row_count,
+            rows_affected=count,
+            bytes_received=batch_bytes,
+            metadata=self._result_metadata,
+            warnings=warnings,
+        )
+
+    def abort(self, _error: BaseException) -> None:
+        self.close()
+
+    def close(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        client.close()
+        self._client = None
+
+
+__all__ = ["MilvusSink"]


### PR DESCRIPTION
## Summary

- add a strict PyMilvus 3 `MilvusSink` on the current `BoundKeyedUpsertSink` contract, with caller-assigned globally unique `INT64`/`VARCHAR` keys and ordinary full-row override upserts
- validate collection/schema constraints, Arrow field mappings, vector dimensions and values, required fields, batch limits, provider results, and dedicated worker-client cleanup before or around remote submission
- keep credentials out of serialized plans through worker-resolved `EnvironmentSecret` references, add the optional `milvus` extra and public export, and document partial visibility/replay semantics
- add SDK-mocked coverage plus an `external_service` test that performs a real collection create, sink upsert, query, and cleanup
- gate the PR with a dedicated CI job using the digest-pinned Milvus 3.0.0 standalone image and the built Python 3.12 wheel

## Related issue

close: #649

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The README documents installation, supported schema and endpoint constraints, full-row behavior, retries, partial visibility, and consistency semantics.

## Validation

- Two consecutive clean reviews after the final workflow changes, followed by one additional clean review after build/test.
- `scripts/format root --changed --check`
- `pre-commit run --show-diff-on-failure --files .github/workflows/ci.yml`
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`
- `scripts/run_installed_pytest.sh tests/fast/test_milvus_datasink.py` — 60 passed, 1 external-service test deselected
- `scripts/run_release_tests.sh` — 757 non-Ray tests passed (19 deselected); 14 real-Ray tests passed (762 deselected)
- Local Milvus 3.0.0 with PyMilvus 3.0.1 — 1 live test passed, 60 deselected in 4.51s
- [Milvus integration test](https://github.com/AstroVela/vane/actions/runs/32948349662/job/98135159435) — digest-pinned Milvus 3.0.0 with PyMilvus 3.0.1; 1 passed, 60 deselected in 4.47s
- [Full CI](https://github.com/AstroVela/vane/actions/runs/32948349662) — all 18 jobs passed, including source packages and native/release tests on Python 3.10–3.14, fast shards, AI tests, and Required CI

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
