### PR TITLE
[fix](ray) Support distributed cross products

### DIFF
--- a/external/duckdb/src/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/src/execution/distributed/CMakeLists.txt
@@ -41,12 +41,14 @@ set(DISTRIBUTED_SOURCES_COMMON
 
 set(DISTRIBUTED_SOURCES_PIPELINE_NODE
     pipeline_node/aggregate.cpp
+    pipeline_node/binary_task_fan_in.cpp
     pipeline_node/data_sink_finish.cpp
     pipeline_node/empty_result_source.cpp
     pipeline_node/expression_scan.cpp
     pipeline_node/extension_write_sink.cpp
     pipeline_node/grouping_set_expand.cpp
     pipeline_node/join/broadcast_join.cpp
+    pipeline_node/join/cross_product.cpp
     pipeline_node/join/delim_join.cpp
     pipeline_node/join/hash_join.cpp
     pipeline_node/limit.cpp

--- a/external/duckdb/src/execution/distributed/pipeline_node/binary_task_fan_in.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/binary_task_fan_in.cpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+namespace {
+
+BinaryTaskPoll EndOfBinaryTaskStream() {
+	return std::make_pair(false, BinarySubmittableTask());
+}
+
+} // namespace
+
+void MoveTaskInputsOrThrow(TaskInputs &target, TaskInputs &source, const std::string &node_name) {
+	for (auto &entry : source) {
+		auto inserted = target.emplace(entry.first, std::move(entry.second));
+		if (!inserted.second) {
+			throw InvalidInputException("%s received duplicate source node id %llu", node_name,
+			                            static_cast<unsigned long long>(entry.first));
+		}
+	}
+	source.clear();
+}
+
+BinaryFragmentInputFanInStream::BinaryFragmentInputFanInStream(SubmittableTaskStream<WorkerTask> left,
+                                                               SubmittableTaskStream<WorkerTask> right,
+                                                               BinaryInitialTaskBuilder build_initial_task,
+                                                               std::shared_ptr<TaskIDCounter> task_id_counter,
+                                                               uint16_t query_idx, NodeID node_id,
+                                                               std::string node_name)
+    : left_(std::move(left)), right_(std::move(right)), build_initial_task_(std::move(build_initial_task)),
+      task_id_counter_(std::move(task_id_counter)), query_idx_(query_idx), node_id_(node_id),
+      node_name_(std::move(node_name)) {
+}
+
+BinaryTaskPoll BinaryFragmentInputFanInStream::poll_next() {
+	if (finished_) {
+		return EndOfBinaryTaskStream();
+	}
+	if (!initialized_) {
+		return PollInitialTask();
+	}
+
+	while (true) {
+		PollReadyInputs();
+		auto ready = EmitContinuationTask();
+		if (ready.first) {
+			return ready;
+		}
+		if (left_exhausted_ && right_exhausted_) {
+			finished_ = true;
+			return EndOfBinaryTaskStream();
+		}
+
+		if (ShouldBlockOnLeft()) {
+			PollLeft(true);
+		} else {
+			PollRight(true);
+		}
+	}
+}
+
+BinaryTaskPoll BinaryFragmentInputFanInStream::try_poll_next() {
+	if (finished_) {
+		return EndOfBinaryTaskStream();
+	}
+	if (!initialized_) {
+		PollReadyInputs();
+		return TryEmitInitialTask();
+	}
+
+	PollReadyInputs();
+	auto ready = EmitContinuationTask();
+	if (ready.first) {
+		return ready;
+	}
+	if (left_exhausted_ && right_exhausted_) {
+		finished_ = true;
+	}
+	return EndOfBinaryTaskStream();
+}
+
+BinaryTaskPoll BinaryFragmentInputFanInStream::PollInitialTask() {
+	while (true) {
+		PollReadyInputs();
+		auto ready = TryEmitInitialTask();
+		if (ready.first || finished_) {
+			return ready;
+		}
+
+		if (!pending_left_ && !left_exhausted_) {
+			PollLeft(true);
+			continue;
+		}
+		if (!pending_right_ && !right_exhausted_) {
+			PollRight(true);
+			continue;
+		}
+	}
+}
+
+BinaryTaskPoll BinaryFragmentInputFanInStream::TryEmitInitialTask() {
+	if (pending_left_ && pending_right_) {
+		auto left_task = std::move(*pending_left_);
+		auto right_task = std::move(*pending_right_);
+		pending_left_.reset();
+		pending_right_.reset();
+
+		auto combined_task = build_initial_task_(std::move(left_task), std::move(right_task));
+		continuation_template_ = combined_task.task()->clone();
+		continuation_template_->mutable_inputs().clear();
+		initialized_ = true;
+		return std::make_pair(true, std::move(combined_task));
+	}
+	if (pending_left_ && right_exhausted_) {
+		throw InvalidInputException("%s received an empty right task stream", node_name_);
+	}
+	if (pending_right_ && left_exhausted_) {
+		throw InvalidInputException("%s received an empty left task stream", node_name_);
+	}
+	if (left_exhausted_ && right_exhausted_) {
+		finished_ = true;
+	}
+	return EndOfBinaryTaskStream();
+}
+
+BinaryTaskPoll BinaryFragmentInputFanInStream::EmitContinuationTask() {
+	if (!pending_left_ && !pending_right_) {
+		return EndOfBinaryTaskStream();
+	}
+
+	TaskInputs inputs;
+	if (pending_left_) {
+		MoveTaskInputsOrThrow(inputs, pending_left_->task()->mutable_inputs(), node_name_);
+		pending_left_.reset();
+	}
+	if (pending_right_) {
+		MoveTaskInputsOrThrow(inputs, pending_right_->task()->mutable_inputs(), node_name_);
+		pending_right_.reset();
+	}
+
+	TaskContext task_context = TaskContext::from_node_context(query_idx_, node_id_, task_id_counter_->next());
+	WorkerTask continuation_task(task_context, continuation_template_->plan(), continuation_template_->config(),
+	                             continuation_template_->context(), continuation_template_->name(), std::move(inputs));
+	return std::make_pair(true, BinarySubmittableTask(std::move(continuation_task)));
+}
+
+void BinaryFragmentInputFanInStream::PollReadyInputs() {
+	PollLeft(false);
+	PollRight(false);
+}
+
+void BinaryFragmentInputFanInStream::PollLeft(bool blocking) {
+	PollSide(left_, pending_left_, left_exhausted_, blocking);
+}
+
+void BinaryFragmentInputFanInStream::PollRight(bool blocking) {
+	PollSide(right_, pending_right_, right_exhausted_, blocking);
+}
+
+void BinaryFragmentInputFanInStream::PollSide(SubmittableTaskStream<WorkerTask> &stream,
+                                              std::unique_ptr<BinarySubmittableTask> &pending, bool &exhausted,
+                                              bool blocking) {
+	if (pending || exhausted) {
+		return;
+	}
+
+	auto next = blocking ? stream.poll_next() : stream.try_poll_next();
+	if (next.first) {
+		pending.reset(new BinarySubmittableTask(std::move(next.second)));
+		if (stream.is_exhausted()) {
+			exhausted = true;
+		}
+		return;
+	}
+	if (blocking || stream.is_exhausted()) {
+		exhausted = true;
+	}
+}
+
+bool BinaryFragmentInputFanInStream::ShouldBlockOnLeft() {
+	if (left_exhausted_) {
+		return false;
+	}
+	if (right_exhausted_) {
+		return true;
+	}
+	const bool block_on_left = prefer_left_;
+	prefer_left_ = !prefer_left_;
+	return block_on_left;
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/cross_product.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/cross_product.cpp
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/join/cross_product.hpp"
+
+#include <algorithm>
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/execution/operator/join/physical_cross_product.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+CrossProductNode::CrossProductNode(NodeID node_id, const PlanConfig &plan_config,
+                                   duckdb::vector<LogicalType> output_types, idx_t estimated_cardinality,
+                                   std::shared_ptr<DistributedPipelineNode> left,
+                                   std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+    : context_(plan_config.query_idx, plan_config.query_id, node_id, "CrossProduct"),
+      output_types_(std::move(output_types)), estimated_cardinality_(estimated_cardinality), left_(std::move(left)),
+      right_(std::move(right)) {
+	size_t num_partitions = 1;
+	if (left_ && right_) {
+		num_partitions = std::max(left_->config().clustering_spec()->num_partitions(),
+		                          right_->config().clustering_spec()->num_partitions());
+	} else if (left_) {
+		num_partitions = left_->config().clustering_spec()->num_partitions();
+	} else if (right_) {
+		num_partitions = right_->config().clustering_spec()->num_partitions();
+	}
+
+	auto clustering = ClusteringSpec::unknown_with_num_partitions(num_partitions);
+	config_ = PipelineNodeConfig(std::move(schema), plan_config.config, std::move(clustering));
+}
+
+std::vector<PipelineNodeRef> CrossProductNode::children() const {
+	std::vector<PipelineNodeRef> result;
+	if (left_) {
+		result.push_back(left_->inner());
+	}
+	if (right_) {
+		result.push_back(right_->inner());
+	}
+	return result;
+}
+
+std::vector<std::string> CrossProductNode::multiline_display(bool /*verbose*/) const {
+	return {"Cross Product"};
+}
+
+SubmittableTask<WorkerTask> CrossProductNode::BuildCrossProductTask(SubmittableTask<WorkerTask> left_task,
+                                                                    SubmittableTask<WorkerTask> right_task,
+                                                                    TaskIDCounter &task_id_counter,
+                                                                    ClientContext *client_context) {
+	auto left_plan_src = left_task.task()->plan();
+	auto right_plan_src = right_task.task()->plan();
+	if (!left_plan_src || !left_plan_src->HasRoot() || !right_plan_src || !right_plan_src->HasRoot()) {
+		throw InvalidInputException("CrossProductNode cannot build task from input without a physical plan root");
+	}
+
+	auto plan = ClonePhysicalPlanOrThrow(left_plan_src, "build_cross_product_task:left", client_context);
+	auto &left_root = plan->Root();
+	// Physical operators only reference their children. Clone the right tree into
+	// the same owning plan before attaching both roots to the cross product.
+	auto &right_root =
+	    ClonePhysicalPlanRootIntoPlanOrThrow(right_plan_src, *plan, "build_cross_product_task:right", client_context);
+
+	duckdb::vector<LogicalType> child_derived_types = left_root.GetTypes();
+	const auto &right_types = right_root.GetTypes();
+	child_derived_types.insert(child_derived_types.end(), right_types.begin(), right_types.end());
+	if (child_derived_types != output_types_) {
+		throw InternalException(
+		    "CrossProductNode output schema does not match its children (%llu translated columns, %llu child-derived "
+		    "columns)",
+		    output_types_.size(), child_derived_types.size());
+	}
+
+	auto &cross_product =
+	    plan->Make<PhysicalCrossProduct>(output_types_, left_root, right_root, estimated_cardinality_);
+	plan->SetRoot(cross_product);
+
+	TaskContext task_context = TaskContext::from_node_context(context_.query_idx(), node_id(), task_id_counter.next());
+	auto merged_context = MergeTaskContext(left_task.task()->context(), right_task.task()->context());
+	merged_context = MergeTaskContext(merged_context, context_.to_hashmap());
+	WorkerTask new_task(task_context, plan, left_task.task()->config(), std::move(merged_context), "WorkerTask");
+	auto &inputs = new_task.mutable_inputs();
+	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs(), context_.node_name());
+	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs(), context_.node_name());
+	return std::move(left_task).with_new_task(std::move(new_task));
+}
+
+SubmittableTaskStream<WorkerTask> CrossProductNode::produce_tasks(PlanExecutionContext &plan_context) {
+	if (!left_ || !right_) {
+		return SubmittableTaskStream<WorkerTask>::from_receiver(Receiver<SubmittableTask<WorkerTask>>());
+	}
+
+	auto left_input = left_->produce_tasks(plan_context);
+	auto right_input = right_->produce_tasks(plan_context);
+	auto task_id_counter = std::make_shared<TaskIDCounter>(plan_context.task_id_counter());
+	auto *client_context = plan_context.client_context();
+	auto self_shared = shared_from_this();
+	BinaryInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
+	                                               client_context](BinarySubmittableTask left_task,
+	                                                               BinarySubmittableTask right_task) mutable {
+		return self_shared->BuildCrossProductTask(std::move(left_task), std::move(right_task), *task_id_counter,
+		                                          client_context);
+	};
+
+	BinaryFragmentInputFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
+	                                      task_id_counter, context_.query_idx(), node_id(), context_.node_name());
+	return SubmittableTaskStream<WorkerTask>(boxed<BinarySubmittableTask>(std::move(stream)));
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/hash_join.cpp
@@ -4,10 +4,9 @@
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 
 #include <algorithm>
-#include <functional>
-
 #include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
@@ -20,26 +19,6 @@ namespace duckdb {
 namespace distributed {
 
 namespace {
-
-using HashJoinSubmittableTask = SubmittableTask<WorkerTask>;
-using HashJoinTaskPoll = std::pair<bool, HashJoinSubmittableTask>;
-using HashJoinInitialTaskBuilder =
-    std::function<HashJoinSubmittableTask(HashJoinSubmittableTask, HashJoinSubmittableTask)>;
-
-HashJoinTaskPoll EndOfHashJoinTaskStream() {
-	return std::make_pair(false, HashJoinSubmittableTask());
-}
-
-void MoveTaskInputsOrThrow(TaskInputs &target, TaskInputs &source) {
-	for (auto &entry : source) {
-		auto inserted = target.emplace(entry.first, std::move(entry.second));
-		if (!inserted.second) {
-			throw InvalidInputException("HashJoinNode received duplicate source node id %llu",
-			                            static_cast<unsigned long long>(entry.first));
-		}
-	}
-	source.clear();
-}
 
 MarkJoinBuildSummary ExtractMarkJoinBuildSummary(const TaskInputs &inputs, optional_idx source_node_id) {
 	if (!source_node_id.IsValid()) {
@@ -55,195 +34,6 @@ MarkJoinBuildSummary ExtractMarkJoinBuildSummary(const TaskInputs &inputs, optio
 	}
 	return descriptor.mark_join_build_summary;
 }
-
-class HashJoinTaskFanInStream {
-public:
-	HashJoinTaskFanInStream(SubmittableTaskStream<WorkerTask> left, SubmittableTaskStream<WorkerTask> right,
-	                        HashJoinInitialTaskBuilder build_initial_task,
-	                        std::shared_ptr<TaskIDCounter> task_id_counter, uint16_t query_idx, NodeID node_id)
-	    : left_(std::move(left)), right_(std::move(right)), build_initial_task_(std::move(build_initial_task)),
-	      task_id_counter_(std::move(task_id_counter)), query_idx_(query_idx), node_id_(node_id) {
-	}
-
-	HashJoinTaskPoll poll_next() {
-		if (finished_) {
-			return EndOfHashJoinTaskStream();
-		}
-		if (!initialized_) {
-			return PollInitialTask();
-		}
-
-		while (true) {
-			PollReadyInputs();
-			auto ready = EmitContinuationTask();
-			if (ready.first) {
-				return ready;
-			}
-			if (left_exhausted_ && right_exhausted_) {
-				finished_ = true;
-				return EndOfHashJoinTaskStream();
-			}
-
-			if (ShouldBlockOnLeft()) {
-				PollLeft(true);
-			} else {
-				PollRight(true);
-			}
-		}
-	}
-
-	HashJoinTaskPoll try_poll_next() {
-		if (finished_) {
-			return EndOfHashJoinTaskStream();
-		}
-		if (!initialized_) {
-			PollReadyInputs();
-			return TryEmitInitialTask();
-		}
-
-		PollReadyInputs();
-		auto ready = EmitContinuationTask();
-		if (ready.first) {
-			return ready;
-		}
-		if (left_exhausted_ && right_exhausted_) {
-			finished_ = true;
-		}
-		return EndOfHashJoinTaskStream();
-	}
-
-	bool is_exhausted() const {
-		return finished_;
-	}
-
-private:
-	HashJoinTaskPoll PollInitialTask() {
-		while (true) {
-			PollReadyInputs();
-			auto ready = TryEmitInitialTask();
-			if (ready.first || finished_) {
-				return ready;
-			}
-
-			if (!pending_left_ && !left_exhausted_) {
-				PollLeft(true);
-				continue;
-			}
-			if (!pending_right_ && !right_exhausted_) {
-				PollRight(true);
-				continue;
-			}
-		}
-	}
-
-	HashJoinTaskPoll TryEmitInitialTask() {
-		if (pending_left_ && pending_right_) {
-			auto left_task = std::move(*pending_left_);
-			auto right_task = std::move(*pending_right_);
-			pending_left_.reset();
-			pending_right_.reset();
-
-			auto joined_task = build_initial_task_(std::move(left_task), std::move(right_task));
-			continuation_template_ = joined_task.task()->clone();
-			continuation_template_->mutable_inputs().clear();
-			initialized_ = true;
-			return std::make_pair(true, std::move(joined_task));
-		}
-		if (pending_left_ && right_exhausted_) {
-			throw InvalidInputException("HashJoinNode received an empty right task stream");
-		}
-		if (pending_right_ && left_exhausted_) {
-			throw InvalidInputException("HashJoinNode received an empty left task stream");
-		}
-		if (left_exhausted_ && right_exhausted_) {
-			finished_ = true;
-		}
-		return EndOfHashJoinTaskStream();
-	}
-
-	HashJoinTaskPoll EmitContinuationTask() {
-		if (!pending_left_ && !pending_right_) {
-			return EndOfHashJoinTaskStream();
-		}
-
-		TaskInputs inputs;
-		if (pending_left_) {
-			MoveTaskInputsOrThrow(inputs, pending_left_->task()->mutable_inputs());
-			pending_left_.reset();
-		}
-		if (pending_right_) {
-			MoveTaskInputsOrThrow(inputs, pending_right_->task()->mutable_inputs());
-			pending_right_.reset();
-		}
-
-		TaskContext task_context = TaskContext::from_node_context(query_idx_, node_id_, task_id_counter_->next());
-		WorkerTask continuation_task(task_context, continuation_template_->plan(), continuation_template_->config(),
-		                             continuation_template_->context(), continuation_template_->name(),
-		                             std::move(inputs));
-		return std::make_pair(true, HashJoinSubmittableTask(std::move(continuation_task)));
-	}
-
-	void PollReadyInputs() {
-		PollLeft(false);
-		PollRight(false);
-	}
-
-	void PollLeft(bool blocking) {
-		PollSide(left_, pending_left_, left_exhausted_, blocking);
-	}
-
-	void PollRight(bool blocking) {
-		PollSide(right_, pending_right_, right_exhausted_, blocking);
-	}
-
-	static void PollSide(SubmittableTaskStream<WorkerTask> &stream, std::unique_ptr<HashJoinSubmittableTask> &pending,
-	                     bool &exhausted, bool blocking) {
-		if (pending || exhausted) {
-			return;
-		}
-
-		auto next = blocking ? stream.poll_next() : stream.try_poll_next();
-		if (next.first) {
-			pending.reset(new HashJoinSubmittableTask(std::move(next.second)));
-			if (stream.is_exhausted()) {
-				exhausted = true;
-			}
-			return;
-		}
-		if (blocking || stream.is_exhausted()) {
-			exhausted = true;
-		}
-	}
-
-	bool ShouldBlockOnLeft() {
-		if (left_exhausted_) {
-			return false;
-		}
-		if (right_exhausted_) {
-			return true;
-		}
-		const bool block_on_left = prefer_left_;
-		prefer_left_ = !prefer_left_;
-		return block_on_left;
-	}
-
-private:
-	SubmittableTaskStream<WorkerTask> left_;
-	SubmittableTaskStream<WorkerTask> right_;
-	HashJoinInitialTaskBuilder build_initial_task_;
-	std::shared_ptr<TaskIDCounter> task_id_counter_;
-	uint16_t query_idx_;
-	NodeID node_id_;
-	std::unique_ptr<HashJoinSubmittableTask> pending_left_;
-	std::unique_ptr<HashJoinSubmittableTask> pending_right_;
-	std::unique_ptr<WorkerTask> continuation_template_;
-	bool left_exhausted_ = false;
-	bool right_exhausted_ = false;
-	bool initialized_ = false;
-	bool finished_ = false;
-	bool prefer_left_ = true;
-};
-
 } // namespace
 
 HashJoinNode::HashJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<JoinCondition> conditions,
@@ -447,8 +237,8 @@ SubmittableTask<WorkerTask> HashJoinNode::BuildHashJoinTask(SubmittableTask<Work
 	merged_ctx = MergeTaskContext(merged_ctx, context_.to_hashmap());
 	WorkerTask new_task(task_context, left_plan, left_task.task()->config(), std::move(merged_ctx), "WorkerTask");
 	auto &inputs = new_task.mutable_inputs();
-	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs());
-	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs());
+	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs(), context_.node_name());
+	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs(), context_.node_name());
 	return std::move(left_task).with_new_task(std::move(new_task));
 }
 
@@ -462,9 +252,9 @@ SubmittableTaskStream<WorkerTask> HashJoinNode::produce_tasks(PlanExecutionConte
 	auto task_id_counter = std::make_shared<TaskIDCounter>(plan_context.task_id_counter());
 	auto *client_context = plan_context.client_context();
 	auto self_shared = shared_from_this();
-	HashJoinInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
-	                                                 client_context](HashJoinSubmittableTask left_task,
-	                                                                 HashJoinSubmittableTask right_task) mutable {
+	BinaryInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
+	                                               client_context](BinarySubmittableTask left_task,
+	                                                               BinarySubmittableTask right_task) mutable {
 		return self_shared->BuildHashJoinTask(std::move(left_task), std::move(right_task), *task_id_counter,
 		                                      client_context);
 	};
@@ -473,9 +263,9 @@ SubmittableTaskStream<WorkerTask> HashJoinNode::produce_tasks(PlanExecutionConte
 	// exchange sources. Later events are dynamic-input updates for that same
 	// fragment: their TaskInputs are keyed by source_node_id, so either side can
 	// advance independently without a positional left/right zip.
-	HashJoinTaskFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
-	                               task_id_counter, context_.query_idx(), node_id());
-	return SubmittableTaskStream<WorkerTask>(boxed<HashJoinSubmittableTask>(std::move(stream)));
+	BinaryFragmentInputFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
+	                                      task_id_counter, context_.query_idx(), node_id(), context_.node_name());
+	return SubmittableTaskStream<WorkerTask>(boxed<BinarySubmittableTask>(std::move(stream)));
 }
 
 } // namespace distributed

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -42,6 +42,7 @@
 #include "duckdb/execution/operator/helper/physical_streaming_sample.hpp"
 #include "duckdb/execution/operator/helper/physical_data_sink.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
 #include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
@@ -372,6 +373,11 @@ void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOpera
 	case PhysicalOperatorType::HASH_JOIN: {
 		auto &hj = static_cast<PhysicalHashJoin &>(op);
 		node_impl = TranslateHashJoin(hj, children);
+		break;
+	}
+	case PhysicalOperatorType::CROSS_PRODUCT: {
+		auto &cross_product = static_cast<PhysicalCrossProduct &>(op);
+		node_impl = TranslateCrossProduct(cross_product, children);
 		break;
 	}
 	case PhysicalOperatorType::LEFT_DELIM_JOIN:

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -12,12 +12,14 @@
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/cross_product.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/delim_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/utils/optional.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
+#include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
@@ -65,6 +67,20 @@ duckdb::vector<std::string> BuildJoinOutputNames(const PhysicalHashJoin &hj, con
 
 	if (output_count != 0 && output_names.size() != output_count) {
 		output_names.clear();
+	}
+	return output_names;
+}
+
+duckdb::vector<std::string> BuildCrossProductOutputNames(const SchemaRef &left_schema, const SchemaRef &right_schema,
+                                                         idx_t output_count) {
+	if (!left_schema || !right_schema) {
+		return {};
+	}
+	auto output_names = duckdb::distributed::GetSchemaNames(left_schema);
+	auto right_names = duckdb::distributed::GetSchemaNames(right_schema);
+	output_names.insert(output_names.end(), right_names.begin(), right_names.end());
+	if (output_names.size() != output_count) {
+		return {};
 	}
 	return output_names;
 }
@@ -206,6 +222,33 @@ Optional<bool> BroadcastReceiverRepartitionOverride() {
 }
 
 } // namespace
+
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateCrossProduct(
+    const PhysicalCrossProduct &cross_product, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	if (children.size() != 2 || !children[0] || !children[1]) {
+		throw InvalidInputException("Distributed cross product requires exactly two input nodes");
+	}
+
+	SchemaRef schema = nullptr;
+	if (!cross_product.GetTypes().empty()) {
+		auto output_names = BuildCrossProductOutputNames(children[0]->config().schema(), children[1]->config().schema(),
+		                                                 cross_product.GetTypes().size());
+		if (!output_names.empty()) {
+			schema = MakeSchemaRef(cross_product.GetTypes(), output_names);
+		} else {
+			schema = MakeSchemaRef(cross_product.GetTypes());
+		}
+	}
+
+	// Correctness baseline: every row on each side must meet every row on the
+	// other side. The gather policy stays in translation so a future broadcast
+	// or partition-pair strategy does not change task fan-in or physical serde.
+	auto left = gen_gather_node(children[0]);
+	auto right = gen_gather_node(children[1]);
+	return std::make_shared<CrossProductNode>(get_next_pipeline_node_id(), plan_config_, cross_product.GetTypes(),
+	                                          cross_product.estimated_cardinality, std::move(left), std::move(right),
+	                                          std::move(schema));
+}
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateHashJoin(
     const PhysicalHashJoin &hj, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {

--- a/external/duckdb/src/execution/operator/join/physical_cross_product.cpp
+++ b/external/duckdb/src/execution/operator/join/physical_cross_product.cpp
@@ -8,10 +8,15 @@ namespace duckdb {
 
 PhysicalCrossProduct::PhysicalCrossProduct(PhysicalPlan &physical_plan, vector<LogicalType> types,
                                            PhysicalOperator &left, PhysicalOperator &right, idx_t estimated_cardinality)
-    : CachingPhysicalOperator(physical_plan, PhysicalOperatorType::CROSS_PRODUCT, std::move(types),
-                              estimated_cardinality) {
+    : PhysicalCrossProduct(physical_plan, CrossProductDeserializeTag {}, std::move(types), estimated_cardinality) {
 	children.push_back(left);
 	children.push_back(right);
+}
+
+PhysicalCrossProduct::PhysicalCrossProduct(PhysicalPlan &physical_plan, CrossProductDeserializeTag,
+                                           vector<LogicalType> types, idx_t estimated_cardinality)
+    : CachingPhysicalOperator(physical_plan, PhysicalOperatorType::CROSS_PRODUCT, std::move(types),
+                              estimated_cardinality) {
 }
 
 //===--------------------------------------------------------------------===//

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -53,6 +53,7 @@
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/execution/operator/join/physical_left_delim_join.hpp"
 #include "duckdb/execution/operator/join/physical_right_delim_join.hpp"
@@ -1051,6 +1052,10 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 			scan->dynamic_filters = state.GetFilters(dynamic_filters_id);
 		}
 		return unique_ptr<PhysicalOperator>(std::move(scan));
+	}
+	case PhysicalOperatorType::CROSS_PRODUCT: {
+		return make_uniq<PhysicalCrossProduct>(physical_plan, CrossProductDeserializeTag {}, std::move(types),
+		                                       estimated_cardinality);
 	}
 	case PhysicalOperatorType::HASH_JOIN: {
 		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class TaskIDCounter;
+
+using BinarySubmittableTask = SubmittableTask<WorkerTask>;
+using BinaryTaskPoll = std::pair<bool, BinarySubmittableTask>;
+using BinaryInitialTaskBuilder = std::function<BinarySubmittableTask(BinarySubmittableTask, BinarySubmittableTask)>;
+
+//! Move source-id keyed task inputs into target while rejecting collisions.
+void MoveTaskInputsOrThrow(TaskInputs &target, TaskInputs &source, const std::string &node_name);
+
+//! Fan two independently advancing input streams into one logical worker fragment.
+//!
+//! The first task from each side is passed to build_initial_task. Later tasks are
+//! emitted as input-only updates that reuse the initial task's plan. This is not
+//! a positional zip: exchange source descriptors on either side may arrive at
+//! different rates.
+class BinaryFragmentInputFanInStream {
+public:
+	BinaryFragmentInputFanInStream(SubmittableTaskStream<WorkerTask> left, SubmittableTaskStream<WorkerTask> right,
+	                               BinaryInitialTaskBuilder build_initial_task,
+	                               std::shared_ptr<TaskIDCounter> task_id_counter, uint16_t query_idx, NodeID node_id,
+	                               std::string node_name);
+
+	BinaryTaskPoll poll_next();
+	BinaryTaskPoll try_poll_next();
+
+	bool is_exhausted() const {
+		return finished_;
+	}
+
+private:
+	BinaryTaskPoll PollInitialTask();
+	BinaryTaskPoll TryEmitInitialTask();
+	BinaryTaskPoll EmitContinuationTask();
+
+	void PollReadyInputs();
+	void PollLeft(bool blocking);
+	void PollRight(bool blocking);
+	static void PollSide(SubmittableTaskStream<WorkerTask> &stream, std::unique_ptr<BinarySubmittableTask> &pending,
+	                     bool &exhausted, bool blocking);
+	bool ShouldBlockOnLeft();
+
+private:
+	SubmittableTaskStream<WorkerTask> left_;
+	SubmittableTaskStream<WorkerTask> right_;
+	BinaryInitialTaskBuilder build_initial_task_;
+	std::shared_ptr<TaskIDCounter> task_id_counter_;
+	uint16_t query_idx_;
+	NodeID node_id_;
+	std::string node_name_;
+	std::unique_ptr<BinarySubmittableTask> pending_left_;
+	std::unique_ptr<BinarySubmittableTask> pending_right_;
+	std::unique_ptr<WorkerTask> continuation_template_;
+	bool left_exhausted_ = false;
+	bool right_exhausted_ = false;
+	bool initialized_ = false;
+	bool finished_ = false;
+	bool prefer_left_ = true;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/cross_product.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/cross_product.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/plan/plan_config.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class TaskIDCounter;
+
+class CrossProductNode : public PipelineNodeImpl, public std::enable_shared_from_this<CrossProductNode> {
+public:
+	CrossProductNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<LogicalType> output_types,
+	                 idx_t estimated_cardinality, std::shared_ptr<DistributedPipelineNode> left,
+	                 std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema);
+
+	const PipelineNodeContext &context() const override {
+		return context_;
+	}
+
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override;
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
+	std::vector<std::string> multiline_display(bool verbose) const override;
+
+private:
+	SubmittableTask<WorkerTask> BuildCrossProductTask(SubmittableTask<WorkerTask> left_task,
+	                                                  SubmittableTask<WorkerTask> right_task,
+	                                                  TaskIDCounter &task_id_counter,
+	                                                  ::duckdb::ClientContext *client_context);
+
+private:
+	PipelineNodeConfig config_;
+	PipelineNodeContext context_;
+	duckdb::vector<LogicalType> output_types_;
+	idx_t estimated_cardinality_;
+	std::shared_ptr<DistributedPipelineNode> left_;
+	std::shared_ptr<DistributedPipelineNode> right_;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -17,6 +17,7 @@ namespace duckdb {
 class RepartitionSpec;
 class PhysicalBatchCopyToFile;
 class PhysicalCopyToFile;
+class PhysicalCrossProduct;
 class PhysicalDataSink;
 class PhysicalOperator;
 class PhysicalDelimJoin;
@@ -135,6 +136,10 @@ private:
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateHashJoin(const PhysicalHashJoin &op,
 	                  const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslateCrossProduct(const PhysicalCrossProduct &op,
+	                      const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
 
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateDelimJoin(const PhysicalDelimJoin &op,

--- a/external/duckdb/src/include/duckdb/execution/operator/join/physical_cross_product.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/join/physical_cross_product.hpp
@@ -13,6 +13,10 @@
 
 namespace duckdb {
 
+struct CrossProductDeserializeTag {
+	constexpr CrossProductDeserializeTag() = default;
+};
+
 //! PhysicalCrossProduct represents a cross product between two tables
 class PhysicalCrossProduct : public CachingPhysicalOperator {
 public:
@@ -21,6 +25,8 @@ public:
 public:
 	PhysicalCrossProduct(PhysicalPlan &physical_plan, vector<LogicalType> types, PhysicalOperator &left,
 	                     PhysicalOperator &right, idx_t estimated_cardinality);
+	PhysicalCrossProduct(PhysicalPlan &physical_plan, CrossProductDeserializeTag, vector<LogicalType> types,
+	                     idx_t estimated_cardinality);
 
 public:
 	// Operator Interface

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -32,6 +32,7 @@
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/distributed/exchange/flight_exchange_manager.hpp"
@@ -1081,6 +1082,40 @@ TEST_CASE("PhysicalPlan tree: TopN -> ColumnDataScan", "[serialization][physical
 	REQUIRE(root_op->children[0].get().type == PhysicalOperatorType::COLUMN_DATA_SCAN);
 
 	std::cerr << "[test] PhysicalPlan tree TopN roundtrip PASSED" << std::endl;
+}
+
+TEST_CASE("PhysicalCrossProduct serialization roundtrip", "[serialization][physical_plan][cross_product]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	vector<LogicalType> left_types = {LogicalType::INTEGER};
+	vector<LogicalType> right_types = {LogicalType::VARCHAR};
+	vector<LogicalType> output_types = {LogicalType::INTEGER, LogicalType::VARCHAR};
+
+	auto &left = MakeColumnDataScan(plan, left_types);
+	auto &right = MakeColumnDataScan(plan, right_types);
+	auto &cross_product = plan.Make<PhysicalCrossProduct>(output_types, left, right, 12);
+	plan.SetRoot(cross_product);
+
+	MemoryStream stream(allocator);
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	plan.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	PhysicalPlan deserialized_plan(allocator);
+	deserializer.Begin();
+	auto root = deserialized_plan.Deserialize(deserializer);
+	deserializer.End();
+
+	REQUIRE(root != nullptr);
+	REQUIRE(root->type == PhysicalOperatorType::CROSS_PRODUCT);
+	REQUIRE(root->GetTypes() == output_types);
+	REQUIRE(root->estimated_cardinality == 12);
+	REQUIRE(root->children.size() == 2);
+	REQUIRE(root->children[0].get().GetTypes() == left_types);
+	REQUIRE(root->children[1].get().GetTypes() == right_types);
 }
 
 TEST_CASE("PhysicalHashJoin serialization roundtrip", "[serialization][physical_plan]") {

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
@@ -39,6 +40,7 @@
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
 #define private public
+#include "duckdb/execution/distributed/pipeline_node/join/cross_product.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
 #undef private
@@ -361,6 +363,30 @@ TEST_CASE("PhysicalPlanTranslator: assigns fresh id when source_node_id is not s
 	REQUIRE(scan_node->node_id() >= 0);
 }
 
+TEST_CASE("PhysicalPlanTranslator: translates cross product with two inputs", "[distributed][cross_product]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> input_types = {LogicalType::BIGINT};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+
+	auto left_collection = MakeCollection(input_types, 2);
+	auto &left = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 2,
+	                                                std::move(left_collection));
+	auto right_collection = MakeCollection(input_types, 3);
+	auto &right = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 3,
+	                                                 std::move(right_collection));
+	auto &cross = plan->Make<PhysicalCrossProduct>(output_types, left, right, 6);
+	plan->SetRoot(cross);
+
+	auto result = physical_plan_to_pipeline_node(PlanConfig {}, plan);
+	REQUIRE(result.ok);
+	REQUIRE(result.value() != nullptr);
+	auto cross_node = std::dynamic_pointer_cast<CrossProductNode>(result.value()->inner());
+	REQUIRE(cross_node != nullptr);
+	REQUIRE(cross_node->children().size() == 2);
+	REQUIRE(cross_node->config().clustering_spec()->num_partitions() == 1);
+}
+
 //===----------------------------------------------------------------------===//
 // WorkerTask inputs_ tests
 //===----------------------------------------------------------------------===//
@@ -469,6 +495,39 @@ TEST_CASE("HashJoinNode: replacement task preserves both side inputs", "[distrib
 	    ClonePhysicalPlanOrThrow(joined_task.task()->plan(), "hash_join_owned_children_test", nullptr);
 	REQUIRE(joined_plan_clone->HasRoot());
 	REQUIRE(joined_plan_clone->Root().children.size() == 2);
+}
+
+TEST_CASE("CrossProductNode: replacement task owns both inputs", "[distributed][source_id][cross_product]") {
+	PlanConfig plan_cfg(1, "cross-product-query", std::make_shared<DuckDBExecutionConfig>());
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto schema = MakeSchemaRef(output_types);
+	CrossProductNode node(302, plan_cfg, output_types, 1, nullptr, nullptr, schema);
+
+	auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+	auto right_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(20, "right", 20, "right_scan"));
+	TaskIDCounter task_id_counter;
+	auto cross_task = node.BuildCrossProductTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+	REQUIRE(cross_task.task()->inputs().size() == 2);
+	REQUIRE(cross_task.task()->inputs().at(10).scan_split_batch_bytes == "left_scan");
+	REQUIRE(cross_task.task()->inputs().at(20).scan_split_batch_bytes == "right_scan");
+	REQUIRE(cross_task.task()->plan()->Root().type == PhysicalOperatorType::CROSS_PRODUCT);
+	REQUIRE(cross_task.task()->plan()->Root().children.size() == 2);
+	auto &cross_root = cross_task.task()->plan()->Root();
+	auto &left_scan = cross_root.children[0].get().Cast<PhysicalColumnDataScan>();
+	auto &right_scan = cross_root.children[1].get().Cast<PhysicalColumnDataScan>();
+	REQUIRE(left_scan.collection);
+	REQUIRE(right_scan.collection);
+	REQUIRE(left_scan.collection->Count() == 1);
+	REQUIRE(right_scan.collection->Count() == 1);
+
+	auto cloned = ClonePhysicalPlanOrThrow(cross_task.task()->plan(), "cross_product_owned_children_test", nullptr);
+	REQUIRE(cloned->HasRoot());
+	REQUIRE(cloned->Root().type == PhysicalOperatorType::CROSS_PRODUCT);
+	REQUIRE(cloned->Root().children.size() == 2);
+	REQUIRE(cloned->Root().GetTypes() == output_types);
+	REQUIRE(cloned->Root().children[0].get().Cast<PhysicalColumnDataScan>().collection->Count() == 1);
+	REQUIRE(cloned->Root().children[1].get().Cast<PhysicalColumnDataScan>().collection->Count() == 1);
 }
 
 TEST_CASE("Join output types follow join semantics", "[distributed][join]") {

--- a/src/vane_py/ray/native_fragment_executor.cpp
+++ b/src/vane_py/ray/native_fragment_executor.cpp
@@ -852,8 +852,22 @@ static bool NativePlanNeedsResultCollector(const duckdb::PhysicalOperator &root_
 	if (root_op.type == PhysicalOperatorType::EXCHANGE_SINK) {
 		return false;
 	}
-	return !root_op.IsSink() || root_op.IsSource() || root_op.type == PhysicalOperatorType::CTE ||
-	       root_op.type == PhysicalOperatorType::RECURSIVE_CTE;
+	if (!root_op.IsSink() || root_op.IsSource()) {
+		return true;
+	}
+
+	// IsSink describes participation in a pipeline, not whether the root is a
+	// terminal consumer. Binary operators such as CROSS_PRODUCT sink their build
+	// side while producing rows from the probe pipeline. Their sources therefore
+	// come from below the root, whereas a terminal sink reports itself as its
+	// source. Use that pipeline topology instead of maintaining an operator-type
+	// allowlist that would need updating for every new build/probe operator.
+	for (const auto &source : root_op.GetSources()) {
+		if (&source.get() != &root_op) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static py::dict BuildNativeProgressTopology(duckdb::ClientContext &context,

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3823,6 +3823,87 @@ def test_ray_join(ray_runner, duckdb_conn, parquet_path):
     )
 
 
+def test_ray_cross_product_gathers_both_inputs(
+    ray_runner,
+    duckdb_conn,
+    parquet_path,
+    partitioned_parquet_path,
+):
+    label = "test_ray_e2e: cross product gathers both inputs"
+    sql = f"""
+        SELECT l.a AS left_a, r.a AS right_a
+        FROM (
+            SELECT a
+            FROM read_parquet('{partitioned_parquet_path}/*/*.parquet', hive_partitioning=1)
+            WHERE a < 3
+        ) AS l
+        CROSS JOIN (
+            SELECT a
+            FROM read_parquet('{parquet_path}')
+            WHERE a < 4
+        ) AS r
+    """
+
+    relation = duckdb_conn.sql(sql)
+    plan_text, num_parts = _get_distributed_plan_info(relation, label)
+    assert plan_text and "CROSS PRODUCT" in plan_text.upper(), (
+        f"{label}: expected distributed cross product:\n{plan_text}"
+    )
+    assert num_parts == 1, f"{label}: correctness fallback must gather to one partition, got {num_parts}"
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["CROSS_PRODUCT"],
+        timeout_s=60.0,
+    )
+
+
+def test_ray_cross_product_values(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: cross product values"
+    sql = """
+        SELECT l.value AS left_value, r.value AS right_value
+        FROM (VALUES (1), (2)) AS l(value)
+        CROSS JOIN (VALUES (3), (4)) AS r(value)
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["CROSS_PRODUCT"],
+        timeout_s=60.0,
+    )
+
+
+@pytest.mark.parametrize("empty_side", ["left", "right"])
+def test_ray_cross_product_empty_input(ray_runner, duckdb_conn, partitioned_parquet_path, empty_side):
+    label = f"test_ray_e2e: cross product empty {empty_side} input"
+    empty = f"""
+        SELECT a
+        FROM read_parquet('{partitioned_parquet_path}/*/*.parquet', hive_partitioning=1)
+        WHERE a < 0
+    """
+    non_empty = "SELECT value AS a FROM (VALUES (10), (20)) AS t(value)"
+    left_sql, right_sql = (empty, non_empty) if empty_side == "left" else (non_empty, empty)
+    sql = f"""
+        SELECT l.a AS left_a, r.a AS right_a
+        FROM ({left_sql}) AS l
+        CROSS JOIN ({right_sql}) AS r
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["CROSS_PRODUCT"],
+        timeout_s=60.0,
+    )
+
+
 def test_ray_join_multi_partition_plan(ray_runner, duckdb_conn, parquet_path):
     label = "test_ray_e2e: join multi-partition plan"
     sql = f"""

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -7580,6 +7580,37 @@ def test_execute_native_empty_result_returns_typed_contract():
     assert result.result_schema["types"] == ["BIGINT"]
 
 
+def test_execute_native_cross_product_root_materializes_probe_output():
+    con = vane.connect()
+    relation = con.sql(
+        """
+        SELECT *
+        FROM (VALUES (1), (2)) AS lhs(value)
+        CROSS JOIN (VALUES (3), (4)) AS rhs(value)
+        """
+    )
+    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(
+        relation,
+        str(uuid.uuid4()),
+    ).to_physical_plan(con)
+
+    topology = vane.ray_cxx.describe_native_progress(con.cursor(), plan)
+    assert any("RESULT_COLLECTOR" in pipeline["operators"] for pipeline in topology["pipelines"])
+
+    runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
+    result = runner.execute_native(con.cursor(), plan, None, None)
+
+    assert result.completion_status == "ok"
+    assert sum(metadata.num_rows for metadata in result.partition_metadatas) == 4
+    payload = list(result.partition_payloads)[0]
+    assert sorted(zip(payload.column(0).to_pylist(), payload.column(1).to_pylist(), strict=True)) == [
+        (1, 3),
+        (1, 4),
+        (2, 3),
+        (2, 4),
+    ]
+
+
 def test_describe_native_progress_materializes_deferred_clone_without_execution(tmp_path):
     import ray
 


### PR DESCRIPTION
## Summary

- Extract reusable binary-fragment input fan-in infrastructure and migrate HashJoin to use it.
- Translate `CROSS_PRODUCT` into a dedicated distributed node, gathering both inputs to one partition as a correctness-first baseline.
- Add `PhysicalCrossProduct` serialization and topology-aware result collection for build/probe operators.
- Cover serialization, child-plan ownership, asymmetric continuations, partitioned inputs, VALUES inputs, and empty inputs.

This implements the `CROSS_PRODUCT` half of #627. `POSITIONAL_JOIN` and `POSITIONAL_SCAN` remain unsupported and are intentionally outside this PR.

## Related issue

Refs #627

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

No public API or configuration changes are introduced.

## Validation

- `scripts/format workspace --changed --check`
- `clang-format --dry-run --Werror` on the four new C++ files
- `build/native-cxx20/test/unittest "[cross_product]"` — 5 test cases, 57 assertions
- `build/native-cxx20/test/unittest "[source_id]"` — 22 test cases, 146 assertions
- Targeted installed-wheel Ray E2E for `test_ray_cross_product_gathers_both_inputs`, `test_ray_cross_product_values`, both `test_ray_cross_product_empty_input` variants, `test_ray_join`, and `test_ray_fixed_row_reservoir_sample_preserves_hash_join_continuations` — 6 passed
- `scripts/run_release_tests.sh` — 811 non-Ray and 14 real-Ray tests passed
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.