### PR TITLE
[feat](file) Enable distributed FILE I/O

### DIFF
--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -145,6 +145,15 @@ inside the authenticated Ray cluster; they are not an untrusted interchange
 format or a persistence format. Executable attachment declarations travel only
 as far as the isolated coordinator planning connection.
 
+Storage-facing scalar functions from the static `file` extension use this same
+contract. FILE values retain only their canonical five fields; connection and
+credential state travels in the separate query/session snapshot. The official
+Vane build loads the statically linked `file` and `httpfs` extensions, and the
+existing snapshot records and verifies those exact extension identities before
+Worker execution. Workers never install or autoload them. Local FILE URLs
+identify Worker-visible paths and therefore require a shared or identically
+mounted filesystem when a query can run on more than one node.
+
 ## Distributed scans
 
 ### Worker bind serialization

--- a/external/duckdb/extension/file/README.md
+++ b/external/duckdb/extension/file/README.md
@@ -93,10 +93,23 @@ deferred.
 
 ## Distributed boundary
 
-Ray plan admission rejects storage-facing FILE scalars (`to_file`,
-`try_to_file`, `file_enrich`, `file_size`, `file_exists`, `file_stat`, and the
-two-argument `file_mime_type`) until workers have an explicit connector,
-credential, path-resolution, and refresh contract. Connection-scoped DuckDB
-Secrets are not serialized to workers. I/O-free FILE construction, field and
-path access, one-argument metadata MIME lookup, comparison, and identity
-functions remain distributable.
+Ray execution treats the source Driver, Ray object transport, and the Workers
+participating in one Vane query as one trusted runtime boundary. FILE values
+remain the canonical five-field value and never carry connector configuration
+or credentials. The immutable connection/session snapshot is transported
+separately and applied to each Worker-owned DuckDB connection before FILE
+functions execute.
+
+The official Vane build loads statically linked `file` and `httpfs` extensions,
+and its existing snapshot records and verifies their exact identities before
+Worker execution. This makes HTTP and S3 connector lookup available without
+runtime extension installation or autoload. Existing Vane session handling
+resolves and refreshes supported AWS credentials per connection session.
+Explicit supported DuckDB connection settings retain their normal precedence.
+DuckDB `CREATE SECRET` objects are not serialized.
+
+This first distributed contract is for controlled, single-trust-domain Ray
+deployments. A local path names a Worker-visible path and is portable only when
+all participating Workers see the same object at that path. Multi-scope Secret
+selection and untrusted-cluster isolation remain a later execution-layer
+contract; neither requires changing FILE's persisted representation.

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -126,33 +126,6 @@ struct PyLogicalPlan {
 	PyPhysicalPlanWrapper to_physical_plan(py::object conn_obj, py::object effective_session_config) const;
 };
 
-static bool IsStorageFacingFileScalar(const ScalarFunction &function) {
-	if (function.catalog_name != SYSTEM_CATALOG || function.schema_name != DEFAULT_SCHEMA ||
-	    function.GetStability() != FunctionStability::VOLATILE) {
-		return false;
-	}
-	// These are the FILE extension overloads registered with accesses_storage=true.
-	return function.name == "to_file" || function.name == "try_to_file" || function.name == "file_enrich" ||
-	       function.name == "file_size" || function.name == "file_exists" || function.name == "file_stat" ||
-	       function.name == "file_mime_type";
-}
-
-class DistributedFileScalarValidator final : public LogicalOperatorVisitor {
-public:
-	void VisitExpression(unique_ptr<Expression> *expression) override {
-		if ((*expression)->GetExpressionClass() == ExpressionClass::BOUND_FUNCTION) {
-			auto &function = (*expression)->Cast<BoundFunctionExpression>().function;
-			if (IsStorageFacingFileScalar(function)) {
-				throw InvalidInputException(
-				    "Ray distributed execution does not yet support storage-facing FILE function '%s'; "
-				    "worker-side FILE connector, credential, and path resolution is not available",
-				    function.name);
-			}
-		}
-		LogicalOperatorVisitor::VisitExpression(expression);
-	}
-};
-
 static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::Relation> &rel) {
 	if (!rel) {
 		throw duckdb::InternalException("Relation is null");
@@ -165,7 +138,6 @@ static string SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::
 		duckdb::Planner planner(*client_context);
 		planner.CreatePlan(std::move(relation_stmt));
 		auto logical_plan = std::move(planner.plan);
-		DistributedFileScalarValidator().VisitOperator(*logical_plan);
 
 		// NOTE: We intentionally do NOT run the Optimizer here.
 		// The unoptimized (bound) logical plan is serialized and sent to the Driver,

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -38,8 +38,6 @@
 #include <duckdb/execution/distributed/pipeline_node/vllm.hpp>
 #include <duckdb/execution/distributed/utils/channel.hpp>
 #include <duckdb/planner/planner.hpp>
-#include <duckdb/planner/logical_operator_visitor.hpp>
-#include <duckdb/planner/expression/bound_function_expression.hpp>
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/limits.hpp>
 #include <duckdb/common/local_file_system.hpp>

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import gc
+import hashlib
 import pickle
 import threading
 
@@ -27,48 +28,79 @@ def _table_from_native_result(result):
     return pa.concat_tables(payloads)
 
 
-@pytest.mark.parametrize(
-    ("function_name", "expression"),
-    [
-        ("to_file", "to_file('file:///driver-only/value.bin')"),
-        ("try_to_file", "try_to_file('file:///driver-only/value.bin')"),
-        (
-            "file_enrich",
-            "file_enrich(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL), ['size'])",
-        ),
-        (
-            "file_size",
-            "file_size(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL))",
-        ),
-        (
-            "file_exists",
-            "file_exists(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL))",
-        ),
-        (
-            "file_stat",
-            "file_stat(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL))",
-        ),
-        (
-            "file_mime_type",
-            "file_mime_type(file('file:///driver-only/value.bin', NULL, NULL, NULL, NULL), 'content')",
-        ),
-    ],
-)
-def test_distributed_plan_rejects_storage_facing_file_scalars(function_name, expression):
+def _sql_string_literal(value):
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def test_distributed_plan_executes_storage_facing_file_scalars_after_transport(tmp_path):
     ray_cxx = _require_ray_cxx()
+    payload = b"\x89PNG\r\n\x1a\n" + b"distributed-file-payload"
+    payload_path = tmp_path / "distributed-file.bin"
+    payload_path.write_bytes(payload)
+    missing_path = tmp_path / "missing.bin"
+    range_position = 8
+    range_size = 12
+    range_digest = hashlib.sha256(payload[range_position : range_position + range_size]).hexdigest()
+    path_sql = _sql_string_literal(payload_path)
+    missing_sql = _sql_string_literal(missing_path)
+
     connection = vane.connect()
     try:
-        relation = connection.sql(f"SELECT {expression} FROM range(2)")
-        with pytest.raises(
-            ValueError,
-            match=rf"storage-facing FILE function '{function_name}'",
-        ):
-            ray_cxx.PyLogicalPlan.from_duckdb_relation(
-                relation,
-                f"storage-facing-file-{function_name}",
-            )
+        relation = connection.sql(
+            f"""
+            SELECT
+                file_size(to_file({path_sql})) AS converted_size,
+                file_size(try_to_file({path_sql})) AS optional_size,
+                file_exists(file({path_sql}, NULL, NULL, NULL, NULL)) AS exists,
+                file_stat(file({path_sql}, NULL, NULL, NULL, NULL)).object_size AS object_size,
+                file_mime_type(file({path_sql}, NULL, NULL, NULL, NULL), 'content') AS mime_type,
+                file_content_id(file_enrich(
+                    file({path_sql}, NULL, {range_position}, {range_size}, NULL),
+                    ['checksum']
+                )) AS content_id,
+                try_to_file({missing_sql}) IS NULL AS missing_is_null
+            FROM range(2)
+            """
+        )
+        logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
+            relation,
+            "storage-facing-file-scalars",
+        )
+        snapshot = logical_plan.__getstate__()[3]
+        extension_names = {extension["name"] for extension in snapshot["extensions"]}
+        assert {"file", "httpfs"}.issubset(extension_names)
+
+        transported_logical_plan = pickle.loads(pickle.dumps(logical_plan))
     finally:
         connection.close()
+
+    planning_connection = vane.connect()
+    try:
+        physical_plan = transported_logical_plan.to_physical_plan(planning_connection)
+        transported_physical_plan = pickle.loads(pickle.dumps(physical_plan))
+    finally:
+        planning_connection.close()
+
+    worker_connection = vane.connect()
+    try:
+        result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            worker_connection.cursor(),
+            transported_physical_plan,
+        )
+        table = _table_from_native_result(result)
+    finally:
+        worker_connection.close()
+
+    expected = (
+        len(payload),
+        len(payload),
+        True,
+        len(payload),
+        "image/png",
+        f"file-content-v1:checksum:sha256:{range_digest}",
+        True,
+    )
+    assert [tuple(row.values()) for row in table.to_pylist()] == [expected, expected]
 
 
 def test_distributed_plan_allows_io_free_file_scalars():
@@ -96,6 +128,65 @@ def test_distributed_plan_allows_io_free_file_scalars():
         assert plan is not None
     finally:
         connection.close()
+
+
+@pytest.mark.parametrize("write_expression", ["check", "default"])
+def test_distributed_write_snapshot_covers_write_owned_file_io_expressions(
+    monkeypatch,
+    tmp_path,
+    write_expression,
+):
+    ray_cxx = _require_ray_cxx()
+    payload_path = tmp_path / f"write-{write_expression}.bin"
+    payload_path.write_bytes(b"write-owned-file-expression")
+    database_path = tmp_path / f"write-{write_expression}.duckdb"
+    path_sql = _sql_string_literal(payload_path)
+    captured_plans = []
+
+    class CapturingRunner:
+        def run_write(self, relation):
+            captured_plans.append(
+                ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
+                    relation,
+                    f"write-owned-file-{write_expression}",
+                )
+            )
+            return {"ok": True}
+
+    import vane.runners as runners_module
+
+    monkeypatch.setattr(runners_module, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
+    connection = vane.connect(str(database_path))
+    try:
+        if write_expression == "check":
+            connection.execute("CREATE TABLE file_target (value FILE, CHECK (file_exists(value)))")
+        else:
+            connection.execute(f"CREATE TABLE file_target (value FILE DEFAULT try_to_file({path_sql}))")
+            connection.execute(f"INSERT INTO file_target VALUES (file({path_sql}, NULL, NULL, NULL, NULL))")
+
+        monkeypatch.setenv("VANE_RUNNER", "ray")
+        if write_expression == "check":
+            connection.sql(f"SELECT file({path_sql}, NULL, NULL, NULL, NULL) AS value").insert_into("file_target")
+        else:
+            connection.table("file_target").update({"value": vane.DefaultExpression()})
+
+        assert len(captured_plans) == 1
+        logical_plan = captured_plans[0]
+        snapshot = logical_plan.__getstate__()[3]
+        extension_names = {extension["name"] for extension in snapshot["extensions"]}
+        assert {"file", "httpfs"}.issubset(extension_names)
+        transported_logical_plan = pickle.loads(pickle.dumps(logical_plan))
+    finally:
+        connection.close()
+
+    planning_connection = vane.connect()
+    try:
+        physical_plan = transported_logical_plan.to_physical_plan(planning_connection)
+        assert physical_plan is not None
+    finally:
+        planning_connection.close()
+    del physical_plan
+    gc.collect()
 
 
 def test_logical_plan_captures_connection_scoped_vane_session(monkeypatch):

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+import threading
 import time
 
 import pytest
@@ -11,6 +13,97 @@ except Exception:
     ray = None
 
 import vane
+
+
+def _sql_string_literal(value):
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _start_s3_object_server(payload):
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    class S3ObjectHandler(BaseHTTPRequestHandler):
+        requests = []
+        requests_lock = threading.Lock()
+
+        def _record_request(self):
+            with type(self).requests_lock:
+                type(self).requests.append(
+                    {
+                        "authorization": self.headers.get("Authorization"),
+                        "command": self.command,
+                        "path": self.path,
+                        "range": self.headers.get("Range"),
+                    }
+                )
+
+        def _send_object(self, include_body):
+            self._record_request()
+            if self.path.split("?", 1)[0] != "/bucket/object.bin":
+                self.send_response(404)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
+            status = 200
+            body = payload
+            content_range = None
+            range_header = self.headers.get("Range")
+            if range_header:
+                unit, separator, bounds = range_header.partition("=")
+                start_text, dash, end_text = bounds.partition("-")
+                if (
+                    unit != "bytes"
+                    or not separator
+                    or not dash
+                    or not start_text.isdigit()
+                    or (end_text and not end_text.isdigit())
+                ):
+                    self.send_response(416)
+                    self.send_header("Content-Range", f"bytes */{len(payload)}")
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                start = int(start_text)
+                end = len(payload) - 1 if not end_text else min(int(end_text), len(payload) - 1)
+                if start >= len(payload) or end < start:
+                    self.send_response(416)
+                    self.send_header("Content-Range", f"bytes */{len(payload)}")
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                status = 206
+                body = payload[start : end + 1]
+                content_range = f"bytes {start}-{end}/{len(payload)}"
+
+            self.send_response(status)
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Content-Type", "image/png")
+            self.send_header("ETag", '"trusted-file-etag"')
+            self.send_header("Last-Modified", "Thu, 27 Aug 2026 00:00:00 GMT")
+            if content_range is not None:
+                self.send_header("Content-Range", content_range)
+            self.end_headers()
+            if include_body:
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+        def do_HEAD(self):
+            self._send_object(False)
+
+        def do_GET(self):
+            self._send_object(True)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), S3ObjectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread, S3ObjectHandler
 
 
 def _collect_rows_from_parts(parts):
@@ -35,7 +128,7 @@ def _collect_rows_from_parts(parts):
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")
 @pytest.mark.usefixtures("ray_local")
-def test_default_ray_rejects_file_io_for_driver_only_path(monkeypatch, tmp_path):
+def test_default_ray_resolves_file_io_in_worker_process(monkeypatch, tmp_path):
     import fcntl
     import os
 
@@ -57,12 +150,108 @@ def test_default_ray_rejects_file_io_for_driver_only_path(monkeypatch, tmp_path)
                 vane.teardown_runner()
                 relation = connection.sql(f"SELECT file_size(try_to_file('{driver_path}')) FROM range(2)")
 
-                with pytest.raises(ValueError, match="storage-facing FILE function"):
-                    relation.fetchall()
+                assert relation.fetchall() == [(None,), (None,)]
             finally:
                 os.close(descriptor)
     finally:
         connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_default_ray_reads_worker_visible_file_with_strict_range(monkeypatch, tmp_path):
+    payload = b"worker-visible-payload"
+    payload_path = tmp_path / "worker-visible.bin"
+    payload_path.write_bytes(payload)
+    path_sql = _sql_string_literal(payload_path)
+
+    monkeypatch.delenv("VANE_RUNNER", raising=False)
+    vane.teardown_runner()
+    connection = vane.connect()
+    try:
+        relation = connection.sql(
+            f"""
+            SELECT
+                file_size(to_file({path_sql})),
+                file_size(file({path_sql}, NULL, 7, 7, NULL)),
+                file_exists(file({path_sql}, NULL, 7, 7, NULL)),
+                file_content_id(file_enrich(
+                    file({path_sql}, NULL, 7, 7, NULL),
+                    ['checksum']
+                ))
+            FROM range(2)
+            """
+        )
+        digest = hashlib.sha256(payload[7:14]).hexdigest()
+        expected = (
+            len(payload),
+            7,
+            True,
+            f"file-content-v1:checksum:sha256:{digest}",
+        )
+        assert relation.fetchall() == [expected, expected]
+    finally:
+        connection.close()
+
+
+@pytest.mark.skipif(ray is None, reason="ray not installed")
+@pytest.mark.usefixtures("ray_local")
+def test_default_ray_file_io_uses_connection_session_s3_context(monkeypatch):
+    payload = b"\x89PNG\r\n\x1a\n" + b"ray-session-file-payload"
+    server, thread, handler = _start_s3_object_server(payload)
+    endpoint = f"http://127.0.0.1:{server.server_address[1]}"
+    http_url_sql = _sql_string_literal(f"{endpoint}/bucket/object.bin")
+    access_key = "trusted-file-access-key"
+    environment_keys = (
+        "AWS_ENDPOINT_URL",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_REGION",
+    )
+    try:
+        monkeypatch.setenv("AWS_ENDPOINT_URL", endpoint)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key)
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "trusted-file-secret-key")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.delenv("VANE_RUNNER", raising=False)
+        vane.teardown_runner()
+        connection = vane.connect()
+        for key in environment_keys:
+            monkeypatch.delenv(key)
+
+        try:
+            connection.execute("SET http_proxy=''")
+            relation = connection.sql(
+                f"""
+                SELECT
+                    file_size(to_file({http_url_sql})),
+                    file_size(to_file('s3://bucket/object.bin')),
+                    file_mime_type(
+                        file('s3://bucket/object.bin', NULL, NULL, NULL, NULL),
+                        'content'
+                    )
+                FROM range(2)
+                """
+            )
+            expected = (len(payload), len(payload), "image/png")
+            assert relation.fetchall() == [expected, expected]
+        finally:
+            connection.close()
+
+        with handler.requests_lock:
+            requests = list(handler.requests)
+        assert requests
+        assert any(
+            request["authorization"] and f"Credential={access_key}/" in request["authorization"] for request in requests
+        )
+        assert any(request["range"] for request in requests)
+    finally:
+        try:
+            vane.teardown_runner()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
 
 
 @pytest.mark.skipif(ray is None, reason="ray not installed")


### PR DESCRIPTION
## Summary

- Allow storage-facing SQL FILE functions to cross the Ray plan boundary and execute on Worker-owned DuckDB connections using the existing immutable connection/session snapshot.
- Keep FILE values credential-free and canonical: connector settings and supported AWS provider-chain credentials travel separately within the trusted Ray query boundary and are refreshed per connection session.
- Cover transported read plans, write-owned CHECK/default expressions, Worker-visible local files, strict byte ranges, HTTP, and signed S3 requests. DuckDB `CREATE SECRET` objects remain intentionally outside the snapshot contract.

This replaces the temporary fail-closed FILE admission check from #682. It does not add a compatibility fallback or change FILE's five-field representation.

## Related issue

close: #689

Part of #661.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`DISTRIBUTED_EXTENSIONS.md` and the FILE extension README document the trusted runtime boundary, extension identity checks, Worker path semantics, AWS session behavior, and the exclusion of `CREATE SECRET` objects.

## Validation

- `scripts/format workspace --changed --check`
- Release native install with `SKBUILD_BUILD_DIR="$PWD/build/python-release"`, `SKBUILD_CMAKE_BUILD_TYPE=Release`, and `CMAKE_BUILD_PARALLEL_LEVEL=32`
- Targeted transported read/write snapshot tests: 3 passed
- Targeted real-Ray local/range/HTTP/S3 tests: 3 passed
- `scripts/run_installed_pytest.sh tests/fast/test_ray_connection_snapshot.py -q`: 53 passed
- `scripts/run_release_tests.sh`: 810 base tests passed; 14 real-Ray tests passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No such additions are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
