### PR TITLE
[feat](qdrant) Add a keyed-upsert DataSink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,84 @@ jobs:
         continue-on-error: true
         run: docker rm --force vane-milvus
 
+  qdrant-tests:
+    name: Qdrant integration test
+    needs:
+      - changes
+      - native-fast-tests
+    if: needs.changes.outputs.run_full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      VANE_TEST_QDRANT_URL: http://127.0.0.1:6333
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download the built wheel
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ci-python-artifacts-3.12
+          path: dist
+
+      - name: Install the wheel and Qdrant test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          wheel_path="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          test -n "$wheel_path"
+          python -m pip install --force-reinstall "${wheel_path}[qdrant]" pytest
+          python -m pip check
+          python -c 'import qdrant_client'
+
+      - name: Start Qdrant
+        run: |
+          docker run --detach \
+            --name vane-qdrant \
+            --publish 127.0.0.1:6333:6333 \
+            qdrant/qdrant:v1.19.0@sha256:6c0652f8d6925b22f2f6f0e0a5365a6c9dbc8768bd6e70ccc1cdc14847e452a0
+
+      - name: Wait for Qdrant to become healthy
+        run: |
+          for attempt in {1..60}; do
+            if curl --fail --silent http://127.0.0.1:6333/healthz > /dev/null; then
+              exit 0
+            fi
+            if [[ "$(docker inspect --format '{{.State.Status}}' vane-qdrant)" != "running" ]]; then
+              echo "Qdrant stopped before becoming healthy" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Qdrant did not become healthy within 120 seconds" >&2
+          exit 1
+
+      - name: Run the live Qdrant sink test
+        run: |
+          timeout --signal=INT --kill-after=30s 300s \
+            scripts/run_installed_pytest.sh \
+              -o addopts= \
+              -m external_service \
+              tests/fast/test_qdrant_datasink.py
+
+      - name: Print Qdrant logs on failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: docker logs vane-qdrant
+
+      - name: Stop Qdrant
+        if: ${{ always() }}
+        continue-on-error: true
+        run: docker rm --force vane-qdrant
+
   ai-tests:
     name: AI tests
     needs:
@@ -581,6 +659,7 @@ jobs:
       - native-fast-tests
       - fast-tests
       - milvus-tests
+      - qdrant-tests
       - ai-tests
     runs-on: ubuntu-24.04
     steps:
@@ -590,6 +669,7 @@ jobs:
           AI_TESTS_RESULT: ${{ needs.ai-tests.result }}
           FAST_TESTS_RESULT: ${{ needs.fast-tests.result }}
           MILVUS_TESTS_RESULT: ${{ needs.milvus-tests.result }}
+          QDRANT_TESTS_RESULT: ${{ needs.qdrant-tests.result }}
           RUN_FULL: ${{ needs.changes.outputs.run_full }}
           SOURCE_PACKAGE_RESULT: ${{ needs.source-package.result }}
           NATIVE_TESTS_RESULT: ${{ needs.native-fast-tests.result }}
@@ -616,8 +696,9 @@ jobs:
                 "$NATIVE_TESTS_RESULT" != "$expected_result" ||
                 "$FAST_TESTS_RESULT" != "$expected_result" ||
                 "$MILVUS_TESTS_RESULT" != "$expected_result" ||
+                "$QDRANT_TESTS_RESULT" != "$expected_result" ||
                 "$AI_TESTS_RESULT" != "$expected_result" ]]; then
-            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT, milvus-tests=$MILVUS_TESTS_RESULT, ai-tests=$AI_TESTS_RESULT" >&2
+            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT, milvus-tests=$MILVUS_TESTS_RESULT, qdrant-tests=$QDRANT_TESTS_RESULT, ai-tests=$AI_TESTS_RESULT" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ pip install 'vane-ai[sglang]'   # Native SGLang 0.5.17 inference on Linux x86-64
 pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
 pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
 pip install 'vane-ai[milvus]'   # distributed full-row Milvus upserts
+pip install 'vane-ai[qdrant]'   # distributed full-point Qdrant upserts
 ```
 
 The SGLang extra follows SGLang 0.5.17's default CUDA 13 dependency set. Python package metadata cannot select a
@@ -165,6 +166,51 @@ batches are acknowledged and applied independently, so a failed operation can
 be partially applied. Vane does not provide an atomic transaction, rollback,
 or exactly-once delivery, and read visibility follows the consistency level
 used by Milvus readers.
+
+### Qdrant DataSink
+
+`QdrantSink` writes distributed relation batches as full-point upserts. Each
+row must provide an explicit Arrow `uint64` or UUID-string point ID. Use a
+single source column for a collection with one unnamed dense vector, or map
+source columns to every named dense vector in the collection. Payload fields
+are also explicitly mapped; project away any relation columns that should not
+be written. Dense vector columns must be Arrow lists of `float32`, and their
+dimensions must match the collection. Payload values may be nulls, booleans,
+integers whose values fit Qdrant's signed 64-bit payload range, finite
+`float32`/`float64` values, strings, or nested Arrow lists and structs composed
+from those types. Convert binary, decimal, temporal, and other values to an
+explicit supported representation before writing.
+
+UUID text is normalized before Vane's global key check, so invalid, null, and
+semantically duplicate point IDs are rejected before workers open.
+`max_batch_rows` limits rows per worker call, while `max_batch_bytes` limits
+the Arrow buffer size before point conversion.
+
+```python
+from vane import EnvironmentSecret, QdrantSink
+
+sink = QdrantSink(
+    "documents",
+    url="https://qdrant.example:6333",
+    point_id="id",
+    vector_mapping="embedding",
+    payload_mapping={"title": "title", "source": "source"},
+    api_key=EnvironmentSecret("QDRANT_API_KEY"),
+)
+summary = relation.write_datasink(sink)
+```
+
+The endpoint itself may instead be supplied as an `EnvironmentSecret` when it
+must not be serialized with the plan. API-key values are always resolved from
+the worker environment. Qdrant receives `wait=True`, and Vane reports a batch
+as applied only when Qdrant returns `completed`. Each upsert replaces all
+vectors and payload for its point ID; partial updates are not exposed.
+
+The default `max_retries=0` disables Vane's full-operation replay after an
+unknown outcome. Enabling retries replays the complete input with the same
+normalized point IDs. Successful worker batches remain independently visible
+if another batch or the overall job later fails. Vane does not provide an
+atomic transaction, rollback, deletion, or exactly-once delivery.
 
 ### Execution Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ Changelog = "https://github.com/AstroVela/vane/releases"
 
 [project.optional-dependencies]
 milvus = ["pymilvus>=3.0.1,<4"]
+qdrant = ["qdrant-client>=1.19.0,<2"]
 openai = ["openai>=1.66.0", "tiktoken"] # floor adds the Responses API used by the default Prompt path
 anthropic = ["anthropic>=0.117.0"] # floor matches the Messages.create option surface validated in vane/ai/providers/anthropic.py
 google = ["google-genai>=1.22.0"] # floor adds GenerateContentConfig.response_json_schema
@@ -98,6 +99,7 @@ all = [ # Cloud providers and dataframe/filesystem integrations; local model run
     "adbc-driver-manager", # for the adbc driver
     "pillow>=10", # used for image inputs and video frames
     "pymilvus>=3.0.1,<4", # Milvus DataSink
+    "qdrant-client>=1.19.0,<2", # Qdrant DataSink
 ]
 
 ######################################################################################################
@@ -228,6 +230,7 @@ include = [
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",
     "/tests/fast/test_milvus_datasink.py",
+    "/tests/fast/test_qdrant_datasink.py",
     "/tests/fast/test_package_metadata.py",
     "/tests/fast/test_ray_test_profile.py",
     "/tests/fast/test_transformers_provider_security.py",

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -24,6 +24,7 @@ release_tests=(
   "$project_root/tests/fast/test_ai_release_contracts.py"
   "$project_root/tests/fast/test_datasink.py"
   "$project_root/tests/fast/test_milvus_datasink.py"
+  "$project_root/tests/fast/test_qdrant_datasink.py"
   "$project_root/tests/fast/test_package_metadata.py"
   "$project_root/tests/fast/test_ray_test_profile.py"
   "$project_root/tests/fast/test_transformers_provider_security.py"

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -317,6 +317,14 @@ def test_provider_extras_match_provider_import_errors():
     assert "sglang" in _requirements_for_extra("sglang")
 
 
+def test_datasink_extras_require_supported_sdk_versions():
+    milvus = _requirement_for_extra("milvus", "pymilvus")
+    qdrant = _requirement_for_extra("qdrant", "qdrant-client")
+
+    assert milvus.specifier == SpecifierSet(">=3.0.1,<4")
+    assert qdrant.specifier == SpecifierSet(">=1.19.0,<2")
+
+
 def test_structured_provider_extras_require_supported_sdk_versions():
     openai = _requirement_for_extra("openai", "openai")
     google = _requirement_for_extra("google", "google-genai")

--- a/tests/fast/test_qdrant_datasink.py
+++ b/tests/fast/test_qdrant_datasink.py
@@ -1,0 +1,725 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import builtins
+import os
+import uuid
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import cloudpickle
+import pyarrow as pa
+import pytest
+
+import vane
+import vane.datasink.qdrant as qdrant
+from vane import EnvironmentSecret, QdrantSink
+from vane.datasink import (
+    BoundKeyedUpsertSink,
+    DataSink,
+    DataSinkWriteError,
+    WriteContext,
+    WriteOutcome,
+)
+
+_REAL_LOAD_QDRANT_SDK = qdrant._load_qdrant_sdk
+
+
+class _UpdateStatus(str, Enum):
+    ACKNOWLEDGED = "acknowledged"
+    COMPLETED = "completed"
+    WAIT_TIMEOUT = "wait_timeout"
+
+
+class _Datatype(str, Enum):
+    FLOAT32 = "float32"
+    FLOAT16 = "float16"
+    UINT8 = "uint8"
+
+
+@dataclass
+class _VectorParams:
+    size: object
+    datatype: _Datatype | None = None
+    multivector_config: object | None = None
+
+
+@dataclass
+class _CollectionParams:
+    vectors: object
+    sparse_vectors: object | None = None
+
+
+@dataclass
+class _CollectionConfig:
+    params: object
+
+
+@dataclass
+class _CollectionInfo:
+    config: object
+
+
+@dataclass
+class _PointStruct:
+    id: int | str
+    vector: list[float] | dict[str, list[float]]
+    payload: dict[str, object]
+
+
+@dataclass
+class _UpdateResult:
+    status: _UpdateStatus
+    operation_id: int | None = 1
+
+
+class _Models:
+    CollectionConfig = _CollectionConfig
+    CollectionInfo = _CollectionInfo
+    CollectionParams = _CollectionParams
+    Datatype = _Datatype
+    PointStruct = _PointStruct
+    UpdateResult = _UpdateResult
+    UpdateStatus = _UpdateStatus
+    VectorParams = _VectorParams
+
+
+def _collection_info(
+    *,
+    vectors: object | None = None,
+    sparse_vectors: object | None = None,
+    params: object | None = None,
+) -> _CollectionInfo:
+    if params is None:
+        params = _CollectionParams(
+            vectors=_VectorParams(size=3) if vectors is None else vectors,
+            sparse_vectors=sparse_vectors,
+        )
+    return _CollectionInfo(config=_CollectionConfig(params=params))
+
+
+_DEFAULT_RESPONSE = object()
+
+
+class _Client:
+    collection_info: object = _collection_info()
+    get_error: BaseException | None = None
+    upsert_error: BaseException | None = None
+    close_error: BaseException | None = None
+    response: object = _DEFAULT_RESPONSE
+    instances: list[_Client] = []
+    store: dict[int | str, _PointStruct] = {}
+
+    def __init__(self, **kwargs: object) -> None:
+        self.options = kwargs
+        self.get_calls: list[dict[str, object]] = []
+        self.upsert_calls: list[dict[str, object]] = []
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    def get_collection(self, **kwargs: object) -> object:
+        self.get_calls.append(kwargs)
+        if self.get_error is not None:
+            raise self.get_error
+        return deepcopy(self.collection_info)
+
+    def upsert(self, **kwargs: object) -> object:
+        self.upsert_calls.append(kwargs)
+        if self.upsert_error is not None:
+            raise self.upsert_error
+        points = kwargs["points"]
+        assert isinstance(points, list)
+        for point in points:
+            assert isinstance(point, _PointStruct)
+            type(self).store[point.id] = deepcopy(point)
+        if self.response is _DEFAULT_RESPONSE:
+            return _UpdateResult(_UpdateStatus.COMPLETED)
+        return self.response
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+@pytest.fixture(autouse=True)
+def _fake_sdk(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    if request.node.get_closest_marker("external_service") is not None:
+        return
+    _Client.collection_info = _collection_info()
+    _Client.get_error = None
+    _Client.upsert_error = None
+    _Client.close_error = None
+    _Client.response = _DEFAULT_RESPONSE
+    _Client.instances = []
+    _Client.store = {}
+    monkeypatch.setattr(qdrant, "_load_qdrant_sdk", lambda: (_Client, _Models))
+
+
+def _arrow_schema(
+    *,
+    id_type: pa.DataType | None = None,
+    vector_type: pa.DataType | None = None,
+    payload_type: pa.DataType | None = None,
+) -> pa.Schema:
+    return pa.schema(
+        [
+            ("id", pa.uint64() if id_type is None else id_type),
+            ("embedding", pa.list_(pa.float32()) if vector_type is None else vector_type),
+            ("title", pa.string() if payload_type is None else payload_type),
+        ]
+    )
+
+
+def _sink(**kwargs: object) -> QdrantSink:
+    options: dict[str, object] = {
+        "url": "https://qdrant.example:6333",
+        "point_id": "id",
+        "vector_mapping": "embedding",
+        "payload_mapping": {"title": "title"},
+        "timeout": 5,
+    }
+    options.update(kwargs)
+    return QdrantSink("items", **options)  # type: ignore[arg-type]
+
+
+def _bound(*, schema: pa.Schema | None = None, **kwargs: object) -> BoundKeyedUpsertSink:
+    return _sink(**kwargs).bind(_arrow_schema() if schema is None else schema)
+
+
+def _worker(*, schema: pa.Schema | None = None, **kwargs: object) -> Any:
+    return _bound(schema=schema, **kwargs).open_worker(WriteContext("qdrant-test"))
+
+
+def _table(
+    *,
+    ids: list[int] | None = None,
+    vectors: list[list[float] | None] | None = None,
+    titles: list[object] | None = None,
+    schema: pa.Schema | None = None,
+) -> pa.Table:
+    return pa.table(
+        {
+            "id": [1, 2] if ids is None else ids,
+            "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] if vectors is None else vectors,
+            "title": ["one", "two"] if titles is None else titles,
+        },
+        schema=_arrow_schema() if schema is None else schema,
+    )
+
+
+def test_qdrant_sink_is_public_without_importing_qdrant_client() -> None:
+    assert vane.QdrantSink is QdrantSink
+    assert qdrant.__all__ == ["QdrantSink"]
+
+
+def test_qdrant_sink_reports_the_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def missing_qdrant_client(name: str, *args: object, **kwargs: object) -> Any:
+        if name == "qdrant_client":
+            raise ModuleNotFoundError("No module named 'qdrant_client'", name="qdrant_client")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_qdrant_client)
+    with pytest.raises(ImportError, match=r"vane-ai\[qdrant\]"):
+        _REAL_LOAD_QDRANT_SDK()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"collection_name": ""}, ValueError, "collection_name"),
+        ({"collection_name": " items"}, ValueError, "whitespace"),
+        ({"url": "qdrant.example:6333"}, ValueError, "HTTP or HTTPS"),
+        ({"url": "https://qdrant.example/path"}, ValueError, "path"),
+        ({"url": "https://qdrant.example:not-a-port"}, ValueError, "valid HTTP or HTTPS"),
+        ({"url": "https://user:secret@qdrant.example"}, ValueError, "credentials"),
+        ({"url": "https://qdrant.example?api_key=secret"}, ValueError, "query parameters"),
+        ({"point_id": ""}, ValueError, "point_id"),
+        ({"vector_mapping": []}, TypeError, "vector_mapping"),
+        ({"vector_mapping": {}}, ValueError, "at least one"),
+        ({"vector_mapping": {"embedding": "v", "other": "v"}}, ValueError, "targets"),
+        ({"payload_mapping": []}, TypeError, "payload_mapping"),
+        ({"payload_mapping": {"title": "x", "other": "x"}}, ValueError, "targets"),
+        ({"api_key": "plain-text"}, TypeError, "EnvironmentSecret"),
+        ({"worker_count": True}, TypeError, "worker_count"),
+        ({"worker_count": 0}, ValueError, "worker_count"),
+        ({"max_batch_rows": -1}, ValueError, "max_batch_rows"),
+        ({"max_batch_bytes": 1.5}, TypeError, "max_batch_bytes"),
+        ({"max_retries": True}, TypeError, "max_retries"),
+        ({"max_retries": -1}, ValueError, "max_retries"),
+        ({"timeout": 1.5}, TypeError, "timeout"),
+        ({"timeout": 0}, ValueError, "timeout"),
+    ],
+)
+def test_qdrant_sink_validates_constructor(overrides: dict[str, object], error: type[Exception], message: str) -> None:
+    options: dict[str, object] = {
+        "collection_name": "items",
+        "url": "https://qdrant.example:6333",
+        "point_id": "id",
+        "vector_mapping": "embedding",
+    }
+    options.update(overrides)
+    with pytest.raises(error, match=message):
+        QdrantSink(**options)  # type: ignore[arg-type]
+
+
+def test_qdrant_sink_binds_key_mappings_and_execution_options() -> None:
+    sink = _sink(worker_count=3, max_batch_rows=17, max_batch_bytes=2_048, max_retries=2)
+    bound = sink.bind(_arrow_schema())
+
+    assert isinstance(bound, BoundKeyedUpsertSink)
+    assert tuple(bound.key_columns) == ("id",)
+    assert bound.execution_options.worker_count == 3
+    assert bound.execution_options.batch_size == 17
+    assert bound.execution_options.target_max_batch_bytes == 2_048
+    assert bound.execution_options.max_retries == 2
+
+
+def test_qdrant_sink_rejects_invalid_bound_schema_and_mappings() -> None:
+    with pytest.raises(TypeError, match="pyarrow.Schema"):
+        _sink().bind(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="case-insensitively unique"):
+        _sink().bind(pa.schema([("id", pa.uint64()), ("ID", pa.uint64())]))
+    with pytest.raises(ValueError, match="uint64 or string UUID"):
+        _sink().bind(_arrow_schema(id_type=pa.int64()))
+    with pytest.raises(ValueError, match="float32"):
+        _sink().bind(_arrow_schema(vector_type=pa.list_(pa.float64())))
+    with pytest.raises(ValueError, match="source columns must be disjoint"):
+        _sink(payload_mapping={"embedding": "payload"}).bind(
+            pa.schema([("id", pa.uint64()), ("embedding", pa.list_(pa.float32()))])
+        )
+    with pytest.raises(ValueError, match="unknown input"):
+        _sink(vector_mapping="missing").bind(_arrow_schema())
+    with pytest.raises(ValueError, match="every input column"):
+        _sink(payload_mapping=None).bind(_arrow_schema())
+    with pytest.raises(ValueError, match="does not support payload"):
+        _sink().bind(_arrow_schema(payload_type=pa.binary()))
+
+
+def test_qdrant_sink_writes_single_vector_full_points_and_bounded_results() -> None:
+    worker = _worker()
+    table = _table()
+
+    first = worker.write(table)
+    second = worker.write(table)
+
+    assert first.rows_received == first.rows_affected == 2
+    assert first.bytes_received == table.nbytes
+    assert first.metadata == {
+        "provider": "qdrant",
+        "collection": "items",
+        "write_mode": "replace",
+        "status": "completed",
+    }
+    assert len(first.warnings) == 1
+    assert second.warnings == ()
+    client = _Client.instances[0]
+    assert client.options == {"url": "https://qdrant.example:6333", "timeout": 5}
+    assert client.get_calls == [{"collection_name": "items"}]
+    assert client.upsert_calls[0]["collection_name"] == "items"
+    assert client.upsert_calls[0]["wait"] is True
+    assert client.upsert_calls[0]["timeout"] == 5
+    assert client.upsert_calls[0]["points"] == [
+        _PointStruct(1, pytest.approx([0.1, 0.2, 0.3]), {"title": "one"}),
+        _PointStruct(2, pytest.approx([0.4, 0.5, 0.6]), {"title": "two"}),
+    ]
+
+
+def test_qdrant_sink_writes_every_named_vector_and_mapped_payload() -> None:
+    _Client.collection_info = _collection_info(
+        vectors={"dense": _VectorParams(size=2), "summary": _VectorParams(size=1)}
+    )
+    schema = pa.schema(
+        [
+            ("point", pa.uint64()),
+            ("dense_source", pa.list_(pa.float32(), 2)),
+            ("summary_source", pa.list_(pa.float32(), 1)),
+            ("source_title", pa.string()),
+            ("attributes", pa.struct([("rank", pa.int32()), ("tags", pa.list_(pa.string()))])),
+        ]
+    )
+    sink = QdrantSink(
+        "items",
+        url="https://qdrant.example:6333",
+        point_id="point",
+        vector_mapping={"dense_source": "dense", "summary_source": "summary"},
+        payload_mapping={"source_title": "title", "attributes": "attributes"},
+    )
+    table = pa.table(
+        {
+            "point": [7],
+            "dense_source": [[0.1, 0.2]],
+            "summary_source": [[0.3]],
+            "source_title": ["seven"],
+            "attributes": [{"rank": 1, "tags": ["a", "b"]}],
+        },
+        schema=schema,
+    )
+
+    sink.bind(schema).open_worker(WriteContext("named")).write(table)
+
+    point = _Client.instances[0].upsert_calls[0]["points"][0]
+    assert point == _PointStruct(
+        7,
+        {"dense": pytest.approx([0.1, 0.2]), "summary": pytest.approx([0.3])},
+        {"title": "seven", "attributes": {"rank": 1, "tags": ["a", "b"]}},
+    )
+
+
+def test_qdrant_sink_defers_endpoint_and_api_key_resolution_to_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VANE_TEST_QDRANT_URL", "https://private-qdrant.example:6333")
+    monkeypatch.setenv("VANE_TEST_QDRANT_API_KEY", "worker-only-api-key")
+    sink = _sink(
+        url=EnvironmentSecret("VANE_TEST_QDRANT_URL"),
+        api_key=EnvironmentSecret("VANE_TEST_QDRANT_API_KEY"),
+    )
+    serialized = cloudpickle.dumps(sink)
+    assert b"private-qdrant.example" not in serialized
+    assert b"worker-only-api-key" not in serialized
+
+    bound = sink.bind(_arrow_schema())
+    assert b"private-qdrant.example" not in cloudpickle.dumps(bound)
+    assert b"worker-only-api-key" not in cloudpickle.dumps(bound)
+    assert not _Client.instances
+    worker = bound.open_worker(WriteContext("secret-test"))
+
+    assert _Client.instances[0].options == {
+        "url": "https://private-qdrant.example:6333",
+        "timeout": 5,
+        "api_key": "worker-only-api-key",
+    }
+    worker.close()
+
+
+class _ProjectionRelation:
+    def __init__(self) -> None:
+        self.projection: str | None = None
+
+    def project(self, projection: str) -> _ProjectionRelation:
+        self.projection = projection
+        return self
+
+
+class _RejectingQdrantBound(BoundKeyedUpsertSink):
+    def __init__(self, delegate: BoundKeyedUpsertSink) -> None:
+        self._delegate = delegate
+
+    @property
+    def execution_options(self) -> Any:
+        return self._delegate.execution_options
+
+    @property
+    def key_columns(self) -> Any:
+        return self._delegate.key_columns
+
+    def prepare_input(self, relation: Any) -> Any:
+        return self._delegate.prepare_input(relation)
+
+    def open_worker(self, _context: WriteContext) -> Any:
+        raise AssertionError("Qdrant worker must not open for rejected point IDs")
+
+
+class _RejectingQdrantSink(DataSink):
+    def __init__(self, sink: QdrantSink) -> None:
+        self._sink = sink
+
+    def bind(self, schema: pa.Schema) -> BoundKeyedUpsertSink:
+        return _RejectingQdrantBound(self._sink.bind(schema))
+
+
+def test_qdrant_sink_normalizes_uuid_ids_before_global_key_validation() -> None:
+    schema = _arrow_schema(id_type=pa.string())
+    bound = _bound(schema=schema)
+    relation = _ProjectionRelation()
+
+    prepared = bound.prepare_input(relation)  # type: ignore[arg-type]
+
+    assert prepared is relation
+    assert relation.projection == ('CAST(TRY_CAST("id" AS UUID) AS VARCHAR) AS "id", "embedding", "title"')
+    assert tuple(bound.key_columns) == ("id",)
+
+
+@pytest.mark.parametrize(
+    ("ids", "operation_id"),
+    [
+        (["not-a-uuid"], "invalid-uuid"),
+        (
+            ["123e4567-e89b-12d3-a456-426614174000", "123E4567-E89B-12D3-A456-426614174000"],
+            "duplicate-normalized-uuid",
+        ),
+    ],
+)
+def test_qdrant_sink_rejects_invalid_or_duplicate_uuid_ids_before_worker_open(
+    monkeypatch: pytest.MonkeyPatch,
+    ids: list[str],
+    operation_id: str,
+) -> None:
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    relation = vane.from_arrow(
+        pa.table(
+            {
+                "id": ids,
+                "embedding": pa.array([[0.1, 0.2, 0.3]] * len(ids), type=pa.list_(pa.float32())),
+                "title": ["title"] * len(ids),
+            },
+            schema=_arrow_schema(id_type=pa.string()),
+        )
+    )
+
+    with pytest.raises(DataSinkWriteError) as exc_info:
+        relation.write_datasink(_RejectingQdrantSink(_sink()), operation_id=operation_id)
+
+    assert exc_info.value.outcome is WriteOutcome.ABORTED
+
+
+@pytest.mark.parametrize(
+    ("collection_info", "message"),
+    [
+        (None, "invalid collection information"),
+        (_CollectionInfo(config=None), "invalid collection configuration"),
+        (_CollectionInfo(config=_CollectionConfig(params=None)), "invalid collection configuration"),
+        (_collection_info(vectors={"dense": _VectorParams(3)}), "one unnamed"),
+        (_collection_info(sparse_vectors={"sparse": object()}), "sparse vectors"),
+        (_collection_info(vectors=_VectorParams(3, datatype=_Datatype.FLOAT16)), "float32"),
+        (_collection_info(vectors=_VectorParams(3, multivector_config=object())), "multivector"),
+        (_collection_info(vectors=_VectorParams(True)), "invalid dimension"),
+    ],
+)
+def test_qdrant_sink_rejects_unsupported_collection_contract(collection_info: object, message: str) -> None:
+    _Client.collection_info = collection_info
+    with pytest.raises(ValueError, match=message):
+        _worker()
+    assert _Client.instances[0].close_calls == 1
+
+
+def test_qdrant_sink_validates_vector_dimensions_and_named_collection_schema() -> None:
+    _Client.collection_info = _collection_info(vectors=_VectorParams(3))
+    with pytest.raises(ValueError, match="fixed dimension"):
+        _worker(schema=_arrow_schema(vector_type=pa.list_(pa.float32(), 2)))
+
+    _Client.collection_info = _collection_info(vectors=_VectorParams(3))
+    named_sink = _sink(vector_mapping={"embedding": "dense"})
+    with pytest.raises(ValueError, match="named dense vectors"):
+        named_sink.bind(_arrow_schema()).open_worker(WriteContext("named-required"))
+
+    _Client.collection_info = _collection_info(vectors={"dense": _VectorParams(3), "other": _VectorParams(3)})
+    with pytest.raises(ValueError, match="cover every named"):
+        named_sink.bind(_arrow_schema()).open_worker(WriteContext("missing-named"))
+
+
+def test_qdrant_sink_validates_all_values_before_upsert() -> None:
+    worker = _worker()
+    with pytest.raises(ValueError, match="point IDs"):
+        worker.write(_table(ids=[None, 2]))  # type: ignore[list-item]
+    with pytest.raises(ValueError, match="invalid dimension"):
+        worker.write(_table(vectors=[[0.1, 0.2], [0.3, 0.4]]))
+    with pytest.raises(ValueError, match="invalid value"):
+        worker.write(_table(vectors=[[0.1, float("nan"), 0.3], [0.4, 0.5, 0.6]]))
+    assert not _Client.instances[0].upsert_calls
+
+    float_schema = _arrow_schema(payload_type=pa.float64())
+    float_worker = _worker(schema=float_schema)
+    with pytest.raises(ValueError, match="non-finite"):
+        float_worker.write(_table(titles=[float("inf"), 1.0], schema=float_schema))
+    assert not _Client.instances[1].upsert_calls
+
+    uint_schema = _arrow_schema(payload_type=pa.uint64())
+    uint_worker = _worker(schema=uint_schema)
+    with pytest.raises(ValueError, match="signed 64-bit"):
+        uint_worker.write(_table(titles=[1 << 63, 1], schema=uint_schema))
+    assert not _Client.instances[2].upsert_calls
+
+
+def test_qdrant_sink_rejects_noncanonical_uuid_values_before_upsert() -> None:
+    schema = _arrow_schema(id_type=pa.string())
+    worker = _worker(schema=schema)
+    canonical = "123e4567-e89b-12d3-a456-426614174000"
+    invalid_tables = [
+        pa.table(
+            {"id": ["not-a-uuid"], "embedding": [[0.1, 0.2, 0.3]], "title": ["bad"]},
+            schema=schema,
+        ),
+        pa.table(
+            {"id": [canonical.upper()], "embedding": [[0.1, 0.2, 0.3]], "title": ["bad"]},
+            schema=schema,
+        ),
+    ]
+    for table in invalid_tables:
+        with pytest.raises(ValueError, match="UUID point IDs"):
+            worker.write(table)
+    assert not _Client.instances[0].upsert_calls
+
+
+def test_qdrant_sink_enforces_batch_and_schema_limits_before_upsert() -> None:
+    worker = _worker(max_batch_rows=1)
+    with pytest.raises(ValueError, match="max_batch_rows"):
+        worker.write(_table())
+    assert not _Client.instances[0].upsert_calls
+
+    worker = _worker(max_batch_bytes=1)
+    with pytest.raises(ValueError, match="max_batch_bytes"):
+        worker.write(_table())
+    assert not _Client.instances[1].upsert_calls
+
+    worker = _worker()
+    bad_schema = pa.schema([("id", pa.uint64()), ("embedding", pa.list_(pa.float32())), ("other", pa.string())])
+    with pytest.raises(ValueError, match="bound input schema"):
+        worker.write(pa.table({"id": [1], "embedding": [[0.1, 0.2, 0.3]], "other": ["x"]}, schema=bad_schema))
+    assert not _Client.instances[2].upsert_calls
+
+
+def test_qdrant_sink_validates_static_result_payload_before_upsert() -> None:
+    collection = "c" * (65 * 1024)
+    sink = QdrantSink(
+        collection,
+        url="https://qdrant.example:6333",
+        point_id="id",
+        vector_mapping="embedding",
+        payload_mapping={"title": "title"},
+    )
+
+    with pytest.raises(ValueError, match="64 KiB"):
+        sink.bind(_arrow_schema()).open_worker(WriteContext("bounded-result"))
+
+    assert _Client.instances[0].close_calls == 1
+    assert not _Client.instances[0].upsert_calls
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        (None, "invalid update result"),
+        ({"status": "completed"}, "invalid update result"),
+        (_UpdateResult(_UpdateStatus.ACKNOWLEDGED), "status=acknowledged"),
+        (_UpdateResult(_UpdateStatus.WAIT_TIMEOUT), "status=wait_timeout"),
+    ],
+)
+def test_qdrant_sink_requires_completed_application_acknowledgement(response: object, message: str) -> None:
+    _Client.response = response
+    worker = _worker()
+    with pytest.raises(RuntimeError, match=message):
+        worker.write(_table())
+
+
+def test_qdrant_sink_propagates_provider_failures_and_closes_on_abort() -> None:
+    _Client.get_error = RuntimeError("get failed")
+    with pytest.raises(RuntimeError, match="get failed"):
+        _worker()
+    assert _Client.instances[0].close_calls == 1
+
+    _Client.get_error = None
+    worker = _worker()
+    _Client.upsert_error = TimeoutError("upsert timed out")
+    with pytest.raises(TimeoutError, match="upsert timed out"):
+        worker.write(_table())
+    worker.abort(TimeoutError("upsert timed out"))
+    assert _Client.instances[1].close_calls == 1
+    worker.close()
+    assert _Client.instances[1].close_calls == 1
+
+
+def test_qdrant_sink_retains_client_ownership_when_close_fails() -> None:
+    worker = _worker()
+    _Client.close_error = RuntimeError("close failed")
+    with pytest.raises(RuntimeError, match="close failed"):
+        worker.close()
+    assert _Client.instances[0].close_calls == 1
+
+    _Client.close_error = None
+    worker.close()
+    assert _Client.instances[0].close_calls == 2
+
+
+def test_qdrant_sink_replay_replaces_the_same_points() -> None:
+    table = _table()
+    first_worker = _bound(max_retries=1).open_worker(WriteContext("stable-operation"))
+    second_worker = _bound(max_retries=1).open_worker(WriteContext("stable-operation"))
+
+    first_worker.write(table)
+    snapshot = deepcopy(_Client.store)
+    second_worker.write(table)
+
+    assert _Client.store == snapshot
+    assert set(_Client.store) == {1, 2}
+    assert sum(len(client.upsert_calls) for client in _Client.instances) == 2
+
+
+@pytest.mark.external_service
+def test_qdrant_sink_live_full_point_upsert() -> None:
+    url = os.environ.get("VANE_TEST_QDRANT_URL")
+    if not url:
+        pytest.skip("VANE_TEST_QDRANT_URL is required for the external Qdrant test")
+    qdrant_client = pytest.importorskip("qdrant_client")
+    models = qdrant_client.models
+    api_key_value = os.environ.get("VANE_TEST_QDRANT_API_KEY")
+    options: dict[str, object] = {"url": url, "timeout": 30}
+    if api_key_value is not None:
+        options["api_key"] = api_key_value
+    client = qdrant_client.QdrantClient(**options)
+    collection = f"vane_sink_e2e_{uuid.uuid4().hex}"
+    collection_created = False
+    try:
+        assert client.create_collection(
+            collection_name=collection,
+            vectors_config=models.VectorParams(size=2, distance=models.Distance.DOT),
+            timeout=30,
+        )
+        collection_created = True
+        seed_result = client.upsert(
+            collection_name=collection,
+            points=[
+                models.PointStruct(id=1, vector=[0.9, 0.9], payload={"title": "old", "obsolete": True}),
+                models.PointStruct(id=2, vector=[0.8, 0.8], payload={"title": "old", "obsolete": True}),
+            ],
+            wait=True,
+            timeout=30,
+        )
+        assert seed_result.status is models.UpdateStatus.COMPLETED
+        relation = vane.from_arrow(
+            pa.table(
+                {
+                    "id": pa.array([1, 2], type=pa.uint64()),
+                    "embedding": pa.array([[0.1, 0.2], [0.3, 0.4]], type=pa.list_(pa.float32(), 2)),
+                    "title": ["one", "two"],
+                }
+            )
+        )
+        api_key = EnvironmentSecret("VANE_TEST_QDRANT_API_KEY") if api_key_value is not None else None
+        summary = relation.write_datasink(
+            QdrantSink(
+                collection,
+                url=url,
+                point_id="id",
+                vector_mapping="embedding",
+                payload_mapping={"title": "title"},
+                api_key=api_key,
+                timeout=30,
+            ),
+            operation_id=f"qdrant-live-{uuid.uuid4()}",
+        )
+        assert summary.rows_affected == 2
+        points = client.retrieve(
+            collection_name=collection,
+            ids=[1, 2],
+            with_payload=True,
+            with_vectors=True,
+        )
+        assert {point.id: point.payload for point in points} == {1: {"title": "one"}, 2: {"title": "two"}}
+        assert {point.id: point.vector for point in points} == {
+            1: pytest.approx([0.1, 0.2]),
+            2: pytest.approx([0.3, 0.4]),
+        }
+    finally:
+        try:
+            if collection_created:
+                client.delete_collection(collection_name=collection, timeout=30)
+        finally:
+            client.close()

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -209,6 +209,7 @@ from vane.datasink import (
     write_datasink,
 )
 from vane.datasink.milvus import MilvusSink
+from vane.datasink.qdrant import QdrantSink
 from vane.extensions import (
     DynamicExtensionDependency,
     DynamicExtensionDescriptor,
@@ -388,6 +389,7 @@ __all__: list[str] = [
     "LocalExtensionProvider",
     "MapValue",
     "MilvusSink",
+    "QdrantSink",
     "NUMBER",
     "NotImplementedException",
     "NotSupportedError",

--- a/vane/datasink/qdrant.py
+++ b/vane/datasink/qdrant.py
@@ -1,0 +1,577 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed, full-point Qdrant upserts.
+
+Each input row must provide a stable unsigned 64-bit integer or UUID point ID,
+one dense vector (or every configured named dense vector), and explicitly
+mapped payload fields. A successful worker batch has been applied by Qdrant,
+but worker batches are independent and are not an atomic transaction.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+from vane.datasink import (
+    BoundKeyedUpsertSink,
+    DataSink,
+    DataSinkExecutionOptions,
+    DataSinkWorker,
+    EnvironmentSecret,
+    WriteContext,
+    WriteResult,
+)
+
+if TYPE_CHECKING:
+    from vane import DuckDBPyRelation
+
+_MAX_INT64 = (1 << 63) - 1
+_MAX_UINT64 = (1 << 64) - 1
+_DEFAULT_MAX_BATCH_ROWS = 1_000
+_DEFAULT_MAX_BATCH_BYTES = 16 * 1024 * 1024
+_DEFAULT_TIMEOUT_SECONDS = 30
+_MAX_PAYLOAD_NESTING = 16
+_PARTIAL_VISIBILITY_WARNING = (
+    "Qdrant applies full-point worker batches independently; a later operation failure can leave this batch visible"
+)
+
+
+def _name(name: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    if value != value.strip() or "\x00" in value:
+        raise ValueError(f"{name} must not contain surrounding whitespace or NUL characters")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ValueError(f"{name} must contain valid UTF-8") from error
+    return value
+
+
+def _url(value: object) -> str:
+    url = _name("url", value)
+    try:
+        parsed = urlsplit(url)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as error:
+        raise ValueError("url must be a valid HTTP or HTTPS Qdrant endpoint") from error
+    if parsed.scheme not in {"http", "https"} or hostname is None:
+        raise ValueError("url must be an absolute HTTP or HTTPS Qdrant endpoint")
+    if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+        raise ValueError(
+            "url must not contain credentials, query parameters, or fragments; use api_key=EnvironmentSecret(...)"
+        )
+    if parsed.path not in {"", "/"}:
+        raise ValueError("url must not contain a path")
+    return url
+
+
+def _positive_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a positive integer")
+    if value <= 0 or value > _MAX_INT64:
+        raise ValueError(f"{name} must be a positive signed 64-bit integer")
+    return value
+
+
+def _non_negative_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a non-negative integer")
+    if value < 0 or value > _MAX_INT64:
+        raise ValueError(f"{name} must be a non-negative signed 64-bit integer")
+    return value
+
+
+def _mapping(name: str, value: object, *, allow_none: bool) -> tuple[tuple[str, str], ...]:
+    if value is None and allow_none:
+        return ()
+    if not isinstance(value, Mapping):
+        suffix = " or None" if allow_none else ""
+        raise TypeError(f"{name} must be a mapping{suffix}")
+    normalized: list[tuple[str, str]] = []
+    for source, target in value.items():
+        normalized.append((_name(f"{name} source", source), _name(f"{name} target", target)))
+    targets = [target for _, target in normalized]
+    if len(set(targets)) != len(targets):
+        raise ValueError(f"{name} targets must be unique")
+    return tuple(normalized)
+
+
+@dataclass(frozen=True)
+class _VectorBinding:
+    source_name: str
+    target_name: str | None
+    data_type: pa.DataType
+    fixed_dimension: int | None
+
+
+@dataclass(frozen=True)
+class _PayloadBinding:
+    source_name: str
+    target_name: str
+    data_type: pa.DataType
+
+
+def _vector_type(field: pa.Field) -> tuple[pa.DataType, int | None]:
+    data_type = field.type
+    if not (
+        pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type)
+    ) or not pa.types.is_float32(data_type.value_type):
+        raise ValueError(
+            f"Qdrant vector source field {field.name!r} must be an Arrow list, large_list, "
+            "or fixed_size_list of float32"
+        )
+    dimension = data_type.list_size if pa.types.is_fixed_size_list(data_type) else None
+    if dimension is not None and dimension <= 0:
+        raise ValueError(f"Qdrant vector source field {field.name!r} must have a positive dimension")
+    return data_type, dimension
+
+
+def _validate_payload_type(field_name: str, data_type: pa.DataType, *, depth: int = 0) -> None:
+    if depth > _MAX_PAYLOAD_NESTING:
+        raise ValueError(f"Qdrant payload source field {field_name!r} exceeds the supported nesting depth")
+    if (
+        pa.types.is_null(data_type)
+        or pa.types.is_boolean(data_type)
+        or pa.types.is_integer(data_type)
+        or pa.types.is_float32(data_type)
+        or pa.types.is_float64(data_type)
+        or pa.types.is_string(data_type)
+        or pa.types.is_large_string(data_type)
+    ):
+        return
+    if pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type):
+        _validate_payload_type(field_name, data_type.value_type, depth=depth + 1)
+        return
+    if pa.types.is_struct(data_type):
+        names = [child.name for child in data_type]
+        if len(set(names)) != len(names):
+            raise ValueError(f"Qdrant payload struct source field {field_name!r} must have unique child names")
+        for child in data_type:
+            _name(f"payload struct field in {field_name!r}", child.name)
+            _validate_payload_type(field_name, child.type, depth=depth + 1)
+        return
+    raise ValueError(f"QdrantSink does not support payload field {field_name!r} with Arrow type {data_type}")
+
+
+def _load_qdrant_sdk() -> tuple[type[Any], Any]:
+    try:
+        from qdrant_client import QdrantClient, models  # type: ignore[import-not-found, import-untyped, unused-ignore]
+    except ModuleNotFoundError as error:
+        if error.name != "qdrant_client":
+            raise
+        raise ImportError("QdrantSink requires qdrant-client; install vane-ai[qdrant]") from error
+    return QdrantClient, models
+
+
+class QdrantSink(DataSink):
+    """Write relation batches to one Qdrant collection with point upserts.
+
+    ``point_id`` names the source relation column containing a caller-assigned
+    Arrow ``uint64`` or UUID string. ``vector_mapping`` is either the source
+    column for a collection with one unnamed dense vector, or a mapping from
+    source columns to Qdrant named dense vectors. ``payload_mapping`` maps
+    source columns to payload keys. Every input column must have exactly one
+    role, so callers must project away intentionally unused columns.
+
+    The URL may be a public endpoint string or an ``EnvironmentSecret`` that
+    is resolved on each worker. API keys must use ``EnvironmentSecret`` and
+    are never stored as plaintext in the serialized sink plan.
+
+    Framework retries are disabled unless ``max_retries`` is positive. A retry
+    replays the full input with the same point IDs. Qdrant replaces the complete
+    vectors and payload of each point; Vane does not coordinate concurrent
+    writers or provide a cross-batch transaction or exactly-once delivery.
+    """
+
+    def __init__(
+        self,
+        collection_name: str,
+        *,
+        url: str | EnvironmentSecret,
+        point_id: str,
+        vector_mapping: str | Mapping[str, str],
+        payload_mapping: Mapping[str, str] | None = None,
+        api_key: EnvironmentSecret | None = None,
+        worker_count: int = 1,
+        max_batch_rows: int = _DEFAULT_MAX_BATCH_ROWS,
+        max_batch_bytes: int = _DEFAULT_MAX_BATCH_BYTES,
+        max_retries: int = 0,
+        timeout: int = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.collection_name = _name("collection_name", collection_name)
+        self.url: str | EnvironmentSecret
+        if isinstance(url, EnvironmentSecret):
+            self.url = url
+        else:
+            self.url = _url(url)
+        self.point_id = _name("point_id", point_id)
+        self._single_vector_source: str | None
+        self._named_vector_mapping: tuple[tuple[str, str], ...]
+        if isinstance(vector_mapping, str):
+            self._single_vector_source = _name("vector_mapping", vector_mapping)
+            self._named_vector_mapping = ()
+        else:
+            named_mapping = _mapping("vector_mapping", vector_mapping, allow_none=False)
+            if not named_mapping:
+                raise ValueError("vector_mapping must contain at least one named vector")
+            self._single_vector_source = None
+            self._named_vector_mapping = named_mapping
+        self._payload_mapping = _mapping("payload_mapping", payload_mapping, allow_none=True)
+        if api_key is not None and not isinstance(api_key, EnvironmentSecret):
+            raise TypeError("api_key must be an EnvironmentSecret or None")
+        self._api_key = api_key
+        self.worker_count = _positive_int("worker_count", worker_count)
+        self.max_batch_rows = _positive_int("max_batch_rows", max_batch_rows)
+        self.max_batch_bytes = _positive_int("max_batch_bytes", max_batch_bytes)
+        self.max_retries = _non_negative_int("max_retries", max_retries)
+        self.timeout = _positive_int("timeout", timeout)
+
+    def bind(self, schema: pa.Schema) -> BoundKeyedUpsertSink:
+        if not isinstance(schema, pa.Schema):
+            raise TypeError("schema must be pyarrow.Schema")
+        if len({name.casefold() for name in schema.names}) != len(schema.names):
+            raise ValueError("QdrantSink requires case-insensitively unique input column names")
+
+        single_vector_source = self._single_vector_source
+        vector_mapping: tuple[tuple[str, str | None], ...] = (
+            ((single_vector_source, None),)
+            if single_vector_source is not None
+            else tuple((source, target) for source, target in self._named_vector_mapping)
+        )
+        source_roles = [self.point_id]
+        source_roles.extend(source for source, _ in vector_mapping)
+        source_roles.extend(source for source, _ in self._payload_mapping)
+        if len(set(source_roles)) != len(source_roles):
+            raise ValueError("point_id, vector_mapping, and payload_mapping source columns must be disjoint")
+        unknown_sources = set(source_roles).difference(schema.names)
+        if unknown_sources:
+            raise ValueError(f"Qdrant mappings contain unknown input columns: {sorted(unknown_sources)!r}")
+        unmapped_sources = set(schema.names).difference(source_roles)
+        if unmapped_sources:
+            raise ValueError(f"QdrantSink requires every input column to be mapped: {sorted(unmapped_sources)!r}")
+
+        point_field = schema.field(self.point_id)
+        point_id_is_uuid = pa.types.is_string(point_field.type)
+        if not point_id_is_uuid and not pa.types.is_uint64(point_field.type):
+            raise ValueError("Qdrant point_id source must be Arrow uint64 or string UUID")
+
+        vectors: list[_VectorBinding] = []
+        for source, target in vector_mapping:
+            data_type, fixed_dimension = _vector_type(schema.field(source))
+            vectors.append(_VectorBinding(source, target, data_type, fixed_dimension))
+
+        payloads: list[_PayloadBinding] = []
+        for source, target in self._payload_mapping:
+            data_type = schema.field(source).type
+            _validate_payload_type(source, data_type)
+            payloads.append(_PayloadBinding(source, target, data_type))
+
+        return _BoundQdrantSink(self, schema, point_id_is_uuid, tuple(vectors), tuple(payloads))
+
+    def _resolve_url(self) -> str:
+        url = self.url
+        if isinstance(url, EnvironmentSecret):
+            return _url(url.resolve())
+        return url
+
+
+class _BoundQdrantSink(BoundKeyedUpsertSink):
+    def __init__(
+        self,
+        sink: QdrantSink,
+        schema: pa.Schema,
+        point_id_is_uuid: bool,
+        vectors: tuple[_VectorBinding, ...],
+        payloads: tuple[_PayloadBinding, ...],
+    ) -> None:
+        self._sink = sink
+        self._schema = schema
+        self._point_id_is_uuid = point_id_is_uuid
+        self._vectors = vectors
+        self._payloads = payloads
+
+    @property
+    def execution_options(self) -> DataSinkExecutionOptions:
+        return DataSinkExecutionOptions(
+            worker_count=self._sink.worker_count,
+            batch_size=self._sink.max_batch_rows,
+            target_max_batch_bytes=self._sink.max_batch_bytes,
+            max_retries=self._sink.max_retries,
+        )
+
+    @property
+    def key_columns(self) -> Sequence[str]:
+        return (self._sink.point_id,)
+
+    def prepare_input(self, relation: DuckDBPyRelation) -> DuckDBPyRelation:
+        if not self._point_id_is_uuid:
+            return relation
+        projections: list[str] = []
+        for name in self._schema.names:
+            quoted = _quote_identifier(name)
+            if name == self._sink.point_id:
+                projections.append(f"CAST(TRY_CAST({quoted} AS UUID) AS VARCHAR) AS {quoted}")
+            else:
+                projections.append(quoted)
+        return relation.project(", ".join(projections))
+
+    def open_worker(self, _context: WriteContext) -> DataSinkWorker:
+        return _QdrantWorker(self._sink, self._schema, self._point_id_is_uuid, self._vectors, self._payloads)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+class _QdrantWorker(DataSinkWorker):
+    def __init__(
+        self,
+        sink: QdrantSink,
+        schema: pa.Schema,
+        point_id_is_uuid: bool,
+        vectors: tuple[_VectorBinding, ...],
+        payloads: tuple[_PayloadBinding, ...],
+    ) -> None:
+        client_type, models = _load_qdrant_sdk()
+        client_options: dict[str, Any] = {"url": sink._resolve_url(), "timeout": sink.timeout}
+        if sink._api_key is not None:
+            client_options["api_key"] = sink._api_key.resolve()
+        self._sink = sink
+        self._schema = schema
+        self._point_id_is_uuid = point_id_is_uuid
+        self._vectors = vectors
+        self._payloads = payloads
+        self._models = models
+        self._client: Any | None = client_type(**client_options)
+        self._warning_pending = True
+        try:
+            self._remote_dimensions = self._validate_collection()
+            self._result_metadata = {
+                "provider": "qdrant",
+                "collection": self._sink.collection_name,
+                "write_mode": "replace",
+                "status": "completed",
+            }
+            WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                metadata=self._result_metadata,
+                warnings=(_PARTIAL_VISIBILITY_WARNING,),
+            )
+        except BaseException as error:
+            try:
+                self.close()
+            except BaseException as close_error:
+                add_note = getattr(error, "add_note", None)
+                if callable(add_note):
+                    try:
+                        add_note(f"Qdrant client cleanup also failed: {type(close_error).__name__}")
+                    except BaseException:
+                        pass
+            raise
+
+    def _client_or_raise(self) -> Any:
+        if self._client is None:
+            raise RuntimeError("QdrantSink worker is closed")
+        return self._client
+
+    def _validate_vector_params(self, name: str | None, params: object, binding: _VectorBinding) -> None:
+        label = "unnamed vector" if name is None else f"vector {name!r}"
+        if not isinstance(params, self._models.VectorParams):
+            raise ValueError(f"Qdrant collection {label} has invalid parameters")
+        dimension = params.size
+        if isinstance(dimension, bool) or not isinstance(dimension, int) or dimension <= 0:
+            raise ValueError(f"Qdrant collection {label} has an invalid dimension")
+        if binding.fixed_dimension is not None and binding.fixed_dimension != dimension:
+            raise ValueError(
+                f"Qdrant collection {label} dimension {dimension} does not match "
+                f"Arrow fixed dimension {binding.fixed_dimension}"
+            )
+        if params.datatype not in {None, self._models.Datatype.FLOAT32}:
+            raise ValueError(f"Qdrant collection {label} must use float32 vectors")
+        if params.multivector_config is not None:
+            raise ValueError("QdrantSink does not support multivector collections")
+
+    def _validate_collection(self) -> dict[str | None, int]:
+        info = self._client_or_raise().get_collection(collection_name=self._sink.collection_name)
+        if not isinstance(info, self._models.CollectionInfo):
+            raise ValueError("Qdrant get_collection returned invalid collection information")
+        if not isinstance(info.config, self._models.CollectionConfig) or not isinstance(
+            info.config.params, self._models.CollectionParams
+        ):
+            raise ValueError("Qdrant get_collection returned invalid collection configuration")
+        params = info.config.params
+        if params.sparse_vectors:
+            raise ValueError("QdrantSink does not support collections with sparse vectors")
+        remote_vectors = params.vectors
+        if self._vectors[0].target_name is None:
+            if not isinstance(remote_vectors, self._models.VectorParams):
+                raise ValueError("Qdrant collection must define one unnamed dense vector")
+            self._validate_vector_params(None, remote_vectors, self._vectors[0])
+            return {None: remote_vectors.size}
+        if not isinstance(remote_vectors, dict):
+            raise ValueError("Qdrant collection must define named dense vectors")
+        expected_names: set[str] = set()
+        for binding in self._vectors:
+            assert binding.target_name is not None
+            expected_names.add(binding.target_name)
+        if set(remote_vectors) != expected_names:
+            raise ValueError(
+                "vector_mapping must cover every named dense vector in the Qdrant collection; "
+                f"expected {sorted(remote_vectors)!r}, got {sorted(expected_names)!r}"
+            )
+        for binding in self._vectors:
+            assert binding.target_name is not None
+            self._validate_vector_params(binding.target_name, remote_vectors[binding.target_name], binding)
+        return {binding.target_name: remote_vectors[binding.target_name].size for binding in self._vectors}
+
+    def _point_id(self, value: object) -> int | str:
+        if self._point_id_is_uuid:
+            if not isinstance(value, str):
+                raise ValueError("Qdrant UUID point IDs must be strings")
+            try:
+                parsed = uuid.UUID(value)
+            except (AttributeError, ValueError) as error:
+                raise ValueError("Qdrant UUID point IDs must contain valid UUIDs") from error
+            if str(parsed) != value:
+                raise ValueError("Qdrant UUID point IDs must be normalized canonical UUID strings")
+            return value
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0 or value > _MAX_UINT64:
+            raise ValueError("Qdrant numeric point IDs must be unsigned 64-bit integers")
+        return value
+
+    def _vector(self, value: object, *, name: str | None, dimension: int) -> list[float]:
+        label = "unnamed vector" if name is None else f"vector {name!r}"
+        if not isinstance(value, list) or len(value) != dimension:
+            raise ValueError(f"Qdrant {label} has an invalid dimension")
+        converted: list[float] = []
+        for element in value:
+            if isinstance(element, bool) or not isinstance(element, (int, float)):
+                raise ValueError(f"Qdrant {label} contains an invalid value")
+            normalized = float(element)
+            if not math.isfinite(normalized):
+                raise ValueError(f"Qdrant {label} contains an invalid value")
+            converted.append(normalized)
+        return converted
+
+    def _payload_value(self, value: object, *, field: str, depth: int = 0) -> object:
+        if depth > _MAX_PAYLOAD_NESTING:
+            raise ValueError(f"Qdrant payload field {field!r} exceeds the supported nesting depth")
+        if value is None or isinstance(value, bool):
+            return value
+        if isinstance(value, int):
+            if value < -_MAX_INT64 - 1 or value > _MAX_INT64:
+                raise ValueError(f"Qdrant payload field {field!r} contains an integer outside signed 64-bit range")
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError(f"Qdrant payload field {field!r} contains a non-finite float")
+            return value
+        if isinstance(value, str):
+            try:
+                value.encode("utf-8")
+            except UnicodeEncodeError as error:
+                raise ValueError(f"Qdrant payload field {field!r} contains invalid UTF-8") from error
+            return value
+        if isinstance(value, list):
+            return [self._payload_value(item, field=field, depth=depth + 1) for item in value]
+        if isinstance(value, dict):
+            normalized: dict[str, object] = {}
+            for key, item in value.items():
+                normalized_key = _name(f"nested key in payload field {field!r}", key)
+                normalized[normalized_key] = self._payload_value(item, field=field, depth=depth + 1)
+            return normalized
+        raise ValueError(f"Qdrant payload field {field!r} contains a non-JSON value")
+
+    def _points(self, table: pa.Table) -> tuple[list[Any], int, int]:
+        if not isinstance(table, pa.Table):
+            raise TypeError(f"QdrantSink expected pyarrow.Table, got {type(table).__name__}")
+        if len(table.schema) != len(self._schema) or any(
+            batch_field.name != bound_field.name or batch_field.type != bound_field.type
+            for batch_field, bound_field in zip(table.schema, self._schema, strict=True)
+        ):
+            raise ValueError("Qdrant batch schema does not match the bound input schema")
+        row_count = table.num_rows
+        batch_bytes = table.nbytes
+        if row_count > self._sink.max_batch_rows:
+            raise ValueError("Qdrant batch exceeds max_batch_rows")
+        if batch_bytes > self._sink.max_batch_bytes:
+            raise ValueError("Qdrant batch exceeds max_batch_bytes")
+
+        points: list[Any] = []
+        for row in table.to_pylist():
+            point_id = self._point_id(row[self._sink.point_id])
+            if self._vectors[0].target_name is None:
+                binding = self._vectors[0]
+                vector: list[float] | dict[str, list[float]] = self._vector(
+                    row[binding.source_name], name=None, dimension=self._remote_dimensions[None]
+                )
+            else:
+                vector = {}
+                for binding in self._vectors:
+                    assert binding.target_name is not None
+                    vector[binding.target_name] = self._vector(
+                        row[binding.source_name],
+                        name=binding.target_name,
+                        dimension=self._remote_dimensions[binding.target_name],
+                    )
+            payload = {
+                binding.target_name: self._payload_value(row[binding.source_name], field=binding.target_name)
+                for binding in self._payloads
+            }
+            points.append(self._models.PointStruct(id=point_id, vector=vector, payload=payload))
+        return points, row_count, batch_bytes
+
+    def write(self, table: pa.Table) -> WriteResult:
+        points, row_count, batch_bytes = self._points(table)
+        if not points:
+            return WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                bytes_received=batch_bytes,
+                metadata=self._result_metadata,
+            )
+        response = self._client_or_raise().upsert(
+            collection_name=self._sink.collection_name,
+            points=points,
+            wait=True,
+            timeout=self._sink.timeout,
+        )
+        if not isinstance(response, self._models.UpdateResult):
+            raise RuntimeError("Qdrant upsert returned an invalid update result")
+        if response.status != self._models.UpdateStatus.COMPLETED:
+            raise RuntimeError(f"Qdrant upsert was not applied: status={response.status.value}")
+        warnings = (_PARTIAL_VISIBILITY_WARNING,) if self._warning_pending else ()
+        self._warning_pending = False
+        return WriteResult(
+            rows_received=row_count,
+            rows_affected=row_count,
+            bytes_received=batch_bytes,
+            metadata=self._result_metadata,
+            warnings=warnings,
+        )
+
+    def abort(self, _error: BaseException) -> None:
+        self.close()
+
+    def close(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        client.close()
+        self._client = None
+
+
+__all__ = ["QdrantSink"]


### PR DESCRIPTION
## Summary

- Add a public QdrantSink built on BoundKeyedUpsertSink with explicit Arrow uint64 or normalized UUID point IDs and global null/duplicate rejection before workers open.
- Support one unnamed dense vector or complete named-vector mappings, explicit JSON-safe payload mappings, collection/dimension validation, bounded batches/results, full-point replacement, and wait=True COMPLETED acknowledgement.
- Resolve endpoint/API-key EnvironmentSecret references only on workers, keep qdrant-client optional, and avoid compatibility or fallback paths.
- Add SDK-mocked coverage, documentation, packaging metadata, and a digest-pinned Qdrant v1.19.0 external-service CI job that verifies real full-point replacement.

qdrant-client is Apache-2.0 licensed and remains an optional, non-vendored dependency.

## Related issue

close: #648

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      AstroVela/vane-website.

README documents installation, mappings, supported Arrow values, credentials, batching, replay, replacement, and partial-visibility behavior.

## Validation

- Two consecutive clean code-review rounds after the final change.
- scripts/format root --changed --check
- pre-commit run on all changed files (YAML/TOML, Ruff, workflow schema, mypy, shfmt)
- SKBUILD_BUILD_DIR=$PWD/build/python-release SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation
- scripts/run_installed_pytest.sh tests/fast/test_qdrant_datasink.py: 52 passed, 1 deselected
- scripts/run_release_tests.sh: 810 passed / 20 deselected, then 14 passed / 816 deselected
- Real Qdrant v1.19.0 (official Linux binary, build 74f3e85b) with qdrant-client 1.19.0: external-service live test passed; verified acknowledged upsert, raw vector mapping, full payload replacement, and cleanup

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
