### PR TITLE
[fix](file) Normalize list_files URL identity

### DIFF
--- a/external/duckdb/extension/file/file_list_function.cpp
+++ b/external/duckdb/extension/file/file_list_function.cpp
@@ -185,24 +185,28 @@ static idx_t GlobPathBegin(const string &path) {
 	return scheme + 3;
 }
 
-static bool HasPathGlob(const string &path) {
+static optional_idx FindPathGlob(const string &path) {
 	auto begin = GlobPathBegin(path);
 	auto suffix = FindURISuffix(path);
 	auto end = suffix.IsValid() ? suffix.GetIndex() : path.size();
 	if (end <= begin) {
-		return false;
+		return optional_idx();
 	}
 	for (idx_t index = begin; index < end; index++) {
 		switch (path[index]) {
 		case '*':
 		case '?':
 		case '[':
-			return true;
+			return optional_idx(index);
 		default:
 			break;
 		}
 	}
-	return false;
+	return optional_idx();
+}
+
+static bool HasPathGlob(const string &path) {
+	return FindPathGlob(path).IsValid();
 }
 
 static string EscapeLiteralGlobPath(const string &path) {
@@ -242,6 +246,89 @@ static string AppendPathComponent(FileSystem &file_system, const string &path, c
 		return base + component + suffix;
 	}
 	return file_system.JoinPath(base, component) + suffix;
+}
+
+static string DiscoveryPathPrefix(FileSystem &file_system, const string &locator) {
+	auto path_end = FindURISuffix(locator);
+	auto end = path_end.IsValid() ? path_end.GetIndex() : locator.size();
+	auto glob = FindPathGlob(locator);
+	auto separator = file_system.PathSeparator(locator);
+	if (separator.empty()) {
+		return string();
+	}
+	if (glob.IsValid()) {
+		auto separator_offset = locator.rfind(separator, glob.GetIndex());
+		if (separator_offset == string::npos) {
+			return string();
+		}
+		return locator.substr(0, separator_offset + separator.size());
+	}
+	auto prefix = locator.substr(0, end);
+	if (!StringUtil::EndsWith(prefix, separator)) {
+		prefix += separator;
+	}
+	return prefix;
+}
+
+static string TrimLeadingURLSeparators(const string &path) {
+	idx_t offset = 0;
+	while (offset < path.size() && path[offset] == '/') {
+		offset++;
+	}
+	return path.substr(offset);
+}
+
+// Filesystem adapters can erase the caller's URI spelling while expanding a
+// glob (for example, file:// to a native path or memory:// to memory:///). Only
+// restore that spelling when the returned key is still below the caller's
+// stable, non-glob prefix; otherwise the provider result remains authoritative.
+static string NormalizeDiscoveredPath(FileSystem &file_system, const string &locator, const string &discovered_path) {
+	auto scheme_separator = locator.find("://");
+	if (scheme_separator == string::npos) {
+		return discovered_path;
+	}
+	auto discovered_scheme_separator = discovered_path.find("://");
+	if (discovered_scheme_separator != string::npos &&
+	    !StringUtil::CIEquals(locator.substr(0, scheme_separator),
+	                          discovered_path.substr(0, discovered_scheme_separator))) {
+		return discovered_path;
+	}
+
+	auto prefix = DiscoveryPathPrefix(file_system, locator);
+	if (prefix.empty()) {
+		return discovered_path;
+	}
+	string prefix_key;
+	string discovered_key;
+	if (IsNativePath(locator)) {
+		prefix_key = file_system.ConvertSeparators(file_system.ExpandPath(prefix));
+		discovered_key = file_system.ConvertSeparators(file_system.ExpandPath(discovered_path));
+	} else {
+		prefix_key = TrimLeadingURLSeparators(prefix.substr(scheme_separator + 3));
+		discovered_key = TrimLeadingURLSeparators(discovered_scheme_separator == string::npos
+		                                              ? discovered_path
+		                                              : discovered_path.substr(discovered_scheme_separator + 3));
+	}
+	if (prefix_key.empty()) {
+		return discovered_path;
+	}
+
+#ifdef _WIN32
+	auto matches_prefix = IsNativePath(locator) ? StringUtil::CIStartsWith(discovered_key, prefix_key)
+	                                            : StringUtil::StartsWith(discovered_key, prefix_key);
+#else
+	auto matches_prefix = StringUtil::StartsWith(discovered_key, prefix_key);
+#endif
+	if (!matches_prefix) {
+		return discovered_path;
+	}
+	auto suffix = discovered_key.substr(prefix_key.size());
+#ifdef _WIN32
+	if (IsNativePath(locator)) {
+		suffix = StringUtil::Replace(suffix, "\\", "/");
+	}
+#endif
+	return prefix + suffix;
 }
 
 static void VerifyNativeDirectoryAccessible(FileSystem &file_system, const string &path) {
@@ -327,7 +414,8 @@ static bool TryListConcreteDirectory(ClientContext &context, FileSystem &file_sy
 				    if (context.IsInterrupted()) {
 					    throw InterruptException();
 				    }
-				    info.path = ResolveListedPath(file_system, directory, info.path);
+				    info.path = NormalizeDiscoveredPath(file_system, directory,
+				                                        ResolveListedPath(file_system, directory, info.path));
 				    if (FileSystem::IsDirectory(info)) {
 					    if (recursive && (!native_directory || !IsNativeSymbolicLink(file_system, info.path)) &&
 					        scheduled_directories.insert(info.path).second) {
@@ -430,6 +518,9 @@ static vector<OpenFileInfo> ExpandGlob(FileSystem &file_system, const string &pa
 			                  path);
 		}
 		files = file_list->GetAllFiles();
+		for (auto &file : files) {
+			file.path = NormalizeDiscoveredPath(file_system, path, file.path);
+		}
 	} catch (const NotImplementedException &) {
 		throw NotImplementedException("list_files() filesystem '%s' does not support %s listing for path '%s'",
 		                              file_system.GetName(), explicit_glob ? "glob" : "directory", path);

--- a/external/duckdb/extension/file/file_list_function.cpp
+++ b/external/duckdb/extension/file/file_list_function.cpp
@@ -154,35 +154,51 @@ static FileStatValue DeserializeFileStat(Deserializer &deserializer) {
 	return result;
 }
 
+// Registered connector protocol identifiers can contain underscores even
+// though RFC URL schemes cannot.
+static optional_idx FindLeadingProtocolSeparator(const string &path) {
+	auto separator = path.find("://");
+	if (separator == string::npos || separator == 0 || !StringUtil::CharacterIsAlpha(path[0])) {
+		return optional_idx();
+	}
+	for (idx_t index = 1; index < separator; index++) {
+		auto character = path[index];
+		if (!StringUtil::CharacterIsAlphaNumeric(character) && character != '+' && character != '-' &&
+		    character != '.' && character != '_') {
+			return optional_idx();
+		}
+	}
+	return optional_idx(separator);
+}
+
 static bool IsNativePath(const string &path) {
-	auto scheme = path.find("://");
-	return scheme == string::npos || StringUtil::CIStartsWith(path, "file://");
+	return !FindLeadingProtocolSeparator(path).IsValid() || StringUtil::CIStartsWith(path, "file://");
 }
 
 static optional_idx FindURISuffix(const string &path) {
-	auto scheme = path.find("://");
-	if (scheme == string::npos ||
+	auto scheme = FindLeadingProtocolSeparator(path);
+	if (!scheme.IsValid() ||
 	    (!StringUtil::CIStartsWith(path, "http://") && !StringUtil::CIStartsWith(path, "https://"))) {
 		return optional_idx();
 	}
 	// HTTP(S) reserves '?' and '#' for query and fragment components.
 	// Connector URLs such as memory:// and s3:// retain them as path syntax.
-	auto suffix = path.find_first_of("?#", scheme + 3);
+	auto suffix = path.find_first_of("?#", scheme.GetIndex() + 3);
 	return suffix == string::npos ? optional_idx() : optional_idx(suffix);
 }
 
 static idx_t GlobPathBegin(const string &path) {
-	auto scheme = path.find("://");
-	if (scheme == string::npos) {
+	auto scheme = FindLeadingProtocolSeparator(path);
+	if (!scheme.IsValid()) {
 		return 0;
 	}
 	if (StringUtil::CIStartsWith(path, "http://") || StringUtil::CIStartsWith(path, "https://")) {
-		auto authority_end = path.find('/', scheme + 3);
+		auto authority_end = path.find('/', scheme.GetIndex() + 3);
 		return authority_end == string::npos ? path.size() : authority_end;
 	}
 	// Connector URLs commonly use everything after :// as their key rather
 	// than an RFC authority, so glob metacharacters there remain significant.
-	return scheme + 3;
+	return scheme.GetIndex() + 3;
 }
 
 static optional_idx FindPathGlob(const string &path) {
@@ -283,14 +299,20 @@ static string TrimLeadingURLSeparators(const string &path) {
 // restore that spelling when the returned key is still below the caller's
 // stable, non-glob prefix; otherwise the provider result remains authoritative.
 static string NormalizeDiscoveredPath(FileSystem &file_system, const string &locator, const string &discovered_path) {
-	auto scheme_separator = locator.find("://");
-	if (scheme_separator == string::npos) {
+	auto scheme_separator = FindLeadingProtocolSeparator(locator);
+	if (!scheme_separator.IsValid()) {
 		return discovered_path;
 	}
-	auto discovered_scheme_separator = discovered_path.find("://");
-	if (discovered_scheme_separator != string::npos &&
-	    !StringUtil::CIEquals(locator.substr(0, scheme_separator),
-	                          discovered_path.substr(0, discovered_scheme_separator))) {
+	auto discovered_scheme_separator = FindLeadingProtocolSeparator(discovered_path);
+	auto discovered_path_begin = discovered_scheme_separator.IsValid() ? discovered_scheme_separator.GetIndex() + 3 : 0;
+	if (discovered_path.find("://", discovered_path_begin) != string::npos) {
+		// A connector key may itself contain ://. Its slash spelling can be
+		// significant to the provider, so retain the provider's representation.
+		return discovered_path;
+	}
+	if (discovered_scheme_separator.IsValid() &&
+	    !StringUtil::CIEquals(locator.substr(0, scheme_separator.GetIndex()),
+	                          discovered_path.substr(0, discovered_scheme_separator.GetIndex()))) {
 		return discovered_path;
 	}
 
@@ -304,10 +326,10 @@ static string NormalizeDiscoveredPath(FileSystem &file_system, const string &loc
 		prefix_key = file_system.ConvertSeparators(file_system.ExpandPath(prefix));
 		discovered_key = file_system.ConvertSeparators(file_system.ExpandPath(discovered_path));
 	} else {
-		prefix_key = TrimLeadingURLSeparators(prefix.substr(scheme_separator + 3));
-		discovered_key = TrimLeadingURLSeparators(discovered_scheme_separator == string::npos
-		                                              ? discovered_path
-		                                              : discovered_path.substr(discovered_scheme_separator + 3));
+		prefix_key = TrimLeadingURLSeparators(prefix.substr(scheme_separator.GetIndex() + 3));
+		discovered_key = TrimLeadingURLSeparators(
+		    discovered_scheme_separator.IsValid() ? discovered_path.substr(discovered_scheme_separator.GetIndex() + 3)
+		                                          : discovered_path);
 	}
 	if (prefix_key.empty()) {
 		return discovered_path;
@@ -356,10 +378,10 @@ static bool IsNativeSymbolicLink(FileSystem &file_system, const string &path) {
 }
 
 static string ResolveListedPath(FileSystem &file_system, const string &directory, const string &path) {
-	if (path.find("://") != string::npos) {
+	if (FindLeadingProtocolSeparator(path).IsValid()) {
 		return path;
 	}
-	if (directory.find("://") != string::npos) {
+	if (FindLeadingProtocolSeparator(directory).IsValid()) {
 		// FileSystem::ListFiles reports direct child names. Registered adapters
 		// may instead return a complete protocol-stripped path, so retain only
 		// its final component and preserve the caller's directory locator.
@@ -576,7 +598,7 @@ static bool IsListedDirectory(FileSystem &file_system, const OpenFileInfo &info)
 
 static vector<string> FileSearchPathCandidates(ClientContext &context, FileSystem &file_system, const string &path) {
 	vector<string> result;
-	if (path.find("://") != string::npos) {
+	if (FindLeadingProtocolSeparator(path).IsValid()) {
 		return result;
 	}
 	auto expanded_path = file_system.ExpandPath(path);

--- a/src/vane_py/include/vane_python/pyfilesystem.hpp
+++ b/src/vane_py/include/vane_python/pyfilesystem.hpp
@@ -56,6 +56,8 @@ private:
 	const bool directory_semantics;
 	std::string DecodeFlags(FileOpenFlags flags);
 	bool Exists(const string &filename, const char *func_name) const;
+	string RestoreCallerPath(const string &locator, const string &returned_path, const string &fallback_path,
+	                         bool glob_pattern) const;
 
 public:
 	explicit PythonFilesystem(vector<string> protocols, AbstractFileSystem filesystem, bool directory_semantics)

--- a/src/vane_py/pyfilesystem.cpp
+++ b/src/vane_py/pyfilesystem.cpp
@@ -166,12 +166,35 @@ static bool IsSameOrChildPathKey(const string &path, const string &prefix) {
 	return path.size() == prefix.size() || StringUtil::EndsWith(prefix, "/") || path[prefix.size()] == '/';
 }
 
+// Registered fsspec protocol identifiers can contain underscores even though
+// RFC URL schemes cannot.
+static optional_idx FindLeadingProtocolSeparator(const string &path) {
+	auto separator = path.find("://");
+	if (separator == string::npos || separator == 0 || !StringUtil::CharacterIsAlpha(path[0])) {
+		return optional_idx();
+	}
+	for (idx_t index = 1; index < separator; index++) {
+		auto character = path[index];
+		if (!StringUtil::CharacterIsAlphaNumeric(character) && character != '+' && character != '-' &&
+		    character != '.' && character != '_') {
+			return optional_idx();
+		}
+	}
+	return optional_idx(separator);
+}
+
+static string URLAuthority(const string &path, idx_t scheme_separator) {
+	auto authority_begin = scheme_separator + 3;
+	auto authority_end = path.find_first_of("/?#", authority_begin);
+	return path.substr(authority_begin, authority_end == string::npos ? string::npos : authority_end - authority_begin);
+}
+
 static bool HasCallerIdentityPrefix(const string &path) {
-	auto scheme_separator = path.find("://");
-	if (scheme_separator == string::npos) {
+	auto scheme_separator = FindLeadingProtocolSeparator(path);
+	if (!scheme_separator.IsValid()) {
 		return true;
 	}
-	auto offset = scheme_separator + 3;
+	auto offset = scheme_separator.GetIndex() + 3;
 	while (offset < path.size() && path[offset] == '/') {
 		offset++;
 	}
@@ -185,9 +208,9 @@ static bool HasCallerIdentityPrefix(const string &path) {
 string PythonFilesystem::RestoreCallerPath(const string &locator, const string &returned_path,
                                            const string &fallback_path, bool glob_pattern) const {
 	D_ASSERT(py::gil_check());
-	auto scheme_separator = returned_path.find("://");
-	if (scheme_separator != string::npos) {
-		auto returned_protocol = returned_path.substr(0, scheme_separator);
+	auto returned_scheme_separator = FindLeadingProtocolSeparator(returned_path);
+	if (returned_scheme_separator.IsValid()) {
+		auto returned_protocol = returned_path.substr(0, returned_scheme_separator.GetIndex());
 		bool supported_protocol = false;
 		for (const auto &protocol : protocols) {
 			if (StringUtil::CIEquals(protocol, returned_protocol)) {
@@ -197,6 +220,15 @@ string PythonFilesystem::RestoreCallerPath(const string &locator, const string &
 		}
 		if (!supported_protocol) {
 			return fallback_path;
+		}
+
+		auto locator_scheme_separator = FindLeadingProtocolSeparator(locator);
+		if (locator_scheme_separator.IsValid()) {
+			auto locator_authority = URLAuthority(locator, locator_scheme_separator.GetIndex());
+			auto returned_authority = URLAuthority(returned_path, returned_scheme_separator.GetIndex());
+			if (!locator_authority.empty() && !returned_authority.empty() && locator_authority != returned_authority) {
+				return fallback_path;
+			}
 		}
 	}
 
@@ -226,7 +258,11 @@ string PythonFilesystem::RestoreCallerPath(const string &locator, const string &
 	if (StringUtil::EndsWith(caller_prefix, "/") && StringUtil::StartsWith(returned_suffix, "/")) {
 		returned_suffix.erase(0, 1);
 	}
-	return caller_prefix + returned_suffix;
+	auto restored_path = caller_prefix + returned_suffix;
+	if (py::str(strip_protocol(py::str(restored_path))).cast<string>() != returned_key) {
+		return fallback_path;
+	}
+	return restored_path;
 }
 
 vector<OpenFileInfo> PythonFilesystem::Glob(const string &path, FileOpener *opener) {
@@ -243,7 +279,7 @@ vector<OpenFileInfo> PythonFilesystem::Glob(const string &path, FileOpener *open
 		for (auto item : returner) {
 			string returned_path = py::str(item);
 			string fallback_path = returned_path;
-			if (returned_path.find("://") == string::npos) {
+			if (!FindLeadingProtocolSeparator(returned_path).IsValid()) {
 				fallback_path = py::str(unstrip_protocol(py::str(item)));
 			}
 			results.emplace_back(RestoreCallerPath(path, returned_path, fallback_path, true));

--- a/src/vane_py/pyfilesystem.cpp
+++ b/src/vane_py/pyfilesystem.cpp
@@ -149,6 +149,86 @@ bool PythonFilesystem::Exists(const string &filename, const char *func_name) con
 		                              func_name);
 	}
 }
+
+static string StablePathKeyPrefix(const string &path, bool glob_pattern) {
+	auto glob = glob_pattern ? path.find_first_of("*?[") : string::npos;
+	if (glob == string::npos) {
+		return path;
+	}
+	auto separator = path.rfind('/', glob);
+	return separator == string::npos ? string() : path.substr(0, separator + 1);
+}
+
+static bool IsSameOrChildPathKey(const string &path, const string &prefix) {
+	if (prefix.empty() || !StringUtil::StartsWith(path, prefix)) {
+		return false;
+	}
+	return path.size() == prefix.size() || StringUtil::EndsWith(prefix, "/") || path[prefix.size()] == '/';
+}
+
+static bool HasCallerIdentityPrefix(const string &path) {
+	auto scheme_separator = path.find("://");
+	if (scheme_separator == string::npos) {
+		return true;
+	}
+	auto offset = scheme_separator + 3;
+	while (offset < path.size() && path[offset] == '/') {
+		offset++;
+	}
+	return offset < path.size();
+}
+
+// fsspec unstrip_protocol() always selects the provider's first protocol and
+// can omit an authority owned by the configured instance. Compare paths in the
+// provider's stripped key space, then restore only the caller's stable locator
+// prefix. Results outside that prefix retain the provider representation.
+string PythonFilesystem::RestoreCallerPath(const string &locator, const string &returned_path,
+                                           const string &fallback_path, bool glob_pattern) const {
+	D_ASSERT(py::gil_check());
+	auto scheme_separator = returned_path.find("://");
+	if (scheme_separator != string::npos) {
+		auto returned_protocol = returned_path.substr(0, scheme_separator);
+		bool supported_protocol = false;
+		for (const auto &protocol : protocols) {
+			if (StringUtil::CIEquals(protocol, returned_protocol)) {
+				supported_protocol = true;
+				break;
+			}
+		}
+		if (!supported_protocol) {
+			return fallback_path;
+		}
+	}
+
+	auto strip_protocol = filesystem.attr("_strip_protocol");
+	string locator_key = py::str(strip_protocol(py::str(locator)));
+	string returned_key = py::str(strip_protocol(py::str(returned_path)));
+	if (locator_key.empty()) {
+		return fallback_path;
+	}
+	auto stable_prefix = StablePathKeyPrefix(locator_key, glob_pattern);
+	if (!IsSameOrChildPathKey(returned_key, stable_prefix)) {
+		return fallback_path;
+	}
+
+	auto caller_prefix = locator;
+	if (stable_prefix.size() < locator_key.size()) {
+		auto pattern_suffix = locator_key.substr(stable_prefix.size());
+		if (!StringUtil::EndsWith(locator, pattern_suffix)) {
+			return fallback_path;
+		}
+		caller_prefix.resize(locator.size() - pattern_suffix.size());
+	}
+	if (stable_prefix == "/" && !HasCallerIdentityPrefix(caller_prefix)) {
+		return fallback_path;
+	}
+	auto returned_suffix = returned_key.substr(stable_prefix.size());
+	if (StringUtil::EndsWith(caller_prefix, "/") && StringUtil::StartsWith(returned_suffix, "/")) {
+		returned_suffix.erase(0, 1);
+	}
+	return caller_prefix + returned_suffix;
+}
+
 vector<OpenFileInfo> PythonFilesystem::Glob(const string &path, FileOpener *opener) {
 	PythonGILWrapper gil;
 
@@ -161,8 +241,12 @@ vector<OpenFileInfo> PythonFilesystem::Glob(const string &path, FileOpener *open
 		vector<OpenFileInfo> results;
 		auto unstrip_protocol = filesystem.attr("unstrip_protocol");
 		for (auto item : returner) {
-			string file_path = py::str(unstrip_protocol(py::str(item)));
-			results.emplace_back(file_path);
+			string returned_path = py::str(item);
+			string fallback_path = returned_path;
+			if (returned_path.find("://") == string::npos) {
+				fallback_path = py::str(unstrip_protocol(py::str(item)));
+			}
+			results.emplace_back(RestoreCallerPath(path, returned_path, fallback_path, true));
 		}
 		return results;
 	} catch (const py::error_already_set &error) {
@@ -253,7 +337,8 @@ bool PythonFilesystem::ListFiles(const string &directory, const std::function<vo
 	try {
 		for (auto item : filesystem.attr("ls")(py::str(directory), py::arg("detail") = true)) {
 			bool is_dir = py::cast<std::string>(item["type"]) == "directory";
-			callback(py::str(item["name"]), is_dir);
+			string returned_path = py::str(item["name"]);
+			callback(RestoreCallerPath(directory, returned_path, returned_path, false), is_dir);
 		}
 	} catch (const py::error_already_set &error) {
 		if (!error.matches(PyExc_NotImplementedError)) {

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -705,6 +705,25 @@ def test_list_files_preserves_hash_in_local_directory_url(duckdb_cursor, tmp_pat
     )
 
 
+def test_list_files_normalizes_file_url_identity_across_directory_and_glob(duckdb_cursor, tmp_path):
+    directory = tmp_path / "identity"
+    directory.mkdir()
+    child = directory / "value.txt"
+    child.write_text("value", encoding="utf-8")
+    directory_url = directory.as_uri()
+
+    direct = duckdb_cursor.execute(
+        "SELECT url, file_locator_id(file), file FROM list_files(?)", [directory_url]
+    ).fetchone()
+    glob = duckdb_cursor.execute(
+        "SELECT url, file_locator_id(file), file FROM list_files(?)", [f"{directory_url}/*"]
+    ).fetchone()
+
+    assert direct[0] == glob[0] == child.as_uri()
+    assert direct[1] == glob[1]
+    assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
+
+
 @pytest.mark.parametrize("mode", [0, 0o400])
 def test_list_files_reports_inaccessible_directory(duckdb_cursor, tmp_path, mode):
     if os.name == "nt":
@@ -951,6 +970,34 @@ def test_list_files_registered_directory_filesystem_does_not_require_glob(duckdb
     assert recursive == [("memory://root/direct.txt",), ("memory://root/nested/child.txt",)]
 
 
+def test_list_files_normalizes_registered_url_identity_across_directory_and_glob(duckdb_cursor):
+    pytest.importorskip("fsspec", minversion="2022.11.0")
+    memory_module = pytest.importorskip("fsspec.implementations.memory")
+
+    class DirectoryMemoryFileSystem(memory_module.MemoryFileSystem):
+        vane_directory_semantics = True
+
+    memory = DirectoryMemoryFileSystem(skip_instance_cache=True)
+    memory.store = {}
+    memory.pseudo_dirs = [""]
+    memory.makedirs("root")
+    memory.pipe("root/value.txt", b"value")
+    duckdb_cursor.register_filesystem(memory)
+    try:
+        direct = duckdb_cursor.execute(
+            "SELECT url, file_locator_id(file), file FROM list_files('memory://root')"
+        ).fetchone()
+        glob = duckdb_cursor.execute(
+            "SELECT url, file_locator_id(file), file FROM list_files('memory://root/*')"
+        ).fetchone()
+    finally:
+        duckdb_cursor.unregister_filesystem("memory")
+
+    assert direct[0] == glob[0] == "memory://root/value.txt"
+    assert direct[1] == glob[1]
+    assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
+
+
 def test_list_files_registered_directory_filesystem_accepts_trailing_directory_separator(duckdb_cursor):
     pytest.importorskip("fsspec", minversion="2022.11.0")
 
@@ -1011,7 +1058,7 @@ def test_list_files_registered_directory_filesystem_falls_back_when_ls_is_not_im
     finally:
         duckdb_cursor.unregister_filesystem("memory")
 
-    assert rows == [("memory:///root/value.txt",)]
+    assert rows == [("memory://root/value.txt",)]
 
 
 def test_file_does_not_implicitly_convert_to_plain_struct():

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -998,6 +998,80 @@ def test_list_files_normalizes_registered_url_identity_across_directory_and_glob
     assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
 
 
+def test_list_files_normalizes_registered_protocol_alias_identity_across_directory_and_glob(duckdb_cursor, tmp_path):
+    fsspec = pytest.importorskip("fsspec", minversion="2022.11.0")
+    directory = tmp_path / "alias-identity"
+    directory.mkdir()
+    child = directory / "value.txt"
+    child.write_text("value", encoding="utf-8")
+    directory_url = directory.as_uri().replace("file://", "local://", 1)
+
+    filesystem = fsspec.filesystem("file", skip_instance_cache=True)
+    duckdb_cursor.register_filesystem(filesystem)
+    try:
+        direct = duckdb_cursor.execute(
+            "SELECT url, file_locator_id(file), file FROM list_files(?)", [directory_url]
+        ).fetchone()
+        glob = duckdb_cursor.execute(
+            "SELECT url, file_locator_id(file), file FROM list_files(?)", [f"{directory_url}/*"]
+        ).fetchone()
+    finally:
+        duckdb_cursor.unregister_filesystem("file")
+
+    assert direct[0] == glob[0] == child.as_uri().replace("file://", "local://", 1)
+    assert direct[1] == glob[1]
+    assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
+
+
+def test_list_files_normalizes_registered_authority_identity_across_directory_and_glob(duckdb_cursor):
+    pytest.importorskip("fsspec", minversion="2022.11.0")
+    ftp_module = pytest.importorskip("fsspec.implementations.ftp")
+    memory_module = pytest.importorskip("fsspec.implementations.memory")
+
+    class DirectoryFTPFileSystem(memory_module.MemoryFileSystem):
+        protocol = "ftp"
+        vane_directory_semantics = True
+        _strip_protocol = classmethod(ftp_module.FTPFileSystem._strip_protocol.__func__)
+
+    filesystem = DirectoryFTPFileSystem(skip_instance_cache=True)
+    filesystem.store = {}
+    filesystem.pseudo_dirs = [""]
+    filesystem.pipe("/root/value.txt", b"value")
+    duckdb_cursor.register_filesystem(filesystem)
+    try:
+        direct = duckdb_cursor.execute(
+            "SELECT url, file_locator_id(file), file FROM list_files('ftp://host/root')"
+        ).fetchone()
+        glob = duckdb_cursor.execute(
+            "SELECT url, file_locator_id(file), file FROM list_files('ftp://host/root/*')"
+        ).fetchone()
+    finally:
+        duckdb_cursor.unregister_filesystem("ftp")
+
+    assert direct[0] == glob[0] == "ftp://host/root/value.txt"
+    assert direct[1] == glob[1]
+    assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
+
+
+def test_list_files_preserves_unrelated_registered_glob_urls(duckdb_cursor):
+    fsspec = pytest.importorskip("fsspec", minversion="2022.11.0")
+
+    class ForeignResultFileSystem(fsspec.AbstractFileSystem):
+        protocol = "source"
+
+        def glob(self, path, **kwargs):
+            return ["other://bucket/value.txt"]
+
+    filesystem = ForeignResultFileSystem(skip_instance_cache=True)
+    duckdb_cursor.register_filesystem(filesystem)
+    try:
+        rows = duckdb_cursor.execute("SELECT url FROM list_files('source://root/*')").fetchall()
+    finally:
+        duckdb_cursor.unregister_filesystem("source")
+
+    assert rows == [("other://bucket/value.txt",)]
+
+
 def test_list_files_registered_directory_filesystem_accepts_trailing_directory_separator(duckdb_cursor):
     pytest.importorskip("fsspec", minversion="2022.11.0")
 

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -607,6 +607,22 @@ def test_list_files_honors_file_search_path(duckdb_cursor, tmp_path, monkeypatch
         vane.list_files("missing", connection=duckdb_cursor).fetchall()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="colon is not valid in a Windows path component")
+def test_list_files_treats_embedded_scheme_delimiter_as_local_search_path_text(duckdb_cursor, tmp_path, monkeypatch):
+    search_path = tmp_path / "search"
+    directory = search_path / "root" / "http:"
+    directory.mkdir(parents=True)
+    child = directory / "value.txt"
+    child.write_text("value", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    duckdb_cursor.execute("SET file_search_path = ?", [str(search_path)])
+
+    rows = duckdb_cursor.execute("SELECT url FROM list_files('root/http://value.txt')").fetchall()
+
+    assert len(rows) == 1
+    assert os.path.samefile(rows[0][0], child)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="symlink traversal semantics differ on Windows")
 def test_list_files_search_path_preserves_direct_directory_symlink(duckdb_cursor, tmp_path, monkeypatch):
     search_path = tmp_path / "search"
@@ -1023,6 +1039,29 @@ def test_list_files_normalizes_registered_protocol_alias_identity_across_directo
     assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
 
 
+def test_list_files_recognizes_registered_protocol_identifier_with_underscore(duckdb_cursor):
+    fsspec = pytest.importorskip("fsspec", minversion="2022.11.0")
+    memory_module = pytest.importorskip("fsspec.implementations.memory")
+
+    class UnderscoreProtocolMemoryFileSystem(memory_module.MemoryFileSystem):
+        protocol = "custom_protocol"
+        vane_directory_semantics = True
+        _strip_protocol = classmethod(fsspec.AbstractFileSystem._strip_protocol.__func__)
+
+    filesystem = UnderscoreProtocolMemoryFileSystem(skip_instance_cache=True)
+    filesystem.store = {}
+    filesystem.pseudo_dirs = [""]
+    filesystem.makedirs("root")
+    filesystem.pipe("root/value.txt", b"value")
+    duckdb_cursor.register_filesystem(filesystem)
+    try:
+        rows = duckdb_cursor.execute("SELECT url FROM list_files('custom_protocol://root')").fetchall()
+    finally:
+        duckdb_cursor.unregister_filesystem("custom_protocol")
+
+    assert rows == [("custom_protocol://root/value.txt",)]
+
+
 def test_list_files_normalizes_registered_authority_identity_across_directory_and_glob(duckdb_cursor):
     pytest.importorskip("fsspec", minversion="2022.11.0")
     ftp_module = pytest.importorskip("fsspec.implementations.ftp")
@@ -1051,6 +1090,54 @@ def test_list_files_normalizes_registered_authority_identity_across_directory_an
     assert direct[0] == glob[0] == "ftp://host/root/value.txt"
     assert direct[1] == glob[1]
     assert duckdb_cursor.execute("SELECT file_same_location(?, ?)", [direct[2], glob[2]]).fetchone() == (True,)
+
+
+def test_list_files_preserves_registered_glob_result_with_different_authority(duckdb_cursor):
+    pytest.importorskip("fsspec", minversion="2022.11.0")
+    ftp_module = pytest.importorskip("fsspec.implementations.ftp")
+    memory_module = pytest.importorskip("fsspec.implementations.memory")
+
+    class DifferentAuthorityFTPFileSystem(memory_module.MemoryFileSystem):
+        protocol = "ftp"
+        _strip_protocol = classmethod(ftp_module.FTPFileSystem._strip_protocol.__func__)
+
+        def glob(self, _path, **_kwargs):
+            return ["ftp://other/root/value.txt"]
+
+    filesystem = DifferentAuthorityFTPFileSystem(skip_instance_cache=True)
+    filesystem.store = {}
+    filesystem.pseudo_dirs = [""]
+    filesystem.pipe("/root/value.txt", b"value")
+    duckdb_cursor.register_filesystem(filesystem)
+    try:
+        rows = duckdb_cursor.execute("SELECT url FROM list_files('ftp://host/root/*')").fetchall()
+    finally:
+        duckdb_cursor.unregister_filesystem("ftp")
+
+    assert rows == [("ftp://other/root/value.txt",)]
+    assert filesystem.isfile(rows[0][0])
+
+
+def test_list_files_treats_embedded_scheme_delimiter_as_registered_path_text(duckdb_cursor):
+    pytest.importorskip("fsspec", minversion="2022.11.0")
+    memory_module = pytest.importorskip("fsspec.implementations.memory")
+
+    class EmbeddedSchemeMemoryFileSystem(memory_module.MemoryFileSystem):
+        def glob(self, _path, **_kwargs):
+            return ["/root/http://value.txt"]
+
+    filesystem = EmbeddedSchemeMemoryFileSystem(skip_instance_cache=True)
+    filesystem.store = {}
+    filesystem.pseudo_dirs = [""]
+    filesystem.pipe("/root/http://value.txt", b"value")
+    duckdb_cursor.register_filesystem(filesystem)
+    try:
+        rows = duckdb_cursor.execute("SELECT url FROM list_files('memory://root/*')").fetchall()
+    finally:
+        duckdb_cursor.unregister_filesystem("memory")
+
+    assert rows == [("memory:///root/http://value.txt",)]
+    assert filesystem.isfile(rows[0][0])
 
 
 def test_list_files_preserves_unrelated_registered_glob_urls(duckdb_cursor):

--- a/tests/fast/test_file_ray.py
+++ b/tests/fast/test_file_ray.py
@@ -74,6 +74,6 @@ def test_default_ray_discovers_connection_registered_filesystem_on_coordinator(m
         connection.close()
 
     assert sorted(rows, key=lambda row: row[0].url) == [
-        (vane.File("memory:///root/a.txt", "text/plain"),),
-        (vane.File("memory:///root/b.json", "application/json"),),
+        (vane.File("memory://root/a.txt", "text/plain"),),
+        (vane.File("memory://root/b.json", "application/json"),),
     ]


### PR DESCRIPTION
## Summary

- normalize direct-directory and glob discovery through one stable caller-prefix rule before constructing FILE values
- preserve caller-visible `file://` and registered-filesystem URL spelling while leaving unrelated provider results authoritative
- add local, fsspec directory-semantic, protocol-alias, authority, locator-identity, same-location, and Ray regression coverage

## Related issue

close: #698

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This is a focused correction to the existing `list_files()` URL identity contract.

## Validation

- `scripts/format workspace --changed --check`
- Release native reinstall with `CMAKE_BUILD_PARALLEL_LEVEL=24 uv pip install . --no-build-isolation`
- `pytest --rootdir=/tmp --import-mode=importlib tests/fast/test_file.py tests/fast/test_filesystem.py tests/fast/test_file_ray.py` — 107 passed, 1 skipped
- `scripts/run_release_tests.sh` — 812 passed in the non-real-Ray shard and 14 passed in the real-Ray shard

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependencies or copied assets are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. Normalization uses only caller locators and provider-returned paths and does not resolve or persist credentials.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.