### PR TITLE
[feat](turbopuffer) Add a keyed-upsert DataSink

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ pip install 'vane-ai[sglang]'   # Native SGLang 0.5.17 inference on Linux x86-64
 pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
 pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
 pip install 'vane-ai[milvus]'   # distributed full-row Milvus upserts
+pip install 'vane-ai[turbopuffer]' # distributed whole-document Turbopuffer upserts
 ```
 
 The SGLang extra follows SGLang 0.5.17's default CUDA 13 dependency set. Python package metadata cannot select a
@@ -165,6 +166,54 @@ batches are acknowledged and applied independently, so a failed operation can
 be partially applied. Vane does not provide an atomic transaction, rollback,
 or exactly-once delivery, and read visibility follows the consistency level
 used by Milvus readers.
+
+### Turbopuffer DataSink
+
+`TurbopufferSink` writes distributed batches with Turbopuffer's columnar
+whole-document upsert API. The sink maps one explicit relation column to the
+reserved `id` field, one to the reserved `vector` field, and only the columns
+listed in `attribute_mapping` to stored attributes. Other relation columns are
+projected away. A first successful write implicitly creates the namespace; the
+same explicit schema and distance metric accompany every batch so concurrent
+workers use one deterministic contract.
+
+IDs must be Arrow `uint64` or UTF-8 strings of at most 64 bytes. Vectors must
+be fixed-size lists of Arrow `float32` with 1 to 10,752 dimensions, and must
+not contain null or non-finite values. Attributes support Arrow booleans,
+signed and unsigned integers, `float32`/`float64`, strings, and one-dimensional
+lists of those scalar types. Attribute names may contain at most 128 UTF-8
+bytes, must not start with `$`, and cannot be `id` or `vector`.
+
+```python
+from vane import EnvironmentSecret, TurbopufferSink
+
+sink = TurbopufferSink(
+    "documents",
+    region="gcp-us-central1",
+    api_key=EnvironmentSecret("TURBOPUFFER_API_KEY"),
+    id_column="document_id",
+    vector_column="embedding",
+    distance_metric="cosine_distance",
+    attribute_mapping={"title": "title", "tags": "tags"},
+)
+summary = relation.write_datasink(sink)
+```
+
+`max_batch_rows` and `max_batch_bytes` bound each actor input batch; the latter
+measures Arrow buffers. Before making a request, the sink also measures the
+compact columnar JSON body and enforces `max_request_bytes`, which cannot
+exceed Turbopuffer's documented 512 MB write-request limit. API keys are
+resolved from the worker environment and never stored as credential values in
+the serialized sink plan. `region` is a lowercase Turbopuffer region DNS label;
+the sink constructs the public Turbopuffer endpoint explicitly and does not
+honor the SDK's ambient base-URL override.
+
+The Turbopuffer SDK is constructed with its retries disabled. The default
+`max_retries=0` also disables Vane replay; when explicitly enabled, Vane
+replays the complete input and each row overwrites the same document ID.
+Concurrent external writers can still race. Acknowledged batches are immediate
+and independent, so a later batch failure can leave earlier documents visible;
+there is no cross-batch transaction, rollback, or exactly-once guarantee.
 
 ### Execution Policy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ Changelog = "https://github.com/AstroVela/vane/releases"
 
 [project.optional-dependencies]
 milvus = ["pymilvus>=3.0.1,<4"]
+turbopuffer = ["turbopuffer>=2.9.0,<3"]
 openai = ["openai>=1.66.0", "tiktoken"] # floor adds the Responses API used by the default Prompt path
 anthropic = ["anthropic>=0.117.0"] # floor matches the Messages.create option surface validated in vane/ai/providers/anthropic.py
 google = ["google-genai>=1.22.0"] # floor adds GenerateContentConfig.response_json_schema
@@ -98,6 +99,7 @@ all = [ # Cloud providers and dataframe/filesystem integrations; local model run
     "adbc-driver-manager", # for the adbc driver
     "pillow>=10", # used for image inputs and video frames
     "pymilvus>=3.0.1,<4", # Milvus DataSink
+    "turbopuffer>=2.9.0,<3", # Turbopuffer DataSink
 ]
 
 ######################################################################################################
@@ -228,6 +230,7 @@ include = [
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",
     "/tests/fast/test_milvus_datasink.py",
+    "/tests/fast/test_turbopuffer_datasink.py",
     "/tests/fast/test_package_metadata.py",
     "/tests/fast/test_ray_test_profile.py",
     "/tests/fast/test_transformers_provider_security.py",

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -24,6 +24,7 @@ release_tests=(
   "$project_root/tests/fast/test_ai_release_contracts.py"
   "$project_root/tests/fast/test_datasink.py"
   "$project_root/tests/fast/test_milvus_datasink.py"
+  "$project_root/tests/fast/test_turbopuffer_datasink.py"
   "$project_root/tests/fast/test_package_metadata.py"
   "$project_root/tests/fast/test_ray_test_profile.py"
   "$project_root/tests/fast/test_transformers_provider_security.py"

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -312,9 +312,12 @@ def test_provider_extras_match_provider_import_errors():
     assert _requirements_for_extra("openai") == {"openai", "tiktoken"}
     assert _requirements_for_extra("anthropic") == {"anthropic"}
     assert _requirements_for_extra("google") == {"google-genai"}
+    assert _requirements_for_extra("milvus") == {"pymilvus"}
+    assert _requirements_for_extra("turbopuffer") == {"turbopuffer"}
     assert {"sentence-transformers", "torch", "transformers"} <= _requirements_for_extra("transformers")
     assert "vllm" in _requirements_for_extra("vllm")
     assert "sglang" in _requirements_for_extra("sglang")
+    assert {"pymilvus", "turbopuffer"} <= _requirements_for_extra("all")
 
 
 def test_structured_provider_extras_require_supported_sdk_versions():
@@ -335,6 +338,14 @@ def test_structured_provider_extras_require_supported_sdk_versions():
     assert google.specifier == SpecifierSet(">=1.22.0")
     assert vllm.specifier == SpecifierSet(">=0.11.0")
     assert sglang.specifier == SpecifierSet("==0.5.17")
+
+
+def test_datasink_extras_require_supported_sdk_versions():
+    milvus = _requirement_for_extra("milvus", "pymilvus")
+    turbopuffer = _requirement_for_extra("turbopuffer", "turbopuffer")
+
+    assert milvus.specifier == SpecifierSet(">=3.0.1,<4")
+    assert turbopuffer.specifier == SpecifierSet(">=2.9.0,<3")
 
 
 def test_wheel_or_install_contains_primary_and_third_party_license_files():

--- a/tests/fast/test_turbopuffer_datasink.py
+++ b/tests/fast/test_turbopuffer_datasink.py
@@ -1,0 +1,614 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+import uuid
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+import cloudpickle
+import pyarrow as pa
+import pytest
+
+import vane
+import vane.datasink.turbopuffer as turbopuffer
+from vane import EnvironmentSecret, TurbopufferSink
+from vane.datasink import BoundKeyedUpsertSink, WriteContext
+
+
+_REAL_LOAD_TURBOPUFFER_SDK = turbopuffer._load_turbopuffer_sdk
+_DEFAULT_RESPONSE = object()
+
+
+@dataclass
+class _Response:
+    rows_affected: object
+    rows_upserted: object
+    status: object = "OK"
+
+
+class _Namespace:
+    def __init__(self, client: _Client, name: str) -> None:
+        self._client = client
+        self.name = name
+
+    def write(self, **kwargs: object) -> object:
+        self._client.write_calls.append(kwargs)
+        if _Client.write_error is not None:
+            raise _Client.write_error
+        columns = kwargs["upsert_columns"]
+        assert isinstance(columns, dict)
+        ids = columns["id"]
+        assert isinstance(ids, list)
+        for index, document_id in enumerate(ids):
+            _Client.store[document_id] = {
+                name: deepcopy(values[index])
+                for name, values in columns.items()
+                if isinstance(values, list)
+            }
+        if _Client.response is _DEFAULT_RESPONSE:
+            return _Response(len(ids), len(ids))
+        return _Client.response
+
+
+class _Client:
+    instances: list[_Client] = []
+    store: dict[object, dict[str, object]] = {}
+    response: object = _DEFAULT_RESPONSE
+    namespace_error: BaseException | None = None
+    write_error: BaseException | None = None
+    close_error: BaseException | None = None
+
+    def __init__(self, **kwargs: object) -> None:
+        self.options = kwargs
+        self.namespace_calls: list[str] = []
+        self.write_calls: list[dict[str, object]] = []
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    def namespace(self, name: str) -> _Namespace:
+        self.namespace_calls.append(name)
+        if type(self).namespace_error is not None:
+            raise type(self).namespace_error
+        return _Namespace(self, name)
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if type(self).close_error is not None:
+            raise type(self).close_error
+
+
+@pytest.fixture(autouse=True)
+def _fake_sdk(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    if request.node.get_closest_marker("external_service") is not None:
+        return
+    _Client.instances = []
+    _Client.store = {}
+    _Client.response = _DEFAULT_RESPONSE
+    _Client.namespace_error = None
+    _Client.write_error = None
+    _Client.close_error = None
+    monkeypatch.setenv("VANE_TEST_TURBOPUFFER_API_KEY", "worker-only-test-secret")
+    monkeypatch.setattr(turbopuffer, "_load_turbopuffer_sdk", lambda: (_Client, _Response))
+
+
+def _schema(
+    *,
+    id_type: pa.DataType | None = None,
+    vector_type: pa.DataType | None = None,
+    title_type: pa.DataType | None = None,
+    include_ignored: bool = True,
+) -> pa.Schema:
+    fields: list[tuple[str, pa.DataType]] = [
+        ("document_id", pa.uint64() if id_type is None else id_type),
+        ("embedding", pa.list_(pa.float32(), 3) if vector_type is None else vector_type),
+        ("title", pa.string() if title_type is None else title_type),
+        ("score", pa.float64()),
+        ("tags", pa.list_(pa.string())),
+    ]
+    if include_ignored:
+        fields.append(("ignored", pa.string()))
+    return pa.schema(fields)
+
+
+def _projected_schema(**kwargs: object) -> pa.Schema:
+    return _schema(include_ignored=False, **kwargs)  # type: ignore[arg-type]
+
+
+def _sink(**overrides: object) -> TurbopufferSink:
+    options: dict[str, object] = {
+        "namespace": "documents",
+        "region": "gcp-us-central1",
+        "api_key": EnvironmentSecret("VANE_TEST_TURBOPUFFER_API_KEY"),
+        "id_column": "document_id",
+        "vector_column": "embedding",
+        "distance_metric": "cosine_distance",
+        "attribute_mapping": {"title": "title", "score": "ranking", "tags": "labels"},
+        "timeout": 5,
+    }
+    options.update(overrides)
+    return TurbopufferSink(**options)  # type: ignore[arg-type]
+
+
+def _bound(schema: pa.Schema | None = None, **overrides: object) -> BoundKeyedUpsertSink:
+    return _sink(**overrides).bind(_schema() if schema is None else schema)
+
+
+def _worker(schema: pa.Schema | None = None, **overrides: object) -> Any:
+    return _bound(schema, **overrides).open_worker(WriteContext("turbopuffer-test"))
+
+
+def _table(
+    *,
+    ids: list[object] | None = None,
+    vectors: list[object] | None = None,
+    titles: list[object] | None = None,
+    scores: list[object] | None = None,
+    tags: list[object] | None = None,
+    schema: pa.Schema | None = None,
+) -> pa.Table:
+    return pa.table(
+        {
+            "document_id": [1, 2] if ids is None else ids,
+            "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] if vectors is None else vectors,
+            "title": ["one", "two"] if titles is None else titles,
+            "score": [1.25, 2.5] if scores is None else scores,
+            "tags": [["a"], ["b", "c"]] if tags is None else tags,
+        },
+        schema=_projected_schema() if schema is None else schema,
+    )
+
+
+def test_turbopuffer_sink_is_public_without_importing_the_optional_sdk() -> None:
+    assert vane.TurbopufferSink is TurbopufferSink
+    assert turbopuffer.__all__ == ["TurbopufferSink"]
+
+
+def test_turbopuffer_sink_reports_the_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def missing_turbopuffer(name: str, *args: object, **kwargs: object) -> Any:
+        if name == "turbopuffer":
+            raise ModuleNotFoundError("No module named 'turbopuffer'", name="turbopuffer")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_turbopuffer)
+    with pytest.raises(ImportError, match=r"vane-ai\[turbopuffer\]"):
+        _REAL_LOAD_TURBOPUFFER_SDK()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"namespace": ""}, ValueError, "namespace"),
+        ({"namespace": "bad/name"}, ValueError, "must match"),
+        ({"namespace": "n" * 129}, ValueError, "must match"),
+        ({"region": " gcp-us-central1"}, ValueError, "whitespace"),
+        ({"region": "GCP-US-CENTRAL1"}, ValueError, "lowercase DNS label"),
+        ({"region": "bad.region"}, ValueError, "lowercase DNS label"),
+        ({"region": "r" * 64}, ValueError, "at most 63"),
+        ({"api_key": "plaintext"}, TypeError, "EnvironmentSecret"),
+        ({"id_column": ""}, ValueError, "id_column"),
+        ({"vector_column": "document_id"}, ValueError, "different"),
+        ({"distance_metric": "dot_product"}, ValueError, "distance_metric"),
+        ({"attribute_mapping": []}, TypeError, "mapping"),
+        ({"attribute_mapping": {"title": "id"}}, ValueError, "reserved"),
+        ({"attribute_mapping": {"title": "vector"}}, ValueError, "reserved"),
+        ({"attribute_mapping": {"title": "$dist"}}, ValueError, "reserved"),
+        ({"attribute_mapping": {"title": "你" * 43}}, ValueError, "128 UTF-8 bytes"),
+        ({"attribute_mapping": {"title": "same", "score": "same"}}, ValueError, "targets"),
+        ({"attribute_mapping": {"document_id": "source"}}, ValueError, "must not reuse"),
+        ({"worker_count": True}, TypeError, "worker_count"),
+        ({"worker_count": 0}, ValueError, "worker_count"),
+        ({"max_batch_rows": -1}, ValueError, "max_batch_rows"),
+        ({"max_batch_bytes": 1.5}, TypeError, "max_batch_bytes"),
+        ({"max_request_bytes": 512 * 1024 * 1024 + 1}, ValueError, "max_request_bytes"),
+        ({"max_request_bytes": 100, "max_batch_bytes": 101}, ValueError, "must not exceed"),
+        ({"max_retries": True}, TypeError, "max_retries"),
+        ({"max_retries": -1}, ValueError, "max_retries"),
+        ({"timeout": None}, TypeError, "timeout"),
+        ({"timeout": float("inf")}, ValueError, "timeout"),
+    ],
+)
+def test_turbopuffer_sink_validates_constructor(
+    overrides: dict[str, object], error: type[Exception], message: str
+) -> None:
+    with pytest.raises(error, match=message):
+        _sink(**overrides)
+
+
+def test_turbopuffer_sink_enforces_the_attribute_name_count_limit() -> None:
+    mapping = {f"source_{index}": f"target_{index}" for index in range(1_023)}
+    with pytest.raises(ValueError, match="1024 attribute-name limit"):
+        _sink(attribute_mapping=mapping)
+
+
+def test_turbopuffer_sink_validates_bound_schema_and_sources() -> None:
+    with pytest.raises(TypeError, match="pyarrow.Schema"):
+        _sink().bind(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="unique ignoring case"):
+        _sink().bind(pa.schema([("document_id", pa.uint64()), ("DOCUMENT_ID", pa.uint64())]))
+    with pytest.raises(ValueError, match="id_column"):
+        _sink(id_column="missing").bind(_schema())
+    with pytest.raises(ValueError, match="attribute_mapping source"):
+        _sink(attribute_mapping={"missing": "target"}).bind(_schema())
+    with pytest.raises(ValueError, match="uint64 or string"):
+        _sink().bind(_schema(id_type=pa.int64()))
+    with pytest.raises(ValueError, match="fixed-size list"):
+        _sink().bind(_schema(vector_type=pa.list_(pa.float32())))
+    with pytest.raises(ValueError, match="fixed-size list"):
+        _sink().bind(_schema(vector_type=pa.list_(pa.float64(), 3)))
+    with pytest.raises(ValueError, match="between 1 and 10752"):
+        _sink().bind(_schema(vector_type=pa.list_(pa.float32(), 10_753)))
+    with pytest.raises(ValueError, match="does not support"):
+        _sink().bind(_schema(title_type=pa.struct([("nested", pa.string())])))
+
+
+def test_turbopuffer_sink_projects_explicit_columns_and_binds_execution_options() -> None:
+    bound = _bound(worker_count=3, max_batch_rows=17, max_batch_bytes=2_048, max_retries=2)
+    relation = vane.from_arrow(
+        pa.table(
+            {
+                "document_id": pa.array([1], type=pa.uint64()),
+                "embedding": pa.array([[0.1, 0.2, 0.3]], type=pa.list_(pa.float32(), 3)),
+                "title": ["one"],
+                "score": [1.25],
+                "tags": [["a"]],
+                "ignored": ["not-written"],
+            }
+        )
+    )
+
+    prepared = bound.prepare_input(relation)
+
+    assert isinstance(bound, BoundKeyedUpsertSink)
+    assert tuple(bound.key_columns) == ("document_id",)
+    assert prepared.columns == ["document_id", "embedding", "title", "score", "tags"]
+    assert bound.execution_options.worker_count == 3
+    assert bound.execution_options.batch_size == 17
+    assert bound.execution_options.target_max_batch_bytes == 2_048
+    assert bound.execution_options.max_retries == 2
+
+
+@pytest.mark.parametrize(
+    ("arrow_type", "value", "expected_schema"),
+    [
+        (pa.bool_(), True, "bool"),
+        (pa.int8(), -8, "int"),
+        (pa.int64(), -64, "int"),
+        (pa.uint8(), 8, "uint"),
+        (pa.uint64(), 64, "uint"),
+        (pa.float32(), 1.25, "float"),
+        (pa.float64(), 2.5, "float"),
+        (pa.string(), "text", "string"),
+        (pa.list_(pa.bool_()), [True, False], "[]bool"),
+        (pa.list_(pa.int64()), [-1, 2], "[]int"),
+        (pa.list_(pa.uint64()), [1, 2], "[]uint"),
+        (pa.list_(pa.float64()), [1.25, 2.5], "[]float"),
+        (pa.list_(pa.string()), ["a", "b"], "[]string"),
+    ],
+)
+def test_turbopuffer_sink_maps_supported_arrow_attributes(
+    arrow_type: pa.DataType, value: object, expected_schema: str
+) -> None:
+    schema = pa.schema(
+        [
+            ("document_id", pa.uint64()),
+            ("embedding", pa.list_(pa.float32(), 2)),
+            ("attribute", arrow_type),
+        ]
+    )
+    worker = _worker(schema, attribute_mapping={"attribute": "stored"})
+    table = pa.table(
+        {
+            "document_id": pa.array([1], type=pa.uint64()),
+            "embedding": pa.array([[0.1, 0.2]], type=pa.list_(pa.float32(), 2)),
+            "attribute": pa.array([value], type=arrow_type),
+        },
+        schema=schema,
+    )
+
+    worker.write(table)
+
+    call = _Client.instances[0].write_calls[0]
+    assert call["schema"] == {
+        "id": "uint",
+        "vector": {"type": "[2]f32", "ann": True},
+        "stored": expected_schema,
+    }
+
+
+def test_turbopuffer_sink_defers_secret_resolution_and_disables_sdk_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VANE_TEST_TURBOPUFFER_API_KEY", "actual-worker-secret")
+    sink = _sink()
+    serialized_sink = cloudpickle.dumps(sink)
+    assert b"actual-worker-secret" not in serialized_sink
+
+    bound = sink.bind(_schema())
+    assert b"actual-worker-secret" not in cloudpickle.dumps(bound)
+    assert not _Client.instances
+    worker = bound.open_worker(WriteContext("secret-test"))
+
+    assert _Client.instances[0].options == {
+        "api_key": "actual-worker-secret",
+        "region": "gcp-us-central1",
+        "base_url": "https://{region}.turbopuffer.com",
+        "timeout": 5.0,
+        "max_retries": 0,
+        "compression": False,
+    }
+    assert _Client.instances[0].namespace_calls == ["documents"]
+    worker.close()
+
+
+def test_turbopuffer_sink_rejects_an_empty_worker_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VANE_TEST_TURBOPUFFER_API_KEY", "")
+    with pytest.raises(RuntimeError, match="non-empty credential"):
+        _worker()
+    assert not _Client.instances
+
+
+def test_turbopuffer_sink_uses_columnar_overwrite_and_returns_bounded_results() -> None:
+    worker = _worker()
+    table = _table()
+
+    first = worker.write(table)
+    second = worker.write(table)
+
+    client = _Client.instances[0]
+    call = client.write_calls[0]
+    columns = call["upsert_columns"]
+    assert isinstance(columns, dict)
+    assert set(columns) == {"id", "vector", "title", "ranking", "labels"}
+    assert columns["id"] == [1, 2]
+    assert columns["title"] == ["one", "two"]
+    assert columns["ranking"] == [1.25, 2.5]
+    assert columns["labels"] == [["a"], ["b", "c"]]
+    assert columns["vector"][0] == pytest.approx([0.1, 0.2, 0.3])
+    assert call["distance_metric"] == "cosine_distance"
+    assert call["schema"] == {
+        "id": "uint",
+        "vector": {"type": "[3]f32", "ann": True},
+        "title": "string",
+        "ranking": "float",
+        "labels": "[]string",
+    }
+    assert call["timeout"] == 5.0
+    assert "upsert_rows" not in call
+    request = {
+        "distance_metric": call["distance_metric"],
+        "schema": call["schema"],
+        "upsert_columns": call["upsert_columns"],
+    }
+    request_bytes = len(json.dumps(request, ensure_ascii=False, allow_nan=False, separators=(",", ":")).encode())
+    assert first.rows_received == first.rows_affected == 2
+    assert first.bytes_received == table.nbytes
+    assert first.metadata == {
+        "provider": "turbopuffer",
+        "namespace": "documents",
+        "write_mode": "overwrite",
+        "request_bytes": request_bytes,
+    }
+    assert len(first.warnings) == 1
+    assert second.warnings == ()
+
+
+def test_turbopuffer_sink_supports_string_ids_and_enforces_the_64_byte_limit() -> None:
+    schema = _projected_schema(id_type=pa.string())
+    worker = _worker(_schema(id_type=pa.string()))
+    worker.write(_table(ids=["first", "second"], schema=schema))
+    assert set(_Client.store) == {"first", "second"}
+    assert _Client.instances[0].write_calls[0]["schema"]["id"] == "string"
+
+    with pytest.raises(ValueError, match="64 UTF-8 bytes"):
+        worker.write(_table(ids=["你" * 22, "second"], schema=schema))
+    assert len(_Client.instances[0].write_calls) == 1
+
+
+def test_turbopuffer_sink_validates_values_before_the_provider_call() -> None:
+    worker = _worker()
+    invalid_tables = [
+        (_table(ids=[None, 2]), "must not be null"),
+        (_table(ids=[1, 1]), "duplicate"),
+        (_table(vectors=[None, [0.4, 0.5, 0.6]]), "null or invalid dimension"),
+        (_table(vectors=[[0.1, float("nan"), 0.3], [0.4, 0.5, 0.6]]), "non-finite"),
+        (_table(scores=[float("inf"), 2.5]), "ranking.*invalid"),
+        (_table(tags=[["a", None], ["b"]]), "array attribute.*invalid"),
+    ]
+    for table, message in invalid_tables:
+        with pytest.raises(ValueError, match=message):
+            worker.write(table)
+    assert not _Client.instances[0].write_calls
+
+
+def test_turbopuffer_sink_enforces_batch_schema_and_request_limits_before_write() -> None:
+    worker = _worker(max_batch_rows=1)
+    with pytest.raises(ValueError, match="max_batch_rows"):
+        worker.write(_table())
+    assert not _Client.instances[0].write_calls
+
+    worker = _worker(max_batch_bytes=1)
+    with pytest.raises(ValueError, match="max_batch_bytes"):
+        worker.write(_table())
+    assert not _Client.instances[1].write_calls
+
+    worker = _worker()
+    bad_schema = pa.schema(
+        [
+            ("document_id", pa.uint64()),
+            ("embedding", pa.list_(pa.float32(), 3)),
+            ("different", pa.string()),
+            ("score", pa.float64()),
+            ("tags", pa.list_(pa.string())),
+        ]
+    )
+    with pytest.raises(ValueError, match="bound input schema"):
+        worker.write(
+            pa.table(
+                {
+                    "document_id": pa.array([1], type=pa.uint64()),
+                    "embedding": pa.array([[0.1, 0.2, 0.3]], type=pa.list_(pa.float32(), 3)),
+                    "different": ["one"],
+                    "score": [1.25],
+                    "tags": [["a"]],
+                },
+                schema=bad_schema,
+            )
+        )
+    assert not _Client.instances[2].write_calls
+
+    table = _table(ids=[1], vectors=[[0.1, 0.2, 0.3]], titles=["one"], scores=[1.25], tags=[["a"]])
+    limit = table.nbytes + 1
+    worker = _worker(max_batch_bytes=limit, max_request_bytes=limit)
+    with pytest.raises(ValueError, match="max_request_bytes"):
+        worker.write(table)
+    assert not _Client.instances[3].write_calls
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        object(),
+        _Response(2, 2, status="NOT_OK"),
+        _Response(True, 2),
+        _Response(1, 2),
+        _Response(2, None),
+        _Response(2, 1),
+    ],
+)
+def test_turbopuffer_sink_rejects_invalid_provider_results(response: object) -> None:
+    _Client.response = response
+    worker = _worker()
+    with pytest.raises(RuntimeError, match="invalid response|affected-row count"):
+        worker.write(_table())
+
+
+def test_turbopuffer_sink_propagates_provider_failures_and_closes_on_abort() -> None:
+    _Client.namespace_error = RuntimeError("namespace failed")
+    with pytest.raises(RuntimeError, match="namespace failed"):
+        _worker()
+    assert _Client.instances[0].close_calls == 1
+
+    _Client.namespace_error = None
+    worker = _worker()
+    _Client.write_error = TimeoutError("write timed out")
+    with pytest.raises(TimeoutError, match="write timed out"):
+        worker.write(_table())
+    worker.abort(TimeoutError("write timed out"))
+    assert _Client.instances[1].close_calls == 1
+    worker.close()
+    assert _Client.instances[1].close_calls == 1
+
+
+def test_turbopuffer_sink_retains_client_ownership_when_close_fails() -> None:
+    worker = _worker()
+    _Client.close_error = RuntimeError("close failed")
+    with pytest.raises(RuntimeError, match="close failed"):
+        worker.close()
+    assert _Client.instances[0].close_calls == 1
+
+    _Client.close_error = None
+    worker.close()
+    assert _Client.instances[0].close_calls == 2
+
+
+def test_turbopuffer_sink_replay_overwrites_the_same_document_ids() -> None:
+    table = _table()
+    first_worker = _bound(max_retries=1).open_worker(WriteContext("stable-operation"))
+    second_worker = _bound(max_retries=1).open_worker(WriteContext("stable-operation"))
+
+    first_worker.write(table)
+    snapshot = deepcopy(_Client.store)
+    second_worker.write(table)
+
+    assert _Client.store == snapshot
+    assert set(_Client.store) == {1, 2}
+    assert sum(len(client.write_calls) for client in _Client.instances) == 2
+    assert all(client.options["max_retries"] == 0 for client in _Client.instances)
+
+
+@pytest.mark.external_service
+def test_turbopuffer_sink_live_whole_document_upsert() -> None:
+    api_key = os.environ.get("VANE_TEST_TURBOPUFFER_API_KEY")
+    region = os.environ.get("VANE_TEST_TURBOPUFFER_REGION")
+    if not api_key or not region:
+        pytest.skip("VANE_TEST_TURBOPUFFER_API_KEY and VANE_TEST_TURBOPUFFER_REGION are required")
+    sdk = pytest.importorskip("turbopuffer")
+    namespace = f"vane-sink-e2e-{uuid.uuid4().hex}"
+    client = sdk.Turbopuffer(
+        api_key=api_key,
+        region=region,
+        base_url="https://{region}.turbopuffer.com",
+        timeout=30.0,
+        max_retries=0,
+        compression=False,
+    )
+    resource = client.namespace(namespace)
+    worker = None
+    namespace_created = False
+    try:
+        schema = pa.schema(
+            [
+                ("document_id", pa.uint64()),
+                ("embedding", pa.list_(pa.float32(), 2)),
+                ("title", pa.string()),
+            ]
+        )
+        sink = TurbopufferSink(
+            namespace,
+            region=region,
+            api_key=EnvironmentSecret("VANE_TEST_TURBOPUFFER_API_KEY"),
+            id_column="document_id",
+            vector_column="embedding",
+            distance_metric="cosine_distance",
+            attribute_mapping={"title": "title"},
+            timeout=30.0,
+        )
+        worker = sink.bind(schema).open_worker(WriteContext(f"turbopuffer-live-{uuid.uuid4()}"))
+        first = pa.table(
+            {
+                "document_id": pa.array([1, 2], type=pa.uint64()),
+                "embedding": pa.array([[0.1, 0.2], [0.3, 0.4]], type=pa.list_(pa.float32(), 2)),
+                "title": ["one", "two"],
+            },
+            schema=schema,
+        )
+        updated = pa.table(
+            {
+                "document_id": pa.array([1, 2], type=pa.uint64()),
+                "embedding": pa.array([[0.1, 0.2], [0.3, 0.4]], type=pa.list_(pa.float32(), 2)),
+                "title": ["updated", "two"],
+            },
+            schema=schema,
+        )
+
+        assert worker.write(first).rows_affected == 2
+        namespace_created = True
+        assert worker.write(updated).rows_affected == 2
+        response = resource.query(
+            rank_by=("id", "asc"),
+            limit=10,
+            include_attributes=True,
+            consistency={"level": "strong"},
+            timeout=30.0,
+        )
+        rows = response.rows or []
+        assert {row.id: row["title"] for row in rows} == {1: "updated", 2: "two"}
+    finally:
+        try:
+            if worker is not None:
+                worker.close()
+        finally:
+            try:
+                if namespace_created:
+                    resource.delete_all(timeout=30.0)
+            finally:
+                client.close()

--- a/tests/fast/test_turbopuffer_datasink.py
+++ b/tests/fast/test_turbopuffer_datasink.py
@@ -20,7 +20,6 @@ import vane.datasink.turbopuffer as turbopuffer
 from vane import EnvironmentSecret, TurbopufferSink
 from vane.datasink import BoundKeyedUpsertSink, WriteContext
 
-
 _REAL_LOAD_TURBOPUFFER_SDK = turbopuffer._load_turbopuffer_sdk
 _DEFAULT_RESPONSE = object()
 
@@ -47,9 +46,7 @@ class _Namespace:
         assert isinstance(ids, list)
         for index, document_id in enumerate(ids):
             _Client.store[document_id] = {
-                name: deepcopy(values[index])
-                for name, values in columns.items()
-                if isinstance(values, list)
+                name: deepcopy(values[index]) for name, values in columns.items() if isinstance(values, list)
             }
         if _Client.response is _DEFAULT_RESPONSE:
             return _Response(len(ids), len(ids))

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -209,6 +209,7 @@ from vane.datasink import (
     write_datasink,
 )
 from vane.datasink.milvus import MilvusSink
+from vane.datasink.turbopuffer import TurbopufferSink
 from vane.extensions import (
     DynamicExtensionDependency,
     DynamicExtensionDescriptor,
@@ -422,6 +423,7 @@ __all__: list[str] = [
     "TimestampTimeZoneValue",
     "TimestampValue",
     "TransactionException",
+    "TurbopufferSink",
     "TypeMismatchException",
     "UUIDValue",
     "UnionType",

--- a/vane/datasink/turbopuffer.py
+++ b/vane/datasink/turbopuffer.py
@@ -206,7 +206,9 @@ def _scalar_kind(data_type: pa.DataType) -> _ScalarKind:
 
 def _attribute_field(source: pa.Field, target: str) -> _AttributeField:
     data_type = source.type
-    is_array = pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type)
+    is_array = (
+        pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type)
+    )
     value_type = data_type.value_type if is_array else data_type
     try:
         kind = _scalar_kind(value_type)
@@ -308,9 +310,7 @@ class TurbopufferSink(DataSink):
         self.distance_metric = normalized_metric
         self.worker_count = _positive_int("worker_count", worker_count)
         self.max_batch_rows = _positive_int("max_batch_rows", max_batch_rows)
-        self.max_request_bytes = _positive_int(
-            "max_request_bytes", max_request_bytes, maximum=_MAX_WRITE_REQUEST_BYTES
-        )
+        self.max_request_bytes = _positive_int("max_request_bytes", max_request_bytes, maximum=_MAX_WRITE_REQUEST_BYTES)
         self.max_batch_bytes = _positive_int("max_batch_bytes", max_batch_bytes)
         if self.max_batch_bytes > self.max_request_bytes:
             raise ValueError("max_batch_bytes must not exceed max_request_bytes")
@@ -495,9 +495,7 @@ class _TurbopufferWorker(DataSinkWorker):
             if not isinstance(vector, list) or len(vector) != self._vector_field.dimension:
                 raise ValueError("Turbopuffer vector contains a null or invalid dimension")
             if any(
-                isinstance(element, bool)
-                or not isinstance(element, (int, float))
-                or not math.isfinite(float(element))
+                isinstance(element, bool) or not isinstance(element, (int, float)) or not math.isfinite(float(element))
                 for element in vector
             ):
                 raise ValueError("Turbopuffer vector contains a null or non-finite value")
@@ -508,26 +506,20 @@ class _TurbopufferWorker(DataSinkWorker):
         if field.scalar_kind is _ScalarKind.BOOL:
             valid = isinstance(value, bool)
         elif field.scalar_kind is _ScalarKind.INT:
-            valid = (
-                isinstance(value, int)
-                and not isinstance(value, bool)
-                and -(1 << 63) <= value <= _MAX_INT64
-            )
+            valid = isinstance(value, int) and not isinstance(value, bool) and -(1 << 63) <= value <= _MAX_INT64
         elif field.scalar_kind is _ScalarKind.UINT:
             valid = isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= _MAX_UINT64
         elif field.scalar_kind is _ScalarKind.FLOAT:
-            valid = (
-                isinstance(value, (int, float))
-                and not isinstance(value, bool)
-                and math.isfinite(float(value))
-            )
+            valid = isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
         else:
-            valid = isinstance(value, str)
-            if valid:
+            if isinstance(value, str):
+                valid = True
                 try:
                     value.encode("utf-8")
                 except UnicodeEncodeError:
                     valid = False
+            else:
+                valid = False
         if not valid:
             raise ValueError(f"Turbopuffer attribute {field.target_name!r} contains an invalid value")
 
@@ -538,16 +530,14 @@ class _TurbopufferWorker(DataSinkWorker):
                 continue
             if field.is_array:
                 if not isinstance(value, list) or any(element is None for element in value):
-                    raise ValueError(
-                        f"Turbopuffer array attribute {field.target_name!r} contains an invalid value"
-                    )
+                    raise ValueError(f"Turbopuffer array attribute {field.target_name!r} contains an invalid value")
                 for element in value:
                     self._validate_scalar(field, element)
             else:
                 self._validate_scalar(field, value)
         return values
 
-    def _request(self, table: pa.Table) -> tuple[dict[str, list[object]], int, int, int]:
+    def _request(self, table: pa.Table) -> tuple[dict[str, Sequence[object]], int, int, int]:
         self._validate_schema(table)
         row_count = table.num_rows
         batch_bytes = table.nbytes
@@ -556,7 +546,7 @@ class _TurbopufferWorker(DataSinkWorker):
         if batch_bytes > self._sink.max_batch_bytes:
             raise ValueError("Turbopuffer batch exceeds max_batch_bytes")
 
-        columns: dict[str, list[object]] = {
+        columns: dict[str, Sequence[object]] = {
             "id": self._ids(table),
             "vector": self._vectors(table),
         }

--- a/vane/datasink/turbopuffer.py
+++ b/vane/datasink/turbopuffer.py
@@ -1,0 +1,625 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed, whole-document Turbopuffer upserts.
+
+The adapter intentionally exposes a narrow contract. Document IDs are explicit
+Arrow ``uint64`` or UTF-8 strings, the vector is a fixed-size list of
+``float32``, and every stored non-vector attribute is selected through an
+explicit mapping. Successful worker batches are durable Turbopuffer writes,
+but batches are independent and Vane does not provide rollback or exactly-once
+delivery.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+from vane.datasink import (
+    BoundKeyedUpsertSink,
+    DataSink,
+    DataSinkExecutionOptions,
+    DataSinkWorker,
+    EnvironmentSecret,
+    WriteContext,
+    WriteResult,
+)
+
+if TYPE_CHECKING:
+    from vane import DuckDBPyRelation
+
+
+_MAX_INT64 = (1 << 63) - 1
+_MAX_UINT64 = (1 << 64) - 1
+_MAX_ID_BYTES = 64
+_MAX_ATTRIBUTE_NAME_BYTES = 128
+_MAX_ATTRIBUTE_NAMES = 1_024
+_MAX_VECTOR_DIMENSIONS = 10_752
+_MAX_WRITE_REQUEST_BYTES = 512 * 1024 * 1024
+_DEFAULT_MAX_BATCH_ROWS = 1_000
+_DEFAULT_MAX_BATCH_BYTES = 16 * 1024 * 1024
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_NAMESPACE_PATTERN = re.compile(r"[A-Za-z0-9._-]{1,128}\Z")
+_REGION_PATTERN = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\Z")
+_DISTANCE_METRICS = frozenset({"cosine_distance", "euclidean_squared"})
+_PARTIAL_VISIBILITY_WARNING = (
+    "Turbopuffer applies worker batches independently; a later operation failure can leave this "
+    "whole-document overwrite visible"
+)
+
+
+def _name(name: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    if value != value.strip() or "\x00" in value:
+        raise ValueError(f"{name} must not contain surrounding whitespace or NUL characters")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ValueError(f"{name} must contain valid UTF-8") from error
+    return value
+
+
+def _namespace(value: object) -> str:
+    normalized = _name("namespace", value)
+    if _NAMESPACE_PATTERN.fullmatch(normalized) is None:
+        raise ValueError("namespace must match [A-Za-z0-9-_.]{1,128}")
+    return normalized
+
+
+def _region(value: object) -> str:
+    normalized = _name("region", value)
+    if _REGION_PATTERN.fullmatch(normalized) is None:
+        raise ValueError("region must be a lowercase DNS label of at most 63 characters")
+    return normalized
+
+
+def _attribute_name(value: object) -> str:
+    normalized = _name("attribute_mapping target", value)
+    if len(normalized.encode("utf-8")) > _MAX_ATTRIBUTE_NAME_BYTES:
+        raise ValueError("attribute_mapping targets must be at most 128 UTF-8 bytes")
+    if normalized.startswith("$"):
+        raise ValueError("attribute_mapping targets must not start with the reserved '$' prefix")
+    if normalized in {"id", "vector"}:
+        raise ValueError(f"attribute_mapping target {normalized!r} is reserved")
+    return normalized
+
+
+def _positive_int(name: str, value: object, *, maximum: int = _MAX_INT64) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a positive integer")
+    if value <= 0 or value > maximum:
+        raise ValueError(f"{name} must be between 1 and {maximum}")
+    return value
+
+
+def _non_negative_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a non-negative integer")
+    if value < 0 or value > _MAX_INT64:
+        raise ValueError(f"{name} must be a non-negative signed 64-bit integer")
+    return value
+
+
+def _positive_number(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a positive number")
+    try:
+        normalized = float(value)
+    except OverflowError as error:
+        raise ValueError(f"{name} must be a finite positive number") from error
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise ValueError(f"{name} must be a finite positive number")
+    return normalized
+
+
+def _attribute_mapping(value: object) -> tuple[tuple[str, str], ...]:
+    if not isinstance(value, Mapping):
+        raise TypeError("attribute_mapping must be a mapping")
+    normalized: list[tuple[str, str]] = []
+    for source, target in value.items():
+        normalized.append((_name("attribute_mapping source", source), _attribute_name(target)))
+    sources = [source.casefold() for source, _ in normalized]
+    targets = [target for _, target in normalized]
+    if len(set(sources)) != len(sources):
+        raise ValueError("attribute_mapping sources must be unique ignoring case")
+    if len(set(targets)) != len(targets):
+        raise ValueError("attribute_mapping targets must be unique")
+    if len(normalized) + 2 > _MAX_ATTRIBUTE_NAMES:
+        raise ValueError("attribute_mapping exceeds Turbopuffer's 1024 attribute-name limit")
+    return tuple(normalized)
+
+
+class _IDKind(str, Enum):
+    UINT = "uint"
+    STRING = "string"
+
+
+class _ScalarKind(str, Enum):
+    BOOL = "bool"
+    INT = "int"
+    UINT = "uint"
+    FLOAT = "float"
+    STRING = "string"
+
+
+@dataclass(frozen=True)
+class _SourceField:
+    name: str
+    data_type: pa.DataType
+
+
+@dataclass(frozen=True)
+class _VectorField(_SourceField):
+    dimension: int
+
+
+@dataclass(frozen=True)
+class _AttributeField(_SourceField):
+    target_name: str
+    scalar_kind: _ScalarKind
+    is_array: bool
+    schema_type: str
+
+
+def _id_kind(field: pa.Field) -> _IDKind:
+    if pa.types.is_uint64(field.type):
+        return _IDKind.UINT
+    if pa.types.is_string(field.type) or pa.types.is_large_string(field.type):
+        return _IDKind.STRING
+    raise ValueError("Turbopuffer ID source must be Arrow uint64 or string")
+
+
+def _vector_dimension(field: pa.Field) -> int:
+    data_type = field.type
+    if not pa.types.is_fixed_size_list(data_type) or not pa.types.is_float32(data_type.value_type):
+        raise ValueError("Turbopuffer vector source must be a fixed-size list of Arrow float32")
+    dimension = data_type.list_size
+    if dimension <= 0 or dimension > _MAX_VECTOR_DIMENSIONS:
+        raise ValueError(f"Turbopuffer vector dimension must be between 1 and {_MAX_VECTOR_DIMENSIONS}")
+    return dimension
+
+
+def _scalar_kind(data_type: pa.DataType) -> _ScalarKind:
+    if pa.types.is_boolean(data_type):
+        return _ScalarKind.BOOL
+    if pa.types.is_signed_integer(data_type):
+        return _ScalarKind.INT
+    if pa.types.is_unsigned_integer(data_type):
+        return _ScalarKind.UINT
+    if pa.types.is_float32(data_type) or pa.types.is_float64(data_type):
+        return _ScalarKind.FLOAT
+    if pa.types.is_string(data_type) or pa.types.is_large_string(data_type):
+        return _ScalarKind.STRING
+    raise ValueError(f"unsupported Arrow attribute type {data_type}")
+
+
+def _attribute_field(source: pa.Field, target: str) -> _AttributeField:
+    data_type = source.type
+    is_array = pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type)
+    value_type = data_type.value_type if is_array else data_type
+    try:
+        kind = _scalar_kind(value_type)
+    except ValueError as error:
+        raise ValueError(
+            f"TurbopufferSink does not support Arrow attribute {source.name!r} with type {data_type}"
+        ) from error
+    schema_type = f"[]{kind.value}" if is_array else kind.value
+    return _AttributeField(source.name, data_type, target, kind, is_array, schema_type)
+
+
+def _resolve_field(schema: pa.Schema, requested: str, role: str) -> pa.Field:
+    matches = [field for field in schema if field.name.casefold() == requested.casefold()]
+    if len(matches) != 1:
+        raise ValueError(f"{role} {requested!r} must match exactly one input column")
+    return matches[0]
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _load_turbopuffer_sdk() -> tuple[type[Any], type[Any]]:
+    try:
+        from turbopuffer import Turbopuffer  # type: ignore[import-not-found, import-untyped, unused-ignore]
+        from turbopuffer.types import (  # type: ignore[import-not-found, import-untyped, unused-ignore]
+            NamespaceWriteResponse,
+        )
+    except ModuleNotFoundError as error:
+        if error.name != "turbopuffer":
+            raise
+        raise ImportError("TurbopufferSink requires the Turbopuffer SDK; install vane-ai[turbopuffer]") from error
+    return Turbopuffer, NamespaceWriteResponse
+
+
+def _compact_json_size(value: object, maximum: int) -> int:
+    """Return current-SDK compact JSON bytes without materializing one large body."""
+
+    encoder = json.JSONEncoder(ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+    total = 0
+    try:
+        for chunk in encoder.iterencode(value):
+            total += len(chunk.encode("utf-8"))
+            if total > maximum:
+                raise ValueError("Turbopuffer write request exceeds max_request_bytes")
+    except (TypeError, UnicodeEncodeError, ValueError) as error:
+        if isinstance(error, ValueError) and str(error) == "Turbopuffer write request exceeds max_request_bytes":
+            raise
+        raise ValueError("Turbopuffer write request contains a value that cannot be encoded as JSON") from error
+    return total
+
+
+class TurbopufferSink(DataSink):
+    """Write relation batches to one Turbopuffer namespace.
+
+    ``id_column`` and ``vector_column`` identify relation columns that become
+    Turbopuffer's reserved ``id`` and ``vector`` fields. ``attribute_mapping``
+    explicitly selects all other stored columns and maps source names to target
+    attribute names. Unmapped relation columns are not written.
+
+    The API key reference is resolved only in a worker. Both SDK retries and
+    Vane framework retries default to disabled; setting ``max_retries`` enables
+    full-input Vane replay with the same operation ID.
+    """
+
+    def __init__(
+        self,
+        namespace: str,
+        *,
+        region: str,
+        api_key: EnvironmentSecret,
+        id_column: str,
+        vector_column: str,
+        distance_metric: str,
+        attribute_mapping: Mapping[str, str],
+        worker_count: int = 1,
+        max_batch_rows: int = _DEFAULT_MAX_BATCH_ROWS,
+        max_batch_bytes: int = _DEFAULT_MAX_BATCH_BYTES,
+        max_request_bytes: int = _MAX_WRITE_REQUEST_BYTES,
+        max_retries: int = 0,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.namespace = _namespace(namespace)
+        self.region = _region(region)
+        self.id_column = _name("id_column", id_column)
+        self.vector_column = _name("vector_column", vector_column)
+        if self.id_column.casefold() == self.vector_column.casefold():
+            raise ValueError("id_column and vector_column must name different input columns")
+        if not isinstance(api_key, EnvironmentSecret):
+            raise TypeError("api_key must be an EnvironmentSecret")
+        normalized_metric = _name("distance_metric", distance_metric)
+        if normalized_metric not in _DISTANCE_METRICS:
+            raise ValueError("distance_metric must be 'cosine_distance' or 'euclidean_squared'")
+        mapping = _attribute_mapping(attribute_mapping)
+        reserved_sources = {self.id_column.casefold(), self.vector_column.casefold()}
+        if any(source.casefold() in reserved_sources for source, _ in mapping):
+            raise ValueError("attribute_mapping sources must not reuse id_column or vector_column")
+
+        self.distance_metric = normalized_metric
+        self.worker_count = _positive_int("worker_count", worker_count)
+        self.max_batch_rows = _positive_int("max_batch_rows", max_batch_rows)
+        self.max_request_bytes = _positive_int(
+            "max_request_bytes", max_request_bytes, maximum=_MAX_WRITE_REQUEST_BYTES
+        )
+        self.max_batch_bytes = _positive_int("max_batch_bytes", max_batch_bytes)
+        if self.max_batch_bytes > self.max_request_bytes:
+            raise ValueError("max_batch_bytes must not exceed max_request_bytes")
+        self.max_retries = _non_negative_int("max_retries", max_retries)
+        self.timeout = _positive_number("timeout", timeout)
+        self._api_key = api_key
+        self._attribute_mapping = mapping
+
+    def bind(self, schema: pa.Schema) -> BoundKeyedUpsertSink:
+        if not isinstance(schema, pa.Schema):
+            raise TypeError("schema must be pyarrow.Schema")
+        folded_names = [name.casefold() for name in schema.names]
+        if len(set(folded_names)) != len(folded_names):
+            raise ValueError("TurbopufferSink requires input column names to be unique ignoring case")
+
+        id_field = _resolve_field(schema, self.id_column, "id_column")
+        vector_field = _resolve_field(schema, self.vector_column, "vector_column")
+        id_kind = _id_kind(id_field)
+        dimension = _vector_dimension(vector_field)
+
+        attributes: list[_AttributeField] = []
+        for source_name, target_name in self._attribute_mapping:
+            source = _resolve_field(schema, source_name, "attribute_mapping source")
+            attributes.append(_attribute_field(source, target_name))
+
+        selected = [id_field.name, vector_field.name, *(field.name for field in attributes)]
+        if len({name.casefold() for name in selected}) != len(selected):
+            raise ValueError("id, vector, and attribute source columns must be distinct")
+        return _BoundTurbopufferSink(
+            self,
+            _SourceField(id_field.name, id_field.type),
+            id_kind,
+            _VectorField(vector_field.name, vector_field.type, dimension),
+            tuple(attributes),
+        )
+
+
+class _BoundTurbopufferSink(BoundKeyedUpsertSink):
+    def __init__(
+        self,
+        sink: TurbopufferSink,
+        id_field: _SourceField,
+        id_kind: _IDKind,
+        vector_field: _VectorField,
+        attributes: tuple[_AttributeField, ...],
+    ) -> None:
+        self._sink = sink
+        self._id_field = id_field
+        self._id_kind = id_kind
+        self._vector_field = vector_field
+        self._attributes = attributes
+
+    @property
+    def execution_options(self) -> DataSinkExecutionOptions:
+        return DataSinkExecutionOptions(
+            worker_count=self._sink.worker_count,
+            batch_size=self._sink.max_batch_rows,
+            target_max_batch_bytes=self._sink.max_batch_bytes,
+            max_retries=self._sink.max_retries,
+        )
+
+    @property
+    def key_columns(self) -> Sequence[str]:
+        return (self._id_field.name,)
+
+    def prepare_input(self, relation: DuckDBPyRelation) -> DuckDBPyRelation:
+        selected = (self._id_field, self._vector_field, *self._attributes)
+        return relation.project(", ".join(_quote_identifier(field.name) for field in selected))
+
+    def open_worker(self, _context: WriteContext) -> DataSinkWorker:
+        return _TurbopufferWorker(
+            self._sink,
+            self._id_field,
+            self._id_kind,
+            self._vector_field,
+            self._attributes,
+        )
+
+
+class _TurbopufferWorker(DataSinkWorker):
+    def __init__(
+        self,
+        sink: TurbopufferSink,
+        id_field: _SourceField,
+        id_kind: _IDKind,
+        vector_field: _VectorField,
+        attributes: tuple[_AttributeField, ...],
+    ) -> None:
+        client_type, response_type = _load_turbopuffer_sdk()
+        api_key = sink._api_key.resolve()
+        if not api_key or api_key != api_key.strip() or "\x00" in api_key:
+            raise RuntimeError("Turbopuffer api_key environment secret must be a non-empty credential")
+        self._sink = sink
+        self._id_field = id_field
+        self._id_kind = id_kind
+        self._vector_field = vector_field
+        self._attributes = attributes
+        self._response_type = response_type
+        self._client: Any | None = None
+        self._namespace_resource: Any | None = None
+        self._warning_pending = True
+        self._schema = {
+            "id": id_kind.value,
+            "vector": {"type": f"[{vector_field.dimension}]f32", "ann": True},
+            **{field.target_name: field.schema_type for field in attributes},
+        }
+        self._base_metadata = {
+            "provider": "turbopuffer",
+            "namespace": sink.namespace,
+            "write_mode": "overwrite",
+        }
+        try:
+            self._client = client_type(
+                api_key=api_key,
+                region=sink.region,
+                base_url="https://{region}.turbopuffer.com",
+                timeout=sink.timeout,
+                max_retries=0,
+                compression=False,
+            )
+            self._namespace_resource = self._client.namespace(sink.namespace)
+            WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                metadata={**self._base_metadata, "request_bytes": 0},
+                warnings=(_PARTIAL_VISIBILITY_WARNING,),
+            )
+        except BaseException as error:
+            try:
+                self.close()
+            except BaseException as close_error:
+                add_note = getattr(error, "add_note", None)
+                if callable(add_note):
+                    try:
+                        add_note(f"Turbopuffer client cleanup also failed: {type(close_error).__name__}")
+                    except BaseException:
+                        pass
+            raise
+
+    def _namespace_or_raise(self) -> Any:
+        if self._client is None or self._namespace_resource is None:
+            raise RuntimeError("TurbopufferSink worker is closed")
+        return self._namespace_resource
+
+    def _validate_schema(self, table: pa.Table) -> None:
+        if not isinstance(table, pa.Table):
+            raise TypeError(f"TurbopufferSink expected pyarrow.Table, got {type(table).__name__}")
+        expected = (self._id_field, self._vector_field, *self._attributes)
+        if len(table.schema) != len(expected):
+            raise ValueError("Turbopuffer batch schema does not match the bound input schema")
+        for index, binding in enumerate(expected):
+            field = table.schema.field(index)
+            if field.name != binding.name or field.type != binding.data_type:
+                raise ValueError("Turbopuffer batch schema does not match the bound input schema")
+
+    def _ids(self, table: pa.Table) -> list[int | str]:
+        raw_values = table.column(self._id_field.name).to_pylist()
+        values: list[int | str] = []
+        for value in raw_values:
+            if value is None:
+                raise ValueError("Turbopuffer document IDs must not be null")
+            if self._id_kind is _IDKind.UINT:
+                if isinstance(value, bool) or not isinstance(value, int) or value < 0 or value > _MAX_UINT64:
+                    raise ValueError("Turbopuffer uint document ID is outside the unsigned 64-bit range")
+            else:
+                if not isinstance(value, str):
+                    raise ValueError("Turbopuffer string document ID contains an invalid value")
+                try:
+                    encoded = value.encode("utf-8")
+                except UnicodeEncodeError as error:
+                    raise ValueError("Turbopuffer string document ID contains invalid UTF-8") from error
+                if len(encoded) > _MAX_ID_BYTES:
+                    raise ValueError("Turbopuffer string document ID exceeds 64 UTF-8 bytes")
+            values.append(value)
+        if len(set(values)) != len(values):
+            raise ValueError("Turbopuffer batch contains duplicate document IDs")
+        return values
+
+    def _vectors(self, table: pa.Table) -> list[list[float]]:
+        values = table.column(self._vector_field.name).to_pylist()
+        for vector in values:
+            if not isinstance(vector, list) or len(vector) != self._vector_field.dimension:
+                raise ValueError("Turbopuffer vector contains a null or invalid dimension")
+            if any(
+                isinstance(element, bool)
+                or not isinstance(element, (int, float))
+                or not math.isfinite(float(element))
+                for element in vector
+            ):
+                raise ValueError("Turbopuffer vector contains a null or non-finite value")
+        return values
+
+    @staticmethod
+    def _validate_scalar(field: _AttributeField, value: object) -> None:
+        if field.scalar_kind is _ScalarKind.BOOL:
+            valid = isinstance(value, bool)
+        elif field.scalar_kind is _ScalarKind.INT:
+            valid = (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and -(1 << 63) <= value <= _MAX_INT64
+            )
+        elif field.scalar_kind is _ScalarKind.UINT:
+            valid = isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= _MAX_UINT64
+        elif field.scalar_kind is _ScalarKind.FLOAT:
+            valid = (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(float(value))
+            )
+        else:
+            valid = isinstance(value, str)
+            if valid:
+                try:
+                    value.encode("utf-8")
+                except UnicodeEncodeError:
+                    valid = False
+        if not valid:
+            raise ValueError(f"Turbopuffer attribute {field.target_name!r} contains an invalid value")
+
+    def _attribute_values(self, table: pa.Table, field: _AttributeField) -> list[object]:
+        values = table.column(field.name).to_pylist()
+        for value in values:
+            if value is None:
+                continue
+            if field.is_array:
+                if not isinstance(value, list) or any(element is None for element in value):
+                    raise ValueError(
+                        f"Turbopuffer array attribute {field.target_name!r} contains an invalid value"
+                    )
+                for element in value:
+                    self._validate_scalar(field, element)
+            else:
+                self._validate_scalar(field, value)
+        return values
+
+    def _request(self, table: pa.Table) -> tuple[dict[str, list[object]], int, int, int]:
+        self._validate_schema(table)
+        row_count = table.num_rows
+        batch_bytes = table.nbytes
+        if row_count > self._sink.max_batch_rows:
+            raise ValueError("Turbopuffer batch exceeds max_batch_rows")
+        if batch_bytes > self._sink.max_batch_bytes:
+            raise ValueError("Turbopuffer batch exceeds max_batch_bytes")
+
+        columns: dict[str, list[object]] = {
+            "id": self._ids(table),
+            "vector": self._vectors(table),
+        }
+        for field in self._attributes:
+            columns[field.target_name] = self._attribute_values(table, field)
+        request = {
+            "distance_metric": self._sink.distance_metric,
+            "schema": self._schema,
+            "upsert_columns": columns,
+        }
+        request_bytes = _compact_json_size(request, self._sink.max_request_bytes)
+        return columns, row_count, batch_bytes, request_bytes
+
+    def write(self, table: pa.Table) -> WriteResult:
+        columns, row_count, batch_bytes, request_bytes = self._request(table)
+        metadata = {**self._base_metadata, "request_bytes": request_bytes}
+        if row_count == 0:
+            return WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                bytes_received=batch_bytes,
+                metadata=metadata,
+            )
+        warnings = (_PARTIAL_VISIBILITY_WARNING,) if self._warning_pending else ()
+        result = WriteResult(
+            rows_received=row_count,
+            rows_affected=row_count,
+            bytes_received=batch_bytes,
+            metadata=metadata,
+            warnings=warnings,
+        )
+        response = self._namespace_or_raise().write(
+            upsert_columns=columns,
+            distance_metric=self._sink.distance_metric,
+            schema=self._schema,
+            timeout=self._sink.timeout,
+        )
+        if not isinstance(response, self._response_type) or response.status != "OK":
+            raise RuntimeError("Turbopuffer write returned an invalid response")
+        affected = response.rows_affected
+        upserted = response.rows_upserted
+        if (
+            isinstance(affected, bool)
+            or not isinstance(affected, int)
+            or affected != row_count
+            or isinstance(upserted, bool)
+            or not isinstance(upserted, int)
+            or upserted != row_count
+        ):
+            raise RuntimeError("Turbopuffer write returned an invalid affected-row count")
+        self._warning_pending = False
+        return result
+
+    def abort(self, _error: BaseException) -> None:
+        self.close()
+
+    def close(self) -> None:
+        client = self._client
+        if client is None:
+            return
+        client.close()
+        self._client = None
+        self._namespace_resource = None
+
+
+__all__ = ["TurbopufferSink"]


### PR DESCRIPTION
## Summary

- Add `TurbopufferSink`, a keyed-upsert `DataSink` that writes validated Arrow batches through Turbopuffer's columnar write API with an explicit namespace schema.
- Resolve `EnvironmentSecret` values only on workers, pin requests to the configured public region endpoint, disable SDK retries and compression, and expose only explicit Vane retry behavior.
- Enforce the supported ID, vector, attribute, schema, batching, and request-size contracts before remote effects; return bounded per-batch `WriteResult` metadata with partial-visibility warnings.
- Add the optional `turbopuffer` dependency, public export, README documentation, mocked contract coverage, and an opt-in live cloud round-trip test.

## Related issue

close: #647

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The README documents installation, the public constructor, worker-side credentials, supported Arrow types, keyed-upsert/replay semantics, request limits, and the lack of transactional or exactly-once guarantees.

## Validation

- `scripts/format root --changed` (with the repository-pinned `shfmt` 3.13.1): passed.
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation`: passed as a non-editable Release wheel build, using the existing bootstrapped vcpkg prefix and its matching static OpenSSL libraries.
- `scripts/run_installed_pytest.sh tests/fast/test_turbopuffer_datasink.py tests/fast/test_package_metadata.py`: 90 passed, 1 deselected.
- `scripts/run_release_tests.sh`: 820 passed, 20 deselected in the non-Ray-owner shard; 14 passed, 826 deselected in the real-Ray shard.
- The opt-in live Turbopuffer test was not run because `VANE_TEST_TURBOPUFFER_API_KEY` and `VANE_TEST_TURBOPUFFER_REGION` are not configured on this machine. The test creates a namespace implicitly, performs two real upserts, verifies the final rows with strong consistency, and deletes the namespace; it is marked `external_service` and excluded from the default release suite.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. The optional Turbopuffer Python SDK is MIT-licensed; no code or assets were copied.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. Secrets resolve only on workers, the endpoint is derived from a validated public region, and input and provider responses are validated.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
