### PR TITLE
[fix](ray) Support distributed positional joins

### DIFF
--- a/external/duckdb/src/execution/distributed/CMakeLists.txt
+++ b/external/duckdb/src/execution/distributed/CMakeLists.txt
@@ -50,6 +50,7 @@ set(DISTRIBUTED_SOURCES_PIPELINE_NODE
     pipeline_node/join/asof_join.cpp
     pipeline_node/join/broadcast_join.cpp
     pipeline_node/join/cross_product.cpp
+    pipeline_node/join/positional_join.cpp
     pipeline_node/join/delim_join.cpp
     pipeline_node/join/hash_join.cpp
     pipeline_node/join/nested_loop_join.cpp

--- a/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
+++ b/external/duckdb/src/execution/distributed/exchange/flight_exchange_manager.cpp
@@ -753,10 +753,19 @@ void FlightExchange::SinkFinished(const ExchangeSinkInstanceHandle &instance, co
 			SinkAttemptMetadata metadata;
 			metadata.task_partition_id = handle.task_partition_id;
 			metadata.attempt_id = attempt_id;
+			metadata.source_task_order = instance.source_task_order;
 			metadata.output_location = instance.output_location;
 			attempt_entry = sink_entry->second.emplace(attempt_id, std::move(metadata)).first;
 		}
 		auto &attempt_metadata = attempt_entry->second;
+		if (attempt_metadata.source_task_order != DConstants::INVALID_INDEX &&
+		    instance.source_task_order != DConstants::INVALID_INDEX &&
+		    attempt_metadata.source_task_order != instance.source_task_order) {
+			throw InvalidInputException("finished Flight sink source task order changed for one attempt");
+		}
+		if (instance.source_task_order != DConstants::INVALID_INDEX) {
+			attempt_metadata.source_task_order = instance.source_task_order;
+		}
 		if (instance.output_location.empty() || attempt_metadata.output_location != instance.output_location) {
 			throw InvalidInputException("finished Flight sink output location does not match instantiated attempt");
 		}
@@ -925,6 +934,28 @@ std::vector<ExchangeSourceHandle> FlightExchange::GetSourceHandles() {
 			attempt_metadata.task_partition_id = sink_partition_id;
 			attempt_metadata.attempt_id = attempt_id;
 			selected_attempts.emplace_back(sink_partition_id, std::move(attempt_metadata));
+		}
+		const bool has_source_order =
+		    std::any_of(selected_attempts.begin(), selected_attempts.end(),
+		                [](const auto &entry) { return entry.second.source_task_order != DConstants::INVALID_INDEX; });
+		if (has_source_order) {
+			if (std::any_of(selected_attempts.begin(), selected_attempts.end(), [](const auto &entry) {
+				    return entry.second.source_task_order == DConstants::INVALID_INDEX;
+			    })) {
+				throw InvalidInputException("selected Flight sinks have inconsistent source task ordering metadata");
+			}
+			std::sort(selected_attempts.begin(), selected_attempts.end(), [](const auto &left, const auto &right) {
+				if (left.second.source_task_order != right.second.source_task_order) {
+					return left.second.source_task_order < right.second.source_task_order;
+				}
+				return left.first < right.first;
+			});
+			for (idx_t entry_idx = 1; entry_idx < selected_attempts.size(); entry_idx++) {
+				if (selected_attempts[entry_idx - 1].second.source_task_order ==
+				    selected_attempts[entry_idx].second.source_task_order) {
+					throw InvalidInputException("selected Flight sinks have duplicate source task ordering metadata");
+				}
+			}
 		}
 	}
 	if (selected_attempts.empty()) {

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/delim_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/delim_join.cpp
@@ -106,7 +106,7 @@ void DelimJoinNode::GatherDelimScans(PhysicalOperator &op, vector<const_referenc
 			delim_scans.push_back(op);
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		GatherDelimScans(child, delim_scans, delim_idx);
 	}
 }

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/delim_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/delim_join.cpp
@@ -106,7 +106,7 @@ void DelimJoinNode::GatherDelimScans(PhysicalOperator &op, vector<const_referenc
 			delim_scans.push_back(op);
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		GatherDelimScans(child, delim_scans, delim_idx);
 	}
 }

--- a/external/duckdb/src/execution/distributed/pipeline_node/join/positional_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/join/positional_join.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "duckdb/execution/distributed/pipeline_node/join/positional_join.hpp"
+
+#include <algorithm>
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/execution/distributed/pipeline_node/binary_task_fan_in.hpp"
+#include "duckdb/execution/distributed/plan/runner.hpp"
+#include "duckdb/execution/operator/join/physical_positional_join.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+PositionalJoinNode::PositionalJoinNode(NodeID node_id, const PlanConfig &plan_config,
+                                       duckdb::vector<LogicalType> output_types, idx_t estimated_cardinality,
+                                       std::shared_ptr<DistributedPipelineNode> left,
+                                       std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema)
+    : context_(plan_config.query_idx, plan_config.query_id, node_id, "PositionalJoin"),
+      output_types_(std::move(output_types)), estimated_cardinality_(estimated_cardinality), left_(std::move(left)),
+      right_(std::move(right)) {
+	size_t num_partitions = 1;
+	if (left_ && right_) {
+		num_partitions = std::max(left_->config().clustering_spec()->num_partitions(),
+		                          right_->config().clustering_spec()->num_partitions());
+	} else if (left_) {
+		num_partitions = left_->config().clustering_spec()->num_partitions();
+	} else if (right_) {
+		num_partitions = right_->config().clustering_spec()->num_partitions();
+	}
+
+	auto clustering = ClusteringSpec::unknown_with_num_partitions(num_partitions);
+	config_ = PipelineNodeConfig(std::move(schema), plan_config.config, std::move(clustering));
+}
+
+std::vector<PipelineNodeRef> PositionalJoinNode::children() const {
+	std::vector<PipelineNodeRef> result;
+	if (left_) {
+		result.push_back(left_->inner());
+	}
+	if (right_) {
+		result.push_back(right_->inner());
+	}
+	return result;
+}
+
+std::vector<std::string> PositionalJoinNode::multiline_display(bool /*verbose*/) const {
+	return {"Positional Join"};
+}
+
+SubmittableTask<WorkerTask> PositionalJoinNode::BuildPositionalJoinTask(SubmittableTask<WorkerTask> left_task,
+                                                                        SubmittableTask<WorkerTask> right_task,
+                                                                        TaskIDCounter &task_id_counter,
+                                                                        ClientContext *client_context) {
+	auto left_plan_src = left_task.task()->plan();
+	auto right_plan_src = right_task.task()->plan();
+	if (!left_plan_src || !left_plan_src->HasRoot() || !right_plan_src || !right_plan_src->HasRoot()) {
+		throw InvalidInputException("PositionalJoinNode cannot build task from input without a physical plan root");
+	}
+
+	auto plan = ClonePhysicalPlanOrThrow(left_plan_src, "build_positional_join_task:left", client_context);
+	auto &left_root = plan->Root();
+	auto &right_root =
+	    ClonePhysicalPlanRootIntoPlanOrThrow(right_plan_src, *plan, "build_positional_join_task:right", client_context);
+
+	duckdb::vector<LogicalType> child_derived_types = left_root.GetTypes();
+	const auto &right_types = right_root.GetTypes();
+	child_derived_types.insert(child_derived_types.end(), right_types.begin(), right_types.end());
+	if (child_derived_types != output_types_) {
+		throw InternalException(
+		    "PositionalJoinNode output schema does not match its children (%llu translated columns, %llu "
+		    "child-derived columns)",
+		    output_types_.size(), child_derived_types.size());
+	}
+
+	auto &positional_join =
+	    plan->Make<PhysicalPositionalJoin>(output_types_, left_root, right_root, estimated_cardinality_);
+	plan->SetRoot(positional_join);
+
+	TaskContext task_context = TaskContext::from_node_context(context_.query_idx(), node_id(), task_id_counter.next());
+	auto merged_context = MergeTaskContext(left_task.task()->context(), right_task.task()->context());
+	merged_context = MergeTaskContext(merged_context, context_.to_hashmap());
+	WorkerTask new_task(task_context, plan, left_task.task()->config(), std::move(merged_context), "WorkerTask");
+	auto &inputs = new_task.mutable_inputs();
+	MoveTaskInputsOrThrow(inputs, left_task.task()->mutable_inputs(), context_.node_name());
+	MoveTaskInputsOrThrow(inputs, right_task.task()->mutable_inputs(), context_.node_name());
+	return std::move(left_task).with_new_task(std::move(new_task));
+}
+
+SubmittableTaskStream<WorkerTask> PositionalJoinNode::produce_tasks(PlanExecutionContext &plan_context) {
+	if (!left_ || !right_) {
+		return SubmittableTaskStream<WorkerTask>::from_receiver(Receiver<SubmittableTask<WorkerTask>>());
+	}
+
+	auto left_input = left_->produce_tasks(plan_context);
+	auto right_input = right_->produce_tasks(plan_context);
+	auto task_id_counter = std::make_shared<TaskIDCounter>(plan_context.task_id_counter());
+	auto *client_context = plan_context.client_context();
+	auto self_shared = shared_from_this();
+	BinaryInitialTaskBuilder build_initial_task = [self_shared, task_id_counter,
+	                                               client_context](BinarySubmittableTask left_task,
+	                                                               BinarySubmittableTask right_task) mutable {
+		return self_shared->BuildPositionalJoinTask(std::move(left_task), std::move(right_task), *task_id_counter,
+		                                            client_context);
+	};
+
+	BinaryFragmentInputFanInStream stream(std::move(left_input), std::move(right_input), std::move(build_initial_task),
+	                                      task_id_counter, context_.query_idx(), node_id(), context_.node_name());
+	return SubmittableTaskStream<WorkerTask>(boxed<BinarySubmittableTask>(std::move(stream)));
+}
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/shuffles/repartition.cpp
@@ -59,6 +59,19 @@ vector<unique_ptr<Expression>> CopyExpressions(const vector<unique_ptr<Expressio
 	return result;
 }
 
+SubmittableTask<WorkerTask> TagOrderedExchangeTask(SubmittableTask<WorkerTask> task, idx_t source_task_order) {
+	auto *worker_task = task.task();
+	if (!worker_task) {
+		throw InvalidInputException("ordered exchange received an invalid worker task");
+	}
+	auto context = worker_task->context();
+	context["source_task_order"] = std::to_string(source_task_order);
+	auto inputs = std::move(worker_task->mutable_inputs());
+	WorkerTask tagged(worker_task->task_context(), worker_task->plan(), worker_task->config(), std::move(context),
+	                  worker_task->name(), std::move(inputs));
+	return std::move(task).with_new_task(std::move(tagged));
+}
+
 vector<unique_ptr<Expression>> CopyHashPartitionByExpressions(const std::shared_ptr<RepartitionSpec> &spec) {
 	vector<unique_ptr<Expression>> result;
 	if (!spec || spec->type() == RepartitionSpec::Type::Random ||
@@ -129,7 +142,8 @@ DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan, const st
                                               const distributed::Exchange &exchange,
                                               std::shared_ptr<distributed::ExchangeManager> exchange_mgr,
                                               bool collect_mark_join_build_summary,
-                                              vector<unique_ptr<Expression>> mark_join_build_expressions) {
+                                              vector<unique_ptr<Expression>> mark_join_build_expressions,
+                                              bool preserve_order) {
 	if (!plan || !plan->HasRoot()) {
 		return plan;
 	}
@@ -154,7 +168,8 @@ DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan, const st
 	auto estimated = old_root.estimated_cardinality;
 	auto &sink = static_cast<PhysicalRemoteExchangeSink &>(plan->Make<PhysicalRemoteExchangeSink>(
 	    old_root.GetTypes(), estimated, exchange_id, num_partitions, repartition_type, std::move(partition_exprs),
-	    exchange_context.query_id, exchange.GetSinkOutputLocationPrefix(), std::move(exchange_mgr)));
+	    exchange_context.query_id, exchange.GetSinkOutputLocationPrefix(), std::move(exchange_mgr), vector<string> {},
+	    vector<string> {}, preserve_order));
 	if (collect_mark_join_build_summary) {
 		sink.EnableMarkJoinBuildSummary(std::move(mark_join_build_expressions));
 	}
@@ -197,13 +212,13 @@ DuckPhysicalPlanRef MakeRemoteExchangeSourcePlan(const vector<LogicalType> &type
                                                  std::vector<distributed::ExchangeSourceHandle> source_handles,
                                                  std::shared_ptr<distributed::ExchangeManager> exchange_mgr,
                                                  const vector<std::string> &source_nodes,
-                                                 optional_idx runtime_source_node_id) {
+                                                 optional_idx runtime_source_node_id, bool preserve_order) {
 	Allocator &alloc = Allocator::DefaultAllocator();
 	auto plan = std::make_shared<duckdb::PhysicalPlan>(alloc);
 	auto types_copy = types;
 	auto &source = plan->Make<PhysicalRemoteExchangeSource>(
 	    std::move(types_copy), estimated_cardinality, exchange_id, std::move(partition_indices),
-	    std::move(source_handles), std::move(exchange_mgr), source_nodes, runtime_source_node_id);
+	    std::move(source_handles), std::move(exchange_mgr), source_nodes, runtime_source_node_id, preserve_order);
 	plan->SetRoot(source);
 	return plan;
 }
@@ -212,9 +227,10 @@ DuckPhysicalPlanRef MakeRemoteExchangeSourcePlan(const vector<LogicalType> &type
 RepartitionNode::RepartitionNode(PipelineNodeConfig config, PipelineNodeContext context,
                                  std::shared_ptr<::duckdb::RepartitionSpec> repartition_spec, size_t num_partitions,
                                  std::shared_ptr<DistributedPipelineNode> child,
-                                 std::shared_ptr<ExchangeManager> exchange_mgr)
+                                 std::shared_ptr<ExchangeManager> exchange_mgr, bool preserve_order)
     : config_(std::move(config)), context_(std::move(context)), repartition_spec_(std::move(repartition_spec)),
-      num_partitions_(num_partitions), child_(std::move(child)), exchange_mgr_(std::move(exchange_mgr)) {
+      num_partitions_(num_partitions), child_(std::move(child)), exchange_mgr_(std::move(exchange_mgr)),
+      preserve_order_(preserve_order) {
 	if (num_partitions_ == 0) {
 		throw InvalidInputException("RepartitionNode requires at least one partition");
 	}
@@ -225,7 +241,8 @@ std::shared_ptr<RepartitionNode> RepartitionNode::create(NodeID node_id, const s
                                                          std::shared_ptr<RepartitionSpec> repartition_spec,
                                                          size_t num_partitions, SchemaRef schema,
                                                          std::shared_ptr<DistributedPipelineNode> child,
-                                                         std::shared_ptr<ExchangeManager> exchange_mgr) {
+                                                         std::shared_ptr<ExchangeManager> exchange_mgr,
+                                                         bool preserve_order) {
 	if (num_partitions == 0) {
 		throw InvalidInputException("RepartitionNode requires at least one partition");
 	}
@@ -244,9 +261,9 @@ std::shared_ptr<RepartitionNode> RepartitionNode::create(NodeID node_id, const s
 	// std::make_shared cannot access the private constructor in some
 	// standard library implementations when used in this static method
 	// context; construct with `new` inside class scope instead.
-	return std::shared_ptr<RepartitionNode>(new RepartitionNode(std::move(config), std::move(context),
-	                                                            std::move(repartition_spec), num_partitions,
-	                                                            std::move(child), std::move(exchange_mgr)));
+	return std::shared_ptr<RepartitionNode>(
+	    new RepartitionNode(std::move(config), std::move(context), std::move(repartition_spec), num_partitions,
+	                        std::move(child), std::move(exchange_mgr), preserve_order));
 }
 
 // Convert to node.
@@ -275,6 +292,9 @@ std::vector<std::string> RepartitionNode::multiline_display(bool verbose) const 
 	result.push_back("Repartition");
 	if (collect_mark_join_build_summary_) {
 		result.push_back("MARK build summary: global");
+	}
+	if (preserve_order_) {
+		result.push_back("Order: preserved");
 	}
 
 	return result;
@@ -351,11 +371,15 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 		auto plan_builder = [self_shared, repartition_spec, exchange, exchange_mgr](DuckPhysicalPlanRef plan) {
 			return AddRemoteExchangeSinkPlan(std::move(plan), repartition_spec, *exchange, exchange_mgr,
 			                                 self_shared->collect_mark_join_build_summary_,
-			                                 CopyExpressions(self_shared->mark_join_build_expressions_));
+			                                 CopyExpressions(self_shared->mark_join_build_expressions_),
+			                                 self_shared->preserve_order_);
 		};
 		auto node_ref = std::static_pointer_cast<PipelineNodeImpl>(self_shared);
 		auto first_with_sink =
 		    append_plan_to_existing_task(std::move(first_task), node_ref, plan_builder, client_context);
+		if (self_shared->preserve_order_) {
+			first_with_sink = TagOrderedExchangeTask(std::move(first_with_sink), 0);
+		}
 
 		struct ExchangeSinkStream {
 			std::shared_ptr<SubmittableTaskStream<WorkerTask>> input;
@@ -363,6 +387,8 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 			PipelineNodeRef node;
 			std::function<DuckPhysicalPlanRef(DuckPhysicalPlanRef)> plan_builder;
 			::duckdb::ClientContext *client_context = nullptr;
+			bool preserve_order = false;
+			idx_t next_source_task_order = 1;
 
 			std::pair<bool, SubmittableTask<WorkerTask>> poll_next() {
 				if (first.first) {
@@ -377,8 +403,11 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 				if (!next.first) {
 					return std::make_pair(false, SubmittableTask<WorkerTask>());
 				}
-				return std::make_pair(
-				    true, append_plan_to_existing_task(std::move(next.second), node, plan_builder, client_context));
+				auto task = append_plan_to_existing_task(std::move(next.second), node, plan_builder, client_context);
+				if (preserve_order) {
+					task = TagOrderedExchangeTask(std::move(task), next_source_task_order++);
+				}
+				return std::make_pair(true, std::move(task));
 			}
 
 			bool is_exhausted() const {
@@ -430,6 +459,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 		stream.node = node_ref;
 		stream.plan_builder = plan_builder;
 		stream.client_context = client_context;
+		stream.preserve_order = self_shared->preserve_order_;
 		auto sink_stream = SubmittableTaskStream<WorkerTask>(boxed<SubmittableTask<WorkerTask>>(std::move(stream)));
 		idx_t target_tasks = ResolveExchangeSourceTaskCount(num_partitions, self_shared->config_.execution_config());
 		auto sent_source_handle_keys = std::make_shared<std::unordered_set<std::string>>();
@@ -486,9 +516,9 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 				source_task.source_partition_count = num_partitions;
 				source_task.source_task_count = target_tasks;
 				source_task.mark_join_build_summary = mark_join_build_summary;
-				auto plan =
-				    MakeRemoteExchangeSourcePlan(output_types, estimated_cardinality, exchange_id, {}, {}, exchange_mgr,
-				                                 source_nodes, optional_idx(self_shared->node_id()));
+				auto plan = MakeRemoteExchangeSourcePlan(
+				    output_types, estimated_cardinality, exchange_id, {}, {}, exchange_mgr, source_nodes,
+				    optional_idx(self_shared->node_id()), self_shared->preserve_order_);
 				TaskContext task_context = TaskContext::from_node_context(
 				    self_shared->context().query_idx(), self_shared->node_id(), task_id_counter->next());
 				WorkerTask task(task_context, plan, self_shared->config_.execution_config(),
@@ -529,7 +559,7 @@ SubmittableTaskStream<WorkerTask> RepartitionNode::produce_tasks(PlanExecutionCo
 			const auto &sink_instance = output.exchange_sink_instance();
 			exchange->AddSink(sink_instance.sink_handle.task_partition_id);
 			exchange->SinkFinished(sink_instance, node_id, output.flight_port());
-			if (self_shared->collect_mark_join_build_summary_) {
+			if (self_shared->collect_mark_join_build_summary_ || self_shared->preserve_order_) {
 				return DuckDBResult<void>::ok();
 			}
 			return send_new_source_handles("sink_output");

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -64,6 +64,14 @@ namespace distributed {
 
 namespace {
 
+vector<const_reference<PhysicalOperator>> TranslationChildren(const PhysicalOperator &op) {
+	return op.GetInputChildren();
+}
+
+vector<reference<PhysicalOperator>> TranslationChildren(PhysicalOperator &op) {
+	return op.GetInputChildren();
+}
+
 void ValidateResolvedExtensionWriteInfo(ClientContext &context, const DistributedExtensionWriteInfo &info,
                                         const DistributedExtensionWritePlan &plan) {
 	info.Validate();
@@ -129,7 +137,7 @@ void PhysicalPlanToPipelineNodeTranslator::CollectUnionOrderRequirements(const P
 		}
 	}
 
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : TranslationChildren(op)) {
 		CollectUnionOrderRequirements(child.get(), child_order_required);
 	}
 }
@@ -242,11 +250,16 @@ PhysicalPlanToPipelineNodeTranslator::gen_ordered_gather_node(std::shared_ptr<Di
 }
 
 void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOperator &op) {
-	// First recurse into children using the base helper
-	PhysicalOperatorVisitor::VisitOperatorChildren(op);
+	// Translate only executable inputs. Some operators expose additional owned
+	// subplans through GetChildren(), but those are serialized into their owning
+	// distributed node rather than translated as independent pipelines.
+	auto physical_children = TranslationChildren(op);
+	for (auto &child : physical_children) {
+		VisitOperator(child.get());
+	}
 
 	// collect child distributed nodes (if any)
-	size_t n_children = op.GetChildren().size();
+	size_t n_children = physical_children.size();
 	std::vector<std::shared_ptr<DistributedPipelineNode>> children;
 	children.reserve(n_children);
 	for (size_t i = 0; i < n_children; ++i) {
@@ -592,7 +605,7 @@ physical_plan_scan_split_map_wrapper(DuckPhysicalPlanRef plan, DuckDBExecutionCo
 				max_id = std::max(max_id, scan.extra_info.scan_group_id.GetIndex());
 			}
 		}
-		for (auto &child : op.GetChildren()) {
+		for (auto &child : op.GetInputChildren()) {
 			update_max(child.get());
 		}
 	};
@@ -622,7 +635,7 @@ physical_plan_scan_split_map_wrapper(DuckPhysicalPlanRef plan, DuckDBExecutionCo
 			auto splits = MakeTableScanSplits(scan, *exec_cfg, db);
 			out.emplace(scan.extra_info.scan_node_id.GetIndex(), std::move(splits));
 		}
-		for (auto &child : op.GetChildren()) {
+		for (auto &child : op.GetInputChildren()) {
 			collect(child.get());
 		}
 	};

--- a/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translate.cpp
@@ -45,9 +45,11 @@
 #include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
+#include "duckdb/execution/operator/join/physical_positional_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/execution/operator/join/physical_range_join.hpp"
 #include "duckdb/execution/operator/join/physical_delim_join.hpp"
+#include "duckdb/execution/operator/scan/physical_positional_scan.hpp"
 #include "duckdb/execution/operator/persistent/physical_copy_to_file.hpp"
 #include "duckdb/execution/operator/persistent/physical_batch_copy_to_file.hpp"
 #include "duckdb/execution/operator/set/physical_union.hpp"
@@ -127,7 +129,7 @@ void PhysicalPlanToPipelineNodeTranslator::CollectUnionOrderRequirements(const P
 		}
 	}
 
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		CollectUnionOrderRequirements(child.get(), child_order_required);
 	}
 }
@@ -183,8 +185,8 @@ PhysicalPlanToPipelineNodeTranslator::physical_plan_to_pipeline_node(
 
 std::shared_ptr<DistributedPipelineNode>
 PhysicalPlanToPipelineNodeTranslator::gen_shuffle_node(std::shared_ptr<RepartitionSpec> repartition_spec,
-                                                       SchemaRef schema,
-                                                       std::shared_ptr<DistributedPipelineNode> child) {
+                                                       SchemaRef schema, std::shared_ptr<DistributedPipelineNode> child,
+                                                       bool preserve_order) {
 	if (!repartition_spec) {
 		throw InternalException("Cannot build shuffle node without a repartition specification");
 	}
@@ -206,7 +208,7 @@ PhysicalPlanToPipelineNodeTranslator::gen_shuffle_node(std::shared_ptr<Repartiti
 	auto plan_cfg_ptr = std::make_shared<PlanConfig>(plan_config_);
 	auto repartition_node =
 	    RepartitionNode::create(get_next_pipeline_node_id(), plan_cfg_ptr, std::move(repartition_spec), num_partitions,
-	                            std::move(schema), std::move(child), exchange_mgr_);
+	                            std::move(schema), std::move(child), exchange_mgr_, preserve_order);
 	if (!repartition_node) {
 		throw InternalException("Failed to build shuffle node");
 	}
@@ -227,12 +229,24 @@ PhysicalPlanToPipelineNodeTranslator::gen_gather_node(std::shared_ptr<Distribute
 	return gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node);
 }
 
+std::shared_ptr<DistributedPipelineNode>
+PhysicalPlanToPipelineNodeTranslator::gen_ordered_gather_node(std::shared_ptr<DistributedPipelineNode> input_node) {
+	if (!input_node) {
+		throw InternalException("Cannot build ordered gather node without an input");
+	}
+	// Always materialize, even when clustering metadata says one partition: a
+	// one-partition node may still emit multiple task fragments. Positional
+	// semantics require one complete, deterministically ordered input stream.
+	auto spec = RepartitionSpec::create_into_partitions(1);
+	return gen_shuffle_node(std::move(spec), input_node->config().schema(), input_node, true);
+}
+
 void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOperator &op) {
 	// First recurse into children using the base helper
 	PhysicalOperatorVisitor::VisitOperatorChildren(op);
 
 	// collect child distributed nodes (if any)
-	size_t n_children = op.children.size();
+	size_t n_children = op.GetChildren().size();
 	std::vector<std::shared_ptr<DistributedPipelineNode>> children;
 	children.reserve(n_children);
 	for (size_t i = 0; i < n_children; ++i) {
@@ -381,6 +395,16 @@ void PhysicalPlanToPipelineNodeTranslator::VisitOperator(::duckdb::PhysicalOpera
 	case PhysicalOperatorType::CROSS_PRODUCT: {
 		auto &cross_product = static_cast<PhysicalCrossProduct &>(op);
 		node_impl = TranslateCrossProduct(cross_product, children);
+		break;
+	}
+	case PhysicalOperatorType::POSITIONAL_JOIN: {
+		auto &positional_join = static_cast<PhysicalPositionalJoin &>(op);
+		node_impl = TranslatePositionalJoin(positional_join, children);
+		break;
+	}
+	case PhysicalOperatorType::POSITIONAL_SCAN: {
+		auto &positional_scan = static_cast<PhysicalPositionalScan &>(op);
+		node_impl = TranslatePositionalScan(positional_scan, children);
 		break;
 	}
 	case PhysicalOperatorType::ASOF_JOIN: {
@@ -568,7 +592,7 @@ physical_plan_scan_split_map_wrapper(DuckPhysicalPlanRef plan, DuckDBExecutionCo
 				max_id = std::max(max_id, scan.extra_info.scan_group_id.GetIndex());
 			}
 		}
-		for (auto &child : op.children) {
+		for (auto &child : op.GetChildren()) {
 			update_max(child.get());
 		}
 	};
@@ -598,7 +622,7 @@ physical_plan_scan_split_map_wrapper(DuckPhysicalPlanRef plan, DuckDBExecutionCo
 			auto splits = MakeTableScanSplits(scan, *exec_cfg, db);
 			out.emplace(scan.extra_info.scan_node_id.GetIndex(), std::move(splits));
 		}
-		for (auto &child : op.children) {
+		for (auto &child : op.GetChildren()) {
 			collect(child.get());
 		}
 	};

--- a/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
+++ b/external/duckdb/src/execution/distributed/pipeline_node/translator_join.cpp
@@ -18,6 +18,7 @@
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/join_output_types.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/positional_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/distributed/utils/optional.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
@@ -26,7 +27,9 @@
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
+#include "duckdb/execution/operator/join/physical_positional_join.hpp"
 #include "duckdb/execution/operator/join/physical_range_join.hpp"
+#include "duckdb/execution/operator/scan/physical_positional_scan.hpp"
 
 namespace duckdb {
 namespace distributed {
@@ -291,6 +294,79 @@ std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::Translat
 	return std::make_shared<CrossProductNode>(get_next_pipeline_node_id(), plan_config_, cross_product.GetTypes(),
 	                                          cross_product.estimated_cardinality, std::move(left), std::move(right),
 	                                          std::move(schema));
+}
+
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslatePositionalJoin(
+    const PhysicalPositionalJoin &positional_join,
+    const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	if (children.size() != 2 || !children[0] || !children[1]) {
+		throw InvalidInputException("Distributed positional join requires exactly two input nodes");
+	}
+
+	SchemaRef schema = nullptr;
+	if (!positional_join.GetTypes().empty()) {
+		auto output_names = BuildCrossProductOutputNames(children[0]->config().schema(), children[1]->config().schema(),
+		                                                 positional_join.GetTypes().size());
+		schema = output_names.empty() ? MakeSchemaRef(positional_join.GetTypes())
+		                              : MakeSchemaRef(positional_join.GetTypes(), output_names);
+	}
+
+	// Each complete input must become one stable stream before the native
+	// positional operator aligns rows and pads the shorter side with NULLs.
+	auto left = gen_ordered_gather_node(children[0]);
+	auto right = gen_ordered_gather_node(children[1]);
+	return std::make_shared<PositionalJoinNode>(get_next_pipeline_node_id(), plan_config_, positional_join.GetTypes(),
+	                                            positional_join.estimated_cardinality, std::move(left),
+	                                            std::move(right), std::move(schema));
+}
+
+std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslatePositionalScan(
+    const PhysicalPositionalScan &positional_scan,
+    const std::vector<std::shared_ptr<DistributedPipelineNode>> &children) {
+	if (children.size() < 2 || children.size() != positional_scan.child_tables.size()) {
+		throw InvalidInputException("Distributed positional scan requires at least two table scan inputs");
+	}
+	for (const auto &child : children) {
+		if (!child) {
+			throw InvalidInputException("Distributed positional scan received a null input node");
+		}
+	}
+
+	auto accumulated = children[0];
+	duckdb::vector<LogicalType> accumulated_types = positional_scan.child_tables[0].get().GetTypes();
+	idx_t accumulated_cardinality = positional_scan.child_tables[0].get().estimated_cardinality;
+
+	for (idx_t child_idx = 1; child_idx < children.size(); child_idx++) {
+		const auto &right_op = positional_scan.child_tables[child_idx].get();
+		auto output_types = accumulated_types;
+		const auto &right_types = right_op.GetTypes();
+		output_types.insert(output_types.end(), right_types.begin(), right_types.end());
+		accumulated_cardinality = MaxValue(accumulated_cardinality, right_op.estimated_cardinality);
+
+		SchemaRef schema = nullptr;
+		if (!output_types.empty()) {
+			auto output_names = BuildCrossProductOutputNames(
+			    accumulated->config().schema(), children[child_idx]->config().schema(), output_types.size());
+			schema = output_names.empty() ? MakeSchemaRef(output_types) : MakeSchemaRef(output_types, output_names);
+		}
+
+		auto left = gen_ordered_gather_node(accumulated);
+		auto right = gen_ordered_gather_node(children[child_idx]);
+		auto join = std::make_shared<PositionalJoinNode>(get_next_pipeline_node_id(), plan_config_, output_types,
+		                                                 accumulated_cardinality, std::move(left), std::move(right),
+		                                                 std::move(schema));
+
+		accumulated_types = std::move(output_types);
+		if (child_idx + 1 == children.size()) {
+			if (accumulated_types != positional_scan.GetTypes()) {
+				throw InternalException("Distributed positional scan output schema does not match its table inputs");
+			}
+			return join;
+		}
+		accumulated = std::make_shared<DistributedPipelineNode>(std::move(join));
+	}
+
+	throw InternalException("Distributed positional scan translation produced no join node");
 }
 
 std::shared_ptr<PipelineNodeImpl> PhysicalPlanToPipelineNodeTranslator::TranslateAsOfJoin(

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -43,7 +43,7 @@ bool FindUniqueRemoteExchangeSink(const PhysicalOperator &op, const PhysicalRemo
 		}
 		sink = candidate;
 	}
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		if (!FindUniqueRemoteExchangeSink(child.get(), sink, count, error)) {
 			return false;
 		}
@@ -64,6 +64,12 @@ bool ValidateRuntimeSinkHandle(const PhysicalRemoteExchangeSink &sink, const Exc
 	}
 	if (runtime_handle.sink_handle.task_partition_id == DConstants::INVALID_INDEX) {
 		return SetValidationError(error, "runtime exchange sink received an invalid task identity");
+	}
+	if (sink.PreservesOrder() && runtime_handle.source_task_order == DConstants::INVALID_INDEX) {
+		return SetValidationError(error, "ordered exchange sink is missing its source task order");
+	}
+	if (!sink.PreservesOrder() && runtime_handle.source_task_order != DConstants::INVALID_INDEX) {
+		return SetValidationError(error, "unordered exchange sink received an unexpected source task order");
 	}
 	const auto expected_output_location = sink.SinkOutputLocationPrefix() + "__sink_" +
 	                                      std::to_string(runtime_handle.sink_handle.task_partition_id) + "__attempt_" +
@@ -88,7 +94,7 @@ bool ValidateRuntimeTaskIndexForOperator(PhysicalOperator &op, const ExchangeSin
 			}
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (!ValidateRuntimeTaskIndexForOperator(child.get(), sink_instance, error)) {
 			return false;
 		}
@@ -109,7 +115,7 @@ bool ValidateExchangeSinkInstanceForOperator(PhysicalOperator &op, const Exchang
 		}
 		validated++;
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (!ValidateExchangeSinkInstanceForOperator(child.get(), sink_instance, error, validated)) {
 			return false;
 		}
@@ -130,7 +136,7 @@ bool ApplyExchangeSinkInstanceToOperator(PhysicalOperator &op, const ExchangeSin
 		sink->ApplyRuntimeSinkHandle(task.sink_instance);
 		applied++;
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (!ApplyExchangeSinkInstanceToOperator(child.get(), task, error, applied)) {
 			return false;
 		}
@@ -145,7 +151,7 @@ void ApplyRuntimeTaskIndexToOperator(PhysicalOperator &op, idx_t task_partition_
 			sample.ApplyRuntimeTaskIndex(task_partition_id);
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		ApplyRuntimeTaskIndexToOperator(child.get(), task_partition_id);
 	}
 }
@@ -181,6 +187,8 @@ void ExchangeSinkInstanceTaskDescriptor::Serialize(Serializer &serializer) const
 	                                          sink_instance.mark_join_build_summary.has_rows, false);
 	serializer.WritePropertyWithDefault<bool>(10, "mark_join_build_has_null",
 	                                          sink_instance.mark_join_build_summary.has_null, false);
+	serializer.WritePropertyWithDefault<idx_t>(11, "source_task_order", sink_instance.source_task_order,
+	                                           DConstants::INVALID_INDEX);
 }
 
 ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deserialize(Deserializer &deserializer) {
@@ -200,6 +208,8 @@ ExchangeSinkInstanceTaskDescriptor ExchangeSinkInstanceTaskDescriptor::Deseriali
 	                                           result.sink_instance.mark_join_build_summary.has_rows);
 	deserializer.ReadPropertyWithDefault<bool>(10, "mark_join_build_has_null",
 	                                           result.sink_instance.mark_join_build_summary.has_null);
+	result.sink_instance.source_task_order =
+	    deserializer.ReadPropertyWithExplicitDefault<idx_t>(11, "source_task_order", DConstants::INVALID_INDEX);
 	if (!result.sink_instance.mark_join_build_summary.IsConsistent()) {
 		throw SerializationException("invalid MARK join build summary in exchange sink task");
 	}

--- a/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_sink_instance_task.cpp
@@ -43,7 +43,7 @@ bool FindUniqueRemoteExchangeSink(const PhysicalOperator &op, const PhysicalRemo
 		}
 		sink = candidate;
 	}
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : op.GetInputChildren()) {
 		if (!FindUniqueRemoteExchangeSink(child.get(), sink, count, error)) {
 			return false;
 		}
@@ -94,7 +94,7 @@ bool ValidateRuntimeTaskIndexForOperator(PhysicalOperator &op, const ExchangeSin
 			}
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (!ValidateRuntimeTaskIndexForOperator(child.get(), sink_instance, error)) {
 			return false;
 		}
@@ -115,7 +115,7 @@ bool ValidateExchangeSinkInstanceForOperator(PhysicalOperator &op, const Exchang
 		}
 		validated++;
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (!ValidateExchangeSinkInstanceForOperator(child.get(), sink_instance, error, validated)) {
 			return false;
 		}
@@ -136,7 +136,7 @@ bool ApplyExchangeSinkInstanceToOperator(PhysicalOperator &op, const ExchangeSin
 		sink->ApplyRuntimeSinkHandle(task.sink_instance);
 		applied++;
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (!ApplyExchangeSinkInstanceToOperator(child.get(), task, error, applied)) {
 			return false;
 		}
@@ -151,7 +151,7 @@ void ApplyRuntimeTaskIndexToOperator(PhysicalOperator &op, idx_t task_partition_
 			sample.ApplyRuntimeTaskIndex(task_partition_id);
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		ApplyRuntimeTaskIndexToOperator(child.get(), task_partition_id);
 	}
 }

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -41,7 +41,7 @@ bool CollectExchangeSourceNodeIds(const PhysicalOperator &op, set<idx_t> &node_i
 			node_ids.insert(source->RuntimeSourceNodeId().GetIndex());
 		}
 	}
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		if (!CollectExchangeSourceNodeIds(child.get(), node_ids, error)) {
 			return false;
 		}
@@ -63,7 +63,7 @@ bool ApplyExchangeSourceTasksToOperator(PhysicalOperator &op,
 			}
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (!ApplyExchangeSourceTasksToOperator(child.get(), tasks, error, applied)) {
 			return false;
 		}

--- a/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
+++ b/external/duckdb/src/execution/distributed/plan/exchange_source_task.cpp
@@ -41,7 +41,7 @@ bool CollectExchangeSourceNodeIds(const PhysicalOperator &op, set<idx_t> &node_i
 			node_ids.insert(source->RuntimeSourceNodeId().GetIndex());
 		}
 	}
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : op.GetInputChildren()) {
 		if (!CollectExchangeSourceNodeIds(child.get(), node_ids, error)) {
 			return false;
 		}
@@ -63,7 +63,7 @@ bool ApplyExchangeSourceTasksToOperator(PhysicalOperator &op,
 			}
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (!ApplyExchangeSourceTasksToOperator(child.get(), tasks, error, applied)) {
 			return false;
 		}

--- a/external/duckdb/src/execution/distributed/plan/fte_split_queue.cpp
+++ b/external/duckdb/src/execution/distributed/plan/fte_split_queue.cpp
@@ -352,7 +352,7 @@ bool CollectFteExchangeSourceNodeIds(const PhysicalOperator &op, set<idx_t> &nod
 			node_ids.insert(source->RuntimeSourceNodeId().GetIndex());
 		}
 	}
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : op.GetInputChildren()) {
 		if (!CollectFteExchangeSourceNodeIds(child.get(), node_ids, error)) {
 			return false;
 		}
@@ -381,7 +381,7 @@ bool ApplyFteExchangeSourceQueuesToOperator(PhysicalOperator &op,
 			}
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (!ApplyFteExchangeSourceQueuesToOperator(child.get(), queues, error, applied)) {
 			return false;
 		}

--- a/external/duckdb/src/execution/distributed/plan/fte_split_queue.cpp
+++ b/external/duckdb/src/execution/distributed/plan/fte_split_queue.cpp
@@ -352,7 +352,7 @@ bool CollectFteExchangeSourceNodeIds(const PhysicalOperator &op, set<idx_t> &nod
 			node_ids.insert(source->RuntimeSourceNodeId().GetIndex());
 		}
 	}
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		if (!CollectFteExchangeSourceNodeIds(child.get(), node_ids, error)) {
 			return false;
 		}
@@ -381,7 +381,7 @@ bool ApplyFteExchangeSourceQueuesToOperator(PhysicalOperator &op,
 			}
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (!ApplyFteExchangeSourceQueuesToOperator(child.get(), queues, error, applied)) {
 			return false;
 		}

--- a/external/duckdb/src/execution/distributed/plan/scan_split.cpp
+++ b/external/duckdb/src/execution/distributed/plan/scan_split.cpp
@@ -235,7 +235,7 @@ static idx_t MaxScanNodeId(const PhysicalOperator &op, idx_t max_id) {
 			}
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		max_id = MaxScanNodeId(child.get(), max_id);
 	}
 	return max_id;
@@ -248,7 +248,7 @@ static void CollectScanNodeIds(const PhysicalOperator &op, set<idx_t> &node_ids)
 			node_ids.insert(scan.extra_info.scan_node_id.GetIndex());
 		}
 	}
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : op.GetInputChildren()) {
 		CollectScanNodeIds(child.get(), node_ids);
 	}
 }
@@ -269,7 +269,7 @@ static bool CollectRequiredScanNodeIds(const PhysicalOperator &op, set<idx_t> &n
 		}
 		node_ids.insert(scan.extra_info.scan_node_id.GetIndex());
 	}
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : op.GetInputChildren()) {
 		if (!CollectRequiredScanNodeIds(child.get(), node_ids, error)) {
 			return false;
 		}
@@ -328,7 +328,7 @@ static void NormalizeScanNodeIdsByGroup(PhysicalOperator &op, unordered_map<idx_
 			}
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		NormalizeScanNodeIdsByGroup(child.get(), base_node_for_group, group_for_node, alias_to_parent, last_id, stats);
 	}
 }
@@ -466,7 +466,7 @@ static bool ApplyScanSplitBatchesToOperator(PhysicalOperator &op, const ScanSpli
 		}
 	}
 
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (ApplyScanSplitBatchesToOperator(child.get(), batches, matched_batches, stats, error)) {
 			applied_any = true;
 		}
@@ -965,7 +965,7 @@ bool ApplyFteScanSourceQueuesToOperator(PhysicalOperator &op,
 			}
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		if (!ApplyFteScanSourceQueuesToOperator(child.get(), queues, extension_batch_cache, dynamic_file_list_cache,
 		                                        matched_queues, error, applied)) {
 			ok = false;
@@ -1100,7 +1100,7 @@ static bool ValidateDistributedScanSplitsAppliedToOperator(const PhysicalOperato
 			return false;
 		}
 	}
-	for (const auto &child : op.GetChildren()) {
+	for (const auto &child : op.GetInputChildren()) {
 		if (!ValidateDistributedScanSplitsAppliedToOperator(child.get(), error)) {
 			return false;
 		}

--- a/external/duckdb/src/execution/distributed/plan/scan_split.cpp
+++ b/external/duckdb/src/execution/distributed/plan/scan_split.cpp
@@ -235,7 +235,7 @@ static idx_t MaxScanNodeId(const PhysicalOperator &op, idx_t max_id) {
 			}
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		max_id = MaxScanNodeId(child.get(), max_id);
 	}
 	return max_id;
@@ -248,7 +248,7 @@ static void CollectScanNodeIds(const PhysicalOperator &op, set<idx_t> &node_ids)
 			node_ids.insert(scan.extra_info.scan_node_id.GetIndex());
 		}
 	}
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		CollectScanNodeIds(child.get(), node_ids);
 	}
 }
@@ -269,7 +269,7 @@ static bool CollectRequiredScanNodeIds(const PhysicalOperator &op, set<idx_t> &n
 		}
 		node_ids.insert(scan.extra_info.scan_node_id.GetIndex());
 	}
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		if (!CollectRequiredScanNodeIds(child.get(), node_ids, error)) {
 			return false;
 		}
@@ -328,7 +328,7 @@ static void NormalizeScanNodeIdsByGroup(PhysicalOperator &op, unordered_map<idx_
 			}
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		NormalizeScanNodeIdsByGroup(child.get(), base_node_for_group, group_for_node, alias_to_parent, last_id, stats);
 	}
 }
@@ -466,7 +466,7 @@ static bool ApplyScanSplitBatchesToOperator(PhysicalOperator &op, const ScanSpli
 		}
 	}
 
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (ApplyScanSplitBatchesToOperator(child.get(), batches, matched_batches, stats, error)) {
 			applied_any = true;
 		}
@@ -965,7 +965,7 @@ bool ApplyFteScanSourceQueuesToOperator(PhysicalOperator &op,
 			}
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		if (!ApplyFteScanSourceQueuesToOperator(child.get(), queues, extension_batch_cache, dynamic_file_list_cache,
 		                                        matched_queues, error, applied)) {
 			ok = false;
@@ -1100,7 +1100,7 @@ static bool ValidateDistributedScanSplitsAppliedToOperator(const PhysicalOperato
 			return false;
 		}
 	}
-	for (const auto &child : op.children) {
+	for (const auto &child : op.GetChildren()) {
 		if (!ValidateDistributedScanSplitsAppliedToOperator(child.get(), error)) {
 			return false;
 		}

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_sink.cpp
@@ -138,12 +138,13 @@ PhysicalRemoteExchangeSink::PhysicalRemoteExchangeSink(
     idx_t num_partitions, RepartitionSpec::Type repartition_type, vector<unique_ptr<Expression>> partition_by,
     std::string sink_query_id, std::string sink_output_location_prefix,
     std::shared_ptr<distributed::ExchangeManager> exchange_mgr, vector<string> range_boundaries,
-    vector<string> range_order_modifiers)
+    vector<string> range_order_modifiers, bool preserve_order)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXCHANGE_SINK, std::move(types), estimated_cardinality),
       exchange_id_(std::move(exchange_id)), num_partitions_(num_partitions), repartition_type_(repartition_type),
       partition_by_(std::move(partition_by)), sink_query_id_(std::move(sink_query_id)),
       sink_output_location_prefix_(std::move(sink_output_location_prefix)), exchange_mgr_(std::move(exchange_mgr)),
-      range_boundaries_(std::move(range_boundaries)), range_order_modifiers_(std::move(range_order_modifiers)) {
+      range_boundaries_(std::move(range_boundaries)), range_order_modifiers_(std::move(range_order_modifiers)),
+      preserve_order_(preserve_order) {
 	if (num_partitions_ == 0) {
 		throw InvalidInputException("remote exchange sink requires at least one partition");
 	}
@@ -341,6 +342,7 @@ InsertionOrderPreservingMap<string> PhysicalRemoteExchangeSink::ParamsToString()
 	result["exchange_id"] = exchange_id_;
 	result["num_partitions"] = std::to_string(num_partitions_);
 	result["type"] = "remote_exchange";
+	result["preserve_order"] = preserve_order_ ? "true" : "false";
 	return result;
 }
 
@@ -372,6 +374,7 @@ void PhysicalRemoteExchangeSink::SerializeOperatorData(Serializer &serializer) c
 	if (collect_mark_join_build_summary_) {
 		serializer.WriteProperty(114, "mark_join_build_expressions", mark_join_build_expressions_);
 	}
+	serializer.WritePropertyWithDefault<bool>(115, "preserve_order", preserve_order_, false);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
+++ b/external/duckdb/src/execution/operator/exchange/physical_remote_exchange_source.cpp
@@ -68,7 +68,11 @@ idx_t ResolveRemoteExchangeMaxThreads(ClientContext &context,
                                       const std::vector<distributed::ExchangeSourceHandle> &source_handles,
                                       const vector<idx_t> &partition_indices, idx_t source_partition_count,
                                       idx_t source_task_count,
-                                      const std::shared_ptr<distributed::FteSplitQueue> &runtime_split_queue) {
+                                      const std::shared_ptr<distributed::FteSplitQueue> &runtime_split_queue,
+                                      bool preserve_order) {
+	if (preserve_order) {
+		return 1;
+	}
 	idx_t max_threads = 1;
 	auto consider = [&](idx_t value) {
 		if (value > 0) {
@@ -170,11 +174,11 @@ PhysicalRemoteExchangeSource::PhysicalRemoteExchangeSource(
     PhysicalPlan &physical_plan, vector<LogicalType> types, idx_t estimated_cardinality, std::string exchange_id,
     vector<idx_t> partition_indices, std::vector<distributed::ExchangeSourceHandle> source_handles,
     std::shared_ptr<distributed::ExchangeManager> exchange_mgr, const vector<std::string> &source_nodes,
-    optional_idx runtime_source_node_id)
+    optional_idx runtime_source_node_id, bool preserve_order)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXCHANGE_SOURCE, std::move(types), estimated_cardinality),
       exchange_id_(std::move(exchange_id)), partition_indices_(std::move(partition_indices)),
       source_handles_(std::move(source_handles)), exchange_mgr_(std::move(exchange_mgr)), source_nodes_(source_nodes),
-      runtime_source_node_id_(runtime_source_node_id) {
+      runtime_source_node_id_(runtime_source_node_id), preserve_order_(preserve_order) {
 	if (!exchange_mgr_) {
 		throw InvalidInputException("remote exchange source requires a non-null ExchangeManager");
 	}
@@ -204,7 +208,7 @@ unique_ptr<GlobalSourceState> PhysicalRemoteExchangeSource::GetGlobalSourceState
 	exchange_mgr_->SetContext(&context);
 	auto max_threads =
 	    ResolveRemoteExchangeMaxThreads(context, source_handles_, partition_indices_, runtime_source_partition_count_,
-	                                    runtime_source_task_count_, runtime_split_queue_);
+	                                    runtime_source_task_count_, runtime_split_queue_, preserve_order_);
 	return make_uniq<RemoteSourceGlobalState>(exchange_mgr_, source_handles_, runtime_split_queue_, max_threads);
 }
 
@@ -301,6 +305,7 @@ InsertionOrderPreservingMap<string> PhysicalRemoteExchangeSource::ParamsToString
 	}
 	result["partition_indices"] = parts_str;
 	result["type"] = "remote_exchange";
+	result["preserve_order"] = preserve_order_ ? "true" : "false";
 	return result;
 }
 
@@ -353,6 +358,7 @@ void PhysicalRemoteExchangeSource::SerializeOperatorData(Serializer &serializer)
 	serializer.WriteProperty(115, "source_catalog_handles_explicit", true);
 	serializer.WriteProperty(116, "source_handle_flight_hosts", handle_flight_hosts);
 	serializer.WriteProperty(117, "source_handle_task_partition_ids", handle_source_task_partition_ids);
+	serializer.WritePropertyWithDefault<bool>(118, "preserve_order", preserve_order_, false);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/execution/operator/join/physical_positional_join.cpp
+++ b/external/duckdb/src/execution/operator/join/physical_positional_join.cpp
@@ -13,6 +13,11 @@ PhysicalPositionalJoin::PhysicalPositionalJoin(PhysicalPlan &physical_plan, vect
 	children.push_back(right);
 }
 
+PhysicalPositionalJoin::PhysicalPositionalJoin(PhysicalPlan &physical_plan, PositionalJoinDeserializeTag,
+                                               vector<LogicalType> types, idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::POSITIONAL_JOIN, std::move(types), estimated_cardinality) {
+}
+
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//

--- a/external/duckdb/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/external/duckdb/src/execution/operator/scan/physical_positional_scan.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/execution/operator/scan/physical_positional_scan.hpp"
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/serializer/serializer.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parallel/interrupt.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
@@ -34,6 +35,20 @@ PhysicalPositionalScan::PhysicalPositionalScan(PhysicalPlan &physical_plan, vect
 	} else {
 		throw InternalException("Invalid right input for PhysicalPositionalScan");
 	}
+}
+
+PhysicalPositionalScan::PhysicalPositionalScan(PhysicalPlan &physical_plan, PositionalScanDeserializeTag,
+                                               vector<LogicalType> types,
+                                               vector<reference<PhysicalOperator>> child_tables_p,
+                                               idx_t estimated_cardinality)
+    : PhysicalOperator(physical_plan, PhysicalOperatorType::POSITIONAL_SCAN, std::move(types), estimated_cardinality),
+      child_tables(std::move(child_tables_p)) {
+}
+
+void PhysicalPositionalScan::SerializeOperatorData(Serializer &serializer) const {
+	serializer.WriteList(103, "child_tables", child_tables.size(), [&](Serializer::List &list, idx_t i) {
+		list.WriteObject([&](Serializer &child_serializer) { child_tables[i].get().Serialize(child_serializer); });
+	});
 }
 
 class PositionalScanGlobalSourceState : public GlobalSourceState {

--- a/external/duckdb/src/execution/operator/scan/physical_positional_scan.cpp
+++ b/external/duckdb/src/execution/operator/scan/physical_positional_scan.cpp
@@ -235,4 +235,8 @@ vector<const_reference<PhysicalOperator>> PhysicalPositionalScan::GetChildren() 
 	return result;
 }
 
+vector<const_reference<PhysicalOperator>> PhysicalPositionalScan::GetInputChildren() const {
+	return GetChildren();
+}
+
 } // namespace duckdb

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -218,10 +218,18 @@ void PhysicalOperator::Print() const {
 }
 // LCOV_EXCL_STOP
 
-vector<reference<PhysicalOperator>> PhysicalOperator::GetChildren() {
+vector<reference<PhysicalOperator>> PhysicalOperator::GetInputChildren() {
 	vector<reference<PhysicalOperator>> result;
-	for (auto &child : static_cast<const PhysicalOperator &>(*this).GetChildren()) {
+	for (auto &child : static_cast<const PhysicalOperator &>(*this).GetInputChildren()) {
 		result.push_back(const_cast<PhysicalOperator &>(child.get()));
+	}
+	return result;
+}
+
+vector<const_reference<PhysicalOperator>> PhysicalOperator::GetInputChildren() const {
+	vector<const_reference<PhysicalOperator>> result;
+	for (auto &child : children) {
+		result.push_back(child.get());
 	}
 	return result;
 }

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -56,6 +56,7 @@
 #include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
+#include "duckdb/execution/operator/join/physical_positional_join.hpp"
 #include "duckdb/execution/operator/join/physical_nested_loop_join.hpp"
 #include "duckdb/execution/operator/join/physical_left_delim_join.hpp"
 #include "duckdb/execution/operator/join/physical_right_delim_join.hpp"
@@ -215,6 +216,14 @@ void PhysicalOperator::Print() const {
 	Printer::Print(ToString());
 }
 // LCOV_EXCL_STOP
+
+vector<reference<PhysicalOperator>> PhysicalOperator::GetChildren() {
+	vector<reference<PhysicalOperator>> result;
+	for (auto &child : static_cast<const PhysicalOperator &>(*this).GetChildren()) {
+		result.push_back(const_cast<PhysicalOperator &>(child.get()));
+	}
+	return result;
+}
 
 vector<const_reference<PhysicalOperator>> PhysicalOperator::GetChildren() const {
 	vector<const_reference<PhysicalOperator>> result;
@@ -1060,6 +1069,10 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		return make_uniq<PhysicalCrossProduct>(physical_plan, CrossProductDeserializeTag {}, std::move(types),
 		                                       estimated_cardinality);
 	}
+	case PhysicalOperatorType::POSITIONAL_JOIN: {
+		return make_uniq<PhysicalPositionalJoin>(physical_plan, PositionalJoinDeserializeTag {}, std::move(types),
+		                                         estimated_cardinality);
+	}
 	case PhysicalOperatorType::BLOCKWISE_NL_JOIN: {
 		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");
 		auto condition = deserializer.ReadProperty<unique_ptr<Expression>>(104, "condition");
@@ -1248,6 +1261,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		    deserializer.ReadPropertyWithDefault<bool>(113, "collect_mark_join_build_summary");
 		auto mark_join_build_expressions =
 		    deserializer.ReadPropertyWithDefault<vector<unique_ptr<Expression>>>(114, "mark_join_build_expressions");
+		auto preserve_order = deserializer.ReadPropertyWithDefault<bool>(115, "preserve_order");
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.local_dirs = std::vector<std::string>(local_dirs.begin(), local_dirs.end());
@@ -1256,7 +1270,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto result = make_uniq<PhysicalRemoteExchangeSink>(
 		    physical_plan, std::move(types), estimated_cardinality, std::move(exchange_id), num_partitions,
 		    repartition_type, std::move(partition_by), std::move(sink_query_id), std::move(sink_output_location_prefix),
-		    std::move(exchange_mgr), std::move(range_boundaries), std::move(range_order_modifiers));
+		    std::move(exchange_mgr), std::move(range_boundaries), std::move(range_order_modifiers), preserve_order);
 		if (collect_mark_join_build_summary) {
 			result->EnableMarkJoinBuildSummary(std::move(mark_join_build_expressions));
 		}
@@ -1287,6 +1301,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		auto source_handle_flight_hosts = deserializer.ReadProperty<vector<string>>(116, "source_handle_flight_hosts");
 		auto source_handle_task_partition_ids =
 		    deserializer.ReadProperty<vector<idx_t>>(117, "source_handle_task_partition_ids");
+		auto preserve_order = deserializer.ReadPropertyWithDefault<bool>(118, "preserve_order");
 		// Create FlightExchangeManager from deserialized config
 		distributed::FlightExchangeConfig flight_config;
 		flight_config.node_id = distributed::ResolveFlightExchangeNodeIdFromEnv();
@@ -1323,7 +1338,7 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 		return make_uniq<PhysicalRemoteExchangeSource>(physical_plan, std::move(types), estimated_cardinality,
 		                                               std::move(exchange_id), std::move(partition_indices),
 		                                               std::move(source_handles), std::move(exchange_mgr), source_nodes,
-		                                               runtime_source_node_id);
+		                                               runtime_source_node_id, preserve_order);
 	}
 	case PhysicalOperatorType::REPARTITION: {
 		auto repartition_type_raw = deserializer.ReadProperty<uint8_t>(103, "repartition_type");

--- a/external/duckdb/src/execution/physical_operator.cpp
+++ b/external/duckdb/src/execution/physical_operator.cpp
@@ -51,6 +51,7 @@
 #include "duckdb/execution/operator/scan/physical_dummy_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_empty_result.hpp"
 #include "duckdb/execution/operator/scan/physical_expression_scan.hpp"
+#include "duckdb/execution/operator/scan/physical_positional_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_asof_join.hpp"
@@ -1072,6 +1073,25 @@ unique_ptr<PhysicalOperator> PhysicalOperator::DeserializeOperatorData(Deseriali
 	case PhysicalOperatorType::POSITIONAL_JOIN: {
 		return make_uniq<PhysicalPositionalJoin>(physical_plan, PositionalJoinDeserializeTag {}, std::move(types),
 		                                         estimated_cardinality);
+	}
+	case PhysicalOperatorType::POSITIONAL_SCAN: {
+		vector<reference<PhysicalOperator>> child_tables;
+		deserializer.ReadList(103, "child_tables", [&](Deserializer::List &list, idx_t /*i*/) {
+			list.ReadObject([&](Deserializer &child_deserializer) {
+				auto child = PhysicalOperator::Deserialize(child_deserializer, physical_plan);
+				if (!child || child->type != PhysicalOperatorType::TABLE_SCAN) {
+					throw SerializationException("PhysicalPositionalScan deserialization requires TABLE_SCAN children");
+				}
+				auto child_ptr = child.get();
+				physical_plan.TakeOwnership(std::move(child));
+				child_tables.emplace_back(*child_ptr);
+			});
+		});
+		if (child_tables.size() < 2) {
+			throw SerializationException("PhysicalPositionalScan deserialization requires at least two child tables");
+		}
+		return make_uniq<PhysicalPositionalScan>(physical_plan, PositionalScanDeserializeTag {}, std::move(types),
+		                                         std::move(child_tables), estimated_cardinality);
 	}
 	case PhysicalOperatorType::BLOCKWISE_NL_JOIN: {
 		auto join_type = deserializer.ReadProperty<JoinType>(103, "join_type");

--- a/external/duckdb/src/execution/physical_operator_visitor.cpp
+++ b/external/duckdb/src/execution/physical_operator_visitor.cpp
@@ -22,7 +22,7 @@ void PhysicalOperatorVisitor::VisitOperator(PhysicalOperator &op) {
 }
 
 void PhysicalOperatorVisitor::VisitOperatorChildren(PhysicalOperator &op) {
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		VisitOperator(child.get());
 	}
 }

--- a/external/duckdb/src/execution/physical_operator_visitor.cpp
+++ b/external/duckdb/src/execution/physical_operator_visitor.cpp
@@ -22,7 +22,7 @@ void PhysicalOperatorVisitor::VisitOperator(PhysicalOperator &op) {
 }
 
 void PhysicalOperatorVisitor::VisitOperatorChildren(PhysicalOperator &op) {
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		VisitOperator(child.get());
 	}
 }

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/exchange_handles.hpp
@@ -39,6 +39,9 @@ struct ExchangeSinkHandle {
 struct ExchangeSinkInstanceHandle {
 	ExchangeSinkHandle sink_handle;
 	idx_t attempt_id = 0;
+	/// Logical input sequence for an order-preserving exchange. This is
+	/// independent of the scheduler-owned task identity above.
+	idx_t source_task_order = DConstants::INVALID_INDEX;
 	/// Query that owns this concrete attempt.
 	std::string query_id;
 	/// Implementation-specific: output directory (Spooling),

--- a/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/exchange/flight_exchange_manager.hpp
@@ -235,6 +235,7 @@ private:
 	struct SinkAttemptMetadata {
 		idx_t task_partition_id = 0;
 		idx_t attempt_id = 0;
+		idx_t source_task_order = DConstants::INVALID_INDEX;
 		std::string output_location;
 		std::string node_id;
 		std::string flight_host;

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/positional_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/join/positional_join.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "duckdb/common/vector.hpp"
+#include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
+#include "duckdb/execution/distributed/plan/plan_config.hpp"
+
+namespace duckdb {
+namespace distributed {
+
+class TaskIDCounter;
+
+class PositionalJoinNode : public PipelineNodeImpl, public std::enable_shared_from_this<PositionalJoinNode> {
+public:
+	PositionalJoinNode(NodeID node_id, const PlanConfig &plan_config, duckdb::vector<LogicalType> output_types,
+	                   idx_t estimated_cardinality, std::shared_ptr<DistributedPipelineNode> left,
+	                   std::shared_ptr<DistributedPipelineNode> right, SchemaRef schema);
+
+	const PipelineNodeContext &context() const override {
+		return context_;
+	}
+
+	const PipelineNodeConfig &config() const override {
+		return config_;
+	}
+
+	std::vector<PipelineNodeRef> children() const override;
+	SubmittableTaskStream<WorkerTask> produce_tasks(PlanExecutionContext &plan_context) override;
+	std::vector<std::string> multiline_display(bool verbose) const override;
+
+private:
+	SubmittableTask<WorkerTask> BuildPositionalJoinTask(SubmittableTask<WorkerTask> left_task,
+	                                                    SubmittableTask<WorkerTask> right_task,
+	                                                    TaskIDCounter &task_id_counter,
+	                                                    ::duckdb::ClientContext *client_context);
+
+private:
+	PipelineNodeConfig config_;
+	PipelineNodeContext context_;
+	duckdb::vector<LogicalType> output_types_;
+	idx_t estimated_cardinality_;
+	std::shared_ptr<DistributedPipelineNode> left_;
+	std::shared_ptr<DistributedPipelineNode> right_;
+};
+
+} // namespace distributed
+} // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp
@@ -30,6 +30,7 @@ private:
 	size_t num_partitions_;
 	std::shared_ptr<DistributedPipelineNode> child_;
 	std::shared_ptr<ExchangeManager> exchange_mgr_;
+	bool preserve_order_ = false;
 	bool collect_mark_join_build_summary_ = false;
 	vector<unique_ptr<Expression>> mark_join_build_expressions_;
 
@@ -40,7 +41,8 @@ public:
 	                                               std::shared_ptr<::duckdb::RepartitionSpec> repartition_spec,
 	                                               size_t num_partitions, SchemaRef schema,
 	                                               std::shared_ptr<DistributedPipelineNode> child,
-	                                               std::shared_ptr<ExchangeManager> exchange_mgr = nullptr);
+	                                               std::shared_ptr<ExchangeManager> exchange_mgr = nullptr,
+	                                               bool preserve_order = false);
 
 	std::shared_ptr<DistributedPipelineNode> into_node();
 
@@ -61,8 +63,12 @@ public:
 		return collect_mark_join_build_summary_;
 	}
 
+	bool PreservesOrder() const {
+		return preserve_order_;
+	}
+
 	bool is_materialization_barrier() const override {
-		return collect_mark_join_build_summary_;
+		return collect_mark_join_build_summary_ || preserve_order_;
 	}
 
 	std::vector<NodeID> materialized_input_node_ids() const override {
@@ -79,7 +85,8 @@ public:
 private:
 	RepartitionNode(PipelineNodeConfig config, PipelineNodeContext context,
 	                std::shared_ptr<::duckdb::RepartitionSpec> repartition_spec, size_t num_partitions,
-	                std::shared_ptr<DistributedPipelineNode> child, std::shared_ptr<ExchangeManager> exchange_mgr);
+	                std::shared_ptr<DistributedPipelineNode> child, std::shared_ptr<ExchangeManager> exchange_mgr,
+	                bool preserve_order);
 
 	// No separate execution_loop; production logic implemented in .cpp
 };
@@ -90,7 +97,8 @@ DuckPhysicalPlanRef AddRemoteExchangeSinkPlan(DuckPhysicalPlanRef plan,
                                               const std::shared_ptr<::duckdb::RepartitionSpec> &spec,
                                               const Exchange &exchange, std::shared_ptr<ExchangeManager> exchange_mgr,
                                               bool collect_mark_join_build_summary = false,
-                                              vector<unique_ptr<Expression>> mark_join_build_expressions = {});
+                                              vector<unique_ptr<Expression>> mark_join_build_expressions = {},
+                                              bool preserve_order = false);
 
 DuckPhysicalPlanRef AddRemoteRangeExchangeSinkPlan(DuckPhysicalPlanRef plan,
                                                    const vector<::duckdb::BoundOrderByNode> &orders,
@@ -103,7 +111,8 @@ DuckPhysicalPlanRef MakeRemoteExchangeSourcePlan(const vector<LogicalType> &type
                                                  std::vector<ExchangeSourceHandle> source_handles,
                                                  std::shared_ptr<ExchangeManager> exchange_mgr,
                                                  const vector<std::string> &source_nodes,
-                                                 optional_idx runtime_source_node_id = optional_idx());
+                                                 optional_idx runtime_source_node_id = optional_idx(),
+                                                 bool preserve_order = false);
 
 } // namespace distributed
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/pipeline_node/translator.hpp
@@ -27,6 +27,8 @@ class PhysicalHashJoin;
 class PhysicalComparisonJoin;
 class PhysicalBlockwiseNLJoin;
 class PhysicalNestedLoopJoin;
+class PhysicalPositionalJoin;
+class PhysicalPositionalScan;
 class PhysicalRangeJoin;
 class PhysicalHashAggregate;
 class PhysicalColumnDataScan;
@@ -108,7 +110,8 @@ private:
 	// Generate a shuffle node using the logic from the Rust implementation
 	std::shared_ptr<DistributedPipelineNode> gen_shuffle_node(std::shared_ptr<RepartitionSpec> repartition_spec,
 	                                                          SchemaRef schema,
-	                                                          std::shared_ptr<DistributedPipelineNode> child);
+	                                                          std::shared_ptr<DistributedPipelineNode> child,
+	                                                          bool preserve_order = false);
 
 	// Generate aggregation nodes without pre-aggregation (GroupBy/Shuffle/Gather)
 	std::shared_ptr<DistributedPipelineNode> gen_without_pre_agg(std::shared_ptr<DistributedPipelineNode> input_node,
@@ -137,6 +140,8 @@ private:
 
 	// Generate a gather node using RepartitionNode with num_partitions=1
 	std::shared_ptr<DistributedPipelineNode> gen_gather_node(std::shared_ptr<DistributedPipelineNode> input_node);
+	std::shared_ptr<DistributedPipelineNode>
+	gen_ordered_gather_node(std::shared_ptr<DistributedPipelineNode> input_node);
 
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateHashJoin(const PhysicalHashJoin &op,
@@ -149,6 +154,14 @@ private:
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateAsOfJoin(const PhysicalAsOfJoin &op,
 	                  const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslatePositionalJoin(const PhysicalPositionalJoin &op,
+	                        const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
+
+	std::shared_ptr<PipelineNodeImpl>
+	TranslatePositionalScan(const PhysicalPositionalScan &op,
+	                        const std::vector<std::shared_ptr<DistributedPipelineNode>> &children);
 
 	std::shared_ptr<PipelineNodeImpl>
 	TranslateDelimJoin(const PhysicalDelimJoin &op,

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_sink.hpp
@@ -32,7 +32,8 @@ public:
 	                           vector<unique_ptr<Expression>> partition_by, std::string sink_query_id,
 	                           std::string sink_output_location_prefix,
 	                           std::shared_ptr<distributed::ExchangeManager> exchange_mgr,
-	                           vector<string> range_boundaries = {}, vector<string> range_order_modifiers = {});
+	                           vector<string> range_boundaries = {}, vector<string> range_order_modifiers = {},
+	                           bool preserve_order = false);
 
 	bool IsSink() const override {
 		return true;
@@ -43,7 +44,11 @@ public:
 	}
 
 	bool ParallelSink() const override {
-		return true;
+		return !preserve_order_;
+	}
+
+	bool SinkOrderDependent() const override {
+		return preserve_order_;
 	}
 
 	SourceResultType GetDataInternal(ExecutionContext &context, DataChunk &chunk,
@@ -93,6 +98,9 @@ public:
 	const vector<string> &RangeOrderModifiers() const {
 		return range_order_modifiers_;
 	}
+	bool PreservesOrder() const {
+		return preserve_order_;
+	}
 	void EnableMarkJoinBuildSummary(vector<unique_ptr<Expression>> expressions) {
 		collect_mark_join_build_summary_ = true;
 		mark_join_build_expressions_ = std::move(expressions);
@@ -120,6 +128,7 @@ private:
 	std::shared_ptr<distributed::ExchangeManager> exchange_mgr_;
 	vector<string> range_boundaries_;
 	vector<string> range_order_modifiers_;
+	bool preserve_order_ = false;
 	bool collect_mark_join_build_summary_ = false;
 	vector<unique_ptr<Expression>> mark_join_build_expressions_;
 };

--- a/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_source.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/exchange/physical_remote_exchange_source.hpp
@@ -36,18 +36,18 @@ public:
 	                             std::vector<distributed::ExchangeSourceHandle> source_handles,
 	                             std::shared_ptr<distributed::ExchangeManager> exchange_mgr,
 	                             const vector<std::string> &source_nodes,
-	                             optional_idx runtime_source_node_id = optional_idx());
+	                             optional_idx runtime_source_node_id = optional_idx(), bool preserve_order = false);
 
 	bool IsSource() const override {
 		return true;
 	}
 
 	bool ParallelSource() const override {
-		return true;
+		return !preserve_order_;
 	}
 
 	OrderPreservationType SourceOrder() const override {
-		return OrderPreservationType::NO_ORDER;
+		return preserve_order_ ? OrderPreservationType::INSERTION_ORDER : OrderPreservationType::NO_ORDER;
 	}
 
 	unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
@@ -77,6 +77,9 @@ public:
 	const optional_idx &RuntimeSourceNodeId() const {
 		return runtime_source_node_id_;
 	}
+	bool PreservesOrder() const {
+		return preserve_order_;
+	}
 	void ApplyRuntimeTaskDescriptor(const distributed::ExchangeSourceTaskDescriptor &descriptor);
 	void ApplyRuntimeSplitQueue(std::shared_ptr<distributed::FteSplitQueue> queue);
 
@@ -87,6 +90,7 @@ private:
 	std::shared_ptr<distributed::ExchangeManager> exchange_mgr_;
 	vector<std::string> source_nodes_;
 	optional_idx runtime_source_node_id_;
+	bool preserve_order_ = false;
 	std::shared_ptr<distributed::FteSplitQueue> runtime_split_queue_;
 	idx_t runtime_source_partition_count_ = 0;
 	idx_t runtime_source_task_count_ = 0;

--- a/external/duckdb/src/include/duckdb/execution/operator/join/physical_positional_join.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/join/physical_positional_join.hpp
@@ -13,6 +13,8 @@
 
 namespace duckdb {
 
+struct PositionalJoinDeserializeTag {};
+
 //! PhysicalPositionalJoin represents a cross product between two tables
 class PhysicalPositionalJoin : public PhysicalOperator {
 public:
@@ -21,6 +23,12 @@ public:
 public:
 	PhysicalPositionalJoin(PhysicalPlan &physical_plan, vector<LogicalType> types, PhysicalOperator &left,
 	                       PhysicalOperator &right, idx_t estimated_cardinality);
+	PhysicalPositionalJoin(PhysicalPlan &physical_plan, PositionalJoinDeserializeTag, vector<LogicalType> types,
+	                       idx_t estimated_cardinality);
+
+	OrderPreservationType OperatorOrder() const override {
+		return OrderPreservationType::FIXED_ORDER;
+	}
 
 public:
 	// Operator Interface
@@ -42,6 +50,10 @@ public:
 	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
 
 	bool IsSink() const override {
+		return true;
+	}
+
+	bool SinkOrderDependent() const override {
 		return true;
 	}
 

--- a/external/duckdb/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
@@ -32,6 +32,10 @@ public:
 	bool Equals(const PhysicalOperator &other) const override;
 	vector<const_reference<PhysicalOperator>> GetChildren() const override;
 
+	OrderPreservationType OperatorOrder() const override {
+		return OrderPreservationType::FIXED_ORDER;
+	}
+
 public:
 	unique_ptr<LocalSourceState> GetLocalSourceState(ExecutionContext &context,
 	                                                 GlobalSourceState &gstate) const override;

--- a/external/duckdb/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
@@ -15,6 +15,8 @@
 
 namespace duckdb {
 
+struct PositionalScanDeserializeTag {};
+
 //! Represents a scan of a base table
 class PhysicalPositionalScan : public PhysicalOperator {
 public:
@@ -24,6 +26,8 @@ public:
 	//! Regular Table Scan
 	PhysicalPositionalScan(PhysicalPlan &physical_plan, vector<LogicalType> types, PhysicalOperator &left,
 	                       PhysicalOperator &right);
+	PhysicalPositionalScan(PhysicalPlan &physical_plan, PositionalScanDeserializeTag, vector<LogicalType> types,
+	                       vector<reference<PhysicalOperator>> child_tables, idx_t estimated_cardinality);
 
 	//! The child table functions
 	vector<reference<PhysicalOperator>> child_tables;
@@ -48,6 +52,9 @@ public:
 	bool IsSource() const override {
 		return true;
 	}
+
+protected:
+	void SerializeOperatorData(Serializer &serializer) const override;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
+++ b/external/duckdb/src/include/duckdb/execution/operator/scan/physical_positional_scan.hpp
@@ -34,6 +34,7 @@ public:
 
 public:
 	bool Equals(const PhysicalOperator &other) const override;
+	vector<const_reference<PhysicalOperator>> GetInputChildren() const override;
 	vector<const_reference<PhysicalOperator>> GetChildren() const override;
 
 	OrderPreservationType OperatorOrder() const override {

--- a/external/duckdb/src/include/duckdb/execution/physical_operator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/physical_operator.hpp
@@ -97,7 +97,10 @@ public:
 	static void SetEstimatedCardinality(InsertionOrderPreservingMap<string> &result, idx_t estimated_cardinality);
 	virtual string ToString(ExplainFormat format = ExplainFormat::DEFAULT) const;
 	void Print() const;
-	virtual vector<reference<PhysicalOperator>> GetChildren();
+	//! Return the operators that provide this operator's executable inputs. This
+	//! intentionally excludes additional owned subplans exposed by GetChildren().
+	vector<reference<PhysicalOperator>> GetInputChildren();
+	virtual vector<const_reference<PhysicalOperator>> GetInputChildren() const;
 	virtual vector<const_reference<PhysicalOperator>> GetChildren() const;
 
 	//! Optional coordinator-side contract for distributed extension writes.

--- a/external/duckdb/src/include/duckdb/execution/physical_operator.hpp
+++ b/external/duckdb/src/include/duckdb/execution/physical_operator.hpp
@@ -97,6 +97,7 @@ public:
 	static void SetEstimatedCardinality(InsertionOrderPreservingMap<string> &result, idx_t estimated_cardinality);
 	virtual string ToString(ExplainFormat format = ExplainFormat::DEFAULT) const;
 	void Print() const;
+	virtual vector<reference<PhysicalOperator>> GetChildren();
 	virtual vector<const_reference<PhysicalOperator>> GetChildren() const;
 
 	//! Optional coordinator-side contract for distributed extension writes.

--- a/external/duckdb/test/execution/distributed/test_exchange.cpp
+++ b/external/duckdb/test/execution/distributed/test_exchange.cpp
@@ -1997,6 +1997,75 @@ TEST_CASE("Exchange: FlightExchange with no sinks has no unpublished source hand
 	exchange->Close();
 }
 
+TEST_CASE("Exchange: ordered Flight source handles use logical source order", "[distributed][exchange][order]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig config;
+	config.node_id = "ordered-coordinator";
+	config.local_dirs = {TestCreatePath("exchange_ordered_handles")};
+	FlightExchangeManager manager(config, conn.context.get());
+
+	ExchangeContext ctx;
+	ctx.query_id = "ordered-query";
+	ctx.exchange_id = "ordered-exchange";
+	auto exchange = manager.CreateExchange(ctx, 1);
+	auto last = exchange->InstantiateSink(exchange->AddSink(101), 0);
+	auto first = exchange->InstantiateSink(exchange->AddSink(202), 0);
+	auto middle = exchange->InstantiateSink(exchange->AddSink(303), 0);
+	last.source_task_order = 2;
+	first.source_task_order = 0;
+	middle.source_task_order = 1;
+	last.flight_host = "ordered-last.internal";
+	first.flight_host = "ordered-first.internal";
+	middle.flight_host = "ordered-middle.internal";
+	last.flight_server_epoch = "ordered-last-epoch";
+	first.flight_server_epoch = "ordered-first-epoch";
+	middle.flight_server_epoch = "ordered-middle-epoch";
+
+	// Completion order is deliberately unrelated to logical input order.
+	exchange->SinkFinished(last, "ordered-last", 5101);
+	exchange->SinkFinished(first, "ordered-first", 5102);
+	exchange->SinkFinished(middle, "ordered-middle", 5103);
+	exchange->AllRequiredSinksFinished();
+
+	auto handles = exchange->GetSourceHandles();
+	REQUIRE(handles.size() == 3);
+	REQUIRE(handles[0].source_task_partition_id == 202);
+	REQUIRE(handles[1].source_task_partition_id == 303);
+	REQUIRE(handles[2].source_task_partition_id == 101);
+	exchange->Close();
+}
+
+TEST_CASE("Exchange: ordered Flight source handles reject duplicate logical order", "[distributed][exchange][order]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+
+	FlightExchangeConfig config;
+	config.node_id = "ordered-duplicate-coordinator";
+	config.local_dirs = {TestCreatePath("exchange_ordered_duplicate_handles")};
+	FlightExchangeManager manager(config, conn.context.get());
+
+	ExchangeContext ctx;
+	ctx.query_id = "ordered-duplicate-query";
+	ctx.exchange_id = "ordered-duplicate-exchange";
+	auto exchange = manager.CreateExchange(ctx, 1);
+	auto first = exchange->InstantiateSink(exchange->AddSink(101), 0);
+	auto duplicate = exchange->InstantiateSink(exchange->AddSink(202), 0);
+	first.source_task_order = 0;
+	duplicate.source_task_order = 0;
+	first.flight_host = "ordered-first.internal";
+	duplicate.flight_host = "ordered-duplicate.internal";
+	first.flight_server_epoch = "ordered-first-epoch";
+	duplicate.flight_server_epoch = "ordered-duplicate-epoch";
+
+	exchange->SinkFinished(first, "ordered-first", 5101);
+	exchange->SinkFinished(duplicate, "ordered-duplicate", 5102);
+	exchange->AllRequiredSinksFinished();
+	REQUIRE_THROWS_WITH(exchange->GetSourceHandles(), Catch::Matchers::Contains("duplicate source task ordering"));
+	exchange->Close();
+}
+
 TEST_CASE("Exchange: FlightExchange reduces MARK build summaries from selected attempts only",
           "[distributed][exchange][join]") {
 	DuckDB db(nullptr);

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -1199,6 +1199,7 @@ TEST_CASE("PhysicalPositionalScan serialization roundtrip", "[serialization][phy
 	REQUIRE(root->children.empty());
 	auto &deserialized_scan = root->Cast<PhysicalPositionalScan>();
 	REQUIRE(deserialized_scan.child_tables.size() == 3);
+	REQUIRE(deserialized_scan.GetInputChildren().size() == 3);
 	REQUIRE(deserialized_scan.GetChildren().size() == 3);
 	for (const auto &child : deserialized_scan.child_tables) {
 		REQUIRE(child.get().type == PhysicalOperatorType::TABLE_SCAN);

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/common/serializer/binary_deserializer.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/execution/physical_plan.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/execution/physical_operator.hpp"
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/execution/operator/projection/physical_grouping_set_expand.hpp"
@@ -29,6 +30,7 @@
 #include "duckdb/execution/operator/exchange/physical_remote_exchange_source.hpp"
 #include "duckdb/execution/operator/scan/physical_column_data_scan.hpp"
 #include "duckdb/execution/operator/scan/physical_empty_result.hpp"
+#include "duckdb/execution/operator/scan/physical_positional_scan.hpp"
 #include "duckdb/execution/operator/aggregate/physical_hash_aggregate.hpp"
 #include "duckdb/execution/operator/aggregate/physical_ungrouped_aggregate.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
@@ -1154,6 +1156,53 @@ TEST_CASE("PhysicalPositionalJoin serialization roundtrip", "[serialization][phy
 	REQUIRE(root->children.size() == 2);
 	REQUIRE(root->children[0].get().GetTypes() == left_types);
 	REQUIRE(root->children[1].get().GetTypes() == right_types);
+}
+
+TEST_CASE("PhysicalPositionalScan serialization roundtrip", "[serialization][physical_plan][positional_scan]") {
+	DuckDB db(nullptr);
+	Connection conn(db);
+	REQUIRE_NO_FAIL(conn.Query("CREATE TABLE positional_left(i INTEGER)"));
+	REQUIRE_NO_FAIL(conn.Query("CREATE TABLE positional_middle(s VARCHAR)"));
+	REQUIRE_NO_FAIL(conn.Query("CREATE TABLE positional_right(b BOOLEAN)"));
+	conn.BeginTransaction();
+
+	auto logical_plan = conn.ExtractPlan("SELECT * FROM positional_left POSITIONAL JOIN positional_middle "
+	                                     "POSITIONAL JOIN positional_right");
+	REQUIRE(logical_plan != nullptr);
+	PhysicalPlanGenerator generator(*conn.context);
+	auto plan = generator.Plan(std::move(logical_plan));
+	REQUIRE(plan != nullptr);
+	REQUIRE(plan->Root().type == PhysicalOperatorType::POSITIONAL_SCAN);
+	auto &positional_scan = plan->Root().Cast<PhysicalPositionalScan>();
+	REQUIRE(positional_scan.children.empty());
+	REQUIRE(positional_scan.child_tables.size() == 3);
+
+	Allocator &allocator = Allocator::DefaultAllocator();
+	MemoryStream stream(allocator);
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	plan->Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	deserializer.Set<ClientContext &>(*conn.context);
+	PhysicalPlan deserialized_plan(allocator);
+	deserializer.Begin();
+	auto root = deserialized_plan.Deserialize(deserializer);
+	deserializer.End();
+
+	REQUIRE(root != nullptr);
+	REQUIRE(root->type == PhysicalOperatorType::POSITIONAL_SCAN);
+	REQUIRE(root->GetTypes() == positional_scan.GetTypes());
+	REQUIRE(root->estimated_cardinality == positional_scan.estimated_cardinality);
+	REQUIRE(root->children.empty());
+	auto &deserialized_scan = root->Cast<PhysicalPositionalScan>();
+	REQUIRE(deserialized_scan.child_tables.size() == 3);
+	REQUIRE(deserialized_scan.GetChildren().size() == 3);
+	for (const auto &child : deserialized_scan.child_tables) {
+		REQUIRE(child.get().type == PhysicalOperatorType::TABLE_SCAN);
+	}
 }
 
 TEST_CASE("PhysicalBlockwiseNLJoin serialization roundtrip", "[serialization][physical_plan][join]") {

--- a/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_serialization.cpp
@@ -35,6 +35,7 @@
 #include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_hash_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
+#include "duckdb/execution/operator/join/physical_positional_join.hpp"
 #include "duckdb/execution/operator/projection/physical_tableinout_function.hpp"
 #include "duckdb/execution/distributed/pipeline_node/pipeline_node.hpp"
 #include "duckdb/execution/distributed/exchange/flight_exchange_manager.hpp"
@@ -1121,6 +1122,40 @@ TEST_CASE("PhysicalCrossProduct serialization roundtrip", "[serialization][physi
 	REQUIRE(root->children[1].get().GetTypes() == right_types);
 }
 
+TEST_CASE("PhysicalPositionalJoin serialization roundtrip", "[serialization][physical_plan][positional_join]") {
+	Allocator allocator;
+	PhysicalPlan plan(allocator);
+	vector<LogicalType> left_types = {LogicalType::INTEGER};
+	vector<LogicalType> right_types = {LogicalType::VARCHAR};
+	vector<LogicalType> output_types = {LogicalType::INTEGER, LogicalType::VARCHAR};
+
+	auto &left = MakeColumnDataScan(plan, left_types);
+	auto &right = MakeColumnDataScan(plan, right_types);
+	auto &positional_join = plan.Make<PhysicalPositionalJoin>(output_types, left, right, 12);
+	plan.SetRoot(positional_join);
+
+	MemoryStream stream(allocator);
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	plan.Serialize(serializer);
+	serializer.End();
+
+	stream.Rewind();
+	BinaryDeserializer deserializer(stream);
+	PhysicalPlan deserialized_plan(allocator);
+	deserializer.Begin();
+	auto root = deserialized_plan.Deserialize(deserializer);
+	deserializer.End();
+
+	REQUIRE(root != nullptr);
+	REQUIRE(root->type == PhysicalOperatorType::POSITIONAL_JOIN);
+	REQUIRE(root->GetTypes() == output_types);
+	REQUIRE(root->estimated_cardinality == 12);
+	REQUIRE(root->children.size() == 2);
+	REQUIRE(root->children[0].get().GetTypes() == left_types);
+	REQUIRE(root->children[1].get().GetTypes() == right_types);
+}
+
 TEST_CASE("PhysicalBlockwiseNLJoin serialization roundtrip", "[serialization][physical_plan][join]") {
 	Allocator allocator;
 	PhysicalPlan plan(allocator);
@@ -1883,7 +1918,11 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves static sink config
 	vector<unique_ptr<Expression>> partition_by;
 	auto &sink = plan.Make<PhysicalRemoteExchangeSink>(types, 123, "exchange", 4, RepartitionSpec::Type::Random,
 	                                                   std::move(partition_by), "query-session-a", "exchange-instance",
-	                                                   exchange_mgr);
+	                                                   exchange_mgr, vector<string> {}, vector<string> {}, true);
+	auto &ordered_sink = sink.Cast<PhysicalRemoteExchangeSink>();
+	REQUIRE(ordered_sink.PreservesOrder());
+	REQUIRE_FALSE(ordered_sink.ParallelSink());
+	REQUIRE(ordered_sink.SinkOrderDependent());
 	vector<unique_ptr<Expression>> mark_join_build_expressions;
 	mark_join_build_expressions.push_back(make_uniq<BoundReferenceExpression>(LogicalType::INTEGER, 0));
 	sink.Cast<PhysicalRemoteExchangeSink>().EnableMarkJoinBuildSummary(std::move(mark_join_build_expressions));
@@ -1913,6 +1952,9 @@ TEST_CASE("PhysicalRemoteExchangeSink serialization preserves static sink config
 	REQUIRE(sink_ptr->CollectsMarkJoinBuildSummary());
 	REQUIRE(sink_ptr->MarkJoinBuildExpressions().size() == 1);
 	REQUIRE(sink_ptr->MarkJoinBuildExpressions()[0]->return_type == LogicalType::INTEGER);
+	REQUIRE(sink_ptr->PreservesOrder());
+	REQUIRE_FALSE(sink_ptr->ParallelSink());
+	REQUIRE(sink_ptr->SinkOrderDependent());
 	auto roundtrip_manager =
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(sink_ptr->GetExchangeManager());
 	const std::vector<std::string> expected_local_dirs = {"/session-a/shuffle-0", "/session-a/shuffle-1"};
@@ -2065,6 +2107,7 @@ TEST_CASE("ExchangeSinkInstanceTaskDescriptor serialization preserves the worker
 	descriptor.sink_instance.query_id = "endpoint-query";
 	descriptor.sink_instance.output_location = "endpoint-exchange__sink_3__attempt_2";
 	descriptor.sink_instance.output_partition_count = 4;
+	descriptor.sink_instance.source_task_order = 17;
 	descriptor.sink_instance.flight_host = "flight-worker.internal";
 	descriptor.sink_instance.flight_server_epoch = "endpoint-epoch";
 	descriptor.sink_instance.mark_join_build_summary = MarkJoinBuildSummary::Create(true, true);
@@ -2077,6 +2120,7 @@ TEST_CASE("ExchangeSinkInstanceTaskDescriptor serialization preserves the worker
 	REQUIRE(roundtrip.sink_instance.query_id == "endpoint-query");
 	REQUIRE(roundtrip.sink_instance.output_location == "endpoint-exchange__sink_3__attempt_2");
 	REQUIRE(roundtrip.sink_instance.output_partition_count == 4);
+	REQUIRE(roundtrip.sink_instance.source_task_order == 17);
 	REQUIRE(roundtrip.sink_instance.flight_host == "flight-worker.internal");
 	REQUIRE(roundtrip.sink_instance.flight_server_epoch == "endpoint-epoch");
 	REQUIRE(roundtrip.sink_instance.mark_join_build_summary.valid);
@@ -2155,7 +2199,11 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	auto exchange_mgr = std::make_shared<distributed::FlightExchangeManager>(std::move(flight_config));
 
 	auto &source = plan.Make<PhysicalRemoteExchangeSource>(types, 456, "exchange", partition_indices, source_handles,
-	                                                       exchange_mgr, source_nodes);
+	                                                       exchange_mgr, source_nodes, optional_idx(), true);
+	auto &ordered_source = source.Cast<PhysicalRemoteExchangeSource>();
+	REQUIRE(ordered_source.PreservesOrder());
+	REQUIRE_FALSE(ordered_source.ParallelSource());
+	REQUIRE(ordered_source.SourceOrder() == OrderPreservationType::INSERTION_ORDER);
 	plan.SetRoot(source);
 	string assignment_error;
 	REQUIRE(distributed::ValidateExchangeSourceAssignments(plan, set<idx_t> {}, &assignment_error));
@@ -2208,6 +2256,9 @@ TEST_CASE("PhysicalRemoteExchangeSource serialization preserves explicit source 
 	REQUIRE(source_ptr->SourceHandles()[2].flight_server_epoch == "epoch-1");
 	REQUIRE(source_ptr->SourceHandles()[2].files.size() == 1);
 	REQUIRE(source_ptr->SourceHandles()[2].files[0].path == "exchange__sink_0__attempt_0");
+	REQUIRE(source_ptr->PreservesOrder());
+	REQUIRE_FALSE(source_ptr->ParallelSource());
+	REQUIRE(source_ptr->SourceOrder() == OrderPreservationType::INSERTION_ORDER);
 	auto roundtrip_manager =
 	    std::dynamic_pointer_cast<distributed::FlightExchangeManager>(source_ptr->GetExchangeManager());
 	REQUIRE(roundtrip_manager != nullptr);

--- a/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
+++ b/external/duckdb/test/execution/distributed/test_physical_plan_translator.cpp
@@ -2145,11 +2145,10 @@ TEST_CASE("PhysicalPlanTranslator: left delim join -> placeholder node", "[distr
 	auto &left_scan = plan_ptr->Make<PhysicalColumnDataScan>(scan_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 1,
 	                                                         std::move(left_collection));
 
-	auto right_collection = MakeSingleValueCollection(scan_types, {Value::INTEGER(2)});
-	auto &right_scan =
-	    plan_ptr
-	        ->Make<PhysicalColumnDataScan>(scan_types, PhysicalOperatorType::DELIM_SCAN, 1, std::move(right_collection))
-	        .Cast<PhysicalColumnDataScan>();
+	auto &right_scan = plan_ptr
+	                       ->Make<PhysicalColumnDataScan>(scan_types, PhysicalOperatorType::DELIM_SCAN, 1,
+	                                                      optionally_owned_ptr<ColumnDataCollection>())
+	                       .Cast<PhysicalColumnDataScan>();
 	right_scan.delim_index = 7;
 
 	vector<JoinCondition> conditions;
@@ -2180,6 +2179,8 @@ TEST_CASE("PhysicalPlanTranslator: left delim join -> placeholder node", "[distr
 	                                                         distinct, delim_scans, 1, optional_idx(7));
 	delim_join.children.push_back(left_scan);
 	plan_ptr->SetRoot(delim_join);
+	REQUIRE(delim_join.GetInputChildren().size() == 1);
+	REQUIRE(delim_join.GetChildren().size() == 3);
 
 	auto res = duckdb::distributed::physical_plan_to_pipeline_node(duckdb::distributed::PlanConfig {}, plan_ptr);
 	REQUIRE(res.ok);

--- a/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
+++ b/external/duckdb/test/execution/distributed/test_source_id_routing.cpp
@@ -36,6 +36,8 @@
 #include "duckdb/execution/operator/join/physical_asof_join.hpp"
 #include "duckdb/execution/operator/join/physical_blockwise_nl_join.hpp"
 #include "duckdb/execution/operator/join/physical_cross_product.hpp"
+#include "duckdb/execution/operator/join/physical_positional_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/shuffles/repartition.hpp"
 #include "duckdb/execution/operator/join/physical_iejoin.hpp"
 #include "duckdb/execution/operator/join/join_filter_pushdown.hpp"
 #include "duckdb/execution/operator/join/physical_piecewise_merge_join.hpp"
@@ -53,6 +55,7 @@
 #include "duckdb/execution/distributed/pipeline_node/join/hash_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/broadcast_join.hpp"
 #include "duckdb/execution/distributed/pipeline_node/join/nested_loop_join.hpp"
+#include "duckdb/execution/distributed/pipeline_node/join/positional_join.hpp"
 #undef private
 
 #include <algorithm>
@@ -422,6 +425,38 @@ TEST_CASE("PhysicalPlanTranslator: translates cross product with two inputs", "[
 	REQUIRE(cross_node->config().clustering_spec()->num_partitions() == 1);
 }
 
+TEST_CASE("PhysicalPlanTranslator: translates positional join through ordered gathers",
+          "[distributed][positional_join]") {
+	Allocator allocator;
+	auto plan = std::make_shared<PhysicalPlan>(allocator);
+	vector<LogicalType> input_types = {LogicalType::BIGINT};
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+
+	auto &left = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 2,
+	                                                MakeCollection(input_types, 2));
+	auto &right = plan->Make<PhysicalColumnDataScan>(input_types, PhysicalOperatorType::COLUMN_DATA_SCAN, 3,
+	                                                 MakeCollection(input_types, 3));
+	auto &join = plan->Make<PhysicalPositionalJoin>(output_types, left, right, 3);
+	plan->SetRoot(join);
+
+	auto result = physical_plan_to_pipeline_node(PlanConfig {}, plan);
+	REQUIRE(result.ok);
+	REQUIRE(result.value() != nullptr);
+	auto positional_node = std::dynamic_pointer_cast<PositionalJoinNode>(result.value()->inner());
+	REQUIRE(positional_node != nullptr);
+	REQUIRE(positional_node->children().size() == 2);
+	REQUIRE(positional_node->config().clustering_spec()->num_partitions() == 1);
+	for (const auto &child : positional_node->children()) {
+		auto ordered_gather = std::dynamic_pointer_cast<RepartitionNode>(child);
+		REQUIRE(ordered_gather != nullptr);
+		REQUIRE(ordered_gather->PreservesOrder());
+		REQUIRE(ordered_gather->is_materialization_barrier());
+		auto materialized_inputs = ordered_gather->materialized_input_node_ids();
+		REQUIRE(materialized_inputs.size() == 1);
+		REQUIRE(materialized_inputs[0] == ordered_gather->children()[0]->node_id());
+	}
+}
+
 TEST_CASE("PhysicalPlanTranslator: translates ASOF joins to a gathered native worker plan",
           "[distributed][join][asof_join]") {
 	Allocator allocator;
@@ -742,6 +777,33 @@ TEST_CASE("CrossProductNode: replacement task owns both inputs", "[distributed][
 	REQUIRE(cloned->Root().GetTypes() == output_types);
 	REQUIRE(cloned->Root().children[0].get().Cast<PhysicalColumnDataScan>().collection->Count() == 1);
 	REQUIRE(cloned->Root().children[1].get().Cast<PhysicalColumnDataScan>().collection->Count() == 1);
+}
+
+TEST_CASE("PositionalJoinNode: replacement task owns both ordered inputs",
+          "[distributed][source_id][positional_join]") {
+	PlanConfig plan_cfg(1, "positional-join-query", std::make_shared<DuckDBExecutionConfig>());
+	vector<LogicalType> output_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+	auto schema = MakeSchemaRef(output_types);
+	PositionalJoinNode node(304, plan_cfg, output_types, 3, nullptr, nullptr, schema);
+
+	auto left_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(10, "left", 10, "left_scan"));
+	auto right_task = SubmittableTask<WorkerTask>(MakeWorkerTaskWithInput(20, "right", 20, "right_scan"));
+	TaskIDCounter task_id_counter;
+	auto join_task =
+	    node.BuildPositionalJoinTask(std::move(left_task), std::move(right_task), task_id_counter, nullptr);
+
+	REQUIRE(join_task.task()->inputs().size() == 2);
+	REQUIRE(join_task.task()->inputs().at(10).scan_split_batch_bytes == "left_scan");
+	REQUIRE(join_task.task()->inputs().at(20).scan_split_batch_bytes == "right_scan");
+	REQUIRE(join_task.task()->plan()->Root().type == PhysicalOperatorType::POSITIONAL_JOIN);
+	REQUIRE(join_task.task()->plan()->Root().children.size() == 2);
+	REQUIRE(join_task.task()->plan()->Root().GetTypes() == output_types);
+
+	auto cloned = ClonePhysicalPlanOrThrow(join_task.task()->plan(), "positional_join_owned_children_test", nullptr);
+	REQUIRE(cloned->HasRoot());
+	REQUIRE(cloned->Root().type == PhysicalOperatorType::POSITIONAL_JOIN);
+	REQUIRE(cloned->Root().children.size() == 2);
+	REQUIRE(cloned->Root().GetTypes() == output_types);
 }
 
 TEST_CASE("NestedLoopJoinNode: replacement tasks own both inputs", "[distributed][source_id][nested_loop_join]") {

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -22,7 +22,7 @@ static void AssignDataSourceQueryOwner(duckdb::PhysicalOperator &op, const strin
 			bind_data->query_id = query_id;
 		}
 	}
-	for (auto &child : op.GetChildren()) {
+	for (auto &child : op.GetInputChildren()) {
 		AssignDataSourceQueryOwner(child.get(), query_id, allow_unacquired_rebind);
 	}
 }
@@ -94,7 +94,7 @@ struct PyPhysicalPlanWrapper {
 					bind_data->actor_handles = WrapPyObjectForUDFActorHandles(handles_obj);
 				}
 			}
-			for (auto &child : op.GetChildren()) {
+			for (auto &child : op.GetInputChildren()) {
 				inject(child.get());
 			}
 		};
@@ -514,7 +514,7 @@ struct PyPhysicalPlanWrapper {
 		auto physical_plan = plan_->physical_plan();
 		std::function<void(PhysicalOperator &)> collect_physical_udfs = [&](PhysicalOperator &op) -> void {
 			CollectMutableUDFBindData(op, physical_udfs);
-			for (auto &child : op.GetChildren()) {
+			for (auto &child : op.GetInputChildren()) {
 				collect_physical_udfs(child.get());
 			}
 		};
@@ -782,7 +782,7 @@ struct PyPhysicalPlanWrapper {
 						}
 					}
 				}
-				for (auto &child : op.GetChildren()) {
+				for (auto &child : op.GetInputChildren()) {
 					update_max(child.get());
 				}
 			};
@@ -843,7 +843,7 @@ struct PyPhysicalPlanWrapper {
 						}
 					}
 				}
-				for (auto &child : op.GetChildren()) {
+				for (auto &child : op.GetInputChildren()) {
 					normalize(child.get());
 				}
 			};
@@ -918,7 +918,7 @@ struct PyPhysicalPlanWrapper {
 				}
 				result.append(meta);
 			}
-			for (auto &child : op.GetChildren()) {
+			for (auto &child : op.GetInputChildren()) {
 				collect(child.get());
 			}
 		};
@@ -992,7 +992,7 @@ struct PyPhysicalPlanWrapper {
 
 				result.append(meta);
 			}
-			for (auto &child : op.GetChildren()) {
+			for (auto &child : op.GetInputChildren()) {
 				collect(child.get());
 			}
 		};
@@ -1030,7 +1030,7 @@ struct PyPhysicalPlanWrapper {
 					bind_data->actor_handles = WrapPyObjectForUDFActorHandles(handles_obj);
 				}
 			}
-			for (auto &child : op.GetChildren()) {
+			for (auto &child : op.GetInputChildren()) {
 				inject(child.get());
 			}
 		};
@@ -3896,7 +3896,7 @@ struct PyPhysicalPlanWrapperRunner {
 							diag << indent << "  agg[" << i << "]: " << expr.GetName() << "\n";
 						}
 					}
-					for (auto &child : op.GetChildren()) {
+					for (auto &child : op.GetInputChildren()) {
 						dump_diag(child.get(), depth + 1);
 					}
 				};

--- a/src/vane_py/ray/distributed_plan_bindings.cpp
+++ b/src/vane_py/ray/distributed_plan_bindings.cpp
@@ -22,7 +22,7 @@ static void AssignDataSourceQueryOwner(duckdb::PhysicalOperator &op, const strin
 			bind_data->query_id = query_id;
 		}
 	}
-	for (auto &child : op.children) {
+	for (auto &child : op.GetChildren()) {
 		AssignDataSourceQueryOwner(child.get(), query_id, allow_unacquired_rebind);
 	}
 }
@@ -94,7 +94,7 @@ struct PyPhysicalPlanWrapper {
 					bind_data->actor_handles = WrapPyObjectForUDFActorHandles(handles_obj);
 				}
 			}
-			for (auto &child : op.children) {
+			for (auto &child : op.GetChildren()) {
 				inject(child.get());
 			}
 		};
@@ -514,7 +514,7 @@ struct PyPhysicalPlanWrapper {
 		auto physical_plan = plan_->physical_plan();
 		std::function<void(PhysicalOperator &)> collect_physical_udfs = [&](PhysicalOperator &op) -> void {
 			CollectMutableUDFBindData(op, physical_udfs);
-			for (auto &child : op.children) {
+			for (auto &child : op.GetChildren()) {
 				collect_physical_udfs(child.get());
 			}
 		};
@@ -782,7 +782,7 @@ struct PyPhysicalPlanWrapper {
 						}
 					}
 				}
-				for (auto &child : op.children) {
+				for (auto &child : op.GetChildren()) {
 					update_max(child.get());
 				}
 			};
@@ -843,7 +843,7 @@ struct PyPhysicalPlanWrapper {
 						}
 					}
 				}
-				for (auto &child : op.children) {
+				for (auto &child : op.GetChildren()) {
 					normalize(child.get());
 				}
 			};
@@ -918,7 +918,7 @@ struct PyPhysicalPlanWrapper {
 				}
 				result.append(meta);
 			}
-			for (auto &child : op.children) {
+			for (auto &child : op.GetChildren()) {
 				collect(child.get());
 			}
 		};
@@ -992,7 +992,7 @@ struct PyPhysicalPlanWrapper {
 
 				result.append(meta);
 			}
-			for (auto &child : op.children) {
+			for (auto &child : op.GetChildren()) {
 				collect(child.get());
 			}
 		};
@@ -1030,7 +1030,7 @@ struct PyPhysicalPlanWrapper {
 					bind_data->actor_handles = WrapPyObjectForUDFActorHandles(handles_obj);
 				}
 			}
-			for (auto &child : op.children) {
+			for (auto &child : op.GetChildren()) {
 				inject(child.get());
 			}
 		};
@@ -3896,7 +3896,7 @@ struct PyPhysicalPlanWrapperRunner {
 							diag << indent << "  agg[" << i << "]: " << expr.GetName() << "\n";
 						}
 					}
-					for (auto &child : op.children) {
+					for (auto &child : op.GetChildren()) {
 						dump_diag(child.get(), depth + 1);
 					}
 				};

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -1681,6 +1681,10 @@ void register_ray_bindings(py::module_ &mod) {
 					        exchange_sink_instance_task.sink_instance.attempt_id =
 					            py::int_(d["attempt_id"]).cast<idx_t>();
 				        }
+				        if (d.contains("source_task_order")) {
+					        exchange_sink_instance_task.sink_instance.source_task_order =
+					            py::int_(d["source_task_order"]).cast<idx_t>();
+				        }
 				        if (d.contains("output_partition_count")) {
 					        exchange_sink_instance_task.sink_instance.output_partition_count =
 					            py::int_(d["output_partition_count"]).cast<idx_t>();

--- a/src/vane_py/ray/task.cpp
+++ b/src/vane_py/ray/task.cpp
@@ -108,6 +108,9 @@ bool ParseExchangeSinkInstanceObject(py::object obj, duckdb::distributed::Exchan
 	if (d.contains("attempt_id")) {
 		out.attempt_id = py::int_(d["attempt_id"]).cast<duckdb::idx_t>();
 	}
+	if (d.contains("source_task_order")) {
+		out.source_task_order = py::int_(d["source_task_order"]).cast<duckdb::idx_t>();
+	}
 	if (d.contains("output_partition_count")) {
 		out.output_partition_count = py::int_(d["output_partition_count"]).cast<duckdb::idx_t>();
 	}
@@ -1383,5 +1386,6 @@ py::object RayWorkerTask::ExchangeSinkConfig() const {
 	result["output_partition_count"] = sink->NumPartitions();
 	result["query_id"] = sink->SinkQueryId();
 	result["output_location_prefix"] = sink->SinkOutputLocationPrefix();
+	result["preserve_order"] = sink->PreservesOrder();
 	return result;
 }

--- a/tests/fast/test_exchange_sink.py
+++ b/tests/fast/test_exchange_sink.py
@@ -27,6 +27,52 @@ def test_bind_scheduler_task_identity_exchange_sink_attempt():
     assert retry["output_location"] == "exchange-a__sink_9__attempt_3"
 
 
+def test_bind_ordered_exchange_sink_carries_independent_source_order():
+    config = {
+        "query_id": "query-ordered",
+        "output_location_prefix": "exchange-ordered",
+        "output_partition_count": 1,
+        "preserve_order": True,
+    }
+
+    instance = bind_exchange_sink_instance(
+        config,
+        attempt_id=2,
+        task_partition_id=991,
+        source_task_order=4,
+    )
+
+    assert instance["sink_handle"]["task_partition_id"] == 991
+    assert instance["source_task_order"] == 4
+    assert instance["output_location"] == "exchange-ordered__sink_991__attempt_2"
+
+
+def test_ordered_exchange_sink_requires_source_order():
+    with pytest.raises(TypeError, match="source_task_order must be an integer"):
+        bind_exchange_sink_instance(
+            {
+                "query_id": "query-ordered",
+                "output_location_prefix": "exchange-ordered",
+                "output_partition_count": 1,
+                "preserve_order": True,
+            },
+            attempt_id=0,
+            task_partition_id=1,
+        )
+
+
+def test_exchange_sink_config_rejects_non_boolean_preserve_order():
+    with pytest.raises(TypeError, match="preserve_order must be a boolean"):
+        normalize_exchange_sink_config(
+            {
+                "query_id": "query-ordered",
+                "output_location_prefix": "exchange-ordered",
+                "output_partition_count": 1,
+                "preserve_order": 1,
+            }
+        )
+
+
 @pytest.mark.parametrize("field", ["identity_source", "plan_task_partition_id"])
 def test_exchange_sink_config_rejects_plan_owned_identity_fields(field):
     with pytest.raises(ValueError, match=f"unexpected fields.*{field}"):

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3878,6 +3878,58 @@ def test_ray_cross_product_values(ray_runner, duckdb_conn):
     )
 
 
+def test_ray_positional_join_values_preserves_order_and_pads_nulls(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: positional join values"
+    sql = """
+        SELECT l.value AS left_value, r.value AS right_value
+        FROM (VALUES (1), (2), (3)) AS l(value)
+        POSITIONAL JOIN (VALUES (10), (20)) AS r(value)
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["POSITIONAL_JOIN"],
+        timeout_s=60.0,
+        ordered=True,
+    )
+
+
+def test_ray_positional_scan_folds_three_ordered_multifile_inputs(
+    ray_runner,
+    duckdb_conn,
+    partitioned_parquet_path,
+):
+    label = "test_ray_e2e: three-way positional scan"
+    sql = f"""
+        SELECT l.a AS left_a, m.a AS middle_a, r.a AS right_a
+        FROM read_parquet(
+            '{partitioned_parquet_path}/*/*.parquet',
+            hive_partitioning=1
+        ) AS l
+        POSITIONAL JOIN read_parquet(
+            '{partitioned_parquet_path}/grp=0/*.parquet',
+            hive_partitioning=1
+        ) AS m
+        POSITIONAL JOIN read_parquet(
+            '{partitioned_parquet_path}/grp=1/*.parquet',
+            hive_partitioning=1
+        ) AS r
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["POSITIONAL_SCAN"],
+        timeout_s=90.0,
+        ordered=True,
+    )
+
+
 def test_ray_piecewise_merge_join(ray_runner, duckdb_conn):
     label = "test_ray_e2e: piecewise merge join"
     sql = """

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -3897,6 +3897,29 @@ def test_ray_positional_join_values_preserves_order_and_pads_nulls(ray_runner, d
     )
 
 
+def test_ray_positional_join_preserves_union_all_order(ray_runner, duckdb_conn):
+    label = "test_ray_e2e: positional join union all"
+    sql = """
+        SELECT l.v AS left_v, r.v AS right_v
+        FROM (
+            SELECT * FROM (VALUES (1), (2)) AS a(v)
+            UNION ALL
+            SELECT * FROM (VALUES (3), (4)) AS b(v)
+        ) AS l
+        POSITIONAL JOIN (VALUES (10), (20), (30), (40)) AS r(v)
+    """
+
+    _run_query_case(
+        duckdb_conn,
+        ray_runner,
+        sql,
+        label,
+        require_all=["POSITIONAL_JOIN"],
+        timeout_s=60.0,
+        ordered=True,
+    )
+
+
 def test_ray_positional_scan_folds_three_ordered_multifile_inputs(
     ray_runner,
     duckdb_conn,

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -5294,6 +5294,32 @@ def test_fte_fragment_execution_binds_scheduler_owned_sink_partition():
     assert worker.calls[0][1]["exchange_sink_instance"] == sink_instance
 
 
+def test_fte_fragment_execution_binds_ordered_sink_to_semantic_partition_order():
+    worker = _FakeLiveWorker("worker-a")
+    stage = _fte_fragment_execution(
+        "q",
+        12,
+        fragment_id="q:node:ordered-shuffle",
+        logical_fragment_identity="q:node:ordered-shuffle",
+        worker=worker,
+        exchange_sink_config={
+            "query_id": "q",
+            "output_partition_count": 1,
+            "output_location_prefix": "q_ordered_shuffle_3",
+            "preserve_order": True,
+        },
+    )
+
+    scheduled_result = stage.apply_assignment_result(
+        AssignmentResult(partitions_added=[PartitionInfo(3)], sealed_partitions=[3])
+    )
+    scheduled = scheduled_result[0]
+    _execute_stage_commands(stage, scheduled_result)
+
+    assert scheduled.request["exchange_sink_instance"]["source_task_order"] == 3
+    assert worker.calls[0][1]["exchange_sink_instance"]["source_task_order"] == 3
+
+
 def test_fte_fragment_execution_allocates_exchange_identity_when_partition_is_created():
     registered_identities = []
     stage = _fte_fragment_execution(
@@ -5653,6 +5679,65 @@ def test_arbitrary_split_assigner_groups_by_node_requirements():
         NodeRequirements(host="host-a"),
         NodeRequirements(host="host-b"),
     ]
+
+
+def test_arbitrary_split_assigner_ordered_mode_does_not_reuse_noncontiguous_host_partition():
+    assigner = ArbitrarySplitAssigner(
+        partitioned_sources={"scan"},
+        preserve_order=True,
+        min_target_partition_size_bytes=1000,
+        standard_split_size_bytes=100,
+    )
+
+    result = assigner.assign(
+        "scan",
+        [
+            {
+                "kind": "scan_split",
+                "split_id": f"scan-{host}-{index}",
+                "data": host.encode(),
+                "addresses": [host],
+                "size_bytes": 100,
+            }
+            for index, host in enumerate(("host-a", "host-b", "host-a"))
+        ],
+        no_more_inputs=True,
+    )
+
+    assert [partition.partition_id for partition in result.partitions_added] == [0, 1, 2]
+    assert [partition.node_requirements.host for partition in result.partitions_added] == [
+        "host-a",
+        "host-b",
+        "host-a",
+    ]
+    data_updates = [update for update in result.partition_updates if update.splits]
+    assert [update.partition_id for update in data_updates] == [0, 1, 2]
+
+
+def test_fte_assigner_enables_contiguous_partitioning_for_ordered_sink():
+    state = _FteFragmentState()
+    state.source_node_ids.add("scan")
+    state.dynamic_scan_source_node_ids.add("scan")
+    state.preserve_order = True
+
+    assigner = make_fte_assigner(state)
+
+    assert isinstance(assigner, ArbitrarySplitAssigner)
+    result = assigner.assign(
+        "scan",
+        [
+            {
+                "kind": "scan_split",
+                "split_id": f"scan-{host}-{index}",
+                "addresses": [host],
+                "size_bytes": 1,
+            }
+            for index, host in enumerate(("host-a", "host-b", "host-a"))
+        ],
+        no_more_inputs=True,
+    )
+
+    assert [partition.partition_id for partition in result.partitions_added] == [0, 1, 2]
 
 
 def test_arbitrary_split_assigner_ranks_available_hosts():

--- a/tests/fast/test_ray_fte.py
+++ b/tests/fast/test_ray_fte.py
@@ -5302,6 +5302,7 @@ def test_fte_fragment_execution_binds_ordered_sink_to_semantic_partition_order()
         fragment_id="q:node:ordered-shuffle",
         logical_fragment_identity="q:node:ordered-shuffle",
         worker=worker,
+        context={"source_task_order": "4"},
         exchange_sink_config={
             "query_id": "q",
             "output_partition_count": 1,
@@ -5316,8 +5317,9 @@ def test_fte_fragment_execution_binds_ordered_sink_to_semantic_partition_order()
     scheduled = scheduled_result[0]
     _execute_stage_commands(stage, scheduled_result)
 
-    assert scheduled.request["exchange_sink_instance"]["source_task_order"] == 3
-    assert worker.calls[0][1]["exchange_sink_instance"]["source_task_order"] == 3
+    expected_source_task_order = (4 << 32) | 3
+    assert scheduled.request["exchange_sink_instance"]["source_task_order"] == expected_source_task_order
+    assert worker.calls[0][1]["exchange_sink_instance"]["source_task_order"] == expected_source_task_order
 
 
 def test_fte_fragment_execution_allocates_exchange_identity_when_partition_is_created():

--- a/vane/runners/exchange_sink.py
+++ b/vane/runners/exchange_sink.py
@@ -10,6 +10,7 @@ _CONFIG_KEYS = {
     "query_id",
     "output_location_prefix",
     "output_partition_count",
+    "preserve_order",
 }
 
 
@@ -43,11 +44,17 @@ def normalize_exchange_sink_config(exchange_sink_config: Any) -> dict[str, Any]:
     if output_partition_count == 0:
         raise ValueError("exchange_sink_config output_partition_count must be positive")
 
+    preserve_order = exchange_sink_config.get("preserve_order", False)
+    if not isinstance(preserve_order, bool):
+        raise TypeError("exchange_sink_config preserve_order must be a boolean")
+
     result: dict[str, Any] = {
         "query_id": query_id,
         "output_location_prefix": output_location_prefix,
         "output_partition_count": output_partition_count,
     }
+    if preserve_order:
+        result["preserve_order"] = True
     return result
 
 
@@ -56,16 +63,25 @@ def bind_exchange_sink_instance(
     *,
     attempt_id: int,
     task_partition_id: int,
+    source_task_order: int | None = None,
 ) -> dict[str, Any]:
     config = normalize_exchange_sink_config(exchange_sink_config)
     attempt_id = _non_negative_integer("attempt_id", attempt_id)
     task_partition_id = _non_negative_integer("task_partition_id", task_partition_id)
 
+    if config.get("preserve_order", False):
+        source_task_order = _non_negative_integer("source_task_order", source_task_order)
+    elif source_task_order is not None:
+        raise ValueError("source_task_order requires an order-preserving exchange sink")
+
     output_location = f"{config['output_location_prefix']}__sink_{task_partition_id}__attempt_{attempt_id}"
-    return {
+    payload = {
         "sink_handle": {"task_partition_id": task_partition_id},
         "attempt_id": attempt_id,
         "query_id": config["query_id"],
         "output_partition_count": config["output_partition_count"],
         "output_location": output_location,
     }
+    if source_task_order is not None:
+        payload["source_task_order"] = source_task_order
+    return payload

--- a/vane/runners/fte/backends/native/backend.py
+++ b/vane/runners/fte/backends/native/backend.py
@@ -2207,10 +2207,17 @@ class NativeFteWorkerManagerBackend:
                 task_context_info,
                 context,
             )
+            source_task_order = None
+            if exchange_sink_config.get("preserve_order", False):
+                raw_source_task_order = context.get("source_task_order")
+                if raw_source_task_order is None:
+                    raise ValueError("ordered native FTE exchange sink requires a task sequence")
+                source_task_order = int(raw_source_task_order)
             exchange_sink_instance = bind_exchange_sink_instance(
                 exchange_sink_config,
                 attempt_id=attempt_id,
                 task_partition_id=scheduler_task_partition_id,
+                source_task_order=source_task_order,
             )
 
         node_name = str(context.get("node_name") or task.name() or "fragment")

--- a/vane/runners/fte/fte_execution.py
+++ b/vane/runners/fte/fte_execution.py
@@ -75,6 +75,25 @@ if TYPE_CHECKING:
     from vane.runners.fte.fte_types import FteSplit
 
 
+_ORDERED_FTE_PARTITION_ORDER_BITS = 32
+_ORDERED_FTE_ORDER_COMPONENT_MAX = (1 << _ORDERED_FTE_PARTITION_ORDER_BITS) - 1
+_INVALID_IDX = (1 << 64) - 1
+
+
+def _ordered_fte_source_task_order(source_task_order: int, partition_id: int) -> int:
+    """Pack the coordinator task order and its FTE partition into one ordered key."""
+    source_task_order = _check_non_negative("source_task_order", source_task_order)
+    partition_id = _check_non_negative("partition_id", partition_id)
+    if source_task_order > _ORDERED_FTE_ORDER_COMPONENT_MAX:
+        raise ValueError("source_task_order exceeds the ordered FTE key range")
+    if partition_id > _ORDERED_FTE_ORDER_COMPONENT_MAX:
+        raise ValueError("partition_id exceeds the ordered FTE key range")
+    result = (source_task_order << _ORDERED_FTE_PARTITION_ORDER_BITS) | partition_id
+    if result == _INVALID_IDX:
+        raise ValueError("ordered FTE source task order collides with the invalid index sentinel")
+    return result
+
+
 class FteWorkerControlFailure(RuntimeError):
     def __init__(
         self,
@@ -152,6 +171,7 @@ class FteTaskPartition:
         max_attempts: int = 4,
         sink_handle: ExchangeSinkHandle | None = None,
         exchange_sink_task_partition_id: int | None = None,
+        source_task_order: int | None = None,
         node_requirements: NodeRequirements | None = None,
         memory_requirement_bytes: int | None = None,
         execution_class: FteTaskExecutionClass | str | None = None,
@@ -169,6 +189,9 @@ class FteTaskPartition:
             None
             if exchange_sink_task_partition_id is None
             else _check_non_negative("exchange_sink_task_partition_id", exchange_sink_task_partition_id)
+        )
+        self.source_task_order = (
+            None if source_task_order is None else _check_non_negative("source_task_order", source_task_order)
         )
         if self.sink_handle is not None and self.exchange_sink_task_partition_id is not None:
             raise ValueError(
@@ -671,24 +694,43 @@ class FteFragmentExecution:
         self,
         partition_id: int,
         node_requirements: NodeRequirements | None = None,
+        *,
+        coordinator_source_task_order: int | None = None,
     ) -> FteTaskPartition:
         with self._state_lock:
-            return self._add_partition_locked(partition_id, node_requirements)
+            return self._add_partition_locked(
+                partition_id,
+                node_requirements,
+                coordinator_source_task_order=coordinator_source_task_order,
+            )
 
     def _add_partition_locked(
         self,
         partition_id: int,
         node_requirements: NodeRequirements | None = None,
+        *,
+        coordinator_source_task_order: int | None = None,
     ) -> FteTaskPartition:
         if not self._state_lock_owned_by_current_thread():
             raise RuntimeError("FTE partition mutation requires the fragment state lock")
         partition_id = _check_non_negative("partition_id", partition_id)
         existing = self.partitions.get(partition_id)
         if existing is not None:
+            if coordinator_source_task_order is not None:
+                expected_source_task_order = self._source_task_order_for_partition(
+                    partition_id,
+                    coordinator_source_task_order,
+                )
+                if existing.source_task_order != expected_source_task_order:
+                    raise ValueError("coordinator source task order cannot change for an FTE partition")
             if existing.node_requirements is None and node_requirements is not None:
                 existing.node_requirements = node_requirements
                 existing._invalidate_placement()
             return existing
+        source_task_order = self._source_task_order_for_partition(
+            partition_id,
+            coordinator_source_task_order,
+        )
         task_id = FteTaskId(self.query_id, self.fragment_execution_id, partition_id)
         if self.exchange is None:
             sink_handle = None
@@ -726,6 +768,7 @@ class FteFragmentExecution:
             max_attempts=self.max_attempts,
             sink_handle=sink_handle,
             exchange_sink_task_partition_id=exchange_sink_task_partition_id,
+            source_task_order=source_task_order,
             node_requirements=node_requirements,
             memory_requirement_bytes=self.task_memory_bytes,
             execution_class=self.execution_class,
@@ -733,6 +776,24 @@ class FteFragmentExecution:
         self.partitions[partition_id] = partition
         self.descriptor_storage.put(task_id, descriptor)
         return partition
+
+    def _source_task_order_for_partition(
+        self,
+        partition_id: int,
+        coordinator_source_task_order: int | None,
+    ) -> int | None:
+        preserves_order = bool(
+            self.exchange_sink_config is not None and self.exchange_sink_config.get("preserve_order", False)
+        )
+        if not preserves_order:
+            if coordinator_source_task_order is not None:
+                raise ValueError("coordinator source task order requires an order-preserving exchange sink")
+            return None
+        if coordinator_source_task_order is None:
+            coordinator_source_task_order = self.context.get("source_task_order")
+        if coordinator_source_task_order is None:
+            raise ValueError("ordered Ray FTE exchange sink requires a coordinator task sequence")
+        return _ordered_fte_source_task_order(coordinator_source_task_order, partition_id)
 
     def merge_submission_metadata(
         self,
@@ -1933,9 +1994,7 @@ class FteFragmentExecution:
                 sink_config,
                 attempt_id=partition.next_attempt_number(),
                 task_partition_id=scheduler_task_partition_id,
-                source_task_order=(
-                    partition.task_id.partition_id if sink_config.get("preserve_order", False) else None
-                ),
+                source_task_order=partition.source_task_order if sink_config.get("preserve_order", False) else None,
             )
         worker_id, worker = self._select_worker(partition)
         if self.exchange is not None:

--- a/vane/runners/fte/fte_execution.py
+++ b/vane/runners/fte/fte_execution.py
@@ -1933,6 +1933,9 @@ class FteFragmentExecution:
                 sink_config,
                 attempt_id=partition.next_attempt_number(),
                 task_partition_id=scheduler_task_partition_id,
+                source_task_order=(
+                    partition.task_id.partition_id if sink_config.get("preserve_order", False) else None
+                ),
             )
         worker_id, worker = self._select_worker(partition)
         if self.exchange is not None:

--- a/vane/runners/fte/fte_split_assigner.py
+++ b/vane/runners/fte/fte_split_assigner.py
@@ -179,6 +179,7 @@ class ArbitrarySplitAssigner(SplitAssigner):
         self,
         max_splits_per_partition: int | None = None,
         *,
+        preserve_order: bool = False,
         catalog_requirement: str | None = None,
         partitioned_sources: set[str] | list[str] | tuple[str, ...] | None = None,
         replicated_sources: set[str] | list[str] | tuple[str, ...] | None = None,
@@ -208,6 +209,7 @@ class ArbitrarySplitAssigner(SplitAssigner):
         if max_target < min_target:
             raise ValueError("max_target_partition_size_bytes must be >= min_target_partition_size_bytes")
         self._next_partition_id = 0
+        self._preserve_order = bool(preserve_order)
         self._source_sequences: dict[str, int] = {}
         self._catalog_requirement = None if catalog_requirement is None else str(catalog_requirement)
         self._partitioned_sources = _normalize_sources(partitioned_sources)
@@ -290,6 +292,23 @@ class ArbitrarySplitAssigner(SplitAssigner):
         for split in splits:
             node_requirements = self._node_requirements(split)
             assignment = self._open_assignments.get(node_requirements)
+            if self._preserve_order and assignment is None and self._open_assignments:
+                # Locality-aware assignment normally keeps one open partition per
+                # node. Reusing an older partition would turn an A, B, A input
+                # sequence into A, A, B when an ordered exchange reads partitions
+                # by ID, so ordered fragments close the current contiguous run.
+                for open_requirements, open_assignment in list(self._open_assignments.items()):
+                    open_assignment.full = True
+                    for partitioned_source_id in self._partitioned_sources:
+                        _append_update(
+                            result,
+                            open_assignment.partition_id,
+                            partitioned_source_id,
+                            no_more_splits=True,
+                        )
+                    if self._completed_sources.issuperset(self._replicated_sources):
+                        _append_seal(result, open_assignment.partition_id)
+                    self._open_assignments.pop(open_requirements, None)
             split_size = _split_size_bytes(split, self._standard_split_size_bytes)
             if assignment is not None and (
                 assignment.assigned_data_size_bytes + split_size > self._rounded_target_partition_size_bytes

--- a/vane/runners/ray/fragment_registry.py
+++ b/vane/runners/ray/fragment_registry.py
@@ -73,6 +73,7 @@ class _FteFragmentState:
         self.exchange_source_partition_ids: set[int] = set()
         self.exchange_source_partition_count: int = 0
         self.exchange_source_task_count: int = 0
+        self.preserve_order: bool = False
         self.exchange_source_partition_ids_by_source: dict[str, set[int]] = {}
         self.exchange_source_split_keys_by_source: dict[str, set[str]] = {}
         self.exchange_source_partition_count_by_source: dict[str, int] = {}

--- a/vane/runners/ray/fragment_worker_assignment.py
+++ b/vane/runners/ray/fragment_worker_assignment.py
@@ -51,6 +51,7 @@ def _make_arbitrary_assigner(
     return ArbitrarySplitAssigner(
         partitioned_sources=partitioned_sources,
         replicated_sources=replicated_sources,
+        preserve_order=fragment_state.preserve_order,
         max_splits_per_partition=max_splits_per_partition,
         min_target_partition_size_bytes=min_target_partition_size_bytes,
         max_target_partition_size_bytes=max_target_partition_size_bytes,

--- a/vane/runners/ray/fragment_worker_state.py
+++ b/vane/runners/ray/fragment_worker_state.py
@@ -44,6 +44,7 @@ def get_or_create_fte_fragment_state(
     replicated_exchange_sources: set[str] | None = None,
     exchange_source_partition_count: int = 0,
     exchange_source_task_count: int = 0,
+    preserve_order: bool = False,
 ) -> _FteFragmentState:
     key = (str(query_id), str(fragment_id))
     with _FTE_REGISTRY_LOCK:
@@ -60,6 +61,9 @@ def get_or_create_fte_fragment_state(
         elif key not in _FTE_FRAGMENT_STATES:
             _FTE_FRAGMENT_STATES[key] = state
         had_assigner = state.assigner is not None
+        if had_assigner and state.preserve_order != bool(preserve_order):
+            raise RuntimeError("FTE fragment order-preservation mode cannot change")
+        state.preserve_order = bool(preserve_order)
         had_exchange_sources = bool(state.dynamic_exchange_source_node_ids)
         previous_exchange_partition_count = state.exchange_source_partition_count
         previous_exchange_task_count = state.exchange_source_task_count

--- a/vane/runners/ray/fragment_worker_submission.py
+++ b/vane/runners/ray/fragment_worker_submission.py
@@ -639,8 +639,12 @@ class FteWorkerSubmissionMixin:
                     "exchange_source_partition_ids": set(),
                     "exchange_source_partition_count": 0,
                     "exchange_source_task_count": 0,
+                    "preserve_order": bool((item.get("exchange_sink_config") or {}).get("preserve_order", False)),
                 },
             )
+            item_preserves_order = bool((item.get("exchange_sink_config") or {}).get("preserve_order", False))
+            if aggregate["preserve_order"] != item_preserves_order:
+                raise ValueError("exchange sink order-preservation mode cannot change within a fragment")
             aggregate["dynamic_scan_sources"].update(dynamic_scan_sources)
             aggregate["dynamic_exchange_sources"].update(dynamic_exchange_sources)
             aggregate["replicated_exchange_sources"].update(replicated_exchange_sources)
@@ -690,6 +694,7 @@ class FteWorkerSubmissionMixin:
                 exchange_source_partition_ids=aggregate["exchange_source_partition_ids"],
                 exchange_source_partition_count=aggregate["exchange_source_partition_count"],
                 exchange_source_task_count=aggregate["exchange_source_task_count"],
+                preserve_order=aggregate["preserve_order"],
             )
 
         for prepared_index, (
@@ -734,6 +739,7 @@ class FteWorkerSubmissionMixin:
                 exchange_source_partition_ids=set(),
                 exchange_source_partition_count=0,
                 exchange_source_task_count=0,
+                preserve_order=bool((item.get("exchange_sink_config") or {}).get("preserve_order", False)),
             )
             if fragment_state.assigner is None:
                 raise RuntimeError("FTE fragment state is missing split assigner")

--- a/vane/runners/ray/fragment_worker_submission.py
+++ b/vane/runners/ray/fragment_worker_submission.py
@@ -741,6 +741,11 @@ class FteWorkerSubmissionMixin:
                 exchange_source_task_count=0,
                 preserve_order=bool((item.get("exchange_sink_config") or {}).get("preserve_order", False)),
             )
+            coordinator_source_task_order = None
+            if fragment_state.preserve_order:
+                coordinator_source_task_order = (item.get("context") or {}).get("source_task_order")
+                if coordinator_source_task_order is None:
+                    raise ValueError("ordered Ray FTE exchange sink requires a coordinator task sequence")
             if fragment_state.assigner is None:
                 raise RuntimeError("FTE fragment state is missing split assigner")
             new_exchange_partition_ids_by_source, final_exchange_sources = mark_exchange_source_partitions_seen(
@@ -770,7 +775,10 @@ class FteWorkerSubmissionMixin:
                     prepared_index=prepared_index,
                     elapsed_ms=int((time.monotonic() - item_started_at) * 1000),
                 )
-                partition = fragment_execution.add_partition(0)
+                partition = fragment_execution.add_partition(
+                    0,
+                    coordinator_source_task_order=coordinator_source_task_order,
+                )
                 _fte_submission_debug_log(
                     "pending_item_empty_source_reserve_start",
                     prepared_index=prepared_index,
@@ -837,6 +845,7 @@ class FteWorkerSubmissionMixin:
                     partition = fragment_execution.add_partition(
                         partition_info.partition_id,
                         partition_info.node_requirements,
+                        coordinator_source_task_order=coordinator_source_task_order,
                     )
                     _fte_submission_debug_log(
                         "pending_item_reserve_start",


### PR DESCRIPTION
## Summary

- translate binary `POSITIONAL_JOIN` and n-ary `POSITIONAL_SCAN` plans into native worker positional joins over ordered single-partition gathers
- preserve global row order across Flight exchanges with an explicit semantic source-task ordinal, including retry validation and deterministic source-handle ordering
- expose nonstandard physical children through the common traversal path so positional-scan inputs participate in split, binding, translation, and serialization logic
- treat ordered gathers as materialization barriers and keep ordered FTE partition assignment contiguous across locality changes

This completes the positional-join portion of #627 after #693 added distributed cross-product support.

## Related issue

close: #627

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The change enables an existing SQL operation in the Ray runner and does not add or alter public API surface.

## Validation

- `scripts/format workspace --changed`
- `cmake --build build/python-release --target unittest -j2`
- `uv pip install . --no-build-isolation --reinstall-package vane-ai`
- affected Python/FTE suites: 653 passed
- targeted distributed C++ suite: 8 test cases, 105 assertions passed
- `scripts/run_release_tests.sh`: 812 passed, 20 deselected; Real Ray shard 14 passed, 818 deselected
- after the final ordered-barrier metadata adjustment:
  - positional C++ translator/ownership tests: 2 test cases, 25 assertions passed
  - positional Ray E2E tests: 2 passed, 99 deselected
  - query resource graph registration tests: 9 passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
