### PR TITLE
[fix](ray) Support distributed ASOF joins

### DIFF
--- a/external/duckdb/src/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/src/execution/distributed/CMakeLists.txt
@@ -47,6 +47,7 @@ set(DISTRIBUTED_SOURCES_PIPELINE_NODE
     pipeline_node/expression_scan.cpp
     pipeline_node/extension_write_sink.cpp
     pipeline_node/grouping_set_expand.cpp
+    pipeline_node/join/asof_join.cpp
     pipeline_node/join/broadcast_join.cpp
     pipeline_node/join/cross_product.cpp
     pipeline_node/join/delim_join.cpp

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/asof_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/asof_join.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/join/asof_join.hpp"
+
+#include <algorithm>
+
+#include "duckdb/common/enum_util.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/hash_join_metadata.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/execution/operator/join/physical_asof_join.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+namespace {
+
+PipelineNodeConfig MakeAsOfJoinConfig(const PlanConfig &plan_config, const SchemaRef &schema,
+                                      const std::shared_ptr<DistributedPipelineNode> &left,
+                                      const std::shared_ptr<DistributedPipelineNode> &right) {
+	size_t num_partitions = 1;
+	if (left && right) {
+		num_partitions = std::max(left->config().clustering_spec()->num_partitions(),
+		                          right->config().clustering_spec()->num_partitions());
+	} else if (left) {
+		num_partitions = left->config().clustering_spec()->num_partitions();
+	} else if (right) {
+		num_partitions = right->config().clustering_spec()->num_partitions();
+	}
+	auto clustering = ClusteringSpec::unknown_with_num_partitions(num_partitions);
+	return PipelineNodeConfig(schema, plan_config.config, std::move(clustering));
+}
+
+duckdb::vector<LogicalType> BuildAsOfOutputTypes(JoinType join_type, const duckdb::vector<LogicalType> &left_types,
+                                                 const duckdb::vector<LogicalType> &right_types,
+                                                 const duckdb::vector<column_t> &right_projection_map) {
+	duckdb::vector<LogicalType> result;
+	if (JoinOutputsLeft(join_type)) {
+		result.insert(result.end(), left_types.begin(), left_types.end());
+	}
+	if (JoinOutputsRight(join_type)) {
+		if (right_projection_map.empty()) {
+			result.insert(result.end(), right_types.begin(), right_types.end());
+		} else {
+			for (auto column_index : right_projection_map) {
+				if (column_index >= right_types.size()) {
+					throw InvalidInputException(
+					    "AsOfJoinNode right projection column %llu is outside a %llu-column input", column_index,
+					    right_types.size());
+				}
+				result.push_back(right_types[column_index]);
+			}
+		}
+	}
+	if (join_type == JoinType::MARK) {
+		result.push_back(LogicalType::BOOLEAN);
+	}
+	return result;
+}
+
+} // namespace
+
+AsOfJoinNode::AsOfJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<JoinCondition> conditions,
+                           JoinType join_type, duckdb::vector<LogicalType> output_types,
+                           duckdb::vector<column_t> right_projection_map, idx_t estimated_cardinality,
+                           std::shared_ptr<DistributedPipelineNode> left,
+                           std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+    : config_(MakeAsOfJoinConfig(plan_config, schema, left, right)),
+      context_(plan_config.query_idx, plan_config.query_id, node_id, "AsOfJoin"), conditions_(std::move(conditions)),
+      join_type_(join_type), output_types_(std::move(output_types)),
+      right_projection_map_(std::move(right_projection_map)), estimated_cardinality_(estimated_cardinality),
+      left_(std::move(left)), right_(std::move(right)) {
+	if (conditions_.empty()) {
+		throw InvalidInputException("AsOfJoinNode requires at least one join condition");
+	}
+}
+
+std::vector<PipelineNodeRef> AsOfJoinNode::children() const {
+	std::vector<PipelineNodeRef> result;
+	if (left_) {
+		result.push_back(left_->inner());
+	}
+	if (right_) {
+		result.push_back(right_->inner());
+	}
+	return result;
+}
+
+std::vector<std::string> AsOfJoinNode::multiline_display(bool /*verbose*/) const {
+	return {"ASOF Join", "Join type: " + EnumUtil::ToString(join_type_)};
+}
+
+duckdb::vector<JoinCondition> AsOfJoinNode::CopyConditions(const duckdb::vector<JoinCondition> &conditions) {
+	duckdb::vector<JoinCondition> result;
+	result.reserve(conditions.size());
+	for (const auto &condition : conditions) {
+		JoinCondition copy;
+		copy.comparison = condition.comparison;
+		if (condition.left) {
+			copy.left = condition.left->Copy();
+		}
+		if (condition.right) {
+			copy.right = condition.right->Copy();
+		}
+		result.push_back(std::move(copy));
+	}
+	return result;
+}
+
+SubmittableTask<WorkerTask> AsOfJoinNode::BuildAsOfJoinTask(SubmittableTask<WorkerTask> left_task,
+                                                            SubmittableTask<WorkerTask> right_task,
+                                                            TaskIDCounter &task_id_counter,
+                                                            ClientContext *client_context) {
+	auto left_plan_src = left_task.task()->plan();
+	auto right_plan_src = right_task.task()->plan();
+	if (!left_plan_src || !left_plan_src->HasRoot() || !right_plan_src || !right_plan_src->HasRoot()) {
+		throw InvalidInputException("AsOfJoinNode cannot build task from input without a physical plan root");
+	}
+
+	auto plan = ClonePhysicalPlanOrThrow(left_plan_src, "build_asof_join_task:left", client_context);
+	auto &left_root = plan->Root();
+	auto &right_root =
+	    ClonePhysicalPlanRootIntoPlanOrThrow(right_plan_src, *plan, "build_asof_join_task:right", client_context);
+
+	auto expected_types =
+	    BuildAsOfOutputTypes(join_type_, left_root.GetTypes(), right_root.GetTypes(), right_projection_map_);
+	if (expected_types != output_types_) {
+		throw InternalException(
+		    "AsOfJoinNode output schema does not match its children and right projection (%llu translated columns, "
+		    "%llu child-derived columns)",
+		    output_types_.size(), expected_types.size());
+	}
+
+	auto conditions = CopyConditions(conditions_);
+	FixHashJoinConditionTypes(conditions, left_root.GetTypes(), right_root.GetTypes());
+	LogicalComparisonJoin dummy_join(join_type_);
+	dummy_join.types = output_types_;
+	dummy_join.conditions = std::move(conditions);
+	dummy_join.right_projection_map = right_projection_map_;
+	dummy_join.estimated_cardinality = estimated_cardinality_;
+	auto &join = plan->Make<PhysicalAsOfJoin>(dummy_join, left_root, right_root);
+	plan->SetRoot(join);
+	if (plan->Root().GetTypes() != output_types_) {
+		throw InternalException("AsOfJoinNode worker plan output does not match the translated schema");
+	}
+
+	TaskContext task_context = TaskContext::from_node_context(context_.query_idx(), node_id(), task_id_counter.next());
+	auto merged_context = MergeTaskContext(left_task.task()->context(), right_task.task()->context());
+	merged_context = MergeTaskContext(merged_context, context_.to_hashmap());
+	WorkerTask new_task(task_context, plan, left_task.task()->config(), std::move(merged_context), "WorkerTask");
+	auto &inputs = new_task.mutable_inputs();
+	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs(), context_.node_name());
+	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs(), context_.node_name());
+	return std::move(left_task).with_new_task(std::move(new_task));
+}
+
+SubmittableTaskStream<WorkerTask> AsOfJoinNode::produce_tasks(PlanExecutionContext &plan_context) {
+	if (!left_ || !right_) {
+		return SubmittableTaskStream<WorkerTask>::from_receiver(Receiver<SubmittableTask<WorkerTask>>());
+	}
+
+	auto left_input = left_->produce_tasks(plan_context);
+	auto right_input = right_->produce_tasks(plan_context);
+	auto task_id_counter = std::make_shared<TaskIDCounter>(plan_context.task_id_counter());
+	auto *client_context = plan_context.client_context();
+	auto self_shared = shared_from_this();
+	BinaryInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
+	                                               client_context](BinarySubmittableTask left_task,
+	                                                               BinarySubmittableTask right_task) mutable {
+		return self_shared->BuildAsOfJoinTask(std::move(left_task), std::move(right_task), *task_id_counter,
+		                                      client_context);
+	};
+
+	BinaryFragmentInputFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
+	                                      task_id_counter, context_.query_idx(), node_id(), context_.node_name());
+	return SubmittableTaskStream<WorkerTask>(boxed<BinarySubmittableTask>(std::move(stream)));
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -42,6 +42,7 @@
 #include "duckdb/execution/operator/helper/physical_streaming_sample.hpp"
 #include "duckdb/execution/operator/helper/physical_data_sink.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
@@ -380,6 +381,11 @@ void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOpera
 	case PhysicalOperatorType::CROSS_PRODUCT: {
 		auto &cross_product = static_cast<PhysicalCrossProduct &>(op);
 		node_impl = TranslateCrossProduct(cross_product, children);
+		break;
+	}
+	case PhysicalOperatorType::ASOF_JOIN: {
+		auto &asof_join = static_cast<PhysicalAsOfJoin &>(op);
+		node_impl = TranslateAsOfJoin(asof_join, children);
 		break;
 	}
 	case PhysicalOperatorType::PIECEWISE_MERGE_JOIN:

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/enums/expression_type.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/asof_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/cross_product.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/delim_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
@@ -20,6 +21,7 @@
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/utils/optional.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
+#include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
@@ -289,6 +291,35 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 	return std::make_shared<CrossProductNode>(get_next_pipeline_node_id(), plan_config_, cross_product.GetTypes(),
 	                                          cross_product.estimated_cardinality, std::move(left), std::move(right),
 	                                          std::move(schema));
+}
+
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateAsOfJoin(
+    const PhysicalAsOfJoin &asof_join, const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	if (children.size() != 2 || !children[0] || !children[1]) {
+		throw InvalidInputException("Distributed ASOF join requires exactly two input nodes");
+	}
+
+	SchemaRef schema = nullptr;
+	if (!asof_join.GetTypes().empty()) {
+		auto output_names = BuildComparisonJoinOutputNames(asof_join.join_type, children[0]->config().schema(),
+		                                                   children[1]->config().schema(), asof_join.GetTypes().size(),
+		                                                   {}, asof_join.right_projection_map);
+		if (!output_names.empty()) {
+			schema = MakeSchemaRef(asof_join.GetTypes(), output_names);
+		} else {
+			schema = MakeSchemaRef(asof_join.GetTypes());
+		}
+	}
+
+	// Correctness baseline: an ASOF match can depend on any row from the
+	// opposite input. Co-locate both complete inputs before rebuilding the
+	// native ASOF operator on the worker.
+	auto left = gen_gather_node(children[0]);
+	auto right = gen_gather_node(children[1]);
+	return std::make_shared<AsOfJoinNode>(
+	    get_next_pipeline_node_id(), plan_config_, CopyJoinConditions(asof_join.conditions), asof_join.join_type,
+	    asof_join.GetTypes(), asof_join.right_projection_map, asof_join.estimated_cardinality, std::move(left),
+	    std::move(right), std::move(schema));
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateHashJoin(

--- a/external/duckdb/src/execution/operator/join/physical_asof_join.cpp
+++ b/external/duckdb/src/execution/operator/join/physical_asof_join.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/join/physical_asof_join.hpp"
 
 #include "duckdb/common/row_operations/row_operations.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/sorting/sort_strategy.hpp"
 #include "duckdb/common/sorting/sort_key.hpp"
 #include "duckdb/common/sorting/sorted_run.hpp"
@@ -18,8 +19,35 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalCompariso
     : PhysicalComparisonJoin(physical_plan, op, PhysicalOperatorType::ASOF_JOIN, std::move(op.conditions), op.join_type,
                              op.estimated_cardinality),
       comparison_type(ExpressionType::INVALID) {
-	// Convert the conditions partitions and sorts
 	D_ASSERT(!op.predicate.get());
+	InitializeJoinConditions();
+
+	children.push_back(left);
+	children.push_back(right);
+
+	// Fill out the right projection map.
+	right_projection_map = op.right_projection_map;
+	if (right_projection_map.empty()) {
+		const auto right_count = children[1].get().GetTypes().size();
+		right_projection_map.reserve(right_count);
+		for (column_t i = 0; i < right_count; ++i) {
+			right_projection_map.emplace_back(i);
+		}
+	}
+}
+
+PhysicalAsOfJoin::PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalComparisonJoin &op,
+                                   vector<JoinCondition> conditions_p, JoinType join_type,
+                                   vector<column_t> right_projection_map_p, idx_t estimated_cardinality,
+                                   bool /*skip_child_init*/)
+    : PhysicalComparisonJoin(physical_plan, op, PhysicalOperatorType::ASOF_JOIN, std::move(conditions_p), join_type,
+                             estimated_cardinality),
+      comparison_type(ExpressionType::INVALID), right_projection_map(std::move(right_projection_map_p)) {
+	InitializeJoinConditions();
+}
+
+void PhysicalAsOfJoin::InitializeJoinConditions() {
+	// Convert the conditions to partitions and sorts.
 	for (auto &cond : conditions) {
 		D_ASSERT(cond.left->return_type == cond.right->return_type);
 		join_key_types.push_back(cond.left->return_type);
@@ -55,19 +83,12 @@ PhysicalAsOfJoin::PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalCompariso
 	}
 	D_ASSERT(!lhs_orders.empty());
 	D_ASSERT(!rhs_orders.empty());
+}
 
-	children.push_back(left);
-	children.push_back(right);
-
-	//	Fill out the right projection map.
-	right_projection_map = op.right_projection_map;
-	if (right_projection_map.empty()) {
-		const auto right_count = children[1].get().GetTypes().size();
-		right_projection_map.reserve(right_count);
-		for (column_t i = 0; i < right_count; ++i) {
-			right_projection_map.emplace_back(i);
-		}
-	}
+void PhysicalAsOfJoin::SerializeOperatorData(Serializer &serializer) const {
+	serializer.WriteProperty(103, "join_type", join_type);
+	serializer.WriteProperty(104, "conditions", conditions);
+	serializer.WriteProperty(105, "right_projection_map", right_projection_map);
 }
 
 //===--------------------------------------------------------------------===//

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -53,6 +53,7 @@
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
+#include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
@@ -1070,6 +1071,16 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		dummy_join.types = std::move(types);
 		return make_uniq<PhysicalBlockwiseNLJoin>(physical_plan, dummy_join, std::move(condition), join_type,
 		                                          estimated_cardinality, true);
+	}
+	case PhysicalOperatorType::ASOF_JOIN: {
+		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");
+		auto conditions = deserializer.ReadProperty<vector<JoinCondition>>(104, "conditions");
+		auto right_projection_map = deserializer.ReadProperty<vector<column_t>>(105, "right_projection_map");
+
+		LogicalComparisonJoin dummy_join(join_type);
+		dummy_join.types = std::move(types);
+		return make_uniq<PhysicalAsOfJoin>(physical_plan, dummy_join, std::move(conditions), join_type,
+		                                   std::move(right_projection_map), estimated_cardinality, true);
 	}
 	case PhysicalOperatorType::HASH_JOIN: {
 		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/asof_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/asof_join.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/plan/plan_config.hpp"
+#include "duckdb/execution/operator/join/physical_comparison_join.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class TaskIDCounter;
+
+//! Executes an ASOF join after co-locating both complete inputs on one worker.
+class AsOfJoinNode : public PipelineNodeImpl, public std::enable_shared_from_this<AsOfJoinNode> {
+public:
+	AsOfJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<JoinCondition> conditions,
+	             JoinType join_type, duckdb::vector<LogicalType> output_types,
+	             duckdb::vector<column_t> right_projection_map, idx_t estimated_cardinality,
+	             std::shared_ptr<DistributedPipelineNode> left, std::shared_ptr<DistributedPipelineNode> right,
+	             SchemaRef schema);
+
+	const PipelineNodeContext &context() const override {
+		return context_;
+	}
+
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override;
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
+	std::vector<std::string> multiline_display(bool verbose) const override;
+
+private:
+	static duckdb::vector<JoinCondition> CopyConditions(const duckdb::vector<JoinCondition> &conditions);
+
+	SubmittableTask<WorkerTask> BuildAsOfJoinTask(SubmittableTask<WorkerTask> left_task,
+	                                              SubmittableTask<WorkerTask> right_task,
+	                                              TaskIDCounter &task_id_counter,
+	                                              ::duckdb::ClientContext *client_context);
+
+private:
+	PipelineNodeConfig config_;
+	PipelineNodeContext context_;
+	duckdb::vector<JoinCondition> conditions_;
+	JoinType join_type_;
+	duckdb::vector<LogicalType> output_types_;
+	duckdb::vector<column_t> right_projection_map_;
+	idx_t estimated_cardinality_;
+	std::shared_ptr<DistributedPipelineNode> left_;
+	std::shared_ptr<DistributedPipelineNode> right_;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -19,6 +19,7 @@ class RepartitionSpec;
 class PhysicalBatchCopyToFile;
 class PhysicalCopyToFile;
 class PhysicalCrossProduct;
+class PhysicalAsOfJoin;
 class PhysicalDataSink;
 class PhysicalOperator;
 class PhysicalDelimJoin;
@@ -144,6 +145,10 @@ private:
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateCrossProduct(const PhysicalCrossProduct &op,
 	                      const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslateAsOfJoin(const PhysicalAsOfJoin &op,
+	                  const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
 
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateDelimJoin(const PhysicalDelimJoin &op,

--- a/external/duckdb/src/include/duckdb/execution/operator/join/physical_asof_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/join/physical_asof_join.hpp
@@ -21,6 +21,10 @@ public:
 public:
 	PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalComparisonJoin &op, PhysicalOperator &left,
 	                 PhysicalOperator &right);
+	//! Constructor for deserialization (children added later)
+	PhysicalAsOfJoin(PhysicalPlan &physical_plan, LogicalComparisonJoin &op, vector<JoinCondition> conditions,
+	                 JoinType join_type, vector<column_t> right_projection_map, idx_t estimated_cardinality,
+	                 bool skip_child_init);
 
 	vector<LogicalType> join_key_types;
 	vector<column_t> null_sensitive;
@@ -36,6 +40,9 @@ public:
 
 	// Projection mappings
 	vector<column_t> right_projection_map;
+
+	//! Serialization
+	void SerializeOperatorData(Serializer &serializer) const override;
 
 protected:
 	// CachingOperator Interface
@@ -75,6 +82,9 @@ public:
 
 public:
 	void BuildPipelines(Pipeline &current, MetaPipeline &meta_pipeline) override;
+
+private:
+	void InitializeJoinConditions();
 };
 
 } // namespace duckdb

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -32,6 +32,7 @@
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
+#include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
@@ -1160,6 +1161,66 @@ TEST_CASE("PhysicalBlockwiseNLJoin serialization roundtrip", "[serialization][ph
 	REQUIRE(roundtrip->children.size() == 2);
 	REQUIRE(roundtrip->children[0].get().GetTypes() == input_types);
 	REQUIRE(roundtrip->children[1].get().GetTypes() == input_types);
+}
+
+TEST_CASE("PhysicalAsOfJoin serialization roundtrip", "[serialization][physical_plan][join][asof_join]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	vector<LogicalType> left_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	vector<LogicalType> right_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::VARCHAR};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::VARCHAR};
+
+	auto &left = MakeColumnDataScan(plan, left_types);
+	auto &right = MakeColumnDataScan(plan, right_types);
+	LogicalComparisonJoin logical_join(JoinType::LEFT);
+	logical_join.types = output_types;
+	logical_join.estimated_cardinality = 12;
+	logical_join.right_projection_map = {2};
+
+	JoinCondition partition;
+	partition.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
+	partition.right = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 0);
+	partition.comparison = ExpressionType::COMPARE_EQUAL;
+	logical_join.conditions.push_back(std::move(partition));
+
+	JoinCondition order;
+	order.left = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1);
+	order.right = make_uniq<BoundReferenceExpression>(LogicalType::BIGINT, 1);
+	order.comparison = ExpressionType::COMPARE_GREATERTHANOREQUALTO;
+	logical_join.conditions.push_back(std::move(order));
+
+	auto &join = plan.Make<PhysicalAsOfJoin>(logical_join, left, right);
+	plan.SetRoot(join);
+
+	MemoryStream stream(allocator);
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	plan.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	PhysicalPlan deserialized_plan(allocator);
+	deserializer.Begin();
+	auto root = deserialized_plan.Deserialize(deserializer);
+	deserializer.End();
+
+	REQUIRE(root != nullptr);
+	auto *roundtrip = dynamic_cast<PhysicalAsOfJoin *>(root.get());
+	REQUIRE(roundtrip != nullptr);
+	REQUIRE(roundtrip->join_type == JoinType::LEFT);
+	REQUIRE(roundtrip->conditions.size() == 2);
+	REQUIRE(roundtrip->lhs_partitions.size() == 1);
+	REQUIRE(roundtrip->rhs_partitions.size() == 1);
+	REQUIRE(roundtrip->lhs_orders.size() == 1);
+	REQUIRE(roundtrip->rhs_orders.size() == 1);
+	REQUIRE(roundtrip->comparison_type == ExpressionType::COMPARE_GREATERTHANOREQUALTO);
+	REQUIRE(roundtrip->right_projection_map == vector<column_t> {2});
+	REQUIRE(roundtrip->GetTypes() == output_types);
+	REQUIRE(roundtrip->estimated_cardinality == 12);
+	REQUIRE(roundtrip->children.size() == 2);
+	REQUIRE(roundtrip->children[0].get().GetTypes() == left_types);
+	REQUIRE(roundtrip->children[1].get().GetTypes() == right_types);
 }
 
 TEST_CASE("PhysicalHashJoin serialization roundtrip", "[serialization][physical_plan]") {

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -33,6 +33,7 @@
 #include "duckdb/execution/distributed/pipeline_node/scan_source.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
+#include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_iejoin.hpp"
@@ -47,6 +48,7 @@
 #include "duckdb/storage/statistics/base_statistics.hpp"
 
 #define private public
+#include "duckdb/execution/distributed/pipeline_node/join/asof_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/cross_product.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
@@ -418,6 +420,62 @@ TEST_CASE("PhysicalPlanTranslator: translates cross product with two inputs", "[
 	REQUIRE(cross_node != nullptr);
 	REQUIRE(cross_node->children().size() == 2);
 	REQUIRE(cross_node->config().clustering_spec()->num_partitions() == 1);
+}
+
+TEST_CASE("PhysicalPlanTranslator: translates ASOF joins to a gathered native worker plan",
+          "[distributed][join][asof_join]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> left_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	vector<LogicalType> right_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT};
+
+	auto &left = plan->Make<PhysicalColumnDataScan>(left_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 2,
+	                                                MakeCollection(left_types, 2));
+	auto &right = plan->Make<PhysicalColumnDataScan>(right_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 3,
+	                                                 MakeCollection(right_types, 3));
+	LogicalComparisonJoin logical_join(JoinType::LEFT);
+	logical_join.types = output_types;
+	logical_join.estimated_cardinality = 6;
+	logical_join.right_projection_map = {2};
+	logical_join.conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_EQUAL, 0, 0));
+	logical_join.conditions.push_back(MakeJoinCondition(ExpressionType::COMPARE_GREATERTHANOREQUALTO, 1, 1));
+	auto &join = plan->Make<PhysicalAsOfJoin>(logical_join, left, right);
+	plan->SetRoot(join);
+
+	auto result = physical_plan_to_pipeline_node(PlanConfig {}, plan);
+	REQUIRE(result.ok);
+	REQUIRE(result.value() != nullptr);
+	auto join_node = std::dynamic_pointer_cast<AsOfJoinNode>(result.value()->inner());
+	REQUIRE(join_node != nullptr);
+	REQUIRE(join_node->children().size() == 2);
+	REQUIRE(join_node->config().clustering_spec()->num_partitions() == 1);
+	REQUIRE(join_node->conditions_.size() == 2);
+	REQUIRE(join_node->right_projection_map_ == vector<column_t> {2});
+
+	auto left_task =
+	    SubmittableTask<WorkerTask>(MakeWorkerTaskWithTypesAndInput(10, "left", 10, "left_scan", left_types));
+	auto right_task =
+	    SubmittableTask<WorkerTask>(MakeWorkerTaskWithTypesAndInput(20, "right", 20, "right_scan", right_types));
+	TaskIDCounter task_id_counter;
+	auto join_task =
+	    join_node->BuildAsOfJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+	REQUIRE(join_task.task()->inputs().size() == 2);
+	REQUIRE(join_task.task()->inputs().at(10).scan_split_batch_bytes == "left_scan");
+	REQUIRE(join_task.task()->inputs().at(20).scan_split_batch_bytes == "right_scan");
+	REQUIRE(join_task.task()->plan()->Root().type == PhysicalOperatorType::ASOF_JOIN);
+	REQUIRE(join_task.task()->plan()->Root().GetTypes() == output_types);
+	auto &worker_join = join_task.task()->plan()->Root().Cast<PhysicalAsOfJoin>();
+	REQUIRE(worker_join.children.size() == 2);
+	REQUIRE(worker_join.conditions.size() == 2);
+	REQUIRE(worker_join.right_projection_map == vector<column_t> {2});
+
+	auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "asof_join_owned_children_test", nullptr);
+	REQUIRE(cloned->Root().type == PhysicalOperatorType::ASOF_JOIN);
+	REQUIRE(cloned->Root().GetTypes() == output_types);
+	REQUIRE(cloned->Root().children.size() == 2);
+	REQUIRE(cloned->Root().Cast<PhysicalAsOfJoin>().right_projection_map == vector<column_t> {2});
 }
 
 TEST_CASE("PhysicalPlanTranslator: normalizes range joins to a gathered nested-loop node",

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3942,6 +3942,33 @@ def test_ray_ie_join(ray_runner, duckdb_conn):
     )
 
 
+def test_ray_native_asof_join_gathers_both_inputs(ray_runner, duckdb_conn, parquet_path):
+    label = "test_ray_e2e: native ASOF join gathers both inputs"
+    sql = f"""
+        SELECT
+            l.a AS left_a,
+            l.b AS left_value,
+            r.c AS right_value
+        FROM read_parquet('{parquet_path}') AS l
+        ASOF LEFT JOIN read_parquet('{parquet_path}') AS r
+          ON (l.a % 8) = (r.a % 8)
+         AND l.a >= r.a
+    """
+
+    relation = duckdb_conn.sql(sql)
+    plan_text, num_parts = _get_distributed_plan_info(relation, label)
+    assert plan_text and "ASOF JOIN" in plan_text.upper(), f"{label}: expected distributed ASOF join:\n{plan_text}"
+    assert num_parts == 1, f"{label}: correctness fallback must gather to one partition, got {num_parts}"
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["ASOF_JOIN"],
+        timeout_s=60.0,
+    )
+
+
 def test_ray_ie_join_preserves_asof_projection(ray_runner, duckdb_conn):
     label = "test_ray_e2e: IE join ASOF projection"
     duckdb_conn.execute("SET debug_asof_iejoin=true")


### PR DESCRIPTION
## Summary

- add a dedicated distributed ASOF join node that gathers both complete inputs and rebuilds DuckDB's native ASOF operator on the worker
- reuse the common binary fragment fan-in while preserving join conditions, join type, output types, estimated cardinality, and right-side projection metadata
- add PhysicalAsOfJoin serialization/deserialization so worker plans can be cloned and transported safely
- cover native plan serialization/translation and a default-threshold Parquet Ray execution path

The one-partition gather is the correctness baseline. Future partition-aware ASOF execution can replace the translation strategy without changing the node fan-in or physical serialization contract.

## Related issue

close: #626

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `scripts/format workspace --changed --check`
- non-editable incremental native install with `uv pip install . --no-build-isolation`
- `VANE_NATIVE_BUILD_JOBS=8 scripts/run_native_tests.sh "*ASOF*"` — 20 test cases, 2764 assertions passed; 4 optional-extension tests skipped
- `scripts/run_installed_pytest.sh tests/fast/test_ray_e2e.py::test_ray_native_asof_join_gathers_both_inputs -q` — 1 passed
- `scripts/run_release_tests.sh` — 812 non-Ray and 14 real-Ray tests passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependencies or assets are introduced.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. Serialization is limited to existing bound ASOF plan metadata and reconstructs derived execution metadata during deserialization.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
