### PR TITLE
[fix](ray) Serialize JSON scan plans

### DIFF
--- a/external/duckdb/extension/json/include/json.json
+++ b/external/duckdb/extension/json/include/json.json
@@ -142,6 +142,11 @@
         "id": 101,
         "name": "options",
         "type": "map<string, Value>"
+      },
+      {
+        "id": 102,
+        "name": "ordinal",
+        "type": "idx_t"
       }
     ],
     "pointer_type": "none"

--- a/external/duckdb/extension/json/include/json.json
+++ b/external/duckdb/extension/json/include/json.json
@@ -32,5 +32,197 @@
       }
     ],
     "pointer_type": "none"
+  },
+  {
+    "class": "JSONReaderOptions",
+    "includes": [
+      "json_reader_options.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "type",
+        "type": "JSONScanType"
+      },
+      {
+        "id": 101,
+        "name": "format",
+        "type": "JSONFormat"
+      },
+      {
+        "id": 102,
+        "name": "record_type",
+        "type": "JSONRecordType"
+      },
+      {
+        "id": 103,
+        "name": "compression",
+        "type": "FileCompressionType"
+      },
+      {
+        "id": 104,
+        "name": "ignore_errors",
+        "type": "bool"
+      },
+      {
+        "id": 105,
+        "name": "maximum_object_size",
+        "type": "idx_t"
+      },
+      {
+        "id": 106,
+        "name": "auto_detect",
+        "type": "bool"
+      },
+      {
+        "id": 107,
+        "name": "sample_size",
+        "type": "idx_t"
+      },
+      {
+        "id": 108,
+        "name": "max_depth",
+        "type": "idx_t"
+      },
+      {
+        "id": 109,
+        "name": "field_appearance_threshold",
+        "type": "double"
+      },
+      {
+        "id": 110,
+        "name": "maximum_sample_files",
+        "type": "idx_t"
+      },
+      {
+        "id": 111,
+        "name": "convert_strings_to_integers",
+        "type": "bool"
+      },
+      {
+        "id": 112,
+        "name": "map_inference_threshold",
+        "type": "idx_t"
+      },
+      {
+        "id": 113,
+        "name": "name_list",
+        "type": "vector<string>"
+      },
+      {
+        "id": 114,
+        "name": "sql_type_list",
+        "type": "vector<LogicalType>"
+      },
+      {
+        "id": 115,
+        "name": "date_format",
+        "type": "string"
+      },
+      {
+        "id": 116,
+        "name": "timestamp_format",
+        "type": "string"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
+    "class": "JSONFileSnapshot",
+    "includes": [
+      "json_scan.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "path",
+        "type": "string"
+      },
+      {
+        "id": 101,
+        "name": "options",
+        "type": "map<string, Value>"
+      }
+    ],
+    "pointer_type": "none"
+  },
+  {
+    "class": "SerializedJSONScanData",
+    "includes": [
+      "json_scan.hpp"
+    ],
+    "members": [
+      {
+        "id": 100,
+        "name": "files",
+        "type": "vector<JSONFileSnapshot>"
+      },
+      {
+        "id": 101,
+        "name": "types",
+        "type": "vector<LogicalType>"
+      },
+      {
+        "id": 102,
+        "name": "names",
+        "type": "vector<string>"
+      },
+      {
+        "id": 103,
+        "name": "file_options",
+        "type": "MultiFileOptions"
+      },
+      {
+        "id": 104,
+        "name": "reader_bind",
+        "type": "MultiFileReaderBindData"
+      },
+      {
+        "id": 105,
+        "name": "table_columns",
+        "type": "vector<string>"
+      },
+      {
+        "id": 106,
+        "name": "bind_column_ids",
+        "type": "vector<idx_t>"
+      },
+      {
+        "id": 107,
+        "name": "options",
+        "type": "JSONReaderOptions"
+      },
+      {
+        "id": 108,
+        "name": "key_names",
+        "type": "vector<string>"
+      },
+      {
+        "id": 109,
+        "name": "date_formats",
+        "type": "vector<StrpTimeFormat>"
+      },
+      {
+        "id": 110,
+        "name": "timestamp_formats",
+        "type": "vector<StrpTimeFormat>"
+      },
+      {
+        "id": 111,
+        "name": "max_threads",
+        "type": "optional_idx"
+      },
+      {
+        "id": 112,
+        "name": "estimated_cardinality_per_file",
+        "type": "optional_idx"
+      },
+      {
+        "id": 113,
+        "name": "reader_column_ids",
+        "type": "vector<idx_t>"
+      }
+    ],
+    "pointer_type": "none"
   }
 ]

--- a/external/duckdb/extension/json/include/json_multi_file_info.hpp
+++ b/external/duckdb/extension/json/include/json_multi_file_info.hpp
@@ -48,6 +48,7 @@ struct JSONMultiFileInfo : MultiFileReaderInterface {
 	void FinishReading(ClientContext &context, GlobalTableFunctionState &global_state,
 	                   LocalTableFunctionState &local_state) override;
 	unique_ptr<NodeStatistics> GetCardinality(const MultiFileBindData &bind_data, idx_t file_count) override;
+	unique_ptr<MultiFileReaderInterface> Copy() override;
 	FileGlobInput GetGlobInput() override;
 };
 

--- a/external/duckdb/extension/json/include/json_reader_options.hpp
+++ b/external/duckdb/extension/json/include/json_reader_options.hpp
@@ -125,6 +125,9 @@ struct JSONReaderOptions {
 	//! Forced date/timestamp formats
 	string date_format;
 	string timestamp_format;
+
+	void Serialize(Serializer &serializer) const;
+	static JSONReaderOptions Deserialize(Deserializer &deserializer);
 };
 
 } // namespace duckdb

--- a/external/duckdb/extension/json/include/json_scan.hpp
+++ b/external/duckdb/extension/json/include/json_scan.hpp
@@ -24,10 +24,14 @@ namespace duckdb {
 //! Owned, deterministic representation of an OpenFileInfo used by a bound JSON scan.
 struct JSONFileSnapshot {
 	JSONFileSnapshot() = default;
-	explicit JSONFileSnapshot(const OpenFileInfo &file);
+	JSONFileSnapshot(idx_t ordinal, const OpenFileInfo &file);
+
+	static constexpr const char *ORDINAL_OPTION = "__vane_json_file_ordinal";
+	static bool TryGetOrdinal(const OpenFileInfo &file, idx_t &ordinal);
 
 	string path;
 	map<string, Value> options;
+	idx_t ordinal = 0;
 
 	OpenFileInfo ToOpenFileInfo() const;
 	void Serialize(Serializer &serializer) const;

--- a/external/duckdb/extension/json/include/json_scan.hpp
+++ b/external/duckdb/extension/json/include/json_scan.hpp
@@ -21,12 +21,27 @@
 
 namespace duckdb {
 
+//! Owned, deterministic representation of an OpenFileInfo used by a bound JSON scan.
+struct JSONFileSnapshot {
+	JSONFileSnapshot() = default;
+	explicit JSONFileSnapshot(const OpenFileInfo &file);
+
+	string path;
+	map<string, Value> options;
+
+	OpenFileInfo ToOpenFileInfo() const;
+	void Serialize(Serializer &serializer) const;
+	static JSONFileSnapshot Deserialize(Deserializer &deserializer);
+};
+
 struct JSONScanData : public TableFunctionData {
 public:
 	JSONScanData();
 
 	void InitializeFormats();
 	void InitializeFormats(bool auto_detect);
+	void InitializeTransformOptions();
+	unique_ptr<FunctionData> Copy() const override;
 
 public:
 	//! JSON reader options
@@ -42,6 +57,27 @@ public:
 
 	optional_idx max_threads;
 	optional_idx estimated_cardinality_per_file;
+};
+
+//! Complete owned state required to reconstruct a bound JSON multi-file scan without reopening or resampling files.
+struct SerializedJSONScanData {
+	vector<JSONFileSnapshot> files;
+	vector<LogicalType> types;
+	vector<string> names;
+	MultiFileOptions file_options;
+	MultiFileReaderBindData reader_bind;
+	vector<string> table_columns;
+	vector<idx_t> bind_column_ids;
+	JSONReaderOptions options;
+	vector<string> key_names;
+	vector<StrpTimeFormat> date_formats;
+	vector<StrpTimeFormat> timestamp_formats;
+	optional_idx max_threads;
+	optional_idx estimated_cardinality_per_file;
+	vector<idx_t> reader_column_ids;
+
+	void Serialize(Serializer &serializer) const;
+	static SerializedJSONScanData Deserialize(Deserializer &deserializer);
 };
 
 struct JSONScanInfo : public TableFunctionInfo {

--- a/external/duckdb/extension/json/json_functions/read_json.cpp
+++ b/external/duckdb/extension/json/json_functions/read_json.cpp
@@ -75,7 +75,7 @@ public:
 			throw InternalException("Union data already set");
 		}
 		auto &reader = *json_reader;
-		auto union_data = make_uniq<BaseUnionData>(files[file_idx].path);
+		auto union_data = make_uniq<BaseUnionData>(files[file_idx]);
 		union_data->reader = std::move(json_reader);
 		bind_data.union_readers[file_idx] = std::move(union_data);
 

--- a/external/duckdb/extension/json/json_functions/read_json.cpp
+++ b/external/duckdb/extension/json/json_functions/read_json.cpp
@@ -70,7 +70,7 @@ public:
 		auto &bind_data = auto_detect_state.bind_data;
 		auto &files = auto_detect_state.files;
 		auto &json_data = bind_data.bind_data->Cast<JSONScanData>();
-		auto json_reader = make_shared_ptr<JSONReader>(context, json_data.options, files[file_idx].path);
+		auto json_reader = make_shared_ptr<JSONReader>(context, json_data.options, files[file_idx]);
 		if (bind_data.union_readers[file_idx]) {
 			throw InternalException("Union data already set");
 		}

--- a/external/duckdb/extension/json/json_multi_file_info.cpp
+++ b/external/duckdb/extension/json/json_multi_file_info.cpp
@@ -310,13 +310,7 @@ void JSONMultiFileInfo::BindReader(ClientContext &context, vector<LogicalType> &
 	bind_data.multi_file_reader->BindOptions(bind_data.file_options, *bind_data.file_list, return_types, names,
 	                                         bind_data.reader_bind);
 
-	auto &transform_options = json_data.transform_options;
-	transform_options.strict_cast = !options.ignore_errors;
-	transform_options.error_duplicate_key = !options.ignore_errors;
-	transform_options.error_missing_key = false;
-	transform_options.error_unknown_key = options.auto_detect && !options.ignore_errors;
-	transform_options.date_format_map = json_data.date_format_map.get();
-	transform_options.delay_error = true;
+	json_data.InitializeTransformOptions();
 
 	if (options.auto_detect) {
 		// JSON may contain columns such as "id" and "Id", which are duplicates for us due to case-insensitivity
@@ -441,7 +435,7 @@ shared_ptr<BaseFileReader> JSONMultiFileInfo::CreateReader(ClientContext &contex
                                                            const OpenFileInfo &file, idx_t file_idx,
                                                            const MultiFileBindData &bind_data) {
 	auto &json_data = bind_data.bind_data->Cast<JSONScanData>();
-	auto reader = make_shared_ptr<JSONReader>(context, json_data.options, file.path);
+	auto reader = make_shared_ptr<JSONReader>(context, json_data.options, file);
 	reader->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(bind_data.names, bind_data.types);
 	return std::move(reader);
 }
@@ -589,6 +583,10 @@ optional_idx JSONMultiFileInfo::MaxThreads(const MultiFileBindData &bind_data, c
 	// get the max threads from the bind data (if it is set)
 	auto &json_data = bind_data.bind_data->Cast<JSONScanData>();
 	return json_data.max_threads;
+}
+
+unique_ptr<MultiFileReaderInterface> JSONMultiFileInfo::Copy() {
+	return make_uniq<JSONMultiFileInfo>();
 }
 
 FileGlobInput JSONMultiFileInfo::GetGlobInput() {

--- a/external/duckdb/extension/json/json_multi_file_info.cpp
+++ b/external/duckdb/extension/json/json_multi_file_info.cpp
@@ -426,7 +426,7 @@ shared_ptr<BaseFileReader> JSONMultiFileInfo::CreateReader(ClientContext &contex
                                                            BaseUnionData &union_data,
                                                            const MultiFileBindData &bind_data_p) {
 	auto &json_data = bind_data_p.bind_data->Cast<JSONScanData>();
-	auto reader = make_shared_ptr<JSONReader>(context, json_data.options, union_data.GetFileName());
+	auto reader = make_shared_ptr<JSONReader>(context, json_data.options, union_data.file);
 	reader->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(union_data.names, union_data.types);
 	return std::move(reader);
 }

--- a/external/duckdb/extension/json/json_reader.cpp
+++ b/external/duckdb/extension/json/json_reader.cpp
@@ -180,6 +180,10 @@ idx_t JSONFileHandle::ReadFromCache(char *&pointer, idx_t &size, atomic<idx_t> &
 JSONReader::JSONReader(ClientContext &context, JSONReaderOptions options_p, OpenFileInfo file_p)
     : BaseFileReader(std::move(file_p)), context(context), options(std::move(options_p)), initialized(0),
       next_buffer_index(0), thrown(false) {
+	idx_t coordinator_ordinal;
+	if (JSONFileSnapshot::TryGetOrdinal(file, coordinator_ordinal)) {
+		file_list_idx = optional_idx(coordinator_ordinal);
+	}
 }
 
 void JSONReader::OpenJSONFile() {

--- a/external/duckdb/extension/json/json_scan.cpp
+++ b/external/duckdb/extension/json/json_scan.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/multi_file/multi_file_reader.hpp"
+#include "duckdb/common/set.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/main/extension_helper.hpp"
@@ -10,6 +11,25 @@
 #include "json_multi_file_info.hpp"
 
 namespace duckdb {
+
+JSONFileSnapshot::JSONFileSnapshot(const OpenFileInfo &file) : path(file.path) {
+	if (file.extended_info) {
+		for (const auto &entry : file.extended_info->options) {
+			options.emplace(entry.first, entry.second);
+		}
+	}
+}
+
+OpenFileInfo JSONFileSnapshot::ToOpenFileInfo() const {
+	OpenFileInfo result(path);
+	if (!options.empty()) {
+		result.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+		for (const auto &entry : options) {
+			result.extended_info->options.emplace(entry.first, entry.second);
+		}
+	}
+	return result;
+}
 
 JSONScanData::JSONScanData() {
 }
@@ -50,6 +70,50 @@ void JSONScanData::InitializeFormats(bool auto_detect_p) {
 		}
 	}
 	date_format_map = make_uniq<DateFormatMap>(std::move(candidate_formats));
+}
+
+void JSONScanData::InitializeTransformOptions() {
+	transform_options.strict_cast = !options.ignore_errors;
+	transform_options.error_duplicate_key = !options.ignore_errors;
+	transform_options.error_missing_key = false;
+	transform_options.error_unknown_key = options.auto_detect && !options.ignore_errors;
+	transform_options.delay_error = true;
+	transform_options.date_format_map = date_format_map.get();
+	transform_options.error_message.clear();
+	transform_options.object_index = DConstants::INVALID_INDEX;
+	transform_options.parameters = CastParameters(false, &transform_options.error_message);
+}
+
+static vector<StrpTimeFormat> CopyJSONFormats(const optional_ptr<const DateFormatMap> format_map, LogicalTypeId type) {
+	if (!format_map || !format_map->HasFormats(type)) {
+		return {};
+	}
+	return format_map->GetFormats(type);
+}
+
+static unique_ptr<DateFormatMap> MakeJSONDateFormatMap(vector<StrpTimeFormat> date_formats,
+                                                       vector<StrpTimeFormat> timestamp_formats) {
+	type_id_map_t<vector<StrpTimeFormat>> candidate_formats;
+	if (!date_formats.empty()) {
+		candidate_formats.emplace(LogicalTypeId::DATE, std::move(date_formats));
+	}
+	if (!timestamp_formats.empty()) {
+		candidate_formats.emplace(LogicalTypeId::TIMESTAMP, std::move(timestamp_formats));
+	}
+	return make_uniq<DateFormatMap>(std::move(candidate_formats));
+}
+
+unique_ptr<FunctionData> JSONScanData::Copy() const {
+	auto result = make_uniq<JSONScanData>();
+	result->column_ids = column_ids;
+	result->options = options;
+	result->key_names = key_names;
+	result->date_format_map = MakeJSONDateFormatMap(CopyJSONFormats(date_format_map.get(), LogicalTypeId::DATE),
+	                                                CopyJSONFormats(date_format_map.get(), LogicalTypeId::TIMESTAMP));
+	result->InitializeTransformOptions();
+	result->max_threads = max_threads;
+	result->estimated_cardinality_per_file = estimated_cardinality_per_file;
+	return std::move(result);
 }
 
 JSONScanGlobalState::JSONScanGlobalState(ClientContext &context, const MultiFileBindData &bind_data_p)
@@ -104,12 +168,220 @@ void JSONScanLocalState::AddTransformError(idx_t object_index, const string &err
 	scan_state.current_reader->AddTransformError(scan_state, object_index, error_message);
 }
 
-void JSONScan::Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p, const TableFunction &) {
-	throw NotImplementedException("JSONScan Serialize not implemented");
+static void ValidateJSONReaderOptions(const JSONReaderOptions &options, const string &function_name) {
+	if (options.type != JSONScanType::READ_JSON && options.type != JSONScanType::READ_JSON_OBJECTS) {
+		throw SerializationException("Cannot serialize %s with invalid JSON scan type", function_name);
+	}
+	switch (options.format) {
+	case JSONFormat::AUTO_DETECT:
+	case JSONFormat::UNSTRUCTURED:
+	case JSONFormat::NEWLINE_DELIMITED:
+	case JSONFormat::ARRAY:
+		break;
+	default:
+		throw SerializationException("Cannot serialize %s with invalid JSON format", function_name);
+	}
+	if (options.record_type != JSONRecordType::RECORDS && options.record_type != JSONRecordType::VALUES) {
+		throw SerializationException("Cannot serialize %s with unresolved JSON record type", function_name);
+	}
+	switch (options.compression) {
+	case FileCompressionType::AUTO_DETECT:
+	case FileCompressionType::UNCOMPRESSED:
+	case FileCompressionType::GZIP:
+	case FileCompressionType::ZSTD:
+		break;
+	default:
+		throw SerializationException("Cannot serialize %s with invalid JSON compression type", function_name);
+	}
+	if (options.maximum_object_size == 0 || options.sample_size == 0 || options.maximum_sample_files == 0) {
+		throw SerializationException("Cannot serialize %s with zero-sized JSON reader limits", function_name);
+	}
+	if (options.maximum_object_size > NumericLimits<idx_t>::Maximum() / 2) {
+		throw SerializationException("Cannot serialize %s with an oversized JSON object limit", function_name);
+	}
+	if (!Value::DoubleIsFinite(options.field_appearance_threshold) || options.field_appearance_threshold < 0 ||
+	    options.field_appearance_threshold > 1) {
+		throw SerializationException("Cannot serialize %s with invalid JSON field appearance threshold", function_name);
+	}
+	if (options.name_list.size() != options.sql_type_list.size()) {
+		throw SerializationException("Cannot serialize %s with mismatched JSON option names and types", function_name);
+	}
+	for (const auto &format : {options.date_format, options.timestamp_format}) {
+		if (format.empty()) {
+			continue;
+		}
+		StrpTimeFormat parsed_format;
+		if (!StrTimeFormat::ParseFormatSpecifier(format, parsed_format).empty()) {
+			throw SerializationException("Cannot serialize %s with an invalid JSON date format", function_name);
+		}
+	}
 }
 
-unique_ptr<FunctionData> JSONScan::Deserialize(Deserializer &deserializer, TableFunction &) {
-	throw NotImplementedException("JSONScan Deserialize not implemented");
+static void ValidateJSONFormats(const vector<StrpTimeFormat> &formats, const string &function_name) {
+	for (const auto &format : formats) {
+		StrpTimeFormat parsed_format;
+		if (format.format_specifier.empty() ||
+		    !StrTimeFormat::ParseFormatSpecifier(format.format_specifier, parsed_format).empty()) {
+			throw SerializationException("Cannot serialize %s with invalid inferred JSON date formats", function_name);
+		}
+	}
+}
+
+static void ValidateJSONSchema(const vector<LogicalType> &types, const vector<string> &names,
+                               const vector<string> &key_names, const MultiFileOptions &file_options,
+                               const MultiFileReaderBindData &reader_bind, const string &function_name) {
+	if (types.empty() || types.size() != names.size() || key_names.empty() || key_names.size() > names.size()) {
+		throw SerializationException("Cannot serialize %s with an invalid JSON schema", function_name);
+	}
+	if (file_options.mapping != MultiFileColumnMappingMode::BY_NAME || !file_options.custom_options.empty() ||
+	    reader_bind.mapping != MultiFileColumnMappingMode::BY_NAME || !reader_bind.schema.empty()) {
+		throw SerializationException("Cannot serialize %s with non-standard multi-file column mapping state",
+		                             function_name);
+	}
+	if (!reader_bind.filename_idx.IsValid()) {
+		throw SerializationException("Cannot serialize %s without bound filename metadata", function_name);
+	}
+	const auto filename_idx = reader_bind.filename_idx.GetIndex();
+	if (file_options.filename) {
+		if (IsVirtualColumn(filename_idx) || filename_idx >= names.size() ||
+		    names[filename_idx] != file_options.filename_column || types[filename_idx].id() != LogicalTypeId::VARCHAR) {
+			throw SerializationException("Cannot serialize %s with an invalid filename column", function_name);
+		}
+	} else if (filename_idx != MultiFileReader::COLUMN_IDENTIFIER_FILENAME) {
+		throw SerializationException("Cannot serialize %s with inconsistent filename metadata", function_name);
+	}
+
+	set<idx_t> hive_indexes;
+	for (const auto &hive_index : reader_bind.hive_partitioning_indexes) {
+		if (!file_options.hive_partitioning || hive_index.value.empty() || hive_index.index >= names.size() ||
+		    !hive_indexes.insert(hive_index.index).second) {
+			throw SerializationException("Cannot serialize %s with invalid hive partition columns", function_name);
+		}
+	}
+	for (idx_t column_idx = key_names.size(); column_idx < names.size(); column_idx++) {
+		if (filename_idx != column_idx && hive_indexes.find(column_idx) == hive_indexes.end()) {
+			throw SerializationException("Cannot serialize %s with incomplete JSON key state", function_name);
+		}
+	}
+}
+
+static void ValidateJSONBindData(const MultiFileBindData &bind_data, const string &function_name) {
+	if (!bind_data.bind_data || !bind_data.file_list || !bind_data.multi_file_reader || !bind_data.interface) {
+		throw SerializationException("Cannot serialize incomplete %s bind data", function_name);
+	}
+
+	auto &json_data = bind_data.bind_data->Cast<JSONScanData>();
+	ValidateJSONReaderOptions(json_data.options, function_name);
+	ValidateJSONSchema(bind_data.types, bind_data.names, json_data.key_names, bind_data.file_options,
+	                   bind_data.reader_bind, function_name);
+	if (!json_data.date_format_map || json_data.transform_options.date_format_map != json_data.date_format_map.get() ||
+	    json_data.transform_options.strict_cast != !json_data.options.ignore_errors ||
+	    json_data.transform_options.error_duplicate_key != !json_data.options.ignore_errors ||
+	    json_data.transform_options.error_missing_key ||
+	    json_data.transform_options.error_unknown_key !=
+	        (json_data.options.auto_detect && !json_data.options.ignore_errors) ||
+	    !json_data.transform_options.delay_error ||
+	    json_data.transform_options.parameters.error_message != &json_data.transform_options.error_message) {
+		throw SerializationException("Cannot serialize %s with inconsistent JSON transform state", function_name);
+	}
+	if ((json_data.max_threads.IsValid() && json_data.max_threads.GetIndex() == 0) ||
+	    (json_data.estimated_cardinality_per_file.IsValid() &&
+	     json_data.estimated_cardinality_per_file.GetIndex() == 0)) {
+		throw SerializationException("Cannot serialize %s with invalid JSON cardinality state", function_name);
+	}
+}
+
+void JSONScan::Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
+                         const TableFunction &function) {
+	if (!bind_data_p) {
+		throw SerializationException("Cannot serialize %s without bind data", function.name);
+	}
+	auto &bind_data = bind_data_p->Cast<MultiFileBindData>();
+	ValidateJSONBindData(bind_data, function.name);
+	auto &json_data = bind_data.bind_data->Cast<JSONScanData>();
+
+	SerializedJSONScanData serialized_data;
+	auto files = bind_data.file_list->GetAllFiles();
+	serialized_data.files.reserve(files.size());
+	for (const auto &file : files) {
+		if (file.path.empty()) {
+			throw SerializationException("Cannot serialize %s with an empty JSON file path", function.name);
+		}
+		serialized_data.files.emplace_back(file);
+	}
+	serialized_data.types = bind_data.types;
+	serialized_data.names = bind_data.names;
+	serialized_data.file_options = bind_data.file_options;
+	serialized_data.reader_bind = bind_data.reader_bind;
+	serialized_data.table_columns = bind_data.table_columns;
+	serialized_data.bind_column_ids = bind_data.column_ids;
+	serialized_data.options = json_data.options;
+	serialized_data.key_names = json_data.key_names;
+	serialized_data.date_formats = CopyJSONFormats(json_data.date_format_map.get(), LogicalTypeId::DATE);
+	serialized_data.timestamp_formats = CopyJSONFormats(json_data.date_format_map.get(), LogicalTypeId::TIMESTAMP);
+	ValidateJSONFormats(serialized_data.date_formats, function.name);
+	ValidateJSONFormats(serialized_data.timestamp_formats, function.name);
+	serialized_data.max_threads = json_data.max_threads;
+	serialized_data.estimated_cardinality_per_file = json_data.estimated_cardinality_per_file;
+	serialized_data.reader_column_ids = json_data.column_ids;
+	serializer.WriteProperty(100, "json_data", serialized_data);
+}
+
+unique_ptr<FunctionData> JSONScan::Deserialize(Deserializer &deserializer, TableFunction &function) {
+	auto &context = deserializer.Get<ClientContext &>();
+	auto serialized_data = deserializer.ReadProperty<SerializedJSONScanData>(100, "json_data");
+	ValidateJSONReaderOptions(serialized_data.options, function.name);
+	ValidateJSONFormats(serialized_data.date_formats, function.name);
+	ValidateJSONFormats(serialized_data.timestamp_formats, function.name);
+	ValidateJSONSchema(serialized_data.types, serialized_data.names, serialized_data.key_names,
+	                   serialized_data.file_options, serialized_data.reader_bind, function.name);
+	for (const auto &file : serialized_data.files) {
+		if (file.path.empty()) {
+			throw SerializationException("Cannot deserialize %s with an empty JSON file path", function.name);
+		}
+	}
+
+	vector<OpenFileInfo> files;
+	files.reserve(serialized_data.files.size());
+	for (const auto &file : serialized_data.files) {
+		files.push_back(file.ToOpenFileInfo());
+	}
+	auto multi_file_reader = MultiFileReader::Create(function);
+	auto file_list = make_shared_ptr<SimpleMultiFileList>(std::move(files));
+	auto interface = make_uniq<JSONMultiFileInfo>();
+	interface->InitializeInterface(context, *multi_file_reader, *file_list);
+
+	auto result = make_uniq<MultiFileBindData>();
+	result->file_list = std::move(file_list);
+	result->multi_file_reader = std::move(multi_file_reader);
+	result->interface = std::move(interface);
+	result->file_options = std::move(serialized_data.file_options);
+	result->reader_bind = std::move(serialized_data.reader_bind);
+	result->types = std::move(serialized_data.types);
+	result->names = std::move(serialized_data.names);
+	result->table_columns = std::move(serialized_data.table_columns);
+	result->column_ids = std::move(serialized_data.bind_column_ids);
+
+	auto reader_options = make_uniq<JSONFileReaderOptions>();
+	reader_options->options = std::move(serialized_data.options);
+	result->bind_data = result->interface->InitializeBindData(*result, std::move(reader_options));
+	auto &json_data = result->bind_data->Cast<JSONScanData>();
+	json_data.key_names = std::move(serialized_data.key_names);
+	json_data.date_format_map =
+	    MakeJSONDateFormatMap(std::move(serialized_data.date_formats), std::move(serialized_data.timestamp_formats));
+	json_data.InitializeTransformOptions();
+	json_data.max_threads = serialized_data.max_threads;
+	json_data.estimated_cardinality_per_file = serialized_data.estimated_cardinality_per_file;
+	json_data.column_ids = std::move(serialized_data.reader_column_ids);
+
+	result->columns = MultiFileColumnDefinition::ColumnsFromNamesAndTypes(result->names, result->types);
+	virtual_column_map_t virtual_columns;
+	MultiFileReader::GetVirtualColumns(context, result->reader_bind, virtual_columns);
+	result->interface->GetVirtualColumns(context, *result, virtual_columns);
+	result->virtual_columns = std::move(virtual_columns);
+	result->interface->FinalizeBindData(*result);
+	ValidateJSONBindData(*result, function.name);
+	return std::move(result);
 }
 
 void JSONScan::TableFunctionDefaults(TableFunction &table_function) {

--- a/external/duckdb/extension/json/json_scan.cpp
+++ b/external/duckdb/extension/json/json_scan.cpp
@@ -12,9 +12,13 @@
 
 namespace duckdb {
 
-JSONFileSnapshot::JSONFileSnapshot(const OpenFileInfo &file) : path(file.path) {
+JSONFileSnapshot::JSONFileSnapshot(idx_t ordinal_p, const OpenFileInfo &file) : path(file.path), ordinal(ordinal_p) {
 	if (file.extended_info) {
 		for (const auto &entry : file.extended_info->options) {
+			if (entry.first == ORDINAL_OPTION) {
+				ordinal = entry.second.GetValue<idx_t>();
+				continue;
+			}
 			options.emplace(entry.first, entry.second);
 		}
 	}
@@ -22,13 +26,24 @@ JSONFileSnapshot::JSONFileSnapshot(const OpenFileInfo &file) : path(file.path) {
 
 OpenFileInfo JSONFileSnapshot::ToOpenFileInfo() const {
 	OpenFileInfo result(path);
-	if (!options.empty()) {
-		result.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
-		for (const auto &entry : options) {
-			result.extended_info->options.emplace(entry.first, entry.second);
-		}
+	result.extended_info = make_shared_ptr<ExtendedOpenFileInfo>();
+	for (const auto &entry : options) {
+		result.extended_info->options.emplace(entry.first, entry.second);
 	}
+	result.extended_info->options[ORDINAL_OPTION] = Value::UBIGINT(ordinal);
 	return result;
+}
+
+bool JSONFileSnapshot::TryGetOrdinal(const OpenFileInfo &file, idx_t &ordinal) {
+	if (!file.extended_info) {
+		return false;
+	}
+	auto entry = file.extended_info->options.find(ORDINAL_OPTION);
+	if (entry == file.extended_info->options.end()) {
+		return false;
+	}
+	ordinal = entry->second.GetValue<idx_t>();
+	return true;
 }
 
 JSONScanData::JSONScanData() {
@@ -291,6 +306,24 @@ static void ValidateJSONBindData(const MultiFileBindData &bind_data, const strin
 	}
 }
 
+static void ValidateJSONFiles(const vector<JSONFileSnapshot> &files, const string &function_name,
+                              const string &operation) {
+	set<idx_t> ordinals;
+	for (const auto &file : files) {
+		if (file.path.empty()) {
+			throw SerializationException("Cannot %s %s with an empty JSON file path", operation, function_name);
+		}
+		if (file.options.find(JSONFileSnapshot::ORDINAL_OPTION) != file.options.end()) {
+			throw SerializationException("Cannot %s %s with nested JSON file ordinal metadata", operation,
+			                             function_name);
+		}
+		if (!ordinals.insert(file.ordinal).second) {
+			throw SerializationException("Cannot %s %s with duplicate JSON file ordinal %llu", operation, function_name,
+			                             static_cast<unsigned long long>(file.ordinal));
+		}
+	}
+}
+
 void JSONScan::Serialize(Serializer &serializer, const optional_ptr<FunctionData> bind_data_p,
                          const TableFunction &function) {
 	if (!bind_data_p) {
@@ -303,12 +336,10 @@ void JSONScan::Serialize(Serializer &serializer, const optional_ptr<FunctionData
 	SerializedJSONScanData serialized_data;
 	auto files = bind_data.file_list->GetAllFiles();
 	serialized_data.files.reserve(files.size());
-	for (const auto &file : files) {
-		if (file.path.empty()) {
-			throw SerializationException("Cannot serialize %s with an empty JSON file path", function.name);
-		}
-		serialized_data.files.emplace_back(file);
+	for (idx_t file_idx = 0; file_idx < files.size(); file_idx++) {
+		serialized_data.files.emplace_back(file_idx, files[file_idx]);
 	}
+	ValidateJSONFiles(serialized_data.files, function.name, "serialize");
 	serialized_data.types = bind_data.types;
 	serialized_data.names = bind_data.names;
 	serialized_data.file_options = bind_data.file_options;
@@ -335,11 +366,7 @@ unique_ptr<FunctionData> JSONScan::Deserialize(Deserializer &deserializer, Table
 	ValidateJSONFormats(serialized_data.timestamp_formats, function.name);
 	ValidateJSONSchema(serialized_data.types, serialized_data.names, serialized_data.key_names,
 	                   serialized_data.file_options, serialized_data.reader_bind, function.name);
-	for (const auto &file : serialized_data.files) {
-		if (file.path.empty()) {
-			throw SerializationException("Cannot deserialize %s with an empty JSON file path", function.name);
-		}
-	}
+	ValidateJSONFiles(serialized_data.files, function.name, "deserialize");
 
 	vector<OpenFileInfo> files;
 	files.reserve(serialized_data.files.size());

--- a/external/duckdb/extension/json/serialize_json.cpp
+++ b/external/duckdb/extension/json/serialize_json.cpp
@@ -14,12 +14,14 @@ namespace duckdb {
 void JSONFileSnapshot::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<string>(100, "path", path);
 	serializer.WritePropertyWithDefault<map<string, Value>>(101, "options", options);
+	serializer.WritePropertyWithDefault<idx_t>(102, "ordinal", ordinal);
 }
 
 JSONFileSnapshot JSONFileSnapshot::Deserialize(Deserializer &deserializer) {
 	JSONFileSnapshot result;
 	deserializer.ReadPropertyWithDefault<string>(100, "path", result.path);
 	deserializer.ReadPropertyWithDefault<map<string, Value>>(101, "options", result.options);
+	deserializer.ReadPropertyWithDefault<idx_t>(102, "ordinal", result.ordinal);
 	return result;
 }
 

--- a/external/duckdb/extension/json/serialize_json.cpp
+++ b/external/duckdb/extension/json/serialize_json.cpp
@@ -6,8 +6,64 @@
 #include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/serializer/deserializer.hpp"
 #include "json_transform.hpp"
+#include "json_reader_options.hpp"
+#include "json_scan.hpp"
 
 namespace duckdb {
+
+void JSONFileSnapshot::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<string>(100, "path", path);
+	serializer.WritePropertyWithDefault<map<string, Value>>(101, "options", options);
+}
+
+JSONFileSnapshot JSONFileSnapshot::Deserialize(Deserializer &deserializer) {
+	JSONFileSnapshot result;
+	deserializer.ReadPropertyWithDefault<string>(100, "path", result.path);
+	deserializer.ReadPropertyWithDefault<map<string, Value>>(101, "options", result.options);
+	return result;
+}
+
+void JSONReaderOptions::Serialize(Serializer &serializer) const {
+	serializer.WriteProperty<JSONScanType>(100, "type", type);
+	serializer.WriteProperty<JSONFormat>(101, "format", format);
+	serializer.WriteProperty<JSONRecordType>(102, "record_type", record_type);
+	serializer.WriteProperty<FileCompressionType>(103, "compression", compression);
+	serializer.WritePropertyWithDefault<bool>(104, "ignore_errors", ignore_errors);
+	serializer.WritePropertyWithDefault<idx_t>(105, "maximum_object_size", maximum_object_size);
+	serializer.WritePropertyWithDefault<bool>(106, "auto_detect", auto_detect);
+	serializer.WritePropertyWithDefault<idx_t>(107, "sample_size", sample_size);
+	serializer.WritePropertyWithDefault<idx_t>(108, "max_depth", max_depth);
+	serializer.WriteProperty<double>(109, "field_appearance_threshold", field_appearance_threshold);
+	serializer.WritePropertyWithDefault<idx_t>(110, "maximum_sample_files", maximum_sample_files);
+	serializer.WritePropertyWithDefault<bool>(111, "convert_strings_to_integers", convert_strings_to_integers);
+	serializer.WritePropertyWithDefault<idx_t>(112, "map_inference_threshold", map_inference_threshold);
+	serializer.WritePropertyWithDefault<vector<string>>(113, "name_list", name_list);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(114, "sql_type_list", sql_type_list);
+	serializer.WritePropertyWithDefault<string>(115, "date_format", date_format);
+	serializer.WritePropertyWithDefault<string>(116, "timestamp_format", timestamp_format);
+}
+
+JSONReaderOptions JSONReaderOptions::Deserialize(Deserializer &deserializer) {
+	JSONReaderOptions result;
+	deserializer.ReadProperty<JSONScanType>(100, "type", result.type);
+	deserializer.ReadProperty<JSONFormat>(101, "format", result.format);
+	deserializer.ReadProperty<JSONRecordType>(102, "record_type", result.record_type);
+	deserializer.ReadProperty<FileCompressionType>(103, "compression", result.compression);
+	deserializer.ReadPropertyWithDefault<bool>(104, "ignore_errors", result.ignore_errors);
+	deserializer.ReadPropertyWithDefault<idx_t>(105, "maximum_object_size", result.maximum_object_size);
+	deserializer.ReadPropertyWithDefault<bool>(106, "auto_detect", result.auto_detect);
+	deserializer.ReadPropertyWithDefault<idx_t>(107, "sample_size", result.sample_size);
+	deserializer.ReadPropertyWithDefault<idx_t>(108, "max_depth", result.max_depth);
+	deserializer.ReadProperty<double>(109, "field_appearance_threshold", result.field_appearance_threshold);
+	deserializer.ReadPropertyWithDefault<idx_t>(110, "maximum_sample_files", result.maximum_sample_files);
+	deserializer.ReadPropertyWithDefault<bool>(111, "convert_strings_to_integers", result.convert_strings_to_integers);
+	deserializer.ReadPropertyWithDefault<idx_t>(112, "map_inference_threshold", result.map_inference_threshold);
+	deserializer.ReadPropertyWithDefault<vector<string>>(113, "name_list", result.name_list);
+	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(114, "sql_type_list", result.sql_type_list);
+	deserializer.ReadPropertyWithDefault<string>(115, "date_format", result.date_format);
+	deserializer.ReadPropertyWithDefault<string>(116, "timestamp_format", result.timestamp_format);
+	return result;
+}
 
 void JSONTransformOptions::Serialize(Serializer &serializer) const {
 	serializer.WritePropertyWithDefault<bool>(100, "strict_cast", strict_cast);
@@ -24,6 +80,42 @@ JSONTransformOptions JSONTransformOptions::Deserialize(Deserializer &deserialize
 	deserializer.ReadPropertyWithDefault<bool>(102, "error_missing_key", result.error_missing_key);
 	deserializer.ReadPropertyWithDefault<bool>(103, "error_unknown_key", result.error_unknown_key);
 	deserializer.ReadPropertyWithDefault<bool>(104, "delay_error", result.delay_error);
+	return result;
+}
+
+void SerializedJSONScanData::Serialize(Serializer &serializer) const {
+	serializer.WritePropertyWithDefault<vector<JSONFileSnapshot>>(100, "files", files);
+	serializer.WritePropertyWithDefault<vector<LogicalType>>(101, "types", types);
+	serializer.WritePropertyWithDefault<vector<string>>(102, "names", names);
+	serializer.WriteProperty<MultiFileOptions>(103, "file_options", file_options);
+	serializer.WriteProperty<MultiFileReaderBindData>(104, "reader_bind", reader_bind);
+	serializer.WritePropertyWithDefault<vector<string>>(105, "table_columns", table_columns);
+	serializer.WritePropertyWithDefault<vector<idx_t>>(106, "bind_column_ids", bind_column_ids);
+	serializer.WriteProperty<JSONReaderOptions>(107, "options", options);
+	serializer.WritePropertyWithDefault<vector<string>>(108, "key_names", key_names);
+	serializer.WritePropertyWithDefault<vector<StrpTimeFormat>>(109, "date_formats", date_formats);
+	serializer.WritePropertyWithDefault<vector<StrpTimeFormat>>(110, "timestamp_formats", timestamp_formats);
+	serializer.WriteProperty<optional_idx>(111, "max_threads", max_threads);
+	serializer.WriteProperty<optional_idx>(112, "estimated_cardinality_per_file", estimated_cardinality_per_file);
+	serializer.WritePropertyWithDefault<vector<idx_t>>(113, "reader_column_ids", reader_column_ids);
+}
+
+SerializedJSONScanData SerializedJSONScanData::Deserialize(Deserializer &deserializer) {
+	SerializedJSONScanData result;
+	deserializer.ReadPropertyWithDefault<vector<JSONFileSnapshot>>(100, "files", result.files);
+	deserializer.ReadPropertyWithDefault<vector<LogicalType>>(101, "types", result.types);
+	deserializer.ReadPropertyWithDefault<vector<string>>(102, "names", result.names);
+	deserializer.ReadProperty<MultiFileOptions>(103, "file_options", result.file_options);
+	deserializer.ReadProperty<MultiFileReaderBindData>(104, "reader_bind", result.reader_bind);
+	deserializer.ReadPropertyWithDefault<vector<string>>(105, "table_columns", result.table_columns);
+	deserializer.ReadPropertyWithDefault<vector<idx_t>>(106, "bind_column_ids", result.bind_column_ids);
+	deserializer.ReadProperty<JSONReaderOptions>(107, "options", result.options);
+	deserializer.ReadPropertyWithDefault<vector<string>>(108, "key_names", result.key_names);
+	deserializer.ReadPropertyWithDefault<vector<StrpTimeFormat>>(109, "date_formats", result.date_formats);
+	deserializer.ReadPropertyWithDefault<vector<StrpTimeFormat>>(110, "timestamp_formats", result.timestamp_formats);
+	deserializer.ReadProperty<optional_idx>(111, "max_threads", result.max_threads);
+	deserializer.ReadProperty<optional_idx>(112, "estimated_cardinality_per_file", result.estimated_cardinality_per_file);
+	deserializer.ReadPropertyWithDefault<vector<idx_t>>(113, "reader_column_ids", result.reader_column_ids);
 	return result;
 }
 

--- a/tests/fast/test_ray_e2e_serialization.py
+++ b/tests/fast/test_ray_e2e_serialization.py
@@ -6,6 +6,8 @@ Tests the core serialization functionality without requiring full execution pipe
 """
 
 import csv
+import datetime
+import pickle
 
 import pytest
 
@@ -15,6 +17,43 @@ except Exception:
     ray = None
 
 import vane
+
+
+def test_json_scan_family_plans_serialize_for_ray(tmp_path):
+    """Every JSON multi-file alias retains a complete worker-owned bind."""
+    input_path = tmp_path / "json-family-plans.ndjson"
+    input_path.write_text('{"id":1,"value":"a"}\n{"id":2,"value":"b"}\n', encoding="utf-8")
+    queries = {
+        "read_json": f"""
+            SELECT * FROM read_json(
+                '{input_path}',
+                format='newline_delimited',
+                auto_detect=false,
+                columns={{'id': 'BIGINT', 'value': 'VARCHAR'}}
+            )
+        """,
+        "read_json_auto": f"SELECT * FROM read_json_auto('{input_path}')",
+        "read_ndjson": f"SELECT * FROM read_ndjson('{input_path}')",
+        "read_ndjson_auto": f"SELECT * FROM read_ndjson_auto('{input_path}')",
+        "read_json_objects": f"SELECT * FROM read_json_objects('{input_path}')",
+        "read_json_objects_auto": f"SELECT * FROM read_json_objects_auto('{input_path}')",
+        "read_ndjson_objects": f"SELECT * FROM read_ndjson_objects('{input_path}')",
+    }
+
+    for function_name, query in queries.items():
+        connection = vane.connect()
+        try:
+            relation = connection.sql(query)
+            logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+                relation,
+                f"{function_name}-serialization-plan",
+            )
+            restored_plan = pickle.loads(pickle.dumps(logical_plan))
+            physical_plan = restored_plan.to_physical_plan(connection)
+            assert physical_plan.num_partitions() == 1
+            assert [len(batches) for batches in physical_plan.scan_split_batch_map().values()] == [1]
+        finally:
+            connection.close()
 
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")
@@ -41,8 +80,6 @@ def test_ray_plan_serialization_core():
     assert plan.idx() == "test-e2e-query"
 
     # Test pickling (this is what Ray uses for serialization)
-    import pickle
-
     serialized = pickle.dumps(plan)
     assert len(serialized) > 0
 
@@ -227,5 +264,78 @@ def test_multi_file_csv_union_reader_state_survives_worker_serde(tmp_path, monke
         (2, "beta", 0),
         (3, "gamma", 1),
         (4, "delta", 1),
+    ]
+    connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_multi_file_json_bind_state_survives_real_ray_serde(tmp_path, monkeypatch):
+    """Ray workers retain JSON options, inferred schema, formats, and multi-file metadata."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+    left_path = tmp_path / "left.ndjson"
+    right_path = tmp_path / "right.ndjson"
+    left_path.write_text(
+        '{"id":1,"event_date":"08-25-2026","event_time":"08-25-2026 03:04:05 PM","left_value":"alpha"}\n',
+        encoding="utf-8",
+    )
+    right_path.write_text(
+        '{"id":2,"event_date":"08-26-2026","event_time":"08-26-2026 04:05:06 PM","right_value":"beta"}\n',
+        encoding="utf-8",
+    )
+
+    connection = vane.connect()
+    relation = connection.sql(
+        f"""
+        SELECT id, event_date, event_time, coalesce(left_value, right_value) AS value, filename
+        FROM read_ndjson_auto(
+            ['{left_path}', '{right_path}'],
+            union_by_name=true,
+            filename=true,
+            dateformat='%m-%d-%Y',
+            timestampformat='%m-%d-%Y %I:%M:%S %p'
+        )
+        """
+    )
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        "multi-json-bind-serde-plan",
+    ).to_physical_plan(connection)
+    assert [len(batches) for batches in plan.scan_split_batch_map().values()] == [2]
+
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+    parts = list(runner.run_iter_tables(relation))
+    assert len(parts) == 2
+    tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+    result = pa.concat_tables(tables)
+    assert sorted(
+        zip(
+            result.column(0).to_pylist(),
+            result.column(1).to_pylist(),
+            result.column(2).to_pylist(),
+            result.column(3).to_pylist(),
+            result.column(4).to_pylist(),
+        )
+    ) == [
+        (
+            1,
+            datetime.date(2026, 8, 25),
+            datetime.datetime(2026, 8, 25, 15, 4, 5),
+            "alpha",
+            str(left_path),
+        ),
+        (
+            2,
+            datetime.date(2026, 8, 26),
+            datetime.datetime(2026, 8, 26, 16, 5, 6),
+            "beta",
+            str(right_path),
+        ),
     ]
     connection.close()

--- a/tests/fast/test_ray_e2e_serialization.py
+++ b/tests/fast/test_ray_e2e_serialization.py
@@ -339,3 +339,45 @@ def test_multi_file_json_bind_state_survives_real_ray_serde(tmp_path, monkeypatc
         ),
     ]
     connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_multi_file_json_preserves_file_index_through_real_ray(tmp_path, monkeypatch):
+    """Each singleton Ray split retains its coordinator-side file ordinal."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("VANE_DISTRIBUTED_WORKER_SLOTS", "2")
+    monkeypatch.setenv("VANE_FTE_DYNAMIC_SCAN_MAX_SPLITS_PER_PARTITION", "1")
+    first_path = tmp_path / "first.ndjson"
+    second_path = tmp_path / "second.ndjson"
+    first_path.write_text('{"id":1}\n', encoding="utf-8")
+    second_path.write_text('{"id":2}\n', encoding="utf-8")
+    paths = f"['{first_path}', '{second_path}']"
+
+    connection = vane.connect()
+    from vane import runners
+
+    runners.set_runner_ray(noop_if_initialized=True)
+    runner = runners.get_or_create_runner()
+
+    def execute(query, plan_id):
+        relation = connection.sql(query)
+        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, plan_id).to_physical_plan(connection)
+        split_batches = next(iter(plan.scan_split_batch_map().values()))
+        assert len(split_batches) == 2
+        assert all(len(vane.ray_cxx.split_scan_split_batch(batch)) == 1 for batch in split_batches)
+        parts = list(runner.run_iter_tables(relation))
+        tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
+        result = pa.concat_tables(tables)
+        return sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist()))
+
+    assert execute(
+        f"SELECT id, file_index FROM read_ndjson_auto({paths})",
+        "multi-json-file-index-projection-plan",
+    ) == [(1, 0), (2, 1)]
+    assert execute(
+        f"SELECT id, file_index FROM read_ndjson_auto({paths}) WHERE file_index = 1",
+        "multi-json-file-index-filter-plan",
+    ) == [(2, 1)]
+    connection.close()


### PR DESCRIPTION
## Summary

- Serialize the complete bound state for JSON and NDJSON scans so their logical plans can be translated and executed by Ray.
- Reconstruct worker-side scan state without reopening, rebinding, or resampling input files, while preserving multi-file metadata and file options.
- Preserve each coordinator-side file ordinal through JSON serde and singleton Ray split execution, including `file_index` projections and filters.
- Add coverage for every JSON/NDJSON table-function alias and for real-Ray multi-file execution with schema union, filenames, explicit date/timestamp formats, and stable file indexes.

## Related issue

close: #632

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change enables an existing execution path and does not change user-facing syntax or configuration.

## Validation

- Two consecutive clean code-review rounds before the initial build, plus two consecutive clean rounds after addressing review feedback
- `scripts/format workspace --changed --check`
- `git diff --check upstream/main`
- JSON serialization generator determinism check
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release CMAKE_BUILD_PARALLEL_LEVEL=12 uv pip install --python .venv/bin/python . --no-build-isolation`
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e_serialization.py::test_json_scan_family_plans_serialize_for_ray`
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e_serialization.py::test_multi_file_json_bind_state_survives_real_ray_serde tests/fast/test_ray_e2e_serialization.py::test_multi_file_json_preserves_file_index_through_real_ray`
- `scripts/run_release_tests.sh` (`692 passed, 5 skipped, 18 deselected`; real Ray: `14 passed, 701 deselected`)

The release suite used a short symlink to the same worktree and installed native artifact. The full worktree path made three unrelated negative-path tests exceed the native 4096-byte exception-detail cap; those tests and the complete suite pass with the shorter path.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
