### PR TITLE
[feat](distributed) Add extension write preparation lifecycle

### DIFF
--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -353,9 +353,19 @@ provider retains the coordinator half of that state. This extension-owned
 handle, not Vane's query ID, is what finalization and pre-finalize abort use to
 identify the write.
 
+After read-only validation, translation, and coordinator setup complete, Vane
+invokes `PrepareDistributedWrite` at most once immediately before worker
+execution can start. The hook may create coordinator-owned state that workers
+must observe, such as an empty catalog table whose schema is loaded by the
+format writer. Whether that state is externally visible or retained after a
+known failure is part of the extension's prepare/abort contract. The write plan
+and worker bind are already frozen at this point, so prepared state must be
+addressable through identifiers already present in that immutable bind.
+
 `PlanRunner` validates the capability, codec, provider, and worker callback
-contract before translation, task selection, or artifact creation. There is no
-mode inference: the physical shape must exactly match the declared mode.
+contract before translation, task selection, preparation, or artifact creation.
+There is no mode inference: the physical shape must exactly match the declared
+mode.
 
 Python relation INSERT, UPDATE, DELETE, and CTAS mutations follow the selected
 backend strictly. This includes `insert_into`, row-value `insert`, `update`,
@@ -434,20 +444,30 @@ Both modes use the same coordinator sequence:
 
 1. Validate the complete provider and worker protocol before physical source
    translation, task enumeration, or side effects.
-2. Execute worker sinks and select successful task attempts.
-3. Validate and aggregate their opaque result envelopes.
-4. Call `FinalizeDistributedWrite` once with exactly the selected envelopes
+2. Translate the physical source, validate the exact sink shape, and complete
+   coordinator-only setup that cannot invoke workers.
+3. Call `PrepareDistributedWrite` at most once.
+4. Execute worker sinks and select successful task attempts.
+5. Validate and aggregate their opaque result envelopes.
+6. Call `FinalizeDistributedWrite` once with exactly the selected envelopes
    inside Vane's active coordinator transaction.
-5. Require the provider's affected-row count to match the envelope total.
-6. Commit through DuckDB's transaction manager.
+7. Require the provider's affected-row count to match the envelope total and
+   commit through DuckDB's transaction manager.
 
 `AbortDistributedWrite` is mandatory. Once the current attempt may have
-created worker or file output, Vane invokes abort once for a known failure only
-while coordinator finalization has not started. The provider uses its own
-coordinator state and extension-planned artifact namespace to locate output from
-this execution.
-Validation, translation, and setup failures before output is possible do not
-invoke abort.
+created coordinator state during preparation or worker/file output, Vane
+invokes abort once for a known failure only while coordinator finalization has
+not started. This includes an exception from `PrepareDistributedWrite` and a
+failure with no selected worker envelope. The provider uses its own coordinator
+state and extension-planned artifact namespace to locate output from this
+execution and applies its format-specific cleanup or retention policy.
+Validation, translation, and setup failures before preparation do not invoke
+prepare or abort.
+
+After worker execution may have started, Vane invokes extension abort only
+after the worker-manager quiescence barrier succeeds. If that barrier fails or
+throws, current-execution output and prepared extension state are retained, and
+Vane does not race a possibly live writer with extension cleanup.
 
 Once `FinalizeDistributedWrite` starts, Vane never invokes abort, deletes
 selected artifacts, or retries finalization. A provider exception, an affected
@@ -461,11 +481,14 @@ boundary; an explicit caller-managed transaction is rejected before workers
 start. This check also applies when `Runner.run_write` is called directly.
 
 A worker or provider failure known to precede catalog commit rolls back the
-transaction. Once current-attempt output may exist, that failure also invokes
-explicit cleanup. Failures before that side-effect boundary return without
-aborting durable state. If the catalog commit call itself fails, Vane retains
-the artifacts and reports an unknown outcome: a remote catalog may have
-committed before its response was lost.
+transaction. Once preparation starts, that failure also invokes explicit
+extension failure handling; file-artifact mode additionally runs Vane's owned
+output cleanup. A callback extension may intentionally retain prepared catalog
+state or uncommitted files when its format delegates cleanup to orphan-file GC.
+Failures before that side-effect boundary return without aborting durable state.
+If the catalog commit call itself fails, Vane retains the artifacts and reports
+an unknown outcome: a remote catalog may have committed before its response was
+lost.
 
 ## Extension author contract
 
@@ -493,14 +516,21 @@ For every distributed write provider:
   physical provider;
 - keep `ValidateDistributedWrite` read-only and limit it to catalog and output
   precondition checks before workers start;
+- implement `PrepareDistributedWrite` only when workers require
+  coordinator-created state, recheck mutable catalog preconditions while
+  establishing it, and treat invocation as the start of the extension-owned
+  side-effect boundary;
+- make prepared state addressable through the already frozen worker bind; the
+  preparation hook cannot replace or mutate the translated write plan;
 - accept only the selected task-result envelopes during finalization;
 - use the extension catalog's own transaction and ACID mechanism in
   `FinalizeDistributedWrite` and do not depend on Vane retrying that call;
 - register or commit exactly the selected files or opaque fragments from that
   one coordinator invocation;
 - return the exact affected row count;
-- implement `AbortDistributedWrite` for known failures before finalization
-  starts, including an empty selected-result set;
+- implement `AbortDistributedWrite` for known failures after preparation starts
+  and before finalization starts, including preparation failures and an empty
+  selected-result set;
 - retain immutable artifacts when a remote catalog commit response is
   ambiguous; never interpret a commit exception as proof of rollback;
 - never require query or task-attempt IDs to be durable idempotency keys.

--- a/external/duckdb/src/include/duckdb/execution/distributed/extension_write_task_provider.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/extension_write_task_provider.hpp
@@ -39,6 +39,15 @@ public:
 	//! callback can run. This hook must not create artifacts.
 	virtual void ValidateDistributedWrite(ClientContext &context) const = 0;
 
+	//! Create coordinator-owned state required before worker callbacks can run.
+	//! Vane invokes this hook at most once after translation and coordinator setup.
+	//! WritePlan is already frozen, so prepared state must be addressable through
+	//! its immutable worker bind. Once invocation starts, a known failure before
+	//! coordinator finalization invokes AbortDistributedWrite, including when no
+	//! worker envelope exists.
+	virtual void PrepareDistributedWrite(ClientContext &context) const {
+	}
+
 	//! Commit the selected task results in the active coordinator transaction.
 	//! Vane invokes this hook at most once and never retries it. Once invocation
 	//! starts, any failure is terminal with an unknown commit outcome and Vane
@@ -47,9 +56,10 @@ public:
 	virtual idx_t FinalizeDistributedWrite(ClientContext &context,
 	                                       const vector<DistributedWriteTaskResult> &results) const = 0;
 
-	//! Remove artifacts after a failure that is known to precede coordinator
-	//! finalization. This hook is never called once FinalizeDistributedWrite has
-	//! started. It must support cleanup when no worker envelope was returned.
+	//! Handle a failure that is known to precede coordinator finalization. The
+	//! extension decides whether its catalog contract cleans, compensates, or
+	//! retains prepared state and artifacts. This hook is never called once
+	//! FinalizeDistributedWrite has started and must accept an empty result set.
 	virtual void AbortDistributedWrite(ClientContext &context,
 	                                   const vector<DistributedWriteTaskResult> &selected_results) const = 0;
 };

--- a/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/plan/runner.hpp
@@ -584,6 +584,7 @@ public:
 		string extension_write_query_id;
 		vector<DistributedWriteTaskResult> selected_task_results;
 		bool extension_abort_attempted = false;
+		bool extension_prepare_started = false;
 		bool extension_finalize_started = false;
 		auto extension_outcome_unknown = [&](DistributedExtensionWriteResult result,
 		                                     string error) -> DuckDBResult<PlanResult> {
@@ -597,7 +598,8 @@ public:
 			return DuckDBResult<PlanResult>::ok(PlanResult::make_extension_write(std::move(result)));
 		};
 		auto abort_extension_write = [&]() -> string {
-			if (!extension_write_provider || extension_abort_attempted || extension_finalize_started) {
+			if (!extension_write_provider || !extension_prepare_started || extension_abort_attempted ||
+			    extension_finalize_started) {
 				return string();
 			}
 			extension_abort_attempted = true;
@@ -933,7 +935,9 @@ public:
 			}
 			auto sender_ptr = std::make_shared<UnboundedSender<MaterializedOutput>>(std::move(sender));
 			auto initial_inputs_ptr = std::make_shared<TaskInputs>(std::move(initial_inputs));
-			execution_may_have_started = true;
+			if (!extension_write_provider) {
+				execution_may_have_started = true;
+			}
 			MaterializedOutputCallback validate_incremental_output;
 			if (data_sink_node) {
 				const auto data_sink_node_id = data_sink_node->result_node_id();
@@ -946,6 +950,19 @@ public:
 				};
 			}
 			const bool bound_execution_errors = static_cast<bool>(validate_incremental_output);
+			if (extension_write_provider) {
+				extension_prepare_started = true;
+				try {
+					extension_write_provider->PrepareDistributedWrite(*client_context_);
+				} catch (const std::exception &ex) {
+					return fail_after_write_cleanup(DuckDBError::external_error(
+					    "distributed extension write preparation failed: " + string(ex.what())));
+				} catch (...) {
+					return fail_after_write_cleanup(DuckDBError::external_error(
+					    "distributed extension write preparation threw an unknown exception"));
+				}
+			}
+			execution_may_have_started = true;
 			task_executor->ScheduleTask(
 			    [self, pipeline_node, sender_ptr, output_state, execute_status, task_executor, initial_inputs_ptr,
 			     bound_execution_errors,

--- a/external/duckdb/test/execution/distributed/test_planrunner_local.cpp
+++ b/external/duckdb/test/execution/distributed/test_planrunner_local.cpp
@@ -534,13 +534,23 @@ public:
 
 	void ValidateDistributedWrite(ClientContext &) const override {
 		validation_calls++;
+		lifecycle_events.push_back("validate");
 		if (fail_validation) {
 			throw InvalidInputException("planned extension write validation failure");
 		}
 	}
 
+	void PrepareDistributedWrite(ClientContext &) const override {
+		prepare_calls++;
+		lifecycle_events.push_back("prepare");
+		if (fail_prepare) {
+			throw IOException("planned extension write preparation failure");
+		}
+	}
+
 	idx_t FinalizeDistributedWrite(ClientContext &, const vector<DistributedWriteTaskResult> &results) const override {
 		finalize_calls++;
+		lifecycle_events.push_back("finalize");
 		if (fail_finalize) {
 			throw IOException("planned extension coordinator finalization failure");
 		}
@@ -551,14 +561,20 @@ public:
 		return mismatch_finalize_rows ? rows + 1 : rows;
 	}
 
-	void AbortDistributedWrite(ClientContext &, const vector<DistributedWriteTaskResult> &) const override {
+	void AbortDistributedWrite(ClientContext &, const vector<DistributedWriteTaskResult> &results) const override {
 		abort_calls++;
+		abort_result_count = results.size();
+		lifecycle_events.push_back("abort");
 	}
 
 	mutable idx_t validation_calls = 0;
+	mutable idx_t prepare_calls = 0;
 	mutable idx_t finalize_calls = 0;
 	mutable idx_t abort_calls = 0;
+	mutable idx_t abort_result_count = 0;
+	mutable vector<string> lifecycle_events;
 	bool fail_validation = false;
+	bool fail_prepare = false;
 	bool fail_finalize = false;
 	bool mismatch_finalize_rows = false;
 
@@ -775,6 +791,7 @@ TEST_CASE("PlanRunner rejects an unregistered extension write capability",
 	REQUIRE(StringUtil::Contains(result.error().what(), "protocol validation failed"));
 	REQUIRE(StringUtil::Contains(result.error().what(), "planrunner_test_extension"));
 	REQUIRE(extension.validation_calls == 0);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 }
 
@@ -814,6 +831,7 @@ TEST_CASE("PlanRunner rejects extension writes inside an explicit DuckDB transac
 	REQUIRE(result.is_err());
 	REQUIRE(StringUtil::Contains(result.error().what(), "auto-commit mode"));
 	REQUIRE(extension.validation_calls == 0);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE_FALSE(FileSystem::GetFileSystem(*con.context).DirectoryExists(output_path));
 }
@@ -852,6 +870,7 @@ TEST_CASE("PlanRunner preserves extension state when coordinator validation fail
 	REQUIRE(missing_transaction.is_err());
 	REQUIRE(StringUtil::Contains(missing_transaction.error().what(), "active Vane-owned auto-commit transaction"));
 	REQUIRE(extension.validation_calls == 0);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE(extension.abort_calls == 0);
 
@@ -861,6 +880,7 @@ TEST_CASE("PlanRunner preserves extension state when coordinator validation fail
 	REQUIRE(result.is_err());
 	REQUIRE(StringUtil::Contains(result.error().what(), "planned extension write validation failure"));
 	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE(extension.abort_calls == 0);
 	REQUIRE_FALSE(FileSystem::GetFileSystem(*con.context).DirectoryExists(output_path));
@@ -895,6 +915,7 @@ TEST_CASE("PlanRunner validates an extension write before translating its source
 	REQUIRE(StringUtil::Contains(result.error().what(), "planned extension write validation failure"));
 	REQUIRE_FALSE(StringUtil::Contains(result.error().what(), "requires exactly one child"));
 	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE(extension.abort_calls == 0);
 }
@@ -924,8 +945,48 @@ TEST_CASE("PlanRunner preserves extension state when source translation fails be
 	REQUIRE(result.is_err());
 	REQUIRE(StringUtil::Contains(result.error().what(), "requires exactly one child"));
 	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE(extension.abort_calls == 0);
+}
+
+TEST_CASE("PlanRunner aborts extension preparation failures before workers start",
+          "[distributed][plan][extension-write]") {
+	DuckDB db(nullptr);
+	Connection con(db);
+	RegisterPlanRunnerTestExtension(*db.instance);
+
+	auto physical_plan = std::make_shared<PhysicalPlan>(Allocator::DefaultAllocator());
+	vector<LogicalType> child_types {LogicalType::BIGINT};
+	auto &child = physical_plan->Make<PhysicalDummyScan>(std::move(child_types), 1);
+	vector<LogicalType> extension_types {LogicalType::BIGINT};
+	auto &extension_operator = physical_plan->Make<PlanRunnerTestExtensionWriteOperator>(
+	    std::move(extension_types), PhysicalOperatorType::EXTENSION, "callback_write");
+	auto &extension = extension_operator.Cast<PlanRunnerTestExtensionWriteOperator>();
+	extension.fail_prepare = true;
+	extension_operator.children.push_back(child);
+	physical_plan->SetRoot(extension_operator);
+
+	auto workers = setup_workers({{make_worker_id("prepare-failure-w1"), 1}});
+	auto worker_manager = std::make_shared<MockWorkerManager>(std::move(workers));
+	auto runner = std::make_shared<PlanRunner>(worker_manager, con.context);
+	auto execution_config = std::make_shared<DuckDBExecutionConfig>(DuckDBExecutionConfig::from_env());
+	auto distributed_plan = std::make_shared<DistributedPhysicalPlan>(28, "planrunner-extension-prepare-failure",
+	                                                                  physical_plan, std::move(execution_config));
+
+	DuckDBResult<PlanRunner::PlanResult> result;
+	con.context->RunFunctionInTransaction([&]() { result = runner->run_plan(std::move(distributed_plan)); });
+
+	REQUIRE(result.is_err());
+	REQUIRE(StringUtil::Contains(result.error().what(), "distributed extension write preparation failed"));
+	REQUIRE(StringUtil::Contains(result.error().what(), "planned extension write preparation failure"));
+	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 1);
+	REQUIRE(extension.finalize_calls == 0);
+	REQUIRE(extension.abort_calls == 1);
+	REQUIRE(extension.abort_result_count == 0);
+	const vector<string> expected_events {"validate", "prepare", "abort"};
+	REQUIRE(extension.lifecycle_events == expected_events);
 }
 
 TEST_CASE("PlanRunner cleans its lifecycle without extension abort when execution setup fails",
@@ -970,6 +1031,7 @@ TEST_CASE("PlanRunner cleans its lifecycle without extension abort when executio
 	REQUIRE(result.is_err());
 	REQUIRE(StringUtil::Contains(result.error().what(), "requires shared_ptr ownership"));
 	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 0);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE(extension.abort_calls == 0);
 	REQUIRE_FALSE(fs.DirectoryExists(output_path));
@@ -1057,11 +1119,14 @@ TEST_CASE("PlanRunner invokes extension coordinator finalization once and never 
 	REQUIRE(extension_result.selected_task_results.size() == 1);
 	REQUIRE(extension_result.selected_task_results[0].query_id == query_id);
 	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 1);
 	REQUIRE(extension.finalize_calls == 1);
 	REQUIRE(extension.abort_calls == 0);
 	REQUIRE(worker_manager->abort_calls == 0);
 	REQUIRE(extension_result.outcome_unknown == (fail_finalize || mismatch_finalize_rows));
 	REQUIRE_FALSE(extension_result.catalog_committed);
+	const vector<string> expected_events {"validate", "prepare", "finalize"};
+	REQUIRE(extension.lifecycle_events == expected_events);
 	if (fail_finalize) {
 		REQUIRE(
 		    StringUtil::Contains(extension_result.outcome_error, "planned extension coordinator finalization failure"));
@@ -1169,8 +1234,11 @@ TEST_CASE("PlanRunner aborts an extension write after failed workers are quiesce
 	REQUIRE(worker_manager->output_existed_during_abort);
 	REQUIRE(worker_manager->late_writer_completed);
 	REQUIRE(extension.validation_calls == 1);
+	REQUIRE(extension.prepare_calls == 1);
 	REQUIRE(extension.finalize_calls == 0);
 	REQUIRE(extension.abort_calls == 1);
+	const vector<string> expected_events {"validate", "prepare", "abort"};
+	REQUIRE(extension.lifecycle_events == expected_events);
 	REQUIRE_FALSE(fs.DirectoryExists(worker_manager->operation_output_root));
 	RemoveDistributedCopyDirectoryTree(fs, output_path);
 	RemoveDistributedCopyDirectoryTree(fs, commit_root);


### PR DESCRIPTION
## Summary

- add an optional, default no-op `PrepareDistributedWrite` coordinator lifecycle hook for extension writes
- invoke preparation at most once after validation, physical translation, and coordinator setup, immediately before worker scheduling
- route known pre-finalize failures through extension abort, including preparation failures with zero worker envelopes, while never aborting after finalization begins
- document the frozen worker-bind requirement and extension-owned cleanup or retention semantics, with focused lifecycle tests

## Related issue

close: #702

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Updated `DISTRIBUTED_EXTENSIONS.md` with the preparation sequence, failure boundary, and provider contract.

## Validation

- `PATH=<format-venv>/bin:$PATH scripts/format workspace --changed`
- `VANE_NATIVE_BUILD_JOBS=16 VCPKG_INSTALLED_DIR=<existing-disk-vcpkg-cache> scripts/run_native_tests.sh '[distributed]'`
  - fresh Release build
  - 273 test cases and 10,166 assertions passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No dependencies or copied assets were added.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. This change adds no new transport or serialization surface.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
