### PR TITLE
[fix](ray) Support distributed non-equality joins

### DIFF
--- a/external/duckdb/src/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/src/execution/distributed/CMakeLists.txt
@@ -51,6 +51,7 @@ set(DISTRIBUTED_SOURCES_PIPELINE_NODE
     pipeline_node/join/cross_product.cpp
     pipeline_node/join/delim_join.cpp
     pipeline_node/join/hash_join.cpp
+    pipeline_node/join/nested_loop_join.cpp
     pipeline_node/limit.cpp
     pipeline_node/materialized_coordinator.cpp
     pipeline_node/translate.cpp

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/nested_loop_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/nested_loop_join.cpp
@@ -13,6 +13,10 @@
 #include "duckdb/execution/distributed/plan/runner.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
+#include "duckdb/execution/operator/projection/physical_projection.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/joinside.hpp"
 #include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 
@@ -37,18 +41,83 @@ PipelineNodeConfig MakeNestedLoopJoinConfig(const PlanConfig &plan_config, const
 	return PipelineNodeConfig(schema, plan_config.config, std::move(clustering));
 }
 
+void OffsetBoundReferenceIndices(Expression &expression, idx_t offset) {
+	if (expression.GetExpressionClass() == ExpressionClass::BOUND_REF) {
+		expression.Cast<BoundReferenceExpression>().index += offset;
+	}
+	ExpressionIterator::EnumerateChildren(expression,
+	                                      [&](Expression &child) { OffsetBoundReferenceIndices(child, offset); });
+}
+
+struct WorkerJoinProjection {
+	duckdb::vector<idx_t> column_indices;
+	duckdb::vector<LogicalType> types;
+};
+
+void AppendProjectedSide(WorkerJoinProjection &projection, const duckdb::vector<LogicalType> &child_types,
+                         const duckdb::vector<idx_t> &projection_map, idx_t output_offset) {
+	const auto count = projection_map.empty() ? child_types.size() : projection_map.size();
+	projection.column_indices.reserve(projection.column_indices.size() + count);
+	projection.types.reserve(projection.types.size() + count);
+	for (idx_t index = 0; index < count; index++) {
+		auto child_index = projection_map.empty() ? index : projection_map[index];
+		if (child_index >= child_types.size()) {
+			throw InvalidInputException("NestedLoopJoinNode projection column %llu is outside a %llu-column input",
+			                            child_index, child_types.size());
+		}
+		projection.column_indices.push_back(output_offset + child_index);
+		projection.types.push_back(child_types[child_index]);
+	}
+}
+
+WorkerJoinProjection BuildWorkerJoinProjection(JoinType join_type, const duckdb::vector<LogicalType> &left_types,
+                                               const duckdb::vector<LogicalType> &right_types,
+                                               const duckdb::vector<idx_t> &left_projection_map,
+                                               const duckdb::vector<idx_t> &right_projection_map) {
+	WorkerJoinProjection projection;
+	idx_t output_offset = 0;
+	if (JoinOutputsLeft(join_type)) {
+		AppendProjectedSide(projection, left_types, left_projection_map, output_offset);
+		output_offset += left_types.size();
+	}
+	if (JoinOutputsRight(join_type)) {
+		AppendProjectedSide(projection, right_types, right_projection_map, output_offset);
+		output_offset += right_types.size();
+	}
+	if (join_type == JoinType::MARK) {
+		projection.column_indices.push_back(output_offset);
+		projection.types.push_back(LogicalType::BOOLEAN);
+	}
+	return projection;
+}
+
+bool NeedsProjection(const WorkerJoinProjection &projection, idx_t full_output_count) {
+	if (projection.column_indices.size() != full_output_count) {
+		return true;
+	}
+	for (idx_t index = 0; index < projection.column_indices.size(); index++) {
+		if (projection.column_indices[index] != index) {
+			return true;
+		}
+	}
+	return false;
+}
+
 } // namespace
 
 NestedLoopJoinNode::NestedLoopJoinNode(NodeID node_id, const PlanConfig &plan_config, PhysicalOperatorType source_type,
                                        duckdb::vector<JoinCondition> conditions, unique_ptr<Expression> predicate,
                                        JoinType join_type, duckdb::vector<LogicalType> output_types,
                                        idx_t estimated_cardinality, std::shared_ptr<DistributedPipelineNode> left,
-                                       std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+                                       std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema,
+                                       duckdb::vector<idx_t> left_projection_map,
+                                       duckdb::vector<idx_t> right_projection_map)
     : config_(MakeNestedLoopJoinConfig(plan_config, schema, left, right)),
       context_(plan_config.query_idx, plan_config.query_id, node_id, "NestedLoopJoin"), source_type_(source_type),
       conditions_(std::move(conditions)), predicate_(std::move(predicate)), join_type_(join_type),
-      output_types_(std::move(output_types)), estimated_cardinality_(estimated_cardinality), left_(std::move(left)),
-      right_(std::move(right)) {
+      output_types_(std::move(output_types)), left_projection_map_(std::move(left_projection_map)),
+      right_projection_map_(std::move(right_projection_map)), estimated_cardinality_(estimated_cardinality),
+      left_(std::move(left)), right_(std::move(right)) {
 	if (source_type_ != PhysicalOperatorType::NESTED_LOOP_JOIN &&
 	    source_type_ != PhysicalOperatorType::PIECEWISE_MERGE_JOIN && source_type_ != PhysicalOperatorType::IE_JOIN) {
 		throw InvalidInputException("NestedLoopJoinNode cannot normalize operator type %s",
@@ -117,31 +186,65 @@ SubmittableTask<WorkerTask> NestedLoopJoinNode::BuildNestedLoopJoinTask(Submitta
 	auto &left_root = plan->Root();
 	auto &right_root = ClonePhysicalPlanRootIntoPlanOrThrow(right_plan_src, *plan, "build_nested_loop_join_task:right",
 	                                                        client_context);
+	auto full_output_types = BuildJoinOutputTypes(join_type_, left_root.GetTypes(), right_root.GetTypes());
 
 	if (source_type_ == PhysicalOperatorType::BLOCKWISE_NL_JOIN) {
 		LogicalAnyJoin dummy_join(join_type_);
-		dummy_join.types = output_types_;
+		dummy_join.types = full_output_types;
 		auto &join = plan->Make<PhysicalBlockwiseNLJoin>(
 		    dummy_join, left_root, right_root, arbitrary_condition_->Copy(), join_type_, estimated_cardinality_);
 		plan->SetRoot(join);
 	} else {
-		LogicalComparisonJoin dummy_join(join_type_);
-		dummy_join.types = output_types_;
-		dummy_join.predicate = predicate_ ? predicate_->Copy() : nullptr;
 		auto conditions = CopyConditions(conditions_);
-		auto &join = plan->Make<PhysicalNestedLoopJoin>(dummy_join, left_root, right_root, std::move(conditions),
-		                                                join_type_, estimated_cardinality_)
-		                 .Cast<PhysicalNestedLoopJoin>();
-		FixHashJoinConditionTypes(join.conditions, left_root.GetTypes(), right_root.GetTypes());
-		plan->SetRoot(join);
+		FixHashJoinConditionTypes(conditions, left_root.GetTypes(), right_root.GetTypes());
+		if (PhysicalNestedLoopJoin::IsSupported(conditions, join_type_)) {
+			LogicalComparisonJoin dummy_join(join_type_);
+			dummy_join.types = full_output_types;
+			dummy_join.predicate = predicate_ ? predicate_->Copy() : nullptr;
+			auto &join = plan->Make<PhysicalNestedLoopJoin>(dummy_join, left_root, right_root, std::move(conditions),
+			                                                join_type_, estimated_cardinality_);
+			plan->SetRoot(join);
+		} else {
+			if (predicate_) {
+				throw InternalException("NestedLoopJoinNode cannot combine an unsupported comparison type with a "
+				                        "separate join predicate");
+			}
+			for (auto &condition : conditions) {
+				if (condition.right) {
+					OffsetBoundReferenceIndices(*condition.right, left_root.GetTypes().size());
+				}
+			}
+			auto blockwise_condition = JoinCondition::CreateExpression(std::move(conditions));
+			LogicalAnyJoin dummy_join(join_type_);
+			dummy_join.types = full_output_types;
+			auto &join = plan->Make<PhysicalBlockwiseNLJoin>(
+			    dummy_join, left_root, right_root, std::move(blockwise_condition), join_type_, estimated_cardinality_);
+			plan->SetRoot(join);
+		}
 	}
 
-	auto child_derived_types = BuildJoinOutputTypes(join_type_, left_root.GetTypes(), right_root.GetTypes());
-	if (plan->Root().GetTypes() != child_derived_types) {
+	auto projection = BuildWorkerJoinProjection(join_type_, left_root.GetTypes(), right_root.GetTypes(),
+	                                            left_projection_map_, right_projection_map_);
+	if (projection.types != output_types_) {
 		throw InternalException(
-		    "NestedLoopJoinNode translated a %s join with an output schema that does not match its children "
-		    "(%llu translated columns, %llu child-derived columns)",
-		    EnumUtil::ToString(join_type_), plan->Root().GetTypes().size(), child_derived_types.size());
+		    "NestedLoopJoinNode translated a %s join with an output schema that does not match its projection "
+		    "(%llu translated columns, %llu projected columns)",
+		    EnumUtil::ToString(join_type_), output_types_.size(), projection.types.size());
+	}
+	if (NeedsProjection(projection, full_output_types.size())) {
+		duckdb::vector<unique_ptr<Expression>> select_list;
+		select_list.reserve(projection.column_indices.size());
+		for (idx_t index = 0; index < projection.column_indices.size(); index++) {
+			select_list.push_back(
+			    make_uniq<BoundReferenceExpression>(projection.types[index], projection.column_indices[index]));
+		}
+		auto &join_root = plan->Root();
+		auto &project = plan->Make<PhysicalProjection>(output_types_, std::move(select_list), estimated_cardinality_);
+		project.children.push_back(join_root);
+		plan->SetRoot(project);
+	}
+	if (plan->Root().GetTypes() != output_types_) {
+		throw InternalException("NestedLoopJoinNode worker plan output does not match the translated schema");
 	}
 
 	TaskContext task_context = TaskContext::from_node_context(context_.query_idx(), node_id(), task_id_counter.next());

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/nested_loop_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/nested_loop_join.cpp
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp"
+
+#include <algorithm>
+
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
+#include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
+#include "duckdb/planner/operator/logical_any_join.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+namespace {
+
+PipelineNodeConfig MakeNestedLoopJoinConfig(const PlanConfig &plan_config, const SchemaRef &schema,
+                                            const std::shared_ptr<DistributedPipelineNode> &left,
+                                            const std::shared_ptr<DistributedPipelineNode> &right) {
+	size_t num_partitions = 1;
+	if (left && right) {
+		num_partitions = std::max(left->config().clustering_spec()->num_partitions(),
+		                          right->config().clustering_spec()->num_partitions());
+	} else if (left) {
+		num_partitions = left->config().clustering_spec()->num_partitions();
+	} else if (right) {
+		num_partitions = right->config().clustering_spec()->num_partitions();
+	}
+	auto clustering = ClusteringSpec::unknown_with_num_partitions(num_partitions);
+	return PipelineNodeConfig(schema, plan_config.config, std::move(clustering));
+}
+
+} // namespace
+
+NestedLoopJoinNode::NestedLoopJoinNode(NodeID node_id, const PlanConfig &plan_config, PhysicalOperatorType source_type,
+                                       duckdb::vector<JoinCondition> conditions, unique_ptr<Expression> predicate,
+                                       JoinType join_type, duckdb::vector<LogicalType> output_types,
+                                       idx_t estimated_cardinality, std::shared_ptr<DistributedPipelineNode> left,
+                                       std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+    : config_(MakeNestedLoopJoinConfig(plan_config, schema, left, right)),
+      context_(plan_config.query_idx, plan_config.query_id, node_id, "NestedLoopJoin"), source_type_(source_type),
+      conditions_(std::move(conditions)), predicate_(std::move(predicate)), join_type_(join_type),
+      output_types_(std::move(output_types)), estimated_cardinality_(estimated_cardinality), left_(std::move(left)),
+      right_(std::move(right)) {
+	if (source_type_ != PhysicalOperatorType::NESTED_LOOP_JOIN &&
+	    source_type_ != PhysicalOperatorType::PIECEWISE_MERGE_JOIN && source_type_ != PhysicalOperatorType::IE_JOIN) {
+		throw InvalidInputException("NestedLoopJoinNode cannot normalize operator type %s",
+		                            EnumUtil::ToString(source_type_));
+	}
+}
+
+NestedLoopJoinNode::NestedLoopJoinNode(NodeID node_id, const PlanConfig &plan_config, unique_ptr<Expression> condition,
+                                       JoinType join_type, duckdb::vector<LogicalType> output_types,
+                                       idx_t estimated_cardinality, std::shared_ptr<DistributedPipelineNode> left,
+                                       std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+    : config_(MakeNestedLoopJoinConfig(plan_config, schema, left, right)),
+      context_(plan_config.query_idx, plan_config.query_id, node_id, "BlockwiseNLJoin"),
+      source_type_(PhysicalOperatorType::BLOCKWISE_NL_JOIN), arbitrary_condition_(std::move(condition)),
+      join_type_(join_type), output_types_(std::move(output_types)), estimated_cardinality_(estimated_cardinality),
+      left_(std::move(left)), right_(std::move(right)) {
+	if (!arbitrary_condition_) {
+		throw InvalidInputException("NestedLoopJoinNode requires a blockwise join condition");
+	}
+}
+
+std::vector<PipelineNodeRef> NestedLoopJoinNode::children() const {
+	std::vector<PipelineNodeRef> result;
+	if (left_) {
+		result.push_back(left_->inner());
+	}
+	if (right_) {
+		result.push_back(right_->inner());
+	}
+	return result;
+}
+
+std::vector<std::string> NestedLoopJoinNode::multiline_display(bool /*verbose*/) const {
+	return {"Nested Loop Join", "Source operator: " + EnumUtil::ToString(source_type_),
+	        "Join type: " + EnumUtil::ToString(join_type_)};
+}
+
+duckdb::vector<JoinCondition> NestedLoopJoinNode::CopyConditions(const duckdb::vector<JoinCondition> &conditions) {
+	duckdb::vector<JoinCondition> result;
+	result.reserve(conditions.size());
+	for (const auto &condition : conditions) {
+		JoinCondition copy;
+		copy.comparison = condition.comparison;
+		if (condition.left) {
+			copy.left = condition.left->Copy();
+		}
+		if (condition.right) {
+			copy.right = condition.right->Copy();
+		}
+		result.push_back(std::move(copy));
+	}
+	return result;
+}
+
+SubmittableTask<WorkerTask> NestedLoopJoinNode::BuildNestedLoopJoinTask(SubmittableTask<WorkerTask> left_task,
+                                                                        SubmittableTask<WorkerTask> right_task,
+                                                                        TaskIDCounter &task_id_counter,
+                                                                        ClientContext *client_context) {
+	auto left_plan_src = left_task.task()->plan();
+	auto right_plan_src = right_task.task()->plan();
+	if (!left_plan_src || !left_plan_src->HasRoot() || !right_plan_src || !right_plan_src->HasRoot()) {
+		throw InvalidInputException("NestedLoopJoinNode cannot build task from input without a physical plan root");
+	}
+
+	auto plan = ClonePhysicalPlanOrThrow(left_plan_src, "build_nested_loop_join_task:left", client_context);
+	auto &left_root = plan->Root();
+	auto &right_root = ClonePhysicalPlanRootIntoPlanOrThrow(right_plan_src, *plan, "build_nested_loop_join_task:right",
+	                                                        client_context);
+
+	if (source_type_ == PhysicalOperatorType::BLOCKWISE_NL_JOIN) {
+		LogicalAnyJoin dummy_join(join_type_);
+		dummy_join.types = output_types_;
+		auto &join = plan->Make<PhysicalBlockwiseNLJoin>(
+		    dummy_join, left_root, right_root, arbitrary_condition_->Copy(), join_type_, estimated_cardinality_);
+		plan->SetRoot(join);
+	} else {
+		LogicalComparisonJoin dummy_join(join_type_);
+		dummy_join.types = output_types_;
+		dummy_join.predicate = predicate_ ? predicate_->Copy() : nullptr;
+		auto conditions = CopyConditions(conditions_);
+		auto &join = plan->Make<PhysicalNestedLoopJoin>(dummy_join, left_root, right_root, std::move(conditions),
+		                                                join_type_, estimated_cardinality_)
+		                 .Cast<PhysicalNestedLoopJoin>();
+		FixHashJoinConditionTypes(join.conditions, left_root.GetTypes(), right_root.GetTypes());
+		plan->SetRoot(join);
+	}
+
+	auto child_derived_types = BuildJoinOutputTypes(join_type_, left_root.GetTypes(), right_root.GetTypes());
+	if (plan->Root().GetTypes() != child_derived_types) {
+		throw InternalException(
+		    "NestedLoopJoinNode translated a %s join with an output schema that does not match its children "
+		    "(%llu translated columns, %llu child-derived columns)",
+		    EnumUtil::ToString(join_type_), plan->Root().GetTypes().size(), child_derived_types.size());
+	}
+
+	TaskContext task_context = TaskContext::from_node_context(context_.query_idx(), node_id(), task_id_counter.next());
+	auto merged_context = MergeTaskContext(left_task.task()->context(), right_task.task()->context());
+	merged_context = MergeTaskContext(merged_context, context_.to_hashmap());
+	WorkerTask new_task(task_context, plan, left_task.task()->config(), std::move(merged_context), "WorkerTask");
+	auto &inputs = new_task.mutable_inputs();
+	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs(), context_.node_name());
+	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs(), context_.node_name());
+	return std::move(left_task).with_new_task(std::move(new_task));
+}
+
+SubmittableTaskStream<WorkerTask> NestedLoopJoinNode::produce_tasks(PlanExecutionContext &plan_context) {
+	if (!left_ || !right_) {
+		return SubmittableTaskStream<WorkerTask>::from_receiver(Receiver<SubmittableTask<WorkerTask>>());
+	}
+
+	auto left_input = left_->produce_tasks(plan_context);
+	auto right_input = right_->produce_tasks(plan_context);
+	auto task_id_counter = std::make_shared<TaskIDCounter>(plan_context.task_id_counter());
+	auto *client_context = plan_context.client_context();
+	auto self_shared = shared_from_this();
+	BinaryInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
+	                                               client_context](BinarySubmittableTask left_task,
+	                                                               BinarySubmittableTask right_task) mutable {
+		return self_shared->BuildNestedLoopJoinTask(std::move(left_task), std::move(right_task), *task_id_counter,
+		                                            client_context);
+	};
+
+	BinaryFragmentInputFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
+	                                      task_id_counter, context_.query_idx(), node_id(), context_.node_name());
+	return SubmittableTaskStream<WorkerTask>(boxed<BinarySubmittableTask>(std::move(stream)));
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -42,8 +42,10 @@
 #include "duckdb/execution/operator/helper/physical_streaming_sample.hpp"
 #include "duckdb/execution/operator/helper/physical_data_sink.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
+#include "duckdb/execution/operator/join/physical_range_join.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
 #include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp"
@@ -378,6 +380,17 @@ void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOpera
 	case PhysicalOperatorType::CROSS_PRODUCT: {
 		auto &cross_product = static_cast<PhysicalCrossProduct &>(op);
 		node_impl = TranslateCrossProduct(cross_product, children);
+		break;
+	}
+	case PhysicalOperatorType::PIECEWISE_MERGE_JOIN:
+	case PhysicalOperatorType::IE_JOIN: {
+		auto &range_join = static_cast<PhysicalRangeJoin &>(op);
+		node_impl = TranslateRangeJoin(range_join, children);
+		break;
+	}
+	case PhysicalOperatorType::BLOCKWISE_NL_JOIN: {
+		auto &blockwise_join = static_cast<PhysicalBlockwiseNLJoin &>(op);
+		node_impl = TranslateBlockwiseNLJoin(blockwise_join, children);
 		break;
 	}
 	case PhysicalOperatorType::LEFT_DELIM_JOIN:

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -16,13 +16,14 @@
 #include "duckdb/execution/distributed/pipeline_node/join/delim_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/utils/optional.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
-#include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -79,6 +80,30 @@ duckdb::vector<std::string> BuildCrossProductOutputNames(const SchemaRef &left_s
 	auto output_names = duckdb::distributed::GetSchemaNames(left_schema);
 	auto right_names = duckdb::distributed::GetSchemaNames(right_schema);
 	output_names.insert(output_names.end(), right_names.begin(), right_names.end());
+	if (output_names.size() != output_count) {
+		return {};
+	}
+	return output_names;
+}
+
+duckdb::vector<std::string> BuildComparisonJoinOutputNames(JoinType join_type, const SchemaRef &left_schema,
+                                                           const SchemaRef &right_schema, idx_t output_count) {
+	if (!left_schema || !right_schema) {
+		return {};
+	}
+
+	duckdb::vector<std::string> output_names;
+	if (JoinOutputsLeft(join_type)) {
+		auto left_names = duckdb::distributed::GetSchemaNames(left_schema);
+		output_names.insert(output_names.end(), left_names.begin(), left_names.end());
+	}
+	if (JoinOutputsRight(join_type)) {
+		auto right_names = duckdb::distributed::GetSchemaNames(right_schema);
+		output_names.insert(output_names.end(), right_names.begin(), right_names.end());
+	}
+	if (join_type == JoinType::MARK) {
+		output_names.push_back("mark");
+	}
 	if (output_names.size() != output_count) {
 		return {};
 	}
@@ -433,80 +458,60 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateNestedLoopJoin(
     const PhysicalNestedLoopJoin &nlj, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
-	DistributedPipelineNodeRef left_node = nullptr;
-	DistributedPipelineNodeRef right_node = nullptr;
-	if (children.size() > 0) {
-		left_node = children[0];
-	}
-	if (children.size() > 1) {
-		right_node = children[1];
-	}
+	return TranslateComparisonNestedLoopJoin(nlj, nlj.predicate.get(), children);
+}
 
-	auto conditions = CopyJoinConditions(nlj.conditions);
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateRangeJoin(
+    const PhysicalComparisonJoin &range_join, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	return TranslateComparisonNestedLoopJoin(range_join, nullptr, children);
+}
+
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateComparisonNestedLoopJoin(
+    const PhysicalComparisonJoin &join, const Expression *predicate,
+    const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	if (children.size() != 2 || !children[0] || !children[1]) {
+		throw InvalidInputException("Distributed %s requires exactly two input nodes", EnumUtil::ToString(join.type));
+	}
 
 	SchemaRef schema = nullptr;
-	if (!nlj.GetTypes().empty()) {
-		schema = MakeSchemaRef(nlj.GetTypes());
+	if (!join.GetTypes().empty()) {
+		auto output_names = BuildComparisonJoinOutputNames(join.join_type, children[0]->config().schema(),
+		                                                   children[1]->config().schema(), join.GetTypes().size());
+		schema = output_names.empty() ? MakeSchemaRef(join.GetTypes()) : MakeSchemaRef(join.GetTypes(), output_names);
 	}
 
-	auto &lhs_input_types = nlj.children[0].get().GetTypes();
-	auto &rhs_input_types = nlj.children[1].get().GetTypes();
+	// Correctness baseline for non-equality joins: every potentially matching
+	// row pair must reach the same worker. Keeping this policy in translation
+	// leaves the task fan-in reusable for a future range-partition strategy.
+	auto left = gen_gather_node(children[0]);
+	auto right = gen_gather_node(children[1]);
+	return std::make_shared<NestedLoopJoinNode>(
+	    get_next_pipeline_node_id(), plan_config_, join.type, CopyJoinConditions(join.conditions),
+	    predicate ? predicate->Copy() : nullptr, join.join_type, join.GetTypes(), join.estimated_cardinality,
+	    std::move(left), std::move(right), std::move(schema));
+}
 
-	duckdb::vector<LogicalType> condition_types;
-	unordered_map<idx_t, idx_t> build_columns_in_conditions;
-	for (idx_t cond_idx = 0; cond_idx < conditions.size(); cond_idx++) {
-		auto &condition = conditions[cond_idx];
-		condition_types.push_back(condition.left->return_type);
-		if (condition.right->GetExpressionClass() == ExpressionClass::BOUND_REF) {
-			build_columns_in_conditions.emplace(condition.right->Cast<BoundReferenceExpression>().index, cond_idx);
-		}
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateBlockwiseNLJoin(
+    const PhysicalBlockwiseNLJoin &join, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	if (children.size() != 2 || !children[0] || !children[1]) {
+		throw InvalidInputException("Distributed blockwise nested-loop join requires exactly two input nodes");
+	}
+	if (!join.condition) {
+		throw InvalidInputException("Distributed blockwise nested-loop join requires a condition");
 	}
 
-	PhysicalHashJoin::JoinProjectionColumns lhs_output_columns;
-	lhs_output_columns.col_idxs.reserve(lhs_input_types.size());
-	for (idx_t i = 0; i < lhs_input_types.size(); i++) {
-		lhs_output_columns.col_idxs.push_back(i);
-		lhs_output_columns.col_types.push_back(lhs_input_types[i]);
+	SchemaRef schema = nullptr;
+	if (!join.GetTypes().empty()) {
+		auto output_names = BuildComparisonJoinOutputNames(join.join_type, children[0]->config().schema(),
+		                                                   children[1]->config().schema(), join.GetTypes().size());
+		schema = output_names.empty() ? MakeSchemaRef(join.GetTypes()) : MakeSchemaRef(join.GetTypes(), output_names);
 	}
 
-	PhysicalHashJoin::JoinProjectionColumns payload_columns;
-	PhysicalHashJoin::JoinProjectionColumns rhs_output_columns;
-
-	if (JoinOutputsRight(nlj.join_type)) {
-		for (idx_t rhs_col = 0; rhs_col < rhs_input_types.size(); rhs_col++) {
-			auto &rhs_col_type = rhs_input_types[rhs_col];
-			auto it = build_columns_in_conditions.find(rhs_col);
-			if (it == build_columns_in_conditions.end()) {
-				payload_columns.col_idxs.push_back(rhs_col);
-				payload_columns.col_types.push_back(rhs_col_type);
-				rhs_output_columns.col_idxs.push_back(condition_types.size() + payload_columns.col_types.size() - 1);
-			} else {
-				rhs_output_columns.col_idxs.push_back(it->second);
-			}
-			rhs_output_columns.col_types.push_back(rhs_col_type);
-		}
-	}
-
-	DistributedPipelineNodeRef join_left = left_node;
-	DistributedPipelineNodeRef join_right = right_node;
-	bool needs_nlj_gather = (plan_config_.num_partitions > 1);
-	if (!needs_nlj_gather && left_node && right_node) {
-		size_t left_parts = left_node->config().clustering_spec()->num_partitions();
-		size_t right_parts = right_node->config().clustering_spec()->num_partitions();
-		if (left_parts > 1 || right_parts > 1) {
-			needs_nlj_gather = true;
-		}
-	}
-	if (needs_nlj_gather && left_node && right_node) {
-		join_left = gen_gather_node(left_node);
-		join_right = gen_gather_node(right_node);
-	}
-
-	return std::make_shared<HashJoinNode>(get_next_pipeline_node_id(), plan_config_, std::move(conditions),
-	                                      nlj.join_type, nlj.GetTypes(), duckdb::vector<LogicalType> {},
-	                                      condition_types, payload_columns, lhs_output_columns, rhs_output_columns,
-	                                      duckdb::vector<unique_ptr<BaseStatistics>> {}, nullptr,
-	                                      nlj.estimated_cardinality, join_left, join_right, schema);
+	auto left = gen_gather_node(children[0]);
+	auto right = gen_gather_node(children[1]);
+	return std::make_shared<NestedLoopJoinNode>(get_next_pipeline_node_id(), plan_config_, join.condition->Copy(),
+	                                            join.join_type, join.GetTypes(), join.estimated_cardinality,
+	                                            std::move(left), std::move(right), std::move(schema));
 }
 
 } // namespace distributed

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -24,6 +24,7 @@
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
+#include "duckdb/execution/operator/join/physical_range_join.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -87,24 +88,39 @@ duckdb::vector<std::string> BuildCrossProductOutputNames(const SchemaRef &left_s
 }
 
 duckdb::vector<std::string> BuildComparisonJoinOutputNames(JoinType join_type, const SchemaRef &left_schema,
-                                                           const SchemaRef &right_schema, idx_t output_count) {
+                                                           const SchemaRef &right_schema, idx_t output_count,
+                                                           const duckdb::vector<idx_t> &left_projection_map = {},
+                                                           const duckdb::vector<idx_t> &right_projection_map = {}) {
 	if (!left_schema || !right_schema) {
 		return {};
 	}
 
 	duckdb::vector<std::string> output_names;
+	bool names_valid = true;
+	auto append_names = [&](const SchemaRef &schema, const duckdb::vector<idx_t> &projection_map) {
+		auto names = duckdb::distributed::GetSchemaNames(schema);
+		if (projection_map.empty()) {
+			output_names.insert(output_names.end(), names.begin(), names.end());
+			return;
+		}
+		for (auto index : projection_map) {
+			if (index >= names.size()) {
+				names_valid = false;
+				return;
+			}
+			output_names.push_back(names[index]);
+		}
+	};
 	if (JoinOutputsLeft(join_type)) {
-		auto left_names = duckdb::distributed::GetSchemaNames(left_schema);
-		output_names.insert(output_names.end(), left_names.begin(), left_names.end());
+		append_names(left_schema, left_projection_map);
 	}
 	if (JoinOutputsRight(join_type)) {
-		auto right_names = duckdb::distributed::GetSchemaNames(right_schema);
-		output_names.insert(output_names.end(), right_names.begin(), right_names.end());
+		append_names(right_schema, right_projection_map);
 	}
 	if (join_type == JoinType::MARK) {
 		output_names.push_back("mark");
 	}
-	if (output_names.size() != output_count) {
+	if (!names_valid || output_names.size() != output_count) {
 		return {};
 	}
 	return output_names;
@@ -462,13 +478,15 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateRangeJoin(
-    const PhysicalComparisonJoin &range_join, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
-	return TranslateComparisonNestedLoopJoin(range_join, nullptr, children);
+    const PhysicalRangeJoin &range_join, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	return TranslateComparisonNestedLoopJoin(range_join, nullptr, children, range_join.left_projection_map,
+	                                         range_join.right_projection_map);
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateComparisonNestedLoopJoin(
     const PhysicalComparisonJoin &join, const Expression *predicate,
-    const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+    const std::vector<std::shared_ptr<DistributedPipelineNode>> &children, duckdb::vector<idx_t> left_projection_map,
+    duckdb::vector<idx_t> right_projection_map) {
 	if (children.size() != 2 || !children[0] || !children[1]) {
 		throw InvalidInputException("Distributed %s requires exactly two input nodes", EnumUtil::ToString(join.type));
 	}
@@ -476,7 +494,8 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 	SchemaRef schema = nullptr;
 	if (!join.GetTypes().empty()) {
 		auto output_names = BuildComparisonJoinOutputNames(join.join_type, children[0]->config().schema(),
-		                                                   children[1]->config().schema(), join.GetTypes().size());
+		                                                   children[1]->config().schema(), join.GetTypes().size(),
+		                                                   left_projection_map, right_projection_map);
 		schema = output_names.empty() ? MakeSchemaRef(join.GetTypes()) : MakeSchemaRef(join.GetTypes(), output_names);
 	}
 
@@ -488,7 +507,8 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 	return std::make_shared<NestedLoopJoinNode>(
 	    get_next_pipeline_node_id(), plan_config_, join.type, CopyJoinConditions(join.conditions),
 	    predicate ? predicate->Copy() : nullptr, join.join_type, join.GetTypes(), join.estimated_cardinality,
-	    std::move(left), std::move(right), std::move(schema));
+	    std::move(left), std::move(right), std::move(schema), std::move(left_projection_map),
+	    std::move(right_projection_map));
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateBlockwiseNLJoin(

--- a/external/duckdb/src/execution/operator/join/physical_blockwise_nl_join.cpp
+++ b/external/duckdb/src/execution/operator/join/physical_blockwise_nl_join.cpp
@@ -1,12 +1,13 @@
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/execution/operator/join/outer_join_marker.hpp"
 #include "duckdb/execution/operator/join/physical_comparison_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
-#include "duckdb/common/enum_util.hpp"
 
 namespace duckdb {
 
@@ -14,13 +15,24 @@ PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(PhysicalPlan &physical_plan, Lo
                                                  PhysicalOperator &left, PhysicalOperator &right,
                                                  unique_ptr<Expression> condition, JoinType join_type,
                                                  idx_t estimated_cardinality)
-    : PhysicalJoin(physical_plan, op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality),
-      condition(std::move(condition)) {
+    : PhysicalBlockwiseNLJoin(physical_plan, op, std::move(condition), join_type, estimated_cardinality, true) {
 	children.push_back(left);
 	children.push_back(right);
+}
+
+PhysicalBlockwiseNLJoin::PhysicalBlockwiseNLJoin(PhysicalPlan &physical_plan, LogicalOperator &op,
+                                                 unique_ptr<Expression> condition, JoinType join_type,
+                                                 idx_t estimated_cardinality, bool /*skip_child_init*/)
+    : PhysicalJoin(physical_plan, op, PhysicalOperatorType::BLOCKWISE_NL_JOIN, join_type, estimated_cardinality),
+      condition(std::move(condition)) {
 	// MARK and SINGLE joins not handled
 	D_ASSERT(join_type != JoinType::MARK);
 	D_ASSERT(join_type != JoinType::SINGLE);
+}
+
+void PhysicalBlockwiseNLJoin::SerializeOperatorData(Serializer &serializer) const {
+	serializer.WriteProperty(103, "join_type", join_type);
+	serializer.WriteProperty(104, "condition", condition);
 }
 
 //===--------------------------------------------------------------------===//

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -52,11 +52,13 @@
 #include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/execution/operator/join/physical_left_delim_join.hpp"
 #include "duckdb/execution/operator/join/physical_right_delim_join.hpp"
+#include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/function/function_serialization.hpp"
 #include "duckdb/catalog/catalog_entry/copy_function_catalog_entry.hpp"
@@ -1056,6 +1058,18 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 	case PhysicalOperatorType::CROSS_PRODUCT: {
 		return make_uniq<PhysicalCrossProduct>(physical_plan, CrossProductDeserializeTag {}, std::move(types),
 		                                       estimated_cardinality);
+	}
+	case PhysicalOperatorType::BLOCKWISE_NL_JOIN: {
+		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");
+		auto condition = deserializer.ReadProperty<unique_ptr<Expression>>(104, "condition");
+		if (!condition) {
+			throw SerializationException("PhysicalBlockwiseNLJoin deserialization requires a condition");
+		}
+
+		LogicalAnyJoin dummy_join(join_type);
+		dummy_join.types = std::move(types);
+		return make_uniq<PhysicalBlockwiseNLJoin>(physical_plan, dummy_join, std::move(condition), join_type,
+		                                          estimated_cardinality, true);
 	}
 	case PhysicalOperatorType::HASH_JOIN: {
 		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/plan/plan_config.hpp"
+#include "duckdb/execution/operator/join/physical_comparison_join.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class TaskIDCounter;
+
+//! Executes comparison and arbitrary-expression joins with a correctness-first
+//! nested-loop strategy after their inputs have been co-located.
+class NestedLoopJoinNode : public PipelineNodeImpl, public std::enable_shared_from_this<NestedLoopJoinNode> {
+public:
+	NestedLoopJoinNode(NodeID node_id, const PlanConfig &plan_config, PhysicalOperatorType source_type,
+	                   duckdb::vector<JoinCondition> conditions, unique_ptr<Expression> predicate, JoinType join_type,
+	                   duckdb::vector<LogicalType> output_types, idx_t estimated_cardinality,
+	                   std::shared_ptr<DistributedPipelineNode> left, std::shared_ptr<DistributedPipelineNode> right,
+	                   SchemaRef schema);
+
+	NestedLoopJoinNode(NodeID node_id, const PlanConfig &plan_config, unique_ptr<Expression> condition,
+	                   JoinType join_type, duckdb::vector<LogicalType> output_types, idx_t estimated_cardinality,
+	                   std::shared_ptr<DistributedPipelineNode> left, std::shared_ptr<DistributedPipelineNode> right,
+	                   SchemaRef schema);
+
+	const PipelineNodeContext &context() const override {
+		return context_;
+	}
+
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override;
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
+	std::vector<std::string> multiline_display(bool verbose) const override;
+
+private:
+	static duckdb::vector<JoinCondition> CopyConditions(const duckdb::vector<JoinCondition> &conditions);
+
+	SubmittableTask<WorkerTask> BuildNestedLoopJoinTask(SubmittableTask<WorkerTask> left_task,
+	                                                    SubmittableTask<WorkerTask> right_task,
+	                                                    TaskIDCounter &task_id_counter,
+	                                                    ::duckdb::ClientContext *client_context);
+
+private:
+	PipelineNodeConfig config_;
+	PipelineNodeContext context_;
+	PhysicalOperatorType source_type_;
+	duckdb::vector<JoinCondition> conditions_;
+	unique_ptr<Expression> predicate_;
+	unique_ptr<Expression> arbitrary_condition_;
+	JoinType join_type_;
+	duckdb::vector<LogicalType> output_types_;
+	idx_t estimated_cardinality_;
+	std::shared_ptr<DistributedPipelineNode> left_;
+	std::shared_ptr<DistributedPipelineNode> right_;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp
@@ -25,7 +25,8 @@ public:
 	                   duckdb::vector<JoinCondition> conditions, unique_ptr<Expression> predicate, JoinType join_type,
 	                   duckdb::vector<LogicalType> output_types, idx_t estimated_cardinality,
 	                   std::shared_ptr<DistributedPipelineNode> left, std::shared_ptr<DistributedPipelineNode> right,
-	                   SchemaRef schema);
+	                   SchemaRef schema, duckdb::vector<idx_t> left_projection_map = {},
+	                   duckdb::vector<idx_t> right_projection_map = {});
 
 	NestedLoopJoinNode(NodeID node_id, const PlanConfig &plan_config, unique_ptr<Expression> condition,
 	                   JoinType join_type, duckdb::vector<LogicalType> output_types, idx_t estimated_cardinality,
@@ -61,6 +62,8 @@ private:
 	unique_ptr<Expression> arbitrary_condition_;
 	JoinType join_type_;
 	duckdb::vector<LogicalType> output_types_;
+	duckdb::vector<idx_t> left_projection_map_;
+	duckdb::vector<idx_t> right_projection_map_;
 	idx_t estimated_cardinality_;
 	std::shared_ptr<DistributedPipelineNode> left_;
 	std::shared_ptr<DistributedPipelineNode> right_;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -26,6 +26,7 @@ class PhysicalHashJoin;
 class PhysicalComparisonJoin;
 class PhysicalBlockwiseNLJoin;
 class PhysicalNestedLoopJoin;
+class PhysicalRangeJoin;
 class PhysicalHashAggregate;
 class PhysicalColumnDataScan;
 class PhysicalDummyScan;
@@ -153,7 +154,7 @@ private:
 	                        const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
 
 	std::shared_ptr<PipelineNodeImpl>
-	TranslateRangeJoin(const PhysicalComparisonJoin &op,
+	TranslateRangeJoin(const PhysicalRangeJoin &op,
 	                   const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
 
 	std::shared_ptr<PipelineNodeImpl>
@@ -162,7 +163,9 @@ private:
 
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateComparisonNestedLoopJoin(const PhysicalComparisonJoin &op, const Expression *predicate,
-	                                  const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+	                                  const std::vector<std::shared_ptr<DistributedPipelineNode>> &children,
+	                                  duckdb::vector<idx_t> left_projection_map = {},
+	                                  duckdb::vector<idx_t> right_projection_map = {});
 
 	std::shared_ptr<DistributedPipelineNode>
 	TranslateHashGroupBy(const PhysicalHashAggregate &op,

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -14,6 +14,7 @@
 #include "duckdb/execution/distributed/pipeline_node/aggregate.hpp"
 
 namespace duckdb {
+class Expression;
 class RepartitionSpec;
 class PhysicalBatchCopyToFile;
 class PhysicalCopyToFile;
@@ -22,6 +23,8 @@ class PhysicalDataSink;
 class PhysicalOperator;
 class PhysicalDelimJoin;
 class PhysicalHashJoin;
+class PhysicalComparisonJoin;
+class PhysicalBlockwiseNLJoin;
 class PhysicalNestedLoopJoin;
 class PhysicalHashAggregate;
 class PhysicalColumnDataScan;
@@ -148,6 +151,18 @@ private:
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateNestedLoopJoin(const PhysicalNestedLoopJoin &op,
 	                        const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslateRangeJoin(const PhysicalComparisonJoin &op,
+	                   const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslateBlockwiseNLJoin(const PhysicalBlockwiseNLJoin &op,
+	                         const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslateComparisonNestedLoopJoin(const PhysicalComparisonJoin &op, const Expression *predicate,
+	                                  const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
 
 	std::shared_ptr<DistributedPipelineNode>
 	TranslateHashGroupBy(const PhysicalHashAggregate &op,

--- a/external/duckdb/src/include/duckdb/execution/operator/join/physical_blockwise_nl_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/join/physical_blockwise_nl_join.hpp
@@ -23,8 +23,14 @@ public:
 	PhysicalBlockwiseNLJoin(PhysicalPlan &physical_plan, LogicalOperator &op, PhysicalOperator &left,
 	                        PhysicalOperator &right, unique_ptr<Expression> condition, JoinType join_type,
 	                        idx_t estimated_cardinality);
+	//! Constructor for deserialization (children added later)
+	PhysicalBlockwiseNLJoin(PhysicalPlan &physical_plan, LogicalOperator &op, unique_ptr<Expression> condition,
+	                        JoinType join_type, idx_t estimated_cardinality, bool skip_child_init);
 
 	unique_ptr<Expression> condition;
+
+	//! Serialization
+	void SerializeOperatorData(Serializer &serializer) const override;
 
 public:
 	// Operator Interface

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -31,6 +31,7 @@
 #include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
@@ -52,6 +53,7 @@
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/operator/logical_any_join.hpp"
 #include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/common/enums/order_type.hpp"
@@ -1116,6 +1118,48 @@ TEST_CASE("PhysicalCrossProduct serialization roundtrip", "[serialization][physi
 	REQUIRE(root->children.size() == 2);
 	REQUIRE(root->children[0].get().GetTypes() == left_types);
 	REQUIRE(root->children[1].get().GetTypes() == right_types);
+}
+
+TEST_CASE("PhysicalBlockwiseNLJoin serialization roundtrip", "[serialization][physical_plan][join]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	vector<LogicalType> input_types = {LogicalType::BIGINT};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+
+	auto &left = MakeColumnDataScan(plan, input_types);
+	auto &right = MakeColumnDataScan(plan, input_types);
+	auto condition = make_uniq<BoundComparisonExpression>(ExpressionType::COMPARE_LESSTHAN,
+	                                                      make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0),
+	                                                      make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1));
+	LogicalAnyJoin logical_join(JoinType::INNER);
+	logical_join.types = output_types;
+	auto &join =
+	    plan.Make<PhysicalBlockwiseNLJoin>(logical_join, left, right, std::move(condition), JoinType::INNER, 12);
+	plan.SetRoot(join);
+
+	MemoryStream stream(allocator);
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	plan.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	PhysicalPlan deserialized_plan(allocator);
+	deserializer.Begin();
+	auto root = deserialized_plan.Deserialize(deserializer);
+	deserializer.End();
+
+	REQUIRE(root != nullptr);
+	auto *roundtrip = dynamic_cast<PhysicalBlockwiseNLJoin *>(root.get());
+	REQUIRE(roundtrip != nullptr);
+	REQUIRE(roundtrip->join_type == JoinType::INNER);
+	REQUIRE(roundtrip->condition != nullptr);
+	REQUIRE(roundtrip->GetTypes() == output_types);
+	REQUIRE(roundtrip->estimated_cardinality == 12);
+	REQUIRE(roundtrip->children.size() == 2);
+	REQUIRE(roundtrip->children[0].get().GetTypes() == input_types);
+	REQUIRE(roundtrip->children[1].get().GetTypes() == input_types);
 }
 
 TEST_CASE("PhysicalHashJoin serialization roundtrip", "[serialization][physical_plan]") {

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -88,6 +88,16 @@ static DuckPhysicalPlanRef MakeScanPlanWithRoot() {
 	return plan;
 }
 
+static DuckPhysicalPlanRef MakeEmptyScanPlanWithRoot(const vector<LogicalType> &types) {
+	Allocator &alloc = Allocator::DefaultAllocator();
+	auto plan = std::make_shared<PhysicalPlan>(alloc);
+	auto collection = make_uniq<ColumnDataCollection>(alloc, types);
+	auto &scan =
+	    plan->Make<PhysicalColumnDataScan>(types, PhysicalOperatorType::COLUMN_DATA_SCAN, 0, std::move(collection));
+	plan->SetRoot(scan);
+	return plan;
+}
+
 static JoinCondition MakeJoinCondition(ExpressionType comparison, idx_t left_index = 0, idx_t right_index = 0) {
 	JoinCondition condition;
 	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, left_index);
@@ -117,6 +127,16 @@ static WorkerTask MakeWorkerTaskWithInput(NodeID node_id, const std::string &nod
                                           const std::string &input_bytes) {
 	WorkerTask task(TaskContext::from_node_context(1, node_id, static_cast<TaskID>(node_id)), MakeScanPlanWithRoot(),
 	                DuckDBExecutionConfigRef(), PipelineNodeContext(1, "join-query", node_id, node_name).to_hashmap());
+	task.mutable_inputs()[source_node_id] = TaskInput::make_scan_split_batch(input_bytes);
+	return task;
+}
+
+static WorkerTask MakeWorkerTaskWithTypesAndInput(NodeID node_id, const std::string &node_name,
+                                                  SourceNodeId source_node_id, const std::string &input_bytes,
+                                                  const vector<LogicalType> &types) {
+	WorkerTask task(TaskContext::from_node_context(1, node_id, static_cast<TaskID>(node_id)),
+	                MakeEmptyScanPlanWithRoot(types), DuckDBExecutionConfigRef(),
+	                PipelineNodeContext(1, "join-query", node_id, node_name).to_hashmap());
 	task.mutable_inputs()[source_node_id] = TaskInput::make_scan_split_batch(input_bytes);
 	return task;
 }
@@ -441,6 +461,59 @@ TEST_CASE("PhysicalPlanTranslator: normalizes range joins to a gathered nested-l
 	}
 }
 
+TEST_CASE("PhysicalPlanTranslator: preserves range join projection maps", "[distributed][join][nested_loop_join]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> left_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	vector<LogicalType> right_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
+	                                    LogicalType::BIGINT};
+	auto &left = plan->Make<PhysicalColumnDataScan>(left_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 2,
+	                                                MakeCollection(left_types, 2));
+	auto &right = plan->Make<PhysicalColumnDataScan>(right_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 3,
+	                                                 MakeCollection(right_types, 3));
+	LogicalComparisonJoin logical_join(JoinType::LEFT);
+	logical_join.types = output_types;
+	logical_join.left_projection_map = {0, 1};
+	logical_join.right_projection_map = {0, 1};
+	vector<JoinCondition> conditions;
+	conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_GREATERTHANOREQUALTO, 0, 0));
+	conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_LESSTHAN, 0, 2));
+	auto &join = plan->Make<PhysicalIEJoin>(logical_join, left, right, std::move(conditions), JoinType::LEFT, 2);
+	plan->SetRoot(join);
+
+	auto result = physical_plan_to_pipeline_node(PlanConfig {}, plan);
+	REQUIRE(result.ok);
+	auto join_node = std::dynamic_pointer_cast<NestedLoopJoinNode>(result.value()->inner());
+	REQUIRE(join_node != nullptr);
+	REQUIRE(join_node->left_projection_map_ == vector<idx_t> {0, 1});
+	REQUIRE(join_node->right_projection_map_ == vector<idx_t> {0, 1});
+
+	auto left_task =
+	    SubmittableTask<WorkerTask>(MakeWorkerTaskWithTypesAndInput(10, "left", 10, "left_scan", left_types));
+	auto right_task =
+	    SubmittableTask<WorkerTask>(MakeWorkerTaskWithTypesAndInput(20, "right", 20, "right_scan", right_types));
+	TaskIDCounter task_id_counter;
+	auto join_task =
+	    join_node->BuildNestedLoopJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+	REQUIRE(join_task.task()->plan()->Root().type == PhysicalOperatorType::PROJECTION);
+	auto &project = join_task.task()->plan()->Root().Cast<PhysicalProjection>();
+	REQUIRE(project.GetTypes() == output_types);
+	REQUIRE(project.children.size() == 1);
+	REQUIRE(project.children[0].get().type == PhysicalOperatorType::NESTED_LOOP_JOIN);
+	REQUIRE(project.children[0].get().GetTypes().size() == 5);
+	REQUIRE(project.select_list.size() == 4);
+	for (idx_t index = 0; index < project.select_list.size(); index++) {
+		REQUIRE(project.select_list[index]->Cast<BoundReferenceExpression>().index == index);
+	}
+
+	auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "range_join_projection_test", nullptr);
+	REQUIRE(cloned->Root().type == PhysicalOperatorType::PROJECTION);
+	REQUIRE(cloned->Root().GetTypes() == output_types);
+	REQUIRE(cloned->Root().children[0].get().type == PhysicalOperatorType::NESTED_LOOP_JOIN);
+}
+
 TEST_CASE("PhysicalPlanTranslator: translates blockwise nested-loop joins", "[distributed][join][nested_loop_join]") {
 	Allocator allocator;
 	auto plan = std::make_shared<PhysicalPlan>(allocator);
@@ -656,6 +729,36 @@ TEST_CASE("NestedLoopJoinNode: replacement tasks own both inputs", "[distributed
 		auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "blockwise_owned_children_test", nullptr);
 		REQUIRE(cloned->Root().type == PhysicalOperatorType::BLOCKWISE_NL_JOIN);
 		REQUIRE(cloned->Root().GetTypes() == output_types);
+	}
+
+	SECTION("nested comparison types fall back to blockwise execution") {
+		auto list_type = LogicalType::LIST(LogicalType::BIGINT);
+		vector<LogicalType> list_output_types = {list_type, list_type};
+		vector<JoinCondition> conditions;
+		JoinCondition condition;
+		condition.left = make_uniq<BoundReferenceExpression>(list_type, 0);
+		condition.right = make_uniq<BoundReferenceExpression>(list_type, 0);
+		condition.comparison = ExpressionType::COMPARE_LESSTHAN;
+		conditions.push_back(std::move(condition));
+		NestedLoopJoinNode node(305, plan_cfg, PhysicalOperatorType::PIECEWISE_MERGE_JOIN, std::move(conditions),
+		                        nullptr, JoinType::INNER, list_output_types, 1, nullptr, nullptr,
+		                        MakeSchemaRef(list_output_types));
+		auto left_task =
+		    SubmittableTask<WorkerTask>(MakeWorkerTaskWithTypesAndInput(10, "left", 10, "left_scan", {list_type}));
+		auto right_task =
+		    SubmittableTask<WorkerTask>(MakeWorkerTaskWithTypesAndInput(20, "right", 20, "right_scan", {list_type}));
+		TaskIDCounter task_id_counter;
+		auto join_task =
+		    node.BuildNestedLoopJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+		REQUIRE(join_task.task()->plan()->Root().type == PhysicalOperatorType::BLOCKWISE_NL_JOIN);
+		auto &join = join_task.task()->plan()->Root().Cast<PhysicalBlockwiseNLJoin>();
+		auto &comparison = join.condition->Cast<BoundComparisonExpression>();
+		REQUIRE(comparison.left->Cast<BoundReferenceExpression>().index == 0);
+		REQUIRE(comparison.right->Cast<BoundReferenceExpression>().index == 1);
+		auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "nested_type_blockwise_test", nullptr);
+		REQUIRE(cloned->Root().type == PhysicalOperatorType::BLOCKWISE_NL_JOIN);
+		REQUIRE(cloned->Root().GetTypes() == list_output_types);
 	}
 }
 

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -13,12 +13,14 @@
 
 #include "catch.hpp"
 
+#include "duckdb/common/enum_util.hpp"
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/optional_idx.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 
 #include "duckdb/execution/distributed/common_types.hpp"
@@ -31,11 +33,16 @@
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
+#include "duckdb/execution/operator/join/physical_iejoin.hpp"
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
+#include "duckdb/execution/operator/join/physical_piecewise_merge_join.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/parallel/task_executor.hpp"
+#include "duckdb/planner/operator/logical_any_join.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/joinside.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
@@ -43,8 +50,10 @@
 #include "duckdb/execution/distributed/pipeline_node/join/cross_product.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp"
 #undef private
 
+#include <algorithm>
 #include <memory>
 
 using namespace duckdb;
@@ -79,13 +88,17 @@ static DuckPhysicalPlanRef MakeScanPlanWithRoot() {
 	return plan;
 }
 
+static JoinCondition MakeJoinCondition(ExpressionType comparison, idx_t left_index = 0, idx_t right_index = 0) {
+	JoinCondition condition;
+	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, left_index);
+	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, right_index);
+	condition.comparison = comparison;
+	return condition;
+}
+
 static vector<JoinCondition> MakeNonEqualityJoinConditions() {
 	vector<JoinCondition> conditions;
-	JoinCondition condition;
-	condition.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
-	condition.right = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
-	condition.comparison = ExpressionType::COMPARE_GREATERTHAN;
-	conditions.push_back(std::move(condition));
+	conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_GREATERTHAN));
 	return conditions;
 }
 
@@ -387,6 +400,76 @@ TEST_CASE("PhysicalPlanTranslator: translates cross product with two inputs", "[
 	REQUIRE(cross_node->config().clustering_spec()->num_partitions() == 1);
 }
 
+TEST_CASE("PhysicalPlanTranslator: normalizes range joins to a gathered nested-loop node",
+          "[distributed][join][nested_loop_join]") {
+	for (auto source_type : {PhysicalOperatorType::PIECEWISE_MERGE_JOIN, PhysicalOperatorType::IE_JOIN}) {
+		CAPTURE(static_cast<int>(source_type));
+		Allocator allocator;
+		auto plan = std::make_shared<PhysicalPlan>(allocator);
+		vector<LogicalType> input_types = {LogicalType::BIGINT};
+		vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+		auto &left = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 2,
+		                                                MakeCollection(input_types, 2));
+		auto &right = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 3,
+		                                                 MakeCollection(input_types, 3));
+		LogicalComparisonJoin logical_join(JoinType::INNER);
+		logical_join.types = output_types;
+		vector<JoinCondition> conditions;
+		conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_LESSTHAN));
+
+		if (source_type == PhysicalOperatorType::PIECEWISE_MERGE_JOIN) {
+			auto &join = plan->Make<PhysicalPiecewiseMergeJoin>(logical_join, left, right, std::move(conditions),
+			                                                    JoinType::INNER, 6, nullptr);
+			plan->SetRoot(join);
+		} else {
+			conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_GREATERTHANOREQUALTO));
+			auto &join =
+			    plan->Make<PhysicalIEJoin>(logical_join, left, right, std::move(conditions), JoinType::INNER, 6);
+			plan->SetRoot(join);
+		}
+
+		auto result = physical_plan_to_pipeline_node(PlanConfig {}, plan);
+		REQUIRE(result.ok);
+		REQUIRE(result.value() != nullptr);
+		auto join_node = std::dynamic_pointer_cast<NestedLoopJoinNode>(result.value()->inner());
+		REQUIRE(join_node != nullptr);
+		REQUIRE(join_node->children().size() == 2);
+		REQUIRE(join_node->config().clustering_spec()->num_partitions() == 1);
+		auto display = join_node->multiline_display(false);
+		REQUIRE(std::find(display.begin(), display.end(), "Source operator: " + EnumUtil::ToString(source_type)) !=
+		        display.end());
+	}
+}
+
+TEST_CASE("PhysicalPlanTranslator: translates blockwise nested-loop joins", "[distributed][join][nested_loop_join]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> input_types = {LogicalType::BIGINT};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto &left = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 2,
+	                                                MakeCollection(input_types, 2));
+	auto &right = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 3,
+	                                                 MakeCollection(input_types, 3));
+	auto condition = make_uniq<BoundComparisonExpression>(ExpressionType::COMPARE_LESSTHAN,
+	                                                      make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0),
+	                                                      make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1));
+	LogicalAnyJoin logical_join(JoinType::INNER);
+	logical_join.types = output_types;
+	auto &join =
+	    plan->Make<PhysicalBlockwiseNLJoin>(logical_join, left, right, std::move(condition), JoinType::INNER, 6);
+	plan->SetRoot(join);
+
+	auto result = physical_plan_to_pipeline_node(PlanConfig {}, plan);
+	REQUIRE(result.ok);
+	REQUIRE(result.value() != nullptr);
+	auto join_node = std::dynamic_pointer_cast<NestedLoopJoinNode>(result.value()->inner());
+	REQUIRE(join_node != nullptr);
+	REQUIRE(join_node->children().size() == 2);
+	REQUIRE(join_node->config().clustering_spec()->num_partitions() == 1);
+	auto display = join_node->multiline_display(false);
+	REQUIRE(std::find(display.begin(), display.end(), "Source operator: BLOCKWISE_NL_JOIN") != display.end());
+}
+
 //===----------------------------------------------------------------------===//
 // WorkerTask inputs_ tests
 //===----------------------------------------------------------------------===//
@@ -528,6 +611,52 @@ TEST_CASE("CrossProductNode: replacement task owns both inputs", "[distributed][
 	REQUIRE(cloned->Root().GetTypes() == output_types);
 	REQUIRE(cloned->Root().children[0].get().Cast<PhysicalColumnDataScan>().collection->Count() == 1);
 	REQUIRE(cloned->Root().children[1].get().Cast<PhysicalColumnDataScan>().collection->Count() == 1);
+}
+
+TEST_CASE("NestedLoopJoinNode: replacement tasks own both inputs", "[distributed][source_id][nested_loop_join]") {
+	PlanConfig plan_cfg(1, "nested-loop-query", std::make_shared<DuckDBExecutionConfig>());
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto schema = MakeSchemaRef(output_types);
+
+	SECTION("comparison join") {
+		NestedLoopJoinNode node(303, plan_cfg, PhysicalOperatorType::PIECEWISE_MERGE_JOIN,
+		                        MakeNonEqualityJoinConditions(), nullptr, JoinType::INNER, output_types, 1, nullptr,
+		                        nullptr, schema);
+		auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+		auto right_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(20, "right", 20, "right_scan"));
+		TaskIDCounter task_id_counter;
+		auto join_task =
+		    node.BuildNestedLoopJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+		REQUIRE(join_task.task()->inputs().size() == 2);
+		REQUIRE(join_task.task()->inputs().at(10).scan_split_batch_bytes == "left_scan");
+		REQUIRE(join_task.task()->inputs().at(20).scan_split_batch_bytes == "right_scan");
+		REQUIRE(join_task.task()->plan()->Root().type == PhysicalOperatorType::NESTED_LOOP_JOIN);
+		REQUIRE(join_task.task()->plan()->Root().children.size() == 2);
+		auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "nested_loop_owned_children_test", nullptr);
+		REQUIRE(cloned->Root().type == PhysicalOperatorType::NESTED_LOOP_JOIN);
+		REQUIRE(cloned->Root().GetTypes() == output_types);
+	}
+
+	SECTION("blockwise join") {
+		auto condition = make_uniq<BoundComparisonExpression>(
+		    ExpressionType::COMPARE_LESSTHAN, make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0),
+		    make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1));
+		NestedLoopJoinNode node(304, plan_cfg, std::move(condition), JoinType::INNER, output_types, 1, nullptr, nullptr,
+		                        schema);
+		auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+		auto right_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(20, "right", 20, "right_scan"));
+		TaskIDCounter task_id_counter;
+		auto join_task =
+		    node.BuildNestedLoopJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+		REQUIRE(join_task.task()->inputs().size() == 2);
+		REQUIRE(join_task.task()->plan()->Root().type == PhysicalOperatorType::BLOCKWISE_NL_JOIN);
+		REQUIRE(join_task.task()->plan()->Root().children.size() == 2);
+		auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "blockwise_owned_children_test", nullptr);
+		REQUIRE(cloned->Root().type == PhysicalOperatorType::BLOCKWISE_NL_JOIN);
+		REQUIRE(cloned->Root().GetTypes() == output_types);
+	}
 }
 
 TEST_CASE("Join output types follow join semantics", "[distributed][join]") {

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3878,6 +3878,70 @@ def test_ray_cross_product_values(ray_runner, duckdb_conn):
     )
 
 
+def test_ray_piecewise_merge_join(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: piecewise merge join"
+    sql = """
+        SELECT l.x AS left_x, r.x AS right_x
+        FROM (VALUES (1), (2), (3), (4), (5)) AS l(x)
+        JOIN (VALUES (1), (2), (3), (4), (5)) AS r(x)
+          ON l.x < r.x
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["PIECEWISE_MERGE_JOIN"],
+        timeout_s=60.0,
+    )
+
+
+def test_ray_ie_join(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: ie join"
+    duckdb_conn.execute("SET nested_loop_join_threshold=0")
+    duckdb_conn.execute("SET merge_join_threshold=0")
+    sql = """
+        SELECT
+            l.begin_value AS left_begin,
+            l.end_value AS left_end,
+            r.begin_value AS right_begin,
+            r.end_value AS right_end
+        FROM (VALUES (1, 4), (2, 6), (5, 8)) AS l(begin_value, end_value)
+        JOIN (VALUES (0, 2), (3, 5), (6, 9)) AS r(begin_value, end_value)
+          ON l.begin_value < r.end_value
+         AND l.end_value > r.begin_value
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["IE_JOIN"],
+        timeout_s=60.0,
+    )
+
+
+def test_ray_blockwise_nested_loop_join(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: blockwise nested-loop join"
+    sql = """
+        SELECT l.x AS left_x, r.x AS right_x
+        FROM (VALUES (1), (2)) AS l(x)
+        JOIN (VALUES (1), (2)) AS r(x)
+          ON l.x + r.x = 3
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["BLOCKWISE_NL_JOIN"],
+        timeout_s=60.0,
+    )
+
+
 @pytest.mark.parametrize("empty_side", ["left", "right"])
 def test_ray_cross_product_empty_input(ray_runner, duckdb_conn, partitioned_parquet_path, empty_side):
     label = f"test_ray_e2e: cross product empty {empty_side} input"

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3897,6 +3897,25 @@ def test_ray_piecewise_merge_join(ray_runner, duckdb_conn):
     )
 
 
+def test_ray_piecewise_merge_join_nested_values(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: piecewise merge join nested values"
+    sql = """
+        SELECT l.x AS left_x, r.x AS right_x
+        FROM (SELECT [i] AS x FROM range(1, 9) AS t(i)) AS l
+        JOIN (SELECT [i] AS x FROM range(1, 9) AS t(i)) AS r
+          ON l.x < r.x
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["PIECEWISE_MERGE_JOIN"],
+        timeout_s=60.0,
+    )
+
+
 def test_ray_ie_join(ray_runner, duckdb_conn):
     label = "test_ray_e2e: ie join"
     duckdb_conn.execute("SET nested_loop_join_threshold=0")
@@ -3911,6 +3930,38 @@ def test_ray_ie_join(ray_runner, duckdb_conn):
         JOIN (VALUES (0, 2), (3, 5), (6, 9)) AS r(begin_value, end_value)
           ON l.begin_value < r.end_value
          AND l.end_value > r.begin_value
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["IE_JOIN"],
+        timeout_s=60.0,
+    )
+
+
+def test_ray_ie_join_preserves_asof_projection(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: IE join ASOF projection"
+    duckdb_conn.execute("SET debug_asof_iejoin=true")
+    sql = """
+        SELECT
+            l.ts AS left_ts,
+            l.value AS left_value,
+            r.ts AS right_ts,
+            r.value AS right_value
+        FROM (
+            VALUES
+                (TIMESTAMP '2026-01-01 00:00:01', 10),
+                (TIMESTAMP '2026-01-01 00:00:03', 30)
+        ) AS l(ts, value)
+        ASOF LEFT JOIN (
+            VALUES
+                (TIMESTAMP '2026-01-01 00:00:01', 100),
+                (TIMESTAMP '2026-01-01 00:00:02', 200)
+        ) AS r(ts, value)
+          ON l.ts >= r.ts
     """
 
     _run_query_case(


### PR DESCRIPTION
## Summary

- add a dedicated binary `NestedLoopJoinNode` for distributed non-equality joins
- gather both inputs for correctness, normalize `PIECEWISE_MERGE_JOIN` and `IE_JOIN` into serializable worker nested-loop plans, and preserve arbitrary `BLOCKWISE_NL_JOIN` predicates
- add physical blockwise join serialization plus native translator/ownership and Ray end-to-end coverage

The pipeline boundary is reusable: a future range-aware partitioning strategy can replace the current gather policy without changing the binary fan-in or worker-plan protocol.

## Testing

- distributed native join suite: 22 cases, 235 assertions
- physical-plan serialization suite: 46 cases, 10,816 assertions
- release matrix: 812 non-Ray tests and 14 real-Ray tests
- final-commit Ray E2E coverage for piecewise merge, IE, and blockwise nested-loop joins
- workspace formatting and pre-commit checks

Closes #625