### PR TITLE
[fix](packaging) Eliminate archive preflight TOCTOU

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -213,10 +213,24 @@ contents exceed that limit. The preflight runs before reading
 dependency, root, or base wheel members. Before constructing Python's ZIP
 reader, every supplied wheel also receives a streaming central-directory
 preflight capped at 10,000 members. Archives with comments, spanning, ZIP64 end records, or
-internally inconsistent counts and bounds are rejected. Extension-wheel
-METADATA is capped at 1 MiB, 1,024 headers, 10,000 lines, and bounded line
-length before the email metadata parser is constructed. The same bounds apply
-to dependency, root, base-wheel, and generic release metadata parsing.
+internally inconsistent counts and bounds are rejected. Untrusted release and
+extension-wheel archive paths are opened once, confirmed to name regular
+files, and copied with an explicit byte bound into a private temporary
+directory. On POSIX the completed snapshot is made read-only. Raw-content
+scanning, ZIP or TAR preflight, and the standard-library semantic parser
+consume that same snapshot; clean extension verification also installs the
+snapshotted root, dependency, and base wheels.
+Clean verification retains at most 1 GiB of snapshot bytes across the complete
+root, dependency, and base-wheel set. It validates the root and base snapshots,
+then snapshots and validates each dependency in order, so an invalid earlier
+artifact stops the verifier before later artifacts consume temporary storage.
+The source path is never reopened after the snapshot boundary, so replacing it
+cannot change the bytes being approved or installed. Snapshot files and their
+private directories are closed and removed on success and on every failure
+path. Their METADATA is capped at 1 MiB, 1,024 headers, 10,000 lines, and
+bounded line length before the email metadata parser is constructed. The same
+bounds apply to dependency, root, base-wheel, and generic release metadata
+parsing.
 Extension descriptors are capped at 64 KiB and receive bounded JSON nesting,
 separator, string, scalar, and dependency-object preflights before a JSON
 object is constructed; each packaged graph is limited to 256 dependency

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -19,11 +19,10 @@ import re
 import stat
 import subprocess
 import sys
-import tarfile
 import unicodedata
-import zipfile
 from collections import Counter
 from collections.abc import Iterable
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from email.parser import BytesParser
 from pathlib import Path, PurePosixPath, PureWindowsPath
@@ -49,7 +48,12 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _ORIGINAL_SYS_PATH = sys.path.copy()
 try:
     sys.path.insert(0, str(REPOSITORY_ROOT))
-    from vane_packaging.archive_safety import validate_tar_member_count, validate_zip_member_count
+    from vane_packaging.archive_safety import (
+        ArchiveSnapshot,
+        open_tar_snapshot,
+        open_zip_snapshot,
+        snapshot_archive,
+    )
 finally:
     sys.path[:] = _ORIGINAL_SYS_PATH
     del _ORIGINAL_SYS_PATH
@@ -129,6 +133,7 @@ BANNED_PATH_SUFFIXES = (
 
 class Artifact(Protocol):
     path: Path
+    raw_content_match: ContentMatch | None
 
     def path_names(self) -> list[str]: ...
 
@@ -201,20 +206,37 @@ class _TarMetadataContentScanner:
 
 
 class WheelArtifact:
-    def __init__(self, path: Path):
-        self.path = path
-        validate_zip_member_count(
-            path,
-            max_members=MAX_ARTIFACT_MEMBERS,
-            description="wheel",
-        )
-        self.archive = zipfile.ZipFile(path)
-        self.all_members = self.archive.infolist()
-        for info in self.all_members:
-            if stat.S_ISLNK(info.external_attr >> 16):
-                self.archive.close()
-                raise ValueError(f"{path}: symbolic links are not allowed in wheels: {info.filename}")
-        self.members = [info.filename for info in self.all_members if not info.is_dir()]
+    def __init__(self, archive_input: Path | ArchiveSnapshot, *, content_rules: tuple[ContentRule, ...] = ()):
+        self.path = archive_input.source_path if isinstance(archive_input, ArchiveSnapshot) else archive_input
+        self._resources = ExitStack()
+        try:
+            if isinstance(archive_input, ArchiveSnapshot):
+                self.snapshot = archive_input
+            else:
+                self.snapshot = self._resources.enter_context(
+                    snapshot_archive(
+                        archive_input,
+                        max_bytes=MAX_ARTIFACT_BYTES,
+                        description="artifact",
+                        size_limit_description="the project's 100 MiB publication limit",
+                    )
+                )
+            self.raw_content_match = _detect_raw_archive_content(self.snapshot, content_rules)
+            self.archive = self._resources.enter_context(
+                open_zip_snapshot(
+                    self.snapshot,
+                    max_members=MAX_ARTIFACT_MEMBERS,
+                    description="wheel",
+                )
+            )
+            self.all_members = self.archive.infolist()
+            for info in self.all_members:
+                if stat.S_ISLNK(info.external_attr >> 16):
+                    raise ValueError(f"{self.path}: symbolic links are not allowed in wheels: {info.filename}")
+            self.members = [info.filename for info in self.all_members if not info.is_dir()]
+        except BaseException:
+            self._resources.close()
+            raise
 
     def path_names(self) -> list[str]:
         return [info.filename for info in self.all_members]
@@ -229,29 +251,47 @@ class WheelArtifact:
         return self.archive.read(name)
 
     def close(self) -> None:
-        self.archive.close()
+        self._resources.close()
 
 
 class SdistArtifact:
-    def __init__(self, path: Path, *, content_rules: tuple[ContentRule, ...] = ()):
-        self.path = path
-        metadata_scanner = _TarMetadataContentScanner(path, content_rules)
-        validate_tar_member_count(
-            path,
-            max_members=MAX_ARTIFACT_MEMBERS,
-            max_member_bytes=MAX_ARTIFACT_UNCOMPRESSED_BYTES,
-            max_total_bytes=MAX_ARTIFACT_UNCOMPRESSED_BYTES,
-            uncompressed_limit_description="the project's 100 MiB uncompressed limit",
-            description="sdist",
-            metadata_chunk_callback=metadata_scanner if content_rules else None,
-        )
-        self.archive = tarfile.open(path, mode="r:gz")
-        self.all_members = self.archive.getmembers()
-        for member in self.all_members:
-            if not member.isfile() and not member.isdir():
-                self.archive.close()
-                raise ValueError(f"{path}: unsupported tar member type for {member.name}")
-        self.members = {member.name: member for member in self.all_members if member.isfile()}
+    def __init__(self, archive_input: Path | ArchiveSnapshot, *, content_rules: tuple[ContentRule, ...] = ()):
+        self.path = archive_input.source_path if isinstance(archive_input, ArchiveSnapshot) else archive_input
+        self._resources = ExitStack()
+        try:
+            if isinstance(archive_input, ArchiveSnapshot):
+                self.snapshot = archive_input
+            else:
+                self.snapshot = self._resources.enter_context(
+                    snapshot_archive(
+                        archive_input,
+                        max_bytes=MAX_ARTIFACT_BYTES,
+                        description="artifact",
+                        size_limit_description="the project's 100 MiB publication limit",
+                    )
+                )
+            self.raw_content_match = _detect_raw_archive_content(self.snapshot, content_rules)
+            metadata_scanner = _TarMetadataContentScanner(self.path, content_rules)
+            self.archive = self._resources.enter_context(
+                open_tar_snapshot(
+                    self.snapshot,
+                    max_members=MAX_ARTIFACT_MEMBERS,
+                    max_member_bytes=MAX_ARTIFACT_UNCOMPRESSED_BYTES,
+                    max_total_bytes=MAX_ARTIFACT_UNCOMPRESSED_BYTES,
+                    uncompressed_limit_description="the project's 100 MiB uncompressed limit",
+                    description="sdist",
+                    metadata_chunk_callback=metadata_scanner if content_rules else None,
+                    mode="r:gz",
+                )
+            )
+            self.all_members = self.archive.getmembers()
+            for member in self.all_members:
+                if not member.isfile() and not member.isdir():
+                    raise ValueError(f"{self.path}: unsupported tar member type for {member.name}")
+            self.members = {member.name: member for member in self.all_members if member.isfile()}
+        except BaseException:
+            self._resources.close()
+            raise
 
     def path_names(self) -> list[str]:
         return [member.name for member in self.all_members]
@@ -269,7 +309,7 @@ class SdistArtifact:
         return extracted.read()
 
     def close(self) -> None:
-        self.archive.close()
+        self._resources.close()
 
 
 def _artifact_version(path: Path) -> Version:
@@ -387,30 +427,29 @@ def _check_internal_content(
 
 
 def _detect_raw_archive_content(
-    path: Path,
+    snapshot: ArchiveSnapshot,
     content_rules: tuple[ContentRule, ...],
 ) -> ContentMatch | None:
     if not content_rules:
         return None
+    path = snapshot.source_path
     overlap_bytes = max(rule.overlap_bytes() for rule in content_rules)
     try:
-        with path.open("rb") as archive_file:
-            metadata = os.fstat(archive_file.fileno())
-            if not stat.S_ISREG(metadata.st_mode):
-                raise ValueError(f"artifact must be a regular file: {path}")
-            if metadata.st_size > MAX_ARTIFACT_BYTES:
+        metadata = os.fstat(snapshot.file.fileno())
+        if not stat.S_ISREG(metadata.st_mode) or metadata.st_size != snapshot.size:
+            raise ValueError(f"{path}: private artifact snapshot changed before content scanning")
+        snapshot.file.seek(0)
+        overlap = b""
+        total_size = 0
+        while chunk := snapshot.file.read(_RAW_ARCHIVE_SCAN_CHUNK_BYTES):
+            total_size += len(chunk)
+            if total_size > MAX_ARTIFACT_BYTES:
                 raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
-            overlap = b""
-            total_size = 0
-            while chunk := archive_file.read(_RAW_ARCHIVE_SCAN_CHUNK_BYTES):
-                total_size += len(chunk)
-                if total_size > MAX_ARTIFACT_BYTES:
-                    raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
-                window = overlap + chunk
-                for rule in content_rules:
-                    if rule.matches(window):
-                        return ContentMatch(rule_id=rule.rule_id, member_name="raw archive bytes")
-                overlap = window[-overlap_bytes:] if overlap_bytes else b""
+            window = overlap + chunk
+            for rule in content_rules:
+                if rule.matches(window):
+                    return ContentMatch(rule_id=rule.rule_id, member_name="raw archive bytes")
+            overlap = window[-overlap_bytes:] if overlap_bytes else b""
     except OSError as exception:
         raise ValueError(f"could not scan artifact contents: {path}") from exception
     return None
@@ -865,11 +904,6 @@ def _check_wheel(artifact: WheelArtifact, layout: DistributionLayout) -> None:
     _check_wheel_record(artifact, layout)
 
 
-def _validate_artifact_size(path: Path) -> None:
-    if path.stat().st_size > MAX_ARTIFACT_BYTES:
-        raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
-
-
 def _validate_artifact_contents_size(artifact: Artifact) -> None:
     total_size = 0
     for member_name, member_size in artifact.member_sizes():
@@ -887,59 +921,58 @@ def _validate_artifact_contents_size(artifact: Artifact) -> None:
 
 
 def _open_artifact(
-    path: Path,
+    archive_input: Path | ArchiveSnapshot,
     *,
     content_rules: tuple[ContentRule, ...] = (),
 ) -> SdistArtifact | WheelArtifact:
+    path = archive_input.source_path if isinstance(archive_input, ArchiveSnapshot) else archive_input
     if path.name.endswith(".tar.gz"):
-        return SdistArtifact(path, content_rules=content_rules)
+        return SdistArtifact(archive_input, content_rules=content_rules)
     if path.suffix == ".whl":
-        return WheelArtifact(path)
+        return WheelArtifact(archive_input, content_rules=content_rules)
     raise ValueError(f"unsupported artifact type: {path}")
 
 
 def check_artifact_contents(
-    path: Path,
+    archive_input: Path | ArchiveSnapshot,
     *,
     content_rules: tuple[ContentRule, ...] = (),
     text_content_rules: tuple[ContentRule, ...] = (),
 ) -> None:
     """Validate generic publication limits, paths, and private-content rules."""
-    _validate_artifact_size(path)
-    raw_content_match = _detect_raw_archive_content(path, content_rules)
-    artifact = _open_artifact(path, content_rules=content_rules)
+    path = archive_input.source_path if isinstance(archive_input, ArchiveSnapshot) else archive_input
+    artifact = _open_artifact(archive_input, content_rules=content_rules)
     try:
         _validate_artifact_contents_size(artifact)
         _check_paths(artifact)
         _check_internal_content(artifact, content_rules, text_content_rules)
-        _check_raw_archive_content(path, raw_content_match)
+        _check_raw_archive_content(path, artifact.raw_content_match)
     finally:
         artifact.close()
 
 
 def check_artifact(
-    path: Path,
+    archive_input: Path | ArchiveSnapshot,
     *,
     expected_version: Version | str,
     content_rules: tuple[ContentRule, ...] = (),
     text_content_rules: tuple[ContentRule, ...] = (),
 ) -> None:
     """Validate one sdist or wheel."""
+    path = archive_input.source_path if isinstance(archive_input, ArchiveSnapshot) else archive_input
     layout = distribution_layout(expected_version)
     artifact_version = _artifact_version(path)
     if artifact_version != layout.version:
         raise ValueError(
             f"{path}: expected version {layout.version}, found {artifact_version} in distribution filename"
         )
-    _validate_artifact_size(path)
-    raw_content_match = _detect_raw_archive_content(path, content_rules)
-    artifact = _open_artifact(path, content_rules=content_rules)
+    artifact = _open_artifact(archive_input, content_rules=content_rules)
 
     try:
         _validate_artifact_contents_size(artifact)
         _check_paths(artifact)
         _check_internal_content(artifact, content_rules, text_content_rules)
-        _check_raw_archive_content(path, raw_content_match)
+        _check_raw_archive_content(path, artifact.raw_content_match)
         if isinstance(artifact, SdistArtifact):
             _check_sdist(artifact, layout)
         else:

--- a/scripts/verify_extension_wheel.py
+++ b/scripts/verify_extension_wheel.py
@@ -16,7 +16,8 @@ import sys
 import tempfile
 import textwrap
 import zipfile
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path, PurePosixPath
@@ -31,9 +32,12 @@ _ORIGINAL_SYS_PATH = sys.path.copy()
 try:
     sys.path.insert(0, str(REPOSITORY_ROOT))
     from scripts.check_release_artifacts import check_artifact as _check_release_artifact
+    from vane_packaging.archive_safety import ArchiveSnapshot, open_zip_snapshot, snapshot_archive
     from vane_packaging.extension_wheel import (
         _ELF_MAGIC,
         _MAX_EXTENSION_DESCRIPTOR_DEPENDENCIES,
+        _MAX_EXTENSION_WHEEL_BYTES,
+        _MAX_EXTENSION_WHEEL_MEMBERS,
         _PE_DOS_MAGIC,
         _PLATFORM_BUILD_DETAILS_FILENAME,
         ENTRY_POINT_GROUP,
@@ -52,8 +56,6 @@ try:
         _validate_dependency_platform_tag,
         _validate_exact_requirements,
         _validate_extension_wheel_archive_size,
-        _validate_extension_wheel_member_count,
-        _validate_extension_wheel_size,
         _validate_linux_elf_platform,
         _validate_macos_wheel_binary_platform,
         _validate_metadata_license_expression,
@@ -77,6 +79,8 @@ _EXTENSION_ARTIFACT_RE = re.compile(
     r"(?P<digest>[0-9a-f]{64})/(?P=name)\.duckdb_extension$"
 )
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_MAX_CLEAN_VERIFICATION_SNAPSHOT_BYTES = 1024 * 1024 * 1024
+_CLEAN_VERIFICATION_SNAPSHOT_LIMIT_DESCRIPTION = "the clean verifier's aggregate 1 GiB snapshot limit"
 _GENERIC_LINUX_BASE_TAG_RE = re.compile(r"^linux_(?:x86_64|aarch64)$")
 _LEGACY_MANYLINUX_BASE_TAG_RE = re.compile(
     r"^(?P<policy>manylinux1|manylinux2010|manylinux2014)_(?P<architecture>x86_64|aarch64)$"
@@ -87,6 +91,24 @@ _LEGACY_MANYLINUX_MINIMUMS = {
     "manylinux2010": (2, 12),
     "manylinux2014": (2, 17),
 }
+
+
+@contextmanager
+def _wheel_snapshot(
+    wheel: Path | ArchiveSnapshot,
+    *,
+    description: str,
+) -> Iterator[ArchiveSnapshot]:
+    if isinstance(wheel, ArchiveSnapshot):
+        yield wheel
+        return
+    with snapshot_archive(
+        wheel,
+        max_bytes=_MAX_EXTENSION_WHEEL_BYTES,
+        description=description,
+        size_limit_description="the project's 100 MiB publication limit",
+    ) as snapshot:
+        yield snapshot
 
 
 @dataclass(frozen=True)
@@ -200,17 +222,32 @@ def _base_windows_policy_tag(platform_tag: str) -> str | None:
 
 
 def _assert_base_wheel(
-    base_wheel: Path,
+    base_wheel: Path | ArchiveSnapshot,
     *,
     expected_vane_version: str,
     required_interpreter_tag: str,
     required_platform_tag: str,
 ) -> None:
     try:
-        _validate_extension_wheel_size(base_wheel, description="base Vane wheel")
-        _validate_extension_wheel_member_count(base_wheel, description="base Vane wheel")
+        with _wheel_snapshot(base_wheel, description="base Vane wheel") as snapshot:
+            _assert_base_wheel_snapshot(
+                snapshot,
+                expected_vane_version=expected_vane_version,
+                required_interpreter_tag=required_interpreter_tag,
+                required_platform_tag=required_platform_tag,
+            )
     except ValueError as exception:
         raise RuntimeError(str(exception)) from exception
+
+
+def _assert_base_wheel_snapshot(
+    snapshot: ArchiveSnapshot,
+    *,
+    expected_vane_version: str,
+    required_interpreter_tag: str,
+    required_platform_tag: str,
+) -> None:
+    base_wheel = snapshot.source_path
     try:
         filename_name, filename_version, build_tag, filename_tags = parse_wheel_filename(base_wheel.name)
     except InvalidWheelFilename as exception:
@@ -271,7 +308,11 @@ def _assert_base_wheel(
     base_elf_members: tuple[tuple[str, bytes], ...] = ()
     base_macho_members: tuple[tuple[str, bytes], ...] = ()
     base_pe_members: tuple[tuple[str, bytes], ...] = ()
-    with zipfile.ZipFile(base_wheel) as wheel:
+    with open_zip_snapshot(
+        snapshot,
+        max_members=_MAX_EXTENSION_WHEEL_MEMBERS,
+        description="base Vane wheel",
+    ) as wheel:
         _assert_bounded_wheel_contents(wheel, description="base Vane wheel")
         names = wheel.namelist()
         artifacts = [name for name in names if name.casefold().endswith(".duckdb_extension")]
@@ -443,7 +484,7 @@ def _assert_base_wheel(
     except ValueError as exception:
         raise RuntimeError(str(exception)) from exception
     try:
-        _check_release_artifact(base_wheel, expected_version=expected_vane_version)
+        _check_release_artifact(snapshot, expected_version=expected_vane_version)
     except (ValueError, zipfile.BadZipFile) as exception:
         raise RuntimeError(f"base Vane wheel failed release-artifact validation: {exception}") from exception
 
@@ -510,15 +551,29 @@ def _extension_wheel_tag(
     return filename_tag
 
 
-def _assert_extension_wheel_layout(extension_wheel: Path, extension_name: str) -> _ExtensionWheelLayout:
+def _assert_extension_wheel_layout(
+    extension_wheel: Path | ArchiveSnapshot,
+    extension_name: str,
+) -> _ExtensionWheelLayout:
     if _EXTENSION_NAME_RE.fullmatch(extension_name) is None:
         raise ValueError("extension_name must use wheel-safe lowercase ASCII snake_case with single underscores")
     try:
-        _validate_extension_wheel_size(extension_wheel)
-        _validate_extension_wheel_member_count(extension_wheel)
+        with _wheel_snapshot(extension_wheel, description="extension wheel") as snapshot:
+            return _assert_extension_wheel_snapshot_layout(snapshot, extension_name)
     except ValueError as exception:
         raise RuntimeError(str(exception)) from exception
-    with zipfile.ZipFile(extension_wheel) as wheel:
+
+
+def _assert_extension_wheel_snapshot_layout(
+    snapshot: ArchiveSnapshot,
+    extension_name: str,
+) -> _ExtensionWheelLayout:
+    extension_wheel = snapshot.source_path
+    with open_zip_snapshot(
+        snapshot,
+        max_members=_MAX_EXTENSION_WHEEL_MEMBERS,
+        description="extension wheel",
+    ) as wheel:
         _assert_bounded_wheel_contents(wheel, description="extension wheel")
         names = wheel.namelist()
         try:
@@ -588,7 +643,8 @@ def _assert_extension_wheel_layout(extension_wheel: Path, extension_name: str) -
         _validate_artifact_platform_tag(artifact_platform, platform_tag)
     except ValueError as exception:
         raise RuntimeError(str(exception)) from exception
-    with zipfile.ZipFile(extension_wheel) as wheel:
+    snapshot.file.seek(0)
+    with zipfile.ZipFile(snapshot.file) as wheel:
         _assert_bounded_wheel_contents(wheel, description="extension wheel")
         try:
             metadata = _read_core_metadata(
@@ -652,7 +708,8 @@ def _assert_extension_wheel_layout(extension_wheel: Path, extension_name: str) -
     expected_wheel_metadata = f"{distribution_root}.dist-info/WHEEL"
     expected_entry_points = f"{distribution_root}.dist-info/entry_points.txt"
     expected_record = f"{distribution_root}.dist-info/RECORD"
-    with zipfile.ZipFile(extension_wheel) as wheel:
+    snapshot.file.seek(0)
+    with zipfile.ZipFile(snapshot.file) as wheel:
         _assert_bounded_wheel_contents(wheel, description="extension wheel")
         if wheel.read(expected_wheel_metadata) != _wheel_metadata(str(filename_tag)).encode("utf-8"):
             raise RuntimeError("extension wheel must contain its exact generated WHEEL metadata")
@@ -736,13 +793,20 @@ def _assert_extension_requirements(
         raise RuntimeError(str(exception)) from exception
 
 
-def _extension_name_from_artifact_path(extension_wheel: Path) -> str:
+def _extension_name_from_artifact_path(extension_wheel: Path | ArchiveSnapshot) -> str:
     try:
-        _validate_extension_wheel_size(extension_wheel, description="dependency extension wheel")
-        _validate_extension_wheel_member_count(extension_wheel, description="dependency extension wheel")
+        with _wheel_snapshot(extension_wheel, description="dependency extension wheel") as snapshot:
+            return _extension_name_from_snapshot_artifact_path(snapshot)
     except ValueError as exception:
         raise RuntimeError(str(exception)) from exception
-    with zipfile.ZipFile(extension_wheel) as wheel:
+
+
+def _extension_name_from_snapshot_artifact_path(snapshot: ArchiveSnapshot) -> str:
+    with open_zip_snapshot(
+        snapshot,
+        max_members=_MAX_EXTENSION_WHEEL_MEMBERS,
+        description="dependency extension wheel",
+    ) as wheel:
         _assert_bounded_wheel_contents(wheel, description="dependency extension wheel")
         artifacts = [name for name in wheel.namelist() if name.casefold().endswith(".duckdb_extension")]
     if len(artifacts) != 1:
@@ -753,9 +817,13 @@ def _extension_name_from_artifact_path(extension_wheel: Path) -> str:
     return match["name"]
 
 
-def _extension_name_from_wheel(extension_wheel: Path) -> str:
-    extension_name = _extension_name_from_artifact_path(extension_wheel)
-    return _assert_extension_wheel_layout(extension_wheel, extension_name).name
+def _extension_name_from_wheel(extension_wheel: Path | ArchiveSnapshot) -> str:
+    try:
+        with _wheel_snapshot(extension_wheel, description="dependency extension wheel") as snapshot:
+            extension_name = _extension_name_from_artifact_path(snapshot)
+            return _assert_extension_wheel_layout(snapshot, extension_name).name
+    except ValueError as exception:
+        raise RuntimeError(str(exception)) from exception
 
 
 def _explicit_dependency_trust_identities(
@@ -798,6 +866,30 @@ def _assert_musl_verification_runtime(layout: _ExtensionWheelLayout) -> None:
         )
 
 
+def _enter_verification_snapshot(
+    snapshot_stack: ExitStack,
+    wheel: Path,
+    *,
+    description: str,
+    remaining_bytes: int,
+) -> tuple[ArchiveSnapshot, int]:
+    max_bytes = min(_MAX_EXTENSION_WHEEL_BYTES, remaining_bytes)
+    size_limit_description = (
+        "the project's 100 MiB publication limit"
+        if max_bytes == _MAX_EXTENSION_WHEEL_BYTES
+        else _CLEAN_VERIFICATION_SNAPSHOT_LIMIT_DESCRIPTION
+    )
+    snapshot = snapshot_stack.enter_context(
+        snapshot_archive(
+            wheel,
+            max_bytes=max_bytes,
+            description=description,
+            size_limit_description=size_limit_description,
+        )
+    )
+    return snapshot, remaining_bytes - snapshot.size
+
+
 def verify_extension_wheel(
     *,
     base_wheel: str | Path,
@@ -826,25 +918,82 @@ def verify_extension_wheel(
     resolved_dependency_wheels = tuple(
         Path(dependency_wheel).expanduser().resolve(strict=True) for dependency_wheel in unresolved_dependency_wheels
     )
-    root_layout = _assert_extension_wheel_layout(resolved_extension_wheel, extension_name)
-    if root_layout.trust_identity != trust_identity:
-        raise RuntimeError(
-            f"root extension trust identity must be {trust_identity!r}, not {root_layout.trust_identity!r}"
-        )
-    dependency_layouts = tuple(
-        _assert_extension_wheel_layout(wheel, _extension_name_from_artifact_path(wheel))
-        for wheel in resolved_dependency_wheels
-    )
+    try:
+        with ExitStack() as snapshot_stack:
+            remaining_snapshot_bytes = _MAX_CLEAN_VERIFICATION_SNAPSHOT_BYTES
+            root_snapshot, remaining_snapshot_bytes = _enter_verification_snapshot(
+                snapshot_stack,
+                resolved_extension_wheel,
+                description="extension wheel",
+                remaining_bytes=remaining_snapshot_bytes,
+            )
+            root_layout = _assert_extension_wheel_layout(root_snapshot, extension_name)
+            if root_layout.trust_identity != trust_identity:
+                raise RuntimeError(
+                    f"root extension trust identity must be {trust_identity!r}, not {root_layout.trust_identity!r}"
+                )
+            _assert_musl_verification_runtime(root_layout)
+
+            base_snapshot, remaining_snapshot_bytes = _enter_verification_snapshot(
+                snapshot_stack,
+                resolved_base_wheel,
+                description="base Vane wheel",
+                remaining_bytes=remaining_snapshot_bytes,
+            )
+            _assert_base_wheel(
+                base_snapshot,
+                expected_vane_version=root_layout.vane_version,
+                required_interpreter_tag=root_layout.interpreter_tag,
+                required_platform_tag=root_layout.platform_tag,
+            )
+
+            dependency_snapshots = []
+            dependency_layouts = []
+            for dependency_wheel in resolved_dependency_wheels:
+                dependency_snapshot, remaining_snapshot_bytes = _enter_verification_snapshot(
+                    snapshot_stack,
+                    dependency_wheel,
+                    description="dependency extension wheel",
+                    remaining_bytes=remaining_snapshot_bytes,
+                )
+                dependency_snapshots.append(dependency_snapshot)
+                dependency_layouts.append(
+                    _assert_extension_wheel_layout(
+                        dependency_snapshot,
+                        _extension_name_from_artifact_path(dependency_snapshot),
+                    )
+                )
+            _verify_extension_wheel_snapshots(
+                base_wheel=base_snapshot,
+                extension_wheel=root_snapshot,
+                extension_name=extension_name,
+                trust_identity=trust_identity,
+                root_layout=root_layout,
+                dependency_wheels=tuple(dependency_snapshots),
+                dependency_layouts=tuple(dependency_layouts),
+                dependency_trust_identities=dependency_trust_identities,
+            )
+    except ValueError as exception:
+        raise RuntimeError(str(exception)) from exception
+
+
+def _verify_extension_wheel_snapshots(
+    *,
+    base_wheel: ArchiveSnapshot,
+    extension_wheel: ArchiveSnapshot,
+    extension_name: str,
+    trust_identity: str,
+    root_layout: _ExtensionWheelLayout,
+    dependency_wheels: tuple[ArchiveSnapshot, ...],
+    dependency_layouts: tuple[_ExtensionWheelLayout, ...],
+    dependency_trust_identities: Iterable[str],
+) -> None:
+    resolved_base_wheel = base_wheel
+    resolved_extension_wheel = extension_wheel
+    resolved_dependency_wheels = dependency_wheels
     trusted_dependency_identities = _explicit_dependency_trust_identities(
         dependency_trust_identities,
         dependency_layouts,
-    )
-    _assert_musl_verification_runtime(root_layout)
-    _assert_base_wheel(
-        resolved_base_wheel,
-        expected_vane_version=root_layout.vane_version,
-        required_interpreter_tag=root_layout.interpreter_tag,
-        required_platform_tag=root_layout.platform_tag,
     )
     dependency_names = tuple(layout.name for layout in dependency_layouts)
     all_extension_names = (extension_name, *dependency_names)
@@ -877,14 +1026,18 @@ def verify_extension_wheel(
             environment=environment,
         )
         python = _python_path(environment_directory)
+        resolved_base_wheel.validate_named_path(description="base Vane wheel")
+        resolved_extension_wheel.validate_named_path(description="extension wheel")
+        for dependency_wheel in resolved_dependency_wheels:
+            dependency_wheel.validate_named_path(description="dependency extension wheel")
         _run(
             _pip_command(
                 python,
                 "--disable-pip-version-check",
                 "install",
-                str(resolved_base_wheel),
-                *(str(dependency_wheel) for dependency_wheel in resolved_dependency_wheels),
-                str(resolved_extension_wheel),
+                str(resolved_base_wheel.path),
+                *(str(dependency_wheel.path) for dependency_wheel in resolved_dependency_wheels),
+                str(resolved_extension_wheel.path),
             ),
             cwd=workspace,
             environment=environment,

--- a/tests/fast/test_extension_wheel.py
+++ b/tests/fast/test_extension_wheel.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import zipfile
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import replace
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from packaging.version import Version
 
 import scripts.verify_extension_wheel as verify_extension_wheel_module
 import vane
+import vane_packaging.archive_safety as archive_safety_module
 import vane_packaging.extension_wheel as extension_wheel_module
 import vane_packaging.manylinux_policy as manylinux_policy_module
 from scripts import check_release_artifacts
@@ -3067,14 +3069,7 @@ def test_platform_wheel_rejects_oversized_dependency_wheels(
         license_expression="Apache-2.0",
         license_files=[REPOSITORY_ROOT / "LICENSE"],
     )
-    validate_size = extension_wheel_module._validate_extension_wheel_size
-
-    def reject_dependency(path):
-        if Path(path) == dependency.path:
-            raise ValueError("extension wheel exceeds the project's 100 MiB publication limit")
-        validate_size(path)
-
-    monkeypatch.setattr(extension_wheel_module, "_validate_extension_wheel_size", reject_dependency)
+    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_BYTES", 0)
 
     with pytest.raises(ValueError, match="100 MiB publication limit"):
         _build_sample_wheel(tmp_path, output_name="root-dist", dependencies=(dependency.path,))
@@ -4382,6 +4377,210 @@ def test_clean_verifier_invokes_pip_in_isolated_mode(
         assert environment["PYTHONSAFEPATH"] == "1"
 
 
+def test_clean_verifier_validates_and_installs_private_snapshots(
+    tmp_path,
+    monkeypatch,
+    synthetic_descriptor_factory,
+):
+    dependency = build_extension_wheel(
+        artifact=_write_artifact(tmp_path / "dependency.duckdb_extension", b"dependency"),
+        extension_name="dependency",
+        output_directory=tmp_path / "dependency-dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity=TEST_TRUST_IDENTITY,
+        license_expression="Apache-2.0",
+        license_files=[REPOSITORY_ROOT / "LICENSE"],
+    )
+    root = _build_sample_wheel(tmp_path, dependencies=(dependency.path,))
+    base = _write_minimal_base_wheel(tmp_path)
+    source_paths = {base, root.path, dependency.path}
+    recorded_snapshots: list[Path] = []
+    installed_snapshots: list[Path] = []
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
+
+    @contextmanager
+    def snapshot_then_replace(path, **kwargs):
+        source_path = Path(path)
+        with snapshot_archive(source_path, **kwargs) as snapshot:
+            recorded_snapshots.append(snapshot.path)
+            replacement = source_path.with_name(f"replacement-{source_path.name}")
+            replacement.write_bytes(b"replacement after snapshot")
+            replacement.replace(source_path)
+            yield snapshot
+
+    def inspect_command(command, *, cwd, environment=None):
+        if "install" not in command:
+            return
+        installed_snapshots.extend(Path(argument) for argument in command if argument.endswith(".whl"))
+        for snapshot_path in installed_snapshots:
+            assert snapshot_path.is_file()
+            assert snapshot_path.read_bytes() != b"replacement after snapshot"
+            with zipfile.ZipFile(snapshot_path) as wheel:
+                assert wheel.namelist()
+
+    def reject_release_resnapshot(*_args, **_kwargs):
+        raise AssertionError("base-wheel release validation must reuse the verifier snapshot")
+
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", snapshot_then_replace)
+    monkeypatch.setattr(check_release_artifacts, "snapshot_archive", reject_release_resnapshot)
+    monkeypatch.setattr(verify_extension_wheel_module, "_run", inspect_command)
+
+    verify_extension_wheel(
+        base_wheel=base,
+        extension_wheel=root.path,
+        extension_name="sample",
+        trust_identity=TEST_TRUST_IDENTITY,
+        dependency_wheels=(dependency.path,),
+        dependency_trust_identities=(TEST_TRUST_IDENTITY,),
+    )
+
+    assert len(recorded_snapshots) == 3
+    assert set(installed_snapshots) == set(recorded_snapshots)
+    assert all(path.read_bytes() == b"replacement after snapshot" for path in source_paths)
+    assert all(not path.exists() and not path.parent.exists() for path in recorded_snapshots)
+
+
+def test_clean_verifier_bounds_aggregate_snapshot_storage_and_cleans_prior_snapshots(
+    tmp_path,
+    monkeypatch,
+    synthetic_descriptor_factory,
+):
+    dependency = build_extension_wheel(
+        artifact=_write_artifact(tmp_path / "dependency.duckdb_extension", b"dependency"),
+        extension_name="dependency",
+        output_directory=tmp_path / "dependency-dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity=TEST_TRUST_IDENTITY,
+        license_expression="Apache-2.0",
+        license_files=[REPOSITORY_ROOT / "LICENSE"],
+    )
+    root = _build_sample_wheel(tmp_path)
+    base = _write_minimal_base_wheel(tmp_path)
+    snapshot_attempts: list[tuple[Path, int, str]] = []
+    retained_snapshot_paths: list[Path] = []
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
+
+    @contextmanager
+    def record_snapshot(path, **kwargs):
+        snapshot_attempts.append((Path(path), kwargs["max_bytes"], kwargs["size_limit_description"]))
+        with snapshot_archive(path, **kwargs) as snapshot:
+            retained_snapshot_paths.append(snapshot.path)
+            yield snapshot
+
+    monkeypatch.setattr(
+        verify_extension_wheel_module,
+        "_MAX_CLEAN_VERIFICATION_SNAPSHOT_BYTES",
+        root.path.stat().st_size + base.stat().st_size,
+    )
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", record_snapshot)
+
+    with pytest.raises(RuntimeError, match="aggregate 1 GiB snapshot limit"):
+        verify_extension_wheel(
+            base_wheel=base,
+            extension_wheel=root.path,
+            extension_name="sample",
+            trust_identity=TEST_TRUST_IDENTITY,
+            dependency_wheels=(dependency.path,),
+            dependency_trust_identities=(TEST_TRUST_IDENTITY,),
+        )
+
+    assert [attempt[0] for attempt in snapshot_attempts] == [root.path, base, dependency.path]
+    assert snapshot_attempts[-1][1:] == (0, "the clean verifier's aggregate 1 GiB snapshot limit")
+    assert len(retained_snapshot_paths) == 2
+    assert all(not path.exists() and not path.parent.exists() for path in retained_snapshot_paths)
+
+
+def test_clean_verifier_validates_each_dependency_before_snapshotting_the_next(
+    tmp_path,
+    monkeypatch,
+    synthetic_descriptor_factory,
+):
+    first_dependency = build_extension_wheel(
+        artifact=_write_artifact(tmp_path / "dependency.duckdb_extension", b"dependency"),
+        extension_name="dependency",
+        output_directory=tmp_path / "dependency-dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity=TEST_TRUST_IDENTITY,
+        license_expression="Apache-2.0",
+        license_files=[REPOSITORY_ROOT / "LICENSE"],
+    )
+    later_dependency = tmp_path / f"later-{first_dependency.path.name}"
+    later_dependency.write_bytes(first_dependency.path.read_bytes())
+    root = _build_sample_wheel(tmp_path)
+    base = _write_minimal_base_wheel(tmp_path)
+    attempted_sources: list[Path] = []
+    retained_snapshot_paths: list[Path] = []
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
+    extension_name_from_artifact_path = verify_extension_wheel_module._extension_name_from_artifact_path
+
+    @contextmanager
+    def record_snapshot(path, **kwargs):
+        attempted_sources.append(Path(path))
+        with snapshot_archive(path, **kwargs) as snapshot:
+            retained_snapshot_paths.append(snapshot.path)
+            yield snapshot
+
+    def reject_first_dependency(snapshot):
+        if snapshot.source_path == first_dependency.path:
+            raise RuntimeError("first dependency is invalid")
+        return extension_name_from_artifact_path(snapshot)
+
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", record_snapshot)
+    monkeypatch.setattr(
+        verify_extension_wheel_module,
+        "_extension_name_from_artifact_path",
+        reject_first_dependency,
+    )
+
+    with pytest.raises(RuntimeError, match="first dependency is invalid"):
+        verify_extension_wheel(
+            base_wheel=base,
+            extension_wheel=root.path,
+            extension_name="sample",
+            trust_identity=TEST_TRUST_IDENTITY,
+            dependency_wheels=(first_dependency.path, later_dependency),
+            dependency_trust_identities=(TEST_TRUST_IDENTITY,),
+        )
+
+    assert attempted_sources == [root.path, base, first_dependency.path]
+    assert later_dependency not in attempted_sources
+    assert all(not path.exists() and not path.parent.exists() for path in retained_snapshot_paths)
+
+
+def test_clean_verifier_removes_snapshots_when_environment_setup_fails(
+    tmp_path,
+    monkeypatch,
+    synthetic_descriptor_factory,
+):
+    root = _build_sample_wheel(tmp_path)
+    base = _write_minimal_base_wheel(tmp_path)
+    recorded_snapshots: list[Path] = []
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
+
+    @contextmanager
+    def record_snapshot(path, **kwargs):
+        with snapshot_archive(path, **kwargs) as snapshot:
+            recorded_snapshots.append(snapshot.path)
+            yield snapshot
+
+    def fail_environment_setup(*_args, **_kwargs):
+        raise RuntimeError("environment setup failed")
+
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", record_snapshot)
+    monkeypatch.setattr(verify_extension_wheel_module, "_run", fail_environment_setup)
+
+    with pytest.raises(RuntimeError, match="environment setup failed"):
+        verify_extension_wheel(
+            base_wheel=base,
+            extension_wheel=root.path,
+            extension_name="sample",
+            trust_identity=TEST_TRUST_IDENTITY,
+        )
+
+    assert len(recorded_snapshots) == 2
+    assert all(not path.exists() and not path.parent.exists() for path in recorded_snapshots)
+
+
 def test_platform_wheel_rejects_an_artifact_changed_after_descriptor_creation(tmp_path, monkeypatch):
     artifact_path = _write_artifact(tmp_path / "sample.duckdb_extension")
 
@@ -4586,12 +4785,9 @@ def test_platform_wheel_rejects_oversized_decompressed_dependency_before_reading
         license_files=[REPOSITORY_ROOT / "LICENSE"],
     )
     root_artifact = _write_artifact(tmp_path / "sample.duckdb_extension", b"root")
-    read_member = extension_wheel_module.zipfile.ZipFile.read
 
     def require_size_check_before_read(wheel, *args, **kwargs):
-        if Path(wheel.filename) == dependency.path:
-            raise AssertionError("oversized dependency member was read before validation")
-        return read_member(wheel, *args, **kwargs)
+        raise AssertionError("oversized dependency member was read before validation")
 
     monkeypatch.setattr(
         extension_wheel_module,
@@ -4635,6 +4831,42 @@ def test_platform_wheel_rejects_too_many_dependency_members_before_opening_the_w
 
     with pytest.raises(ValueError, match="dependency extension wheel contains more than 1 archive members"):
         _build_sample_wheel(tmp_path, output_name="root-dist", dependencies=(dependency.path,))
+
+
+def test_platform_wheel_dependency_preflight_and_parser_use_the_same_snapshot(
+    tmp_path,
+    synthetic_descriptor_factory,
+    monkeypatch,
+):
+    dependency = build_extension_wheel(
+        artifact=_write_artifact(tmp_path / "dependency.duckdb_extension", b"dependency"),
+        extension_name="dependency",
+        output_directory=tmp_path / "dependency-dist",
+        platform_tag=_wheel_platform_tag(),
+        trust_identity=TEST_TRUST_IDENTITY,
+        license_expression="Apache-2.0",
+        license_files=[REPOSITORY_ROOT / "LICENSE"],
+    )
+    validate_snapshot = archive_safety_module.validate_zip_member_count
+    replacement = dependency.path.with_name(f"replacement-{dependency.path.name}")
+    replacement.write_bytes(b"replacement after preflight")
+    replaced = False
+
+    def validate_then_replace(*args, **kwargs):
+        nonlocal replaced
+        member_count = validate_snapshot(*args, **kwargs)
+        if kwargs["description"] == "dependency extension wheel" and not replaced:
+            replacement.replace(dependency.path)
+            replaced = True
+        return member_count
+
+    monkeypatch.setattr(archive_safety_module, "validate_zip_member_count", validate_then_replace)
+
+    built = _build_sample_wheel(tmp_path, output_name="root-dist", dependencies=(dependency.path,))
+
+    assert built.path.is_file()
+    assert replaced
+    assert dependency.path.read_bytes() == b"replacement after preflight"
 
 
 def test_platform_wheel_bounds_dependency_wheel_count_before_reading_wheels(
@@ -4689,7 +4921,8 @@ def test_platform_wheel_bounds_dependency_descriptor_before_json_parsing(
     read_member = extension_wheel_module.zipfile.ZipFile.read
 
     def reject_whole_descriptor_read(wheel, member, *args, **kwargs):
-        if Path(wheel.filename) == tampered_dependency and member == descriptor_member:
+        member_name = member.filename if isinstance(member, zipfile.ZipInfo) else member
+        if member_name == descriptor_member:
             raise AssertionError("oversized dependency descriptor was whole-read before its byte bound")
         return read_member(wheel, member, *args, **kwargs)
 
@@ -4793,7 +5026,16 @@ def test_clean_verifier_rejects_an_oversized_extension_wheel(
     monkeypatch,
 ):
     built = _build_sample_wheel(tmp_path)
-    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_BYTES", 0)
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
+
+    @contextmanager
+    def reject_extension(path, **kwargs):
+        if kwargs["description"] == "extension wheel":
+            raise ValueError("extension wheel exceeds the project's 100 MiB publication limit")
+        with snapshot_archive(path, **kwargs) as snapshot:
+            yield snapshot
+
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", reject_extension)
 
     with pytest.raises(RuntimeError, match="100 MiB publication limit"):
         verify_extension_wheel(
@@ -4856,7 +5098,8 @@ def test_clean_verifier_bounds_descriptor_before_json_parsing(
     read_member = verify_extension_wheel_module.zipfile.ZipFile.read
 
     def reject_whole_descriptor_read(wheel, member, *args, **kwargs):
-        if Path(wheel.filename) == tampered_wheel and member == descriptor_member:
+        member_name = member.filename if isinstance(member, zipfile.ZipInfo) else member
+        if member_name == descriptor_member:
             raise AssertionError("oversized root descriptor was whole-read before its byte bound")
         return read_member(wheel, member, *args, **kwargs)
 
@@ -4894,21 +5137,16 @@ def test_clean_verifier_rejects_an_oversized_base_wheel_before_opening_it(
 ):
     root = _build_sample_wheel(tmp_path)
     base_wheel = _write_minimal_base_wheel(tmp_path)
-    validate_size = verify_extension_wheel_module._validate_extension_wheel_size
-    open_wheel = verify_extension_wheel_module.zipfile.ZipFile
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
 
-    def reject_base(path, *, description="extension wheel"):
-        if Path(path) == base_wheel:
+    @contextmanager
+    def reject_base(path, **kwargs):
+        if kwargs["description"] == "base Vane wheel":
             raise ValueError("base Vane wheel exceeds the project's 100 MiB publication limit")
-        validate_size(path, description=description)
+        with snapshot_archive(path, **kwargs) as snapshot:
+            yield snapshot
 
-    def require_size_check_before_open(path, *args, **kwargs):
-        if Path(path) == base_wheel:
-            raise AssertionError("oversized base wheel was opened before validation")
-        return open_wheel(path, *args, **kwargs)
-
-    monkeypatch.setattr(verify_extension_wheel_module, "_validate_extension_wheel_size", reject_base)
-    monkeypatch.setattr(verify_extension_wheel_module.zipfile, "ZipFile", require_size_check_before_open)
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", reject_base)
 
     with pytest.raises(RuntimeError, match="base Vane wheel exceeds.*100 MiB publication limit"):
         verify_extension_wheel(
@@ -4934,21 +5172,16 @@ def test_clean_verifier_rejects_an_oversized_dependency_before_opening_it(
         license_expression="Apache-2.0",
         license_files=[REPOSITORY_ROOT / "LICENSE"],
     )
-    validate_size = verify_extension_wheel_module._validate_extension_wheel_size
-    open_wheel = verify_extension_wheel_module.zipfile.ZipFile
+    snapshot_archive = verify_extension_wheel_module.snapshot_archive
 
-    def reject_dependency(path, *, description="extension wheel"):
-        if Path(path) == dependency.path:
-            raise ValueError("extension wheel exceeds the project's 100 MiB publication limit")
-        validate_size(path, description=description)
+    @contextmanager
+    def reject_dependency(path, **kwargs):
+        if kwargs["description"] == "dependency extension wheel":
+            raise ValueError("dependency extension wheel exceeds the project's 100 MiB publication limit")
+        with snapshot_archive(path, **kwargs) as snapshot:
+            yield snapshot
 
-    def require_size_check_before_open(path, *args, **kwargs):
-        if Path(path) == dependency.path:
-            raise AssertionError("oversized dependency wheel was opened before validation")
-        return open_wheel(path, *args, **kwargs)
-
-    monkeypatch.setattr(verify_extension_wheel_module, "_validate_extension_wheel_size", reject_dependency)
-    monkeypatch.setattr(verify_extension_wheel_module.zipfile, "ZipFile", require_size_check_before_open)
+    monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", reject_dependency)
 
     with pytest.raises(RuntimeError, match="100 MiB publication limit"):
         verify_extension_wheel(

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -5,6 +5,7 @@ import base64
 import gzip
 import io
 import json
+import os
 import secrets
 import string
 import subprocess
@@ -13,6 +14,7 @@ import tarfile
 import traceback
 import zipfile
 from collections.abc import Callable
+from contextlib import contextmanager
 from email.message import Message
 from pathlib import Path
 
@@ -103,6 +105,20 @@ def _write_archive_members(path: Path, members: dict[str, bytes]) -> None:
     with zipfile.ZipFile(path, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
         for member_name, data in members.items():
             archive.writestr(member_name, data)
+
+
+def _validate_tar_member_count(path: Path, **kwargs) -> int:
+    with archive_safety.snapshot_archive(
+        path,
+        max_bytes=100 * 1024 * 1024,
+        description="sdist",
+        size_limit_description="the test archive limit",
+    ) as snapshot:
+        return archive_safety.validate_tar_member_count(
+            snapshot.file,
+            archive_path=path,
+            **kwargs,
+        )
 
 
 def _pax_record(key: bytes, value: bytes) -> bytes:
@@ -654,7 +670,7 @@ def test_content_scan_validates_raw_wheel_directory_before_constructing_zip_read
         raise AssertionError("wheel ZIP reader was constructed before its member-count preflight")
 
     monkeypatch.setattr(check_release_artifacts, "MAX_ARTIFACT_MEMBERS", member_limit)
-    monkeypatch.setattr(check_release_artifacts.zipfile, "ZipFile", reject_zip_reader_construction)
+    monkeypatch.setattr(archive_safety.zipfile, "ZipFile", reject_zip_reader_construction)
 
     with pytest.raises(ValueError, match=expected_message):
         check_release_artifacts.check_artifact_contents(artifact)
@@ -674,10 +690,233 @@ def test_content_scan_bounds_sdist_members_before_materializing_tar_metadata(tmp
         raise AssertionError("sdist members were materialized before their streaming count preflight")
 
     monkeypatch.setattr(check_release_artifacts, "MAX_ARTIFACT_MEMBERS", 1)
-    monkeypatch.setattr(check_release_artifacts.tarfile.TarFile, "getmembers", reject_member_materialization)
+    monkeypatch.setattr(archive_safety.tarfile.TarFile, "getmembers", reject_member_materialization)
 
     with pytest.raises(ValueError, match="sdist contains more than 1 archive members"):
         check_release_artifacts.check_artifact_contents(artifact)
+
+
+def test_archive_snapshot_is_private_read_only_and_removed(tmp_path):
+    artifact = tmp_path / "artifact.whl"
+    artifact.write_bytes(b"bounded snapshot")
+
+    with archive_safety.snapshot_archive(
+        artifact,
+        max_bytes=len(b"bounded snapshot"),
+        description="artifact",
+        size_limit_description="the test limit",
+    ) as snapshot:
+        snapshot_path = snapshot.path
+        snapshot_directory = snapshot_path.parent
+        snapshot_file = snapshot.file
+        assert snapshot.source_path == artifact
+        assert snapshot_path.name == artifact.name
+        assert snapshot_path.read_bytes() == b"bounded snapshot"
+        if os.name != "nt":
+            assert snapshot_path.stat().st_mode & 0o777 == 0o400
+            assert snapshot_directory.stat().st_mode & 0o077 == 0
+
+    assert snapshot_file.closed
+    assert not snapshot_path.exists()
+    assert not snapshot_directory.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows rejects replacing an open snapshot file")
+def test_archive_snapshot_detects_replacement_of_its_private_named_path(tmp_path):
+    artifact = tmp_path / "artifact.whl"
+    artifact.write_bytes(b"bounded snapshot")
+
+    with archive_safety.snapshot_archive(
+        artifact,
+        max_bytes=len(b"bounded snapshot"),
+        description="artifact",
+        size_limit_description="the test limit",
+    ) as snapshot:
+        replacement = snapshot.path.with_name("replacement")
+        replacement.write_bytes(b"bounded snapshot")
+        replacement.replace(snapshot.path)
+
+        with pytest.raises(ValueError, match="private artifact snapshot changed after validation"):
+            snapshot.validate_named_path(description="artifact")
+        snapshot.file.seek(0)
+        assert snapshot.file.read() == b"bounded snapshot"
+
+
+def test_archive_snapshot_rejects_non_regular_inputs_before_allocating_storage(tmp_path, monkeypatch):
+    def reject_temporary_directory(*_args, **_kwargs):
+        raise AssertionError("non-regular input reached snapshot allocation")
+
+    monkeypatch.setattr(archive_safety.tempfile, "TemporaryDirectory", reject_temporary_directory)
+    with pytest.raises(ValueError, match="(?:must be a regular file|could not snapshot artifact)"):
+        with archive_safety.snapshot_archive(
+            tmp_path,
+            max_bytes=1024,
+            description="artifact",
+            size_limit_description="the test limit",
+        ):
+            pass
+
+
+def test_archive_snapshot_rejects_oversized_inputs_before_allocating_storage(tmp_path, monkeypatch):
+    artifact = tmp_path / "artifact.whl"
+    artifact.write_bytes(b"too large")
+
+    def reject_temporary_directory(*_args, **_kwargs):
+        raise AssertionError("oversized input reached snapshot allocation")
+
+    monkeypatch.setattr(archive_safety.tempfile, "TemporaryDirectory", reject_temporary_directory)
+    with pytest.raises(ValueError, match="artifact exceeds the test limit"):
+        with archive_safety.snapshot_archive(
+            artifact,
+            max_bytes=len(b"too large") - 1,
+            description="artifact",
+            size_limit_description="the test limit",
+        ):
+            pass
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symbolic-link creation is not generally available on Windows")
+def test_archive_snapshot_rejects_symbolic_links_before_allocating_storage(tmp_path, monkeypatch):
+    artifact = tmp_path / "artifact.whl"
+    artifact.write_bytes(b"archive")
+    link = tmp_path / "linked.whl"
+    link.symlink_to(artifact)
+
+    def reject_temporary_directory(*_args, **_kwargs):
+        raise AssertionError("symbolic-link input reached snapshot allocation")
+
+    monkeypatch.setattr(archive_safety.tempfile, "TemporaryDirectory", reject_temporary_directory)
+    with pytest.raises(ValueError, match="must be a regular file"):
+        with archive_safety.snapshot_archive(
+            link,
+            max_bytes=1024,
+            description="artifact",
+            size_limit_description="the test limit",
+        ):
+            pass
+
+
+@pytest.mark.skipif(os.name == "nt", reason="named pipes are POSIX filesystem objects")
+def test_archive_snapshot_rejects_named_pipes_before_allocating_storage(tmp_path, monkeypatch):
+    pipe = tmp_path / "artifact.whl"
+    os.mkfifo(pipe)
+
+    def reject_temporary_directory(*_args, **_kwargs):
+        raise AssertionError("named-pipe input reached snapshot allocation")
+
+    monkeypatch.setattr(archive_safety.tempfile, "TemporaryDirectory", reject_temporary_directory)
+    with pytest.raises(ValueError, match="must be a regular file"):
+        with archive_safety.snapshot_archive(
+            pipe,
+            max_bytes=1024,
+            description="artifact",
+            size_limit_description="the test limit",
+        ):
+            pass
+
+
+@pytest.mark.parametrize("suffix", [".whl", ".tar.gz"], ids=["zip", "compressed-tar"])
+def test_release_preflight_and_parser_use_the_same_snapshot(tmp_path, monkeypatch, suffix):
+    artifact = _artifact_path(tmp_path, suffix, "original")
+    replacement = _artifact_path(tmp_path, suffix, "replacement")
+    original_member = "project/original"
+    _write_archive(artifact, original_member, b"original")
+    _write_archive_members(
+        replacement,
+        {
+            "project/replacement-one": b"replacement",
+            "project/replacement-two": b"replacement",
+        },
+    )
+    validator_name = "validate_tar_member_count" if suffix == ".tar.gz" else "validate_zip_member_count"
+    validate_snapshot = getattr(archive_safety, validator_name)
+    replaced = False
+
+    def validate_then_replace(*args, **kwargs):
+        nonlocal replaced
+        member_count = validate_snapshot(*args, **kwargs)
+        if not replaced:
+            replacement.replace(artifact)
+            replaced = True
+        return member_count
+
+    monkeypatch.setattr(archive_safety, validator_name, validate_then_replace)
+    monkeypatch.setattr(check_release_artifacts, "MAX_ARTIFACT_MEMBERS", 1)
+    artifact_type = (
+        check_release_artifacts.SdistArtifact if suffix == ".tar.gz" else check_release_artifacts.WheelArtifact
+    )
+
+    inspected = artifact_type(artifact)
+    try:
+        assert inspected.names() == [original_member]
+        assert inspected.read(original_member) == b"original"
+    finally:
+        inspected.close()
+    assert replaced
+
+
+def test_uncompressed_tar_preflight_and_parser_use_the_same_snapshot(tmp_path, monkeypatch):
+    artifact = tmp_path / "original.tar"
+    replacement = tmp_path / "replacement.tar"
+    with tarfile.open(artifact, mode="w:") as archive:
+        member = tarfile.TarInfo("project/original")
+        member.size = len(b"original")
+        archive.addfile(member, io.BytesIO(b"original"))
+    with tarfile.open(replacement, mode="w:") as archive:
+        for name in ("project/replacement-one", "project/replacement-two"):
+            member = tarfile.TarInfo(name)
+            archive.addfile(member, io.BytesIO())
+
+    validate_snapshot = archive_safety.validate_tar_member_count
+
+    def validate_then_replace(*args, **kwargs):
+        member_count = validate_snapshot(*args, **kwargs)
+        replacement.replace(artifact)
+        return member_count
+
+    monkeypatch.setattr(archive_safety, "validate_tar_member_count", validate_then_replace)
+    with archive_safety.snapshot_archive(
+        artifact,
+        max_bytes=1024 * 1024,
+        description="test TAR",
+        size_limit_description="the test limit",
+    ) as snapshot:
+        with archive_safety.open_tar_snapshot(
+            snapshot,
+            max_members=1,
+            max_member_bytes=1024,
+            max_total_bytes=1024,
+            uncompressed_limit_description="the test limit",
+            description="test TAR",
+        ) as archive:
+            members = archive.getmembers()
+            assert [member.name for member in members] == ["project/original"]
+            assert archive.extractfile(members[0]).read() == b"original"
+
+
+def test_failed_archive_construction_removes_its_snapshot(tmp_path, monkeypatch):
+    artifact = _artifact_path(tmp_path, ".whl", "cleanup")
+    _write_archive(artifact, "project/member", b"content")
+    snapshot_paths: list[Path] = []
+    snapshot_files = []
+    snapshot_archive = check_release_artifacts.snapshot_archive
+
+    @contextmanager
+    def record_snapshot(*args, **kwargs):
+        with snapshot_archive(*args, **kwargs) as snapshot:
+            snapshot_paths.append(snapshot.path)
+            snapshot_files.append(snapshot.file)
+            yield snapshot
+
+    monkeypatch.setattr(check_release_artifacts, "snapshot_archive", record_snapshot)
+    monkeypatch.setattr(check_release_artifacts, "MAX_ARTIFACT_MEMBERS", 0)
+    with pytest.raises(ValueError, match="wheel contains more than 0 archive members"):
+        check_release_artifacts.WheelArtifact(artifact)
+
+    assert len(snapshot_paths) == 1
+    assert snapshot_files[0].closed
+    assert not snapshot_paths[0].exists()
+    assert not snapshot_paths[0].parent.exists()
 
 
 def test_sdist_streaming_preflight_normalizes_corrupt_deflate_errors(tmp_path, monkeypatch):
@@ -697,7 +936,7 @@ def test_sdist_streaming_preflight_normalizes_corrupt_deflate_errors(tmp_path, m
     monkeypatch.setattr(archive_safety.gzip, "GzipFile", lambda **_kwargs: CorruptGzipStream())
 
     with pytest.raises(ValueError, match="could not inspect sdist"):
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -731,7 +970,7 @@ def test_sdist_streaming_preflight_rejects_oversized_header_before_advancing(
     monkeypatch.setattr(archive_safety, "_read_tar_payload", reject_payload_read)
 
     with pytest.raises(ValueError, match="archive member.*uncompressed test limit"):
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=512,
@@ -758,7 +997,7 @@ def test_sdist_streaming_preflight_bounds_extension_header_payloads(tmp_path, mo
     monkeypatch.setattr(archive_safety, "_read_tar_payload", reject_payload_read)
 
     with pytest.raises(ValueError, match="TAR extension header.*bounded 1 MiB metadata limit"):
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -782,7 +1021,7 @@ def test_sdist_streaming_preflight_rejects_gnu_sparse_before_special_parsing(tmp
     monkeypatch.setattr(archive_safety, "_read_tar_payload", reject_payload_read)
 
     with pytest.raises(ValueError, match="unsupported TAR member type"):
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -804,7 +1043,7 @@ def test_sdist_streaming_preflight_matches_tarfile_for_nonzero_directory_sizes(t
         compressed.write(b"\0" * (2 * tarfile.BLOCKSIZE))
 
     assert (
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -834,7 +1073,7 @@ def test_sdist_streaming_preflight_matches_tarfile_local_pax_size_precedence(tmp
         compressed.write(b"\0" * (2 * tarfile.BLOCKSIZE))
 
     assert (
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -857,7 +1096,7 @@ def test_sdist_streaming_preflight_rejects_ambiguous_global_pax_size(tmp_path):
         compressed.write(b"\0" * (2 * tarfile.BLOCKSIZE))
 
     with pytest.raises(ValueError, match="unsupported global PAX size override"):
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -875,7 +1114,7 @@ def test_sdist_streaming_preflight_rejects_a_concatenated_gzip_payload_after_the
     artifact.write_bytes(gzip.compress(first_stream) + gzip.compress(_runtime_sentinel()))
 
     with pytest.raises(ValueError, match="nonzero data after its TAR terminator"):
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,
@@ -897,7 +1136,7 @@ def test_sdist_streaming_preflight_accepts_bounded_zero_padding_after_the_termin
     artifact.write_bytes(gzip.compress(stream))
 
     assert (
-        archive_safety.validate_tar_member_count(
+        _validate_tar_member_count(
             artifact,
             max_members=10,
             max_member_bytes=2048,

--- a/vane_packaging/archive_safety.py
+++ b/vane_packaging/archive_safety.py
@@ -10,10 +10,14 @@ import os
 import stat
 import struct
 import tarfile
+import tempfile
+import zipfile
 import zlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, cast
 
 _END_OF_CENTRAL_DIRECTORY = struct.Struct("<4s4H2LH")
 _CENTRAL_DIRECTORY_HEADER = struct.Struct("<4s6H3L5H2L")
@@ -32,36 +36,197 @@ _PAX_HEADER_TYPES = frozenset({tarfile.XHDTYPE, tarfile.XGLTYPE, tarfile.SOLARIS
 _GNU_LONG_HEADER_TYPES = frozenset({tarfile.GNUTYPE_LONGNAME, tarfile.GNUTYPE_LONGLINK})
 _REGULAR_TAR_MEMBER_TYPES = frozenset({tarfile.REGTYPE, tarfile.AREGTYPE, tarfile.CONTTYPE})
 _ALLOWED_TAR_MEMBER_TYPES = _REGULAR_TAR_MEMBER_TYPES | {tarfile.DIRTYPE}
+_ARCHIVE_SNAPSHOT_CHUNK_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ArchiveSnapshot:
+    """One private, bounded copy of an untrusted archive input."""
+
+    source_path: Path
+    path: Path
+    size: int
+    file: BinaryIO = field(repr=False, compare=False)
+
+    def validate_named_path(self, *, description: str) -> None:
+        """Require the private path to still name the retained snapshot file."""
+        try:
+            path_metadata = self.path.lstat()
+            file_metadata = os.fstat(self.file.fileno())
+        except OSError as exception:
+            raise ValueError(
+                f"private {description} snapshot is no longer available: {self.source_path}"
+            ) from exception
+        if (
+            not stat.S_ISREG(path_metadata.st_mode)
+            or path_metadata.st_nlink != 1
+            or path_metadata.st_size != self.size
+            or not os.path.samestat(path_metadata, file_metadata)
+        ):
+            raise ValueError(f"private {description} snapshot changed after validation: {self.source_path}")
+
+
+@contextmanager
+def snapshot_archive(
+    path: str | Path,
+    *,
+    max_bytes: int,
+    description: str,
+    size_limit_description: str,
+) -> Iterator[ArchiveSnapshot]:
+    """Copy one regular input into a private file that outlives all readers."""
+    archive_path = Path(path)
+    if max_bytes < 0:
+        raise ValueError("max_bytes must be non-negative")
+
+    temporary_directory: tempfile.TemporaryDirectory[str] | None = None
+    snapshot_file: BinaryIO | None = None
+    try:
+        source_path_metadata = archive_path.lstat()
+        if not stat.S_ISREG(source_path_metadata.st_mode):
+            raise ValueError(f"{description} must be a regular file: {archive_path}")
+        source_flags = os.O_RDONLY
+        for flag_name in ("O_BINARY", "O_CLOEXEC", "O_NONBLOCK", "O_NOFOLLOW"):
+            source_flags |= getattr(os, flag_name, 0)
+        source_descriptor = os.open(archive_path, source_flags)
+        with _binary_file_from_descriptor(source_descriptor, "rb") as source_file:
+            metadata = os.fstat(source_file.fileno())
+            if not stat.S_ISREG(metadata.st_mode) or not os.path.samestat(source_path_metadata, metadata):
+                raise ValueError(f"{description} must be a regular file: {archive_path}")
+            if metadata.st_size > max_bytes:
+                raise ValueError(f"{archive_path}: {description} exceeds {size_limit_description}")
+
+            temporary_directory = tempfile.TemporaryDirectory(prefix="vane-archive-snapshot-")
+            snapshot_directory = Path(temporary_directory.name)
+            snapshot_directory_metadata = snapshot_directory.lstat()
+            if not stat.S_ISDIR(snapshot_directory_metadata.st_mode) or (
+                os.name != "nt" and stat.S_IMODE(snapshot_directory_metadata.st_mode) & 0o077
+            ):
+                raise ValueError(f"could not create a private snapshot directory for {description}: {archive_path}")
+            snapshot_path = snapshot_directory / archive_path.name
+            destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            for flag_name in ("O_BINARY", "O_CLOEXEC"):
+                destination_flags |= getattr(os, flag_name, 0)
+            destination_descriptor = os.open(snapshot_path, destination_flags, 0o600)
+            with _binary_file_from_descriptor(destination_descriptor, "wb") as destination_file:
+                snapshot_size = _copy_archive_snapshot(
+                    source_file,
+                    destination_file,
+                    archive_path=archive_path,
+                    max_bytes=max_bytes,
+                    description=description,
+                    size_limit_description=size_limit_description,
+                )
+                destination_file.flush()
+                if os.name != "nt":
+                    os.fchmod(destination_file.fileno(), 0o400)
+                written_snapshot_metadata = os.fstat(destination_file.fileno())
+
+        snapshot_file = _binary_file_from_descriptor(os.open(snapshot_path, source_flags), "rb")
+        snapshot_metadata = snapshot_path.lstat()
+        retained_snapshot_metadata = os.fstat(snapshot_file.fileno())
+        if (
+            not stat.S_ISREG(snapshot_metadata.st_mode)
+            or not stat.S_ISREG(retained_snapshot_metadata.st_mode)
+            or snapshot_metadata.st_nlink != 1
+            or snapshot_metadata.st_size != snapshot_size
+            or retained_snapshot_metadata.st_size != snapshot_size
+            or not os.path.samestat(written_snapshot_metadata, retained_snapshot_metadata)
+            or not os.path.samestat(snapshot_metadata, retained_snapshot_metadata)
+            or (os.name != "nt" and stat.S_IMODE(retained_snapshot_metadata.st_mode) != 0o400)
+        ):
+            raise ValueError(f"could not create a private regular snapshot for {description}: {archive_path}")
+        snapshot = ArchiveSnapshot(
+            source_path=archive_path,
+            path=snapshot_path,
+            size=snapshot_size,
+            file=snapshot_file,
+        )
+    except OSError as exception:
+        try:
+            if snapshot_file is not None:
+                snapshot_file.close()
+        finally:
+            if temporary_directory is not None:
+                temporary_directory.cleanup()
+        raise ValueError(f"could not snapshot {description}: {archive_path}") from exception
+    except BaseException:
+        try:
+            if snapshot_file is not None:
+                snapshot_file.close()
+        finally:
+            if temporary_directory is not None:
+                temporary_directory.cleanup()
+        raise
+
+    try:
+        yield snapshot
+    finally:
+        if temporary_directory is None:  # pragma: no cover - assigned before every successful yield
+            raise RuntimeError("archive snapshot lost its temporary-directory owner")
+        try:
+            snapshot.file.close()
+        finally:
+            temporary_directory.cleanup()
+
+
+def _binary_file_from_descriptor(descriptor: int, mode: str) -> BinaryIO:
+    try:
+        return cast(BinaryIO, os.fdopen(descriptor, mode))
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _copy_archive_snapshot(
+    source_file: BinaryIO,
+    destination_file: BinaryIO,
+    *,
+    archive_path: Path,
+    max_bytes: int,
+    description: str,
+    size_limit_description: str,
+) -> int:
+    copied_bytes = 0
+    while True:
+        remaining_with_overflow = max_bytes - copied_bytes + 1
+        chunk = source_file.read(min(_ARCHIVE_SNAPSHOT_CHUNK_BYTES, remaining_with_overflow))
+        if not chunk:
+            return copied_bytes
+        copied_bytes += len(chunk)
+        if copied_bytes > max_bytes:
+            raise ValueError(f"{archive_path}: {description} exceeds {size_limit_description}")
+        destination_file.write(chunk)
 
 
 def validate_zip_member_count(
-    path: str | Path,
+    archive_file: BinaryIO,
     *,
+    archive_path: str | Path,
+    file_size: int,
     max_members: int,
     description: str,
 ) -> int:
     """Validate and count central-directory entries without creating ``ZipInfo`` objects."""
-    archive_path = Path(path)
+    archive_path = Path(archive_path)
     if max_members < 0:
         raise ValueError("max_members must be non-negative")
     try:
-        with archive_path.open("rb") as archive_file:
-            metadata = os.fstat(archive_file.fileno())
-            if not stat.S_ISREG(metadata.st_mode):
-                raise ValueError(f"{description} must be a regular file: {archive_path}")
-            return _validate_zip_central_directory(
-                archive_file,
-                file_size=metadata.st_size,
-                max_members=max_members,
-                description=description,
-            )
+        archive_file.seek(0)
+        return _validate_zip_central_directory(
+            archive_file,
+            file_size=file_size,
+            max_members=max_members,
+            description=description,
+        )
     except OSError as exception:
         raise ValueError(f"could not inspect {description}: {archive_path}") from exception
 
 
 def validate_tar_member_count(
-    path: str | Path,
+    archive_file: BinaryIO,
     *,
+    archive_path: str | Path,
     max_members: int,
     max_member_bytes: int,
     max_total_bytes: int,
@@ -75,40 +240,85 @@ def validate_tar_member_count(
     payload chunks. Its second argument is true when a header starts a new,
     physically contiguous metadata region.
     """
-    archive_path = Path(path)
+    archive_path = Path(archive_path)
     if max_members < 0 or max_member_bytes < 0 or max_total_bytes < 0:
         raise ValueError("TAR member and size limits must be non-negative")
     try:
-        with archive_path.open("rb") as archive_file:
-            metadata = os.fstat(archive_file.fileno())
-            if not stat.S_ISREG(metadata.st_mode):
-                raise ValueError(f"{description} must be a regular file: {archive_path}")
-            magic = archive_file.read(2)
-            archive_file.seek(0)
-            if magic == b"\x1f\x8b":
-                with gzip.GzipFile(fileobj=archive_file, mode="rb") as tar_stream:
-                    return _validate_tar_stream(
-                        tar_stream,
-                        archive_path=archive_path,
-                        max_members=max_members,
-                        max_member_bytes=max_member_bytes,
-                        max_total_bytes=max_total_bytes,
-                        uncompressed_limit_description=uncompressed_limit_description,
-                        description=description,
-                        metadata_chunk_callback=metadata_chunk_callback,
-                    )
-            return _validate_tar_stream(
-                archive_file,
-                archive_path=archive_path,
-                max_members=max_members,
-                max_member_bytes=max_member_bytes,
-                max_total_bytes=max_total_bytes,
-                uncompressed_limit_description=uncompressed_limit_description,
-                description=description,
-                metadata_chunk_callback=metadata_chunk_callback,
-            )
+        archive_file.seek(0)
+        magic = archive_file.read(2)
+        archive_file.seek(0)
+        if magic == b"\x1f\x8b":
+            with gzip.GzipFile(fileobj=archive_file, mode="rb") as tar_stream:
+                return _validate_tar_stream(
+                    tar_stream,
+                    archive_path=archive_path,
+                    max_members=max_members,
+                    max_member_bytes=max_member_bytes,
+                    max_total_bytes=max_total_bytes,
+                    uncompressed_limit_description=uncompressed_limit_description,
+                    description=description,
+                    metadata_chunk_callback=metadata_chunk_callback,
+                )
+        return _validate_tar_stream(
+            archive_file,
+            archive_path=archive_path,
+            max_members=max_members,
+            max_member_bytes=max_member_bytes,
+            max_total_bytes=max_total_bytes,
+            uncompressed_limit_description=uncompressed_limit_description,
+            description=description,
+            metadata_chunk_callback=metadata_chunk_callback,
+        )
     except (EOFError, OSError, tarfile.TarError, zlib.error) as exception:
         raise ValueError(f"could not inspect {description}: {archive_path}") from exception
+
+
+@contextmanager
+def open_zip_snapshot(
+    snapshot: ArchiveSnapshot,
+    *,
+    max_members: int,
+    description: str,
+) -> Iterator[zipfile.ZipFile]:
+    """Preflight and parse one ZIP from the same snapshotted file descriptor."""
+    validate_zip_member_count(
+        snapshot.file,
+        archive_path=snapshot.source_path,
+        file_size=snapshot.size,
+        max_members=max_members,
+        description=description,
+    )
+    snapshot.file.seek(0)
+    with zipfile.ZipFile(snapshot.file) as archive:
+        yield archive
+
+
+@contextmanager
+def open_tar_snapshot(
+    snapshot: ArchiveSnapshot,
+    *,
+    max_members: int,
+    max_member_bytes: int,
+    max_total_bytes: int,
+    uncompressed_limit_description: str,
+    description: str,
+    metadata_chunk_callback: Callable[[bytes, bool], None] | None = None,
+    mode: str = "r:*",
+) -> Iterator[tarfile.TarFile]:
+    """Preflight and parse one TAR from the same snapshotted file descriptor."""
+    validate_tar_member_count(
+        snapshot.file,
+        archive_path=snapshot.source_path,
+        max_members=max_members,
+        max_member_bytes=max_member_bytes,
+        max_total_bytes=max_total_bytes,
+        uncompressed_limit_description=uncompressed_limit_description,
+        description=description,
+        metadata_chunk_callback=metadata_chunk_callback,
+    )
+    snapshot.file.seek(0)
+    with tarfile.open(fileobj=snapshot.file, mode=mode) as archive:
+        yield archive
 
 
 def _validate_tar_stream(
@@ -424,4 +634,11 @@ def _read_exact(archive_file: BinaryIO, size: int, *, description: str) -> bytes
     return contents
 
 
-__all__ = ["validate_tar_member_count", "validate_zip_member_count"]
+__all__ = [
+    "ArchiveSnapshot",
+    "open_tar_snapshot",
+    "open_zip_snapshot",
+    "snapshot_archive",
+    "validate_tar_member_count",
+    "validate_zip_member_count",
+]

--- a/vane_packaging/extension_wheel.py
+++ b/vane_packaging/extension_wheel.py
@@ -42,7 +42,7 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel_filename
 from packaging.version import InvalidVersion, Version
 
-from vane_packaging.archive_safety import validate_zip_member_count
+from vane_packaging.archive_safety import ArchiveSnapshot, open_zip_snapshot, snapshot_archive
 from vane_packaging.manylinux_policy import ManylinuxPolicy, manylinux_policy
 
 if TYPE_CHECKING:
@@ -650,10 +650,19 @@ def _validate_dependency_trust_identities(
 
 
 def _read_dependency_wheel(path: Path) -> _DependencyWheel:
+    with snapshot_archive(
+        path,
+        max_bytes=_MAX_EXTENSION_WHEEL_BYTES,
+        description="dependency extension wheel",
+        size_limit_description="the project's 100 MiB publication limit",
+    ) as snapshot:
+        return _read_dependency_wheel_snapshot(snapshot)
+
+
+def _read_dependency_wheel_snapshot(snapshot: ArchiveSnapshot) -> _DependencyWheel:
     from vane.extensions import DynamicExtensionDescriptor, DynamicExtensionError
 
-    _validate_extension_wheel_size(path)
-    _validate_extension_wheel_member_count(path, description="dependency extension wheel")
+    path = snapshot.source_path
     try:
         filename_name, filename_version, build_tag, filename_tags = parse_wheel_filename(path.name)
     except InvalidWheelFilename as exception:
@@ -670,7 +679,11 @@ def _read_dependency_wheel(path: Path) -> _DependencyWheel:
     platform_tag = _validate_platform_tag(filename_tag.platform)
 
     try:
-        with zipfile.ZipFile(path) as wheel:
+        with open_zip_snapshot(
+            snapshot,
+            max_members=_MAX_EXTENSION_WHEEL_MEMBERS,
+            description="dependency extension wheel",
+        ) as wheel:
             _validate_extension_wheel_archive_size(wheel, description="dependency extension wheel")
             names = wheel.namelist()
             _validate_wheel_path_component_lengths(
@@ -3239,14 +3252,6 @@ def _normalize_extension_wheel_permissions(path: Path) -> None:
 def _validate_extension_wheel_size(path: Path, *, description: str = "extension wheel") -> None:
     if path.stat().st_size > _MAX_EXTENSION_WHEEL_BYTES:
         raise ValueError(f"{description} exceeds the project's 100 MiB publication limit")
-
-
-def _validate_extension_wheel_member_count(path: Path, *, description: str = "extension wheel") -> None:
-    validate_zip_member_count(
-        path,
-        max_members=_MAX_EXTENSION_WHEEL_MEMBERS,
-        description=description,
-    )
 
 
 def _validate_extension_wheel_archive_size(


### PR DESCRIPTION
## Summary

- Snapshot untrusted ZIP and TAR inputs into private, bounded, read-only temporary files while retaining an open descriptor, so archive preflight and semantic parsing consume the same immutable bytes.
- Reuse those snapshots across release artifact validation and clean root/dependency/base-wheel verification, cap retained clean-verifier snapshots at 1 GiB, validate each artifact before snapshotting the next, and validate retained identities before passing snapshot paths to pip.
- Add deterministic source-replacement, non-regular input, size-bound, descriptor, and cleanup coverage without sleeps or a new third-party dependency.

## Related issue

close: #705

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] A documentation follow-up is required and tracked in a linked issue.

`DEVELOPMENT.md` now documents the immutable archive snapshot and clean-verifier behavior.

## Validation

- `pre-commit run --files DEVELOPMENT.md scripts/check_release_artifacts.py scripts/verify_extension_wheel.py tests/fast/test_extension_wheel.py tests/fast/test_release_artifact_security.py vane_packaging/archive_safety.py vane_packaging/extension_wheel.py`
- `git diff --check upstream/main...HEAD`
- `scripts/run_installed_pytest.sh -n 24 tests/fast/test_release_artifact_security.py tests/fast/test_extension_wheel.py` (`401 passed, 1 skipped`)
- No native rebuild was needed because this PR changes only Python, tests, and documentation.

## Checklist

- [x] I ran the focused tests for this change and the required project checks.
- [x] I documented public behavior and compatibility implications where applicable.
- [x] I reviewed dependency and copied-code licensing implications; this PR adds neither.
- [x] I verified that the change contains no secrets, machine-specific paths, or generated artifacts.
- [x] I considered security implications for untrusted archive paths and contents.
- [x] I compiled native changes where required; this PR has no native changes, and the Python checks above passed.
