### PR TITLE
[feat](file) Support FILE inputs in AI prompts

### DIFF
--- a/src/vane_py/CMakeLists.txt
+++ b/src/vane_py/CMakeLists.txt
@@ -47,3 +47,5 @@ add_library(
   vllm_executor.cpp)
 
 target_link_libraries(python_src PRIVATE vane_python_dependencies)
+target_include_directories(
+  python_src PRIVATE "${DUCKDB_SOURCE_PATH}/extension/file/include")

--- a/src/vane_py/ai_sql_functions.cpp
+++ b/src/vane_py/ai_sql_functions.cpp
@@ -6,6 +6,7 @@
 #include "vane_python/python_conversion.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/function_binder.hpp"
@@ -29,9 +30,30 @@ namespace duckdb {
 namespace {
 
 enum class AISQLKind : uint8_t { PROMPT, EMBED };
+enum class PromptInputKind : uint8_t { TEXT, BLOB, BLOB_LIST, FILE, FILE_LIST };
 
 static constexpr const char *HIDDEN_EMBED_FUNCTION = "__vane_ai_embed";
 static constexpr const char *HIDDEN_PROMPT_FUNCTION = "__vane_ai_prompt";
+
+static bool IsPromptFileList(const LogicalType &type) {
+	return type.id() == LogicalTypeId::LIST && FileLogicalType::IsFile(ListType::GetChildType(type));
+}
+
+static const char *PromptInputKindName(PromptInputKind kind) {
+	switch (kind) {
+	case PromptInputKind::TEXT:
+		return "text";
+	case PromptInputKind::BLOB:
+		return "blob";
+	case PromptInputKind::BLOB_LIST:
+		return "blob_list";
+	case PromptInputKind::FILE:
+		return "file";
+	case PromptInputKind::FILE_LIST:
+		return "file_list";
+	}
+	throw InternalException("unknown ai_prompt input kind");
+}
 
 struct NativeVLLMSpec {
 	string model;
@@ -152,11 +174,12 @@ static py::object ConstantArgumentToPython(ClientContext &context, vector<unique
 }
 
 static py::dict BuildAISQLSpec(AISQLKind kind, ClientContext &context, vector<unique_ptr<Expression>> &arguments,
-                               idx_t options_index, bool image_input) {
+                               idx_t options_index, PromptInputKind prompt_input_kind) {
 	auto sql_module = py::module_::import("vane.ai._sql");
 	auto py_options = OptionsToPython(context, arguments, options_index, true);
 	if (kind == AISQLKind::PROMPT) {
-		auto constant_offset = image_input ? idx_t(2) : idx_t(1);
+		auto has_media_input = prompt_input_kind != PromptInputKind::TEXT;
+		auto constant_offset = has_media_input ? idx_t(2) : idx_t(1);
 		auto return_format = ConstantArgumentToPython(context, arguments, constant_offset, "return_format");
 		auto system_message = ConstantArgumentToPython(context, arguments, constant_offset + 1, "system_message");
 		auto provider = ConstantArgumentToPython(context, arguments, constant_offset + 2, "provider");
@@ -165,7 +188,8 @@ static py::dict BuildAISQLSpec(AISQLKind kind, ClientContext &context, vector<un
 		    ConstantArgumentToPython(context, arguments, constant_offset + 4, "return_raw_response");
 		auto on_error = ConstantArgumentToPython(context, arguments, constant_offset + 5, "on_error");
 		return py::cast<py::dict>(sql_module.attr("build_ai_prompt_sql_spec")(
-		    provider, model, system_message, on_error, py_options, image_input, return_format, return_raw_response));
+		    provider, model, system_message, on_error, py_options, PromptInputKindName(prompt_input_kind),
+		    return_format, return_raw_response));
 	}
 	auto provider = ConstantArgumentToPython(context, arguments, 1, "provider");
 	auto model = ConstantArgumentToPython(context, arguments, 2, "model");
@@ -290,16 +314,29 @@ static unique_ptr<Expression> LowerNativeVLLMPrompt(FunctionBindExpressionInput 
 static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction &bound_function,
                                           vector<unique_ptr<Expression>> &arguments, AISQLKind kind) {
 	auto options_index = OptionsArgumentIndex(kind, arguments.size());
-	auto image_input = kind == AISQLKind::PROMPT && arguments.size() == 9;
-	auto runtime_argument_count = image_input ? idx_t(2) : idx_t(1);
+	auto has_media_input = kind == AISQLKind::PROMPT && arguments.size() == 9;
+	auto runtime_argument_count = has_media_input ? idx_t(2) : idx_t(1);
+	auto prompt_input_kind = PromptInputKind::TEXT;
 	auto input_type_id = arguments[0]->return_type.id();
 	if (input_type_id != LogicalTypeId::VARCHAR && input_type_id != LogicalTypeId::SQLNULL) {
 		throw BinderException("ai SQL input argument must be VARCHAR");
 	}
-	if (image_input && arguments[1]->return_type != LogicalType::BLOB &&
-	    arguments[1]->return_type != LogicalType::LIST(LogicalType::BLOB) &&
-	    arguments[1]->return_type.id() != LogicalTypeId::SQLNULL) {
-		throw BinderException("ai_prompt image argument must be BLOB or BLOB[]");
+	if (has_media_input) {
+		auto media_type = arguments[1]->return_type;
+		if (media_type.id() == LogicalTypeId::SQLNULL && bound_function.arguments.size() > 1) {
+			media_type = bound_function.arguments[1];
+		}
+		if (media_type == LogicalType::BLOB) {
+			prompt_input_kind = PromptInputKind::BLOB;
+		} else if (media_type == LogicalType::LIST(LogicalType::BLOB)) {
+			prompt_input_kind = PromptInputKind::BLOB_LIST;
+		} else if (FileLogicalType::IsFile(media_type)) {
+			prompt_input_kind = PromptInputKind::FILE;
+		} else if (IsPromptFileList(media_type)) {
+			prompt_input_kind = PromptInputKind::FILE_LIST;
+		} else {
+			throw BinderException("ai_prompt media argument must be BLOB, BLOB[], FILE, or FILE[]");
+		}
 	}
 	Value payload;
 	Value native_validation_payload;
@@ -307,7 +344,7 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 	unique_ptr<NativeVLLMSpec> native_vllm;
 	{
 		PythonGILWrapper acquire;
-		auto spec = BuildAISQLSpec(kind, context, arguments, options_index, image_input);
+		auto spec = BuildAISQLSpec(kind, context, arguments, options_index, prompt_input_kind);
 		auto return_type_obj = DictGetOrNone(spec, "return_type");
 		if (!py::isinstance<py::str>(return_type_obj)) {
 			throw BinderException("ai SQL helper returned invalid return_type");
@@ -356,7 +393,7 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 		}
 	} else {
 		// Prompt call-level constants are consumed by the binder. Only the
-		// prompt and optional image expression become row inputs.
+		// prompt and optional media expression become row inputs.
 		for (idx_t index = arguments.size(); index-- > runtime_argument_count;) {
 			Function::EraseArgument(bound_function, arguments, index);
 		}
@@ -450,8 +487,9 @@ static unique_ptr<Expression> LowerAIPromptInput(FunctionBindExpressionInput &in
 		return make_uniq<BoundConstantExpression>(Value(LogicalType::VARCHAR));
 	}
 	if (input_type != LogicalType::VARCHAR && input_type != LogicalType::BLOB &&
-	    input_type != LogicalType::LIST(LogicalType::BLOB)) {
-		throw BinderException("Prompt messages must have type VARCHAR, BLOB, or BLOB[]");
+	    input_type != LogicalType::LIST(LogicalType::BLOB) && !FileLogicalType::IsFile(input_type) &&
+	    !IsPromptFileList(input_type)) {
+		throw BinderException("Prompt messages must have type VARCHAR, BLOB, BLOB[], FILE, or FILE[]");
 	}
 	return std::move(message);
 }
@@ -460,6 +498,12 @@ static unique_ptr<Expression> LowerAIPromptTextInput(FunctionBindExpressionInput
 	if (input.children.size() != 2) {
 		throw BinderException("ai_prompt text validation expected two runtime arguments");
 	}
+	ThrowIfNotConstant(*input.children[1], "media_policy");
+	auto policy = EvaluateConstant(input.context, *input.children[1]);
+	if (policy.IsNull() || policy.type().id() != LogicalTypeId::BOOLEAN) {
+		throw BinderException("ai_prompt media policy must be a constant BOOLEAN");
+	}
+	auto text_only = BooleanValue::Get(policy);
 	auto &message = input.children[0];
 	auto input_type_id = message->return_type.id();
 	if (input_type_id == LogicalTypeId::UNKNOWN) {
@@ -468,8 +512,12 @@ static unique_ptr<Expression> LowerAIPromptTextInput(FunctionBindExpressionInput
 	if (input_type_id == LogicalTypeId::SQLNULL) {
 		return make_uniq<BoundConstantExpression>(Value(LogicalType::VARCHAR));
 	}
-	if (input_type_id != LogicalTypeId::VARCHAR) {
-		throw BinderException("Provider 'vllm' Prompt messages must have type VARCHAR");
+	if (input_type_id != LogicalTypeId::VARCHAR &&
+	    (text_only || (!FileLogicalType::IsFile(message->return_type) && !IsPromptFileList(message->return_type)))) {
+		if (text_only) {
+			throw BinderException("Native Prompt messages must have type VARCHAR");
+		}
+		throw BinderException("Prompt messages for this provider must have type VARCHAR, FILE, or FILE[]");
 	}
 	return std::move(message);
 }
@@ -506,16 +554,23 @@ ScalarFunctionSet AISQLFunction::GetPromptImplementationFunctions() {
 	add_implementation({LogicalType::VARCHAR, LogicalType::LIST(LogicalType::BLOB), LogicalType::JSON(),
 	                    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BOOLEAN,
 	                    LogicalType::VARCHAR, LogicalType::ANY});
+	auto file_type = FileLogicalType::Create();
+	add_implementation({LogicalType::VARCHAR, file_type, LogicalType::JSON(), LogicalType::VARCHAR,
+	                    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::VARCHAR,
+	                    LogicalType::ANY});
+	add_implementation({LogicalType::VARCHAR, LogicalType::LIST(file_type), LogicalType::JSON(), LogicalType::VARCHAR,
+	                    LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::VARCHAR,
+	                    LogicalType::ANY});
 	return set;
 }
 
 unique_ptr<CreateMacroInfo> AISQLFunction::GetPromptMacro() {
-	auto make_function = [&](const LogicalType *image_type, const char *image_parameter) {
+	auto make_function = [&](const LogicalType *media_type, const char *media_parameter) {
 		auto macro_arguments =
-		    image_type
+		    media_type
 		        ? StringUtil::Format("prompt, %s, return_format, system_message, provider, model, return_raw_response, "
 		                             "on_error, options",
-		                             image_parameter)
+		                             media_parameter)
 		        : "prompt, return_format, system_message, provider, model, return_raw_response, on_error, options";
 		auto expressions =
 		    Parser::ParseExpressionList(StringUtil::Format("%s(%s)", HIDDEN_PROMPT_FUNCTION, macro_arguments));
@@ -538,8 +593,8 @@ unique_ptr<CreateMacroInfo> AISQLFunction::GetPromptMacro() {
 		};
 
 		add_parameter("prompt", LogicalType::VARCHAR, nullptr);
-		if (image_type) {
-			add_parameter(image_parameter, *image_type, nullptr);
+		if (media_type) {
+			add_parameter(media_parameter, *media_type, nullptr);
 		}
 		// JSON registers a zero-cost implicit cast from BLOB, which makes a
 		// positional image ambiguous with the text overload's return_format.
@@ -565,6 +620,10 @@ unique_ptr<CreateMacroInfo> AISQLFunction::GetPromptMacro() {
 	info->macros.push_back(make_function(&blob_type, "image"));
 	auto blob_list_type = LogicalType::LIST(LogicalType::BLOB);
 	info->macros.push_back(make_function(&blob_list_type, "images"));
+	auto file_type = FileLogicalType::Create();
+	info->macros.push_back(make_function(&file_type, "file"));
+	auto file_list_type = LogicalType::LIST(file_type);
+	info->macros.push_back(make_function(&file_list_type, "files"));
 	return info;
 }
 

--- a/src/vane_py/ai_sql_functions.cpp
+++ b/src/vane_py/ai_sql_functions.cpp
@@ -41,8 +41,9 @@ static constexpr const char *HIDDEN_EMBED_FUNCTION = "__vane_ai_embed";
 static constexpr const char *HIDDEN_PROMPT_FUNCTION = "__vane_ai_prompt";
 static constexpr const char *HIDDEN_PROMPT_PACK_FUNCTION = "__vane_ai_prompt_pack";
 static constexpr idx_t PROMPT_PACK_MEDIA_SUPPORTED_INDEX = 0;
-static constexpr idx_t PROMPT_PACK_SINGLE_MESSAGE_INDEX = 1;
-static constexpr idx_t PROMPT_PACK_MESSAGE_OFFSET = 2;
+static constexpr idx_t PROMPT_PACK_SUPPORTED_MIME_TYPES_INDEX = 1;
+static constexpr idx_t PROMPT_PACK_SINGLE_MESSAGE_INDEX = 2;
+static constexpr idx_t PROMPT_PACK_MESSAGE_OFFSET = 3;
 
 // Prompt providers receive media inline. Keep both an individual FILE and the
 // materialized input vector bounded before allocating its bytes. The vector
@@ -55,6 +56,7 @@ static constexpr const char *PROMPT_MEDIA_ERROR_UNSUPPORTED = "unsupported";
 static constexpr const char *PROMPT_MEDIA_ERROR_READ = "read";
 static constexpr const char *PROMPT_MEDIA_ERROR_MIME = "mime";
 static constexpr const char *PROMPT_MEDIA_ERROR_INVALID_MIME = "invalid_mime";
+static constexpr const char *PROMPT_MEDIA_ERROR_UNSUPPORTED_MIME = "unsupported_mime";
 static constexpr const char *PROMPT_MEDIA_ERROR_EMPTY = "empty";
 static constexpr const char *PROMPT_MEDIA_ERROR_TOO_LARGE = "too_large";
 static constexpr const char *PROMPT_MEDIA_ERROR_VECTOR_TOO_LARGE = "vector_too_large";
@@ -95,6 +97,18 @@ static bool NormalizePromptContentType(const string &value, string &result) {
 		}
 	}
 	return true;
+}
+
+static bool PromptContentTypeSupported(const string &content_type, const vector<string> &supported_mime_types) {
+	if (supported_mime_types.empty()) {
+		return true;
+	}
+	for (auto &supported : supported_mime_types) {
+		if (supported == content_type) {
+			return true;
+		}
+	}
+	return false;
 }
 
 static bool MustPropagatePromptFileError(const ErrorData &error) {
@@ -152,7 +166,8 @@ struct PreparedPromptMedia {
 	}
 };
 
-static void PreparePromptMedia(ClientContext &context, const Value &value, bool media_supported, uint64_t &vector_bytes,
+static void PreparePromptMedia(ClientContext &context, const Value &value, bool media_supported,
+                               const vector<string> &supported_mime_types, uint64_t &vector_bytes,
                                PreparedPromptMedia &result) {
 	if (value.IsNull()) {
 		result.is_null = true;
@@ -170,6 +185,10 @@ static void PreparePromptMedia(ClientContext &context, const Value &value, bool 
 		result.has_content_type = NormalizePromptContentType(file.content_type, result.content_type);
 		if (!result.has_content_type) {
 			result.error = PROMPT_MEDIA_ERROR_INVALID_MIME;
+			return;
+		}
+		if (!PromptContentTypeSupported(result.content_type, supported_mime_types)) {
+			result.error = PROMPT_MEDIA_ERROR_UNSUPPORTED_MIME;
 			return;
 		}
 	}
@@ -199,6 +218,11 @@ static void PreparePromptMedia(ClientContext &context, const Value &value, bool 
 				result.resolved.reset();
 				return;
 			}
+			if (!PromptContentTypeSupported(result.content_type, supported_mime_types)) {
+				result.error = PROMPT_MEDIA_ERROR_UNSUPPORTED_MIME;
+				result.resolved.reset();
+				return;
+			}
 		}
 		vector_bytes += result.size;
 	} catch (const std::exception &exception) {
@@ -220,6 +244,7 @@ struct MaterializedPromptFileInput {
 
 static MaterializedPromptFileInput MaterializePromptFileInput(ClientContext &context, const Value &value,
                                                               const LogicalType &input_type, bool media_supported,
+                                                              const vector<string> &supported_mime_types,
                                                               uint64_t &vector_bytes) {
 	auto media_type = PromptMediaLogicalType();
 	if (value.IsNull()) {
@@ -227,7 +252,7 @@ static MaterializedPromptFileInput MaterializePromptFileInput(ClientContext &con
 	}
 	if (FileLogicalType::IsFile(input_type)) {
 		PreparedPromptMedia item;
-		PreparePromptMedia(context, value, media_supported, vector_bytes, item);
+		PreparePromptMedia(context, value, media_supported, supported_mime_types, vector_bytes, item);
 		auto materialized = item.Materialize();
 		return {std::move(materialized), !item.error.empty()};
 	}
@@ -240,7 +265,7 @@ static MaterializedPromptFileInput MaterializePromptFileInput(ClientContext &con
 	values.reserve(children.size());
 	for (auto &child : children) {
 		PreparedPromptMedia item;
-		PreparePromptMedia(context, child, media_supported, vector_bytes, item);
+		PreparePromptMedia(context, child, media_supported, supported_mime_types, vector_bytes, item);
 		values.push_back(item.Materialize());
 		if (!item.error.empty()) {
 			// Only the first error is observable by the row wrapper. Drop bytes
@@ -266,6 +291,24 @@ static bool PromptPackBooleanArgument(DataChunk &args, idx_t argument_index, idx
 	return BooleanValue::Get(value);
 }
 
+static vector<string> PromptPackMimeTypesArgument(DataChunk &args, idx_t row_index) {
+	auto value = args.data[PROMPT_PACK_SUPPORTED_MIME_TYPES_INDEX].GetValue(row_index);
+	if (value.IsNull()) {
+		throw InvalidInputException("ai_prompt supported MIME types cannot be NULL");
+	}
+	vector<string> result;
+	auto &children = ListValue::GetChildren(value);
+	result.reserve(children.size());
+	for (auto &child : children) {
+		string normalized;
+		if (child.IsNull() || !NormalizePromptContentType(StringValue::Get(child), normalized)) {
+			throw InvalidInputException("ai_prompt supported MIME types must contain valid MIME strings");
+		}
+		result.push_back(std::move(normalized));
+	}
+	return result;
+}
+
 static void PromptPackFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &expression = state.expr.Cast<BoundFunctionExpression>();
 	if (!expression.bind_info) {
@@ -284,6 +327,7 @@ static void PromptPackFunction(DataChunk &args, ExpressionState &state, Vector &
 	for (idx_t row_index = 0; row_index < args.size(); row_index++) {
 		auto media_supported =
 		    PromptPackBooleanArgument(args, PROMPT_PACK_MEDIA_SUPPORTED_INDEX, row_index, "media policy");
+		auto supported_mime_types = PromptPackMimeTypesArgument(args, row_index);
 		auto single_message =
 		    PromptPackBooleanArgument(args, PROMPT_PACK_SINGLE_MESSAGE_INDEX, row_index, "single-message policy");
 		auto first_value = args.data[PROMPT_PACK_MESSAGE_OFFSET].GetValue(row_index);
@@ -309,8 +353,8 @@ static void PromptPackFunction(DataChunk &args, ExpressionState &state, Vector &
 					fields.push_back(Value(return_children[field_index].second));
 					continue;
 				}
-				auto materialized =
-				    MaterializePromptFileInput(state.GetContext(), value, input_type, media_supported, vector_bytes);
+				auto materialized = MaterializePromptFileInput(state.GetContext(), value, input_type, media_supported,
+				                                               supported_mime_types, vector_bytes);
 				fields.push_back(std::move(materialized.value));
 				if (materialized.has_error) {
 					// A failed row never reaches the provider. Release successful
@@ -337,7 +381,7 @@ static unique_ptr<FunctionData> PromptPackBind(ClientContext &context, ScalarFun
 	if (arguments.size() < PROMPT_PACK_MESSAGE_OFFSET + 1) {
 		throw BinderException("ai_prompt pack requires at least one message");
 	}
-	for (idx_t policy_index = 0; policy_index < PROMPT_PACK_MESSAGE_OFFSET; policy_index++) {
+	for (auto policy_index : {PROMPT_PACK_MEDIA_SUPPORTED_INDEX, PROMPT_PACK_SINGLE_MESSAGE_INDEX}) {
 		auto &policy = *arguments[policy_index];
 		if (!policy.IsFoldable()) {
 			throw BinderException("ai_prompt pack policies must be constant BOOLEAN values");
@@ -348,6 +392,23 @@ static unique_ptr<FunctionData> PromptPackBind(ClientContext &context, ScalarFun
 		auto value = ExpressionExecutor::EvaluateScalar(context, policy);
 		if (value.IsNull() || value.type().id() != LogicalTypeId::BOOLEAN) {
 			throw BinderException("ai_prompt pack policies must be non-NULL BOOLEAN values");
+		}
+	}
+	auto &mime_policy = *arguments[PROMPT_PACK_SUPPORTED_MIME_TYPES_INDEX];
+	if (!mime_policy.IsFoldable()) {
+		throw BinderException("ai_prompt pack supported MIME types must be constant");
+	}
+	if (mime_policy.HasParameter()) {
+		throw ParameterNotResolvedException();
+	}
+	auto mime_types = ExpressionExecutor::EvaluateScalar(context, mime_policy);
+	if (mime_types.IsNull() || mime_types.type() != LogicalType::LIST(LogicalType::VARCHAR)) {
+		throw BinderException("ai_prompt pack supported MIME types must be a non-NULL VARCHAR[]");
+	}
+	for (auto &mime_type : ListValue::GetChildren(mime_types)) {
+		string normalized;
+		if (mime_type.IsNull() || !NormalizePromptContentType(StringValue::Get(mime_type), normalized)) {
+			throw BinderException("ai_prompt pack supported MIME types must contain valid MIME strings");
 		}
 	}
 	auto media_supported =
@@ -476,6 +537,26 @@ static vector<string> ParseInputNames(const py::object &input_names) {
 			throw BinderException("ai SQL helper returned non-string input_names");
 		}
 		result.push_back(py::cast<string>(name_obj));
+	}
+	return result;
+}
+
+static vector<string> ParsePromptMediaMimeTypes(const py::object &mime_types) {
+	if (!py::isinstance<py::list>(mime_types) && !py::isinstance<py::tuple>(mime_types)) {
+		throw BinderException("ai SQL helper returned invalid supported_media_mime_types");
+	}
+	vector<string> result;
+	auto values = py::list(mime_types);
+	result.reserve(values.size());
+	for (auto &value : values) {
+		if (!py::isinstance<py::str>(value)) {
+			throw BinderException("ai SQL helper returned a non-string supported media MIME type");
+		}
+		string normalized;
+		if (!NormalizePromptContentType(py::cast<string>(value), normalized)) {
+			throw BinderException("ai SQL helper returned an invalid supported media MIME type");
+		}
+		result.push_back(std::move(normalized));
 	}
 	return result;
 }
@@ -622,10 +703,18 @@ static unique_ptr<Expression> BindScalarFunction(ClientContext &context, const s
 }
 
 static unique_ptr<Expression> BindPromptPack(ClientContext &context, vector<unique_ptr<Expression>> messages,
-                                             bool media_supported, bool single_message) {
+                                             bool media_supported, const vector<string> &supported_mime_types,
+                                             bool single_message) {
 	vector<unique_ptr<Expression>> children;
 	children.reserve(PROMPT_PACK_MESSAGE_OFFSET + messages.size());
 	children.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(media_supported)));
+	vector<Value> mime_type_values;
+	mime_type_values.reserve(supported_mime_types.size());
+	for (auto &mime_type : supported_mime_types) {
+		mime_type_values.emplace_back(mime_type);
+	}
+	children.push_back(
+	    make_uniq<BoundConstantExpression>(Value::LIST(LogicalType::VARCHAR, std::move(mime_type_values))));
 	children.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(single_message)));
 	for (auto &message : messages) {
 		children.push_back(std::move(message));
@@ -715,6 +804,7 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 	LogicalType public_return_type;
 	unique_ptr<NativeVLLMSpec> native_vllm;
 	bool supports_prompt_media = true;
+	vector<string> supported_prompt_media_mime_types;
 	{
 		PythonGILWrapper acquire;
 		auto spec = BuildAISQLSpec(kind, context, arguments, options_index, prompt_input_kind);
@@ -744,6 +834,8 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 					throw BinderException("ai SQL helper returned invalid supports_media_inputs");
 				}
 				supports_prompt_media = py::cast<bool>(supports_media_obj);
+				supported_prompt_media_mime_types =
+				    ParsePromptMediaMimeTypes(DictGetOrNone(spec, "supported_media_mime_types"));
 			}
 			payload = BuildAISQLPayload(context, spec);
 		} else {
@@ -761,7 +853,8 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 		messages.reserve(2);
 		messages.push_back(std::move(arguments[0]));
 		messages.push_back(std::move(arguments[1]));
-		arguments[0] = BindPromptPack(context, std::move(messages), supports_prompt_media, true);
+		arguments[0] = BindPromptPack(context, std::move(messages), supports_prompt_media,
+		                              supported_prompt_media_mime_types, true);
 		bound_function.arguments[0] = arguments[0]->return_type;
 		Function::EraseArgument(bound_function, arguments, 1);
 		runtime_argument_count = 1;
@@ -922,8 +1015,8 @@ static unique_ptr<Expression> LowerAIPromptTextInput(FunctionBindExpressionInput
 
 ScalarFunctionSet AISQLFunction::GetPromptPackFunctions() {
 	ScalarFunctionSet set(HIDDEN_PROMPT_PACK_FUNCTION);
-	auto pack = ScalarFunction({LogicalType::BOOLEAN, LogicalType::BOOLEAN}, LogicalTypeId::STRUCT, PromptPackFunction,
-	                           PromptPackBind);
+	auto pack = ScalarFunction({LogicalType::BOOLEAN, LogicalType::LIST(LogicalType::VARCHAR), LogicalType::BOOLEAN},
+	                           LogicalTypeId::STRUCT, PromptPackFunction, PromptPackBind);
 	pack.varargs = LogicalType::ANY;
 	pack.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	pack.SetStability(FunctionStability::VOLATILE);

--- a/src/vane_py/ai_sql_functions.cpp
+++ b/src/vane_py/ai_sql_functions.cpp
@@ -3,8 +3,12 @@
 
 #include "vane_python/ai_sql_functions.hpp"
 
+#include "file_resolver.hpp"
+#include "file_value.hpp"
 #include "vane_python/python_conversion.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/execution/expression_executor.hpp"
@@ -34,6 +38,209 @@ enum class PromptInputKind : uint8_t { TEXT, BLOB, BLOB_LIST, FILE, FILE_LIST };
 
 static constexpr const char *HIDDEN_EMBED_FUNCTION = "__vane_ai_embed";
 static constexpr const char *HIDDEN_PROMPT_FUNCTION = "__vane_ai_prompt";
+static constexpr const char *HIDDEN_PROMPT_MEDIA_FUNCTION = "__vane_ai_prompt_media";
+
+// Prompt providers receive media inline. Keep both an individual FILE and the
+// materialized input vector bounded before allocating its bytes. The vector
+// limit matches the default UDF transport target; the per-FILE limit matches
+// the largest common inline request limit among the initial providers.
+static constexpr uint64_t MAX_PROMPT_FILE_BYTES = 20ULL * 1024ULL * 1024ULL;
+static constexpr uint64_t MAX_PROMPT_MEDIA_VECTOR_BYTES = 128ULL * 1024ULL * 1024ULL;
+
+static constexpr const char *PROMPT_MEDIA_ERROR_UNSUPPORTED = "unsupported";
+static constexpr const char *PROMPT_MEDIA_ERROR_READ = "read";
+static constexpr const char *PROMPT_MEDIA_ERROR_MIME = "mime";
+static constexpr const char *PROMPT_MEDIA_ERROR_INVALID_MIME = "invalid_mime";
+static constexpr const char *PROMPT_MEDIA_ERROR_EMPTY = "empty";
+static constexpr const char *PROMPT_MEDIA_ERROR_TOO_LARGE = "too_large";
+static constexpr const char *PROMPT_MEDIA_ERROR_VECTOR_TOO_LARGE = "vector_too_large";
+
+static LogicalType PromptMediaLogicalType() {
+	child_list_t<LogicalType> fields;
+	fields.emplace_back("content_type", LogicalType::VARCHAR);
+	fields.emplace_back("data", LogicalType::BLOB);
+	fields.emplace_back("error", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(fields));
+}
+
+static bool IsPromptMimeTokenCharacter(char value) {
+	return (value >= '0' && value <= '9') || (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z') ||
+	       value == '!' || value == '#' || value == '$' || value == '%' || value == '&' || value == '\'' ||
+	       value == '*' || value == '+' || value == '-' || value == '.' || value == '^' || value == '_' ||
+	       value == '`' || value == '|' || value == '~';
+}
+
+static bool NormalizePromptContentType(const string &value, string &result) {
+	auto separator = value.find(';');
+	result = value.substr(0, separator);
+	StringUtil::Trim(result);
+	result = StringUtil::Lower(result);
+	auto slash = result.find('/');
+	if (slash == string::npos || slash == 0 || slash + 1 == result.size() ||
+	    result.find('/', slash + 1) != string::npos) {
+		return false;
+	}
+	auto media_type = result.substr(0, slash);
+	auto media_subtype = result.substr(slash + 1);
+	if (media_type == "*" || media_subtype == "*") {
+		return false;
+	}
+	for (auto character : result) {
+		if (character != '/' && !IsPromptMimeTokenCharacter(character)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static bool MustPropagatePromptFileError(const ErrorData &error) {
+	switch (error.Type()) {
+	case ExceptionType::INTERRUPT:
+	case ExceptionType::OUT_OF_MEMORY:
+	case ExceptionType::FATAL:
+	case ExceptionType::INTERNAL:
+	case ExceptionType::NULL_POINTER:
+		return true;
+	default:
+		return false;
+	}
+}
+
+struct PreparedPromptMedia {
+	bool is_null = false;
+	bool has_content_type = false;
+	string content_type;
+	string error;
+	uint64_t size = 0;
+	unique_ptr<ResolvedFile> resolved;
+
+	Value Materialize() {
+		auto media_type = PromptMediaLogicalType();
+		if (is_null) {
+			return Value(media_type);
+		}
+
+		Value data(LogicalType::BLOB);
+		if (error.empty()) {
+			try {
+				string bytes(NumericCast<idx_t>(size), '\0');
+				resolved->ReadExact(reinterpret_cast<data_ptr_t>(bytes.data()), size);
+				data = Value::BLOB_RAW(bytes);
+			} catch (const std::exception &exception) {
+				ErrorData error_data(exception);
+				if (MustPropagatePromptFileError(error_data)) {
+					throw;
+				}
+				// FILE validation already ran before opening. Everything left at
+				// this boundary is an execution-time resolver/read failure, which
+				// must reach the Python row policy without exposing its details.
+				error = PROMPT_MEDIA_ERROR_READ;
+			}
+		}
+		resolved.reset();
+
+		vector<Value> fields;
+		fields.reserve(3);
+		fields.push_back(has_content_type ? Value(content_type) : Value(LogicalType::VARCHAR));
+		fields.push_back(std::move(data));
+		fields.push_back(error.empty() ? Value(LogicalType::VARCHAR) : Value(error));
+		return Value::STRUCT(media_type, std::move(fields));
+	}
+};
+
+static void PreparePromptMedia(ClientContext &context, const Value &value, bool media_supported, uint64_t &vector_bytes,
+                               PreparedPromptMedia &result) {
+	if (value.IsNull()) {
+		result.is_null = true;
+		return;
+	}
+
+	// Validate the canonical FILE contract even when the selected provider
+	// cannot consume media. This is pure and intentionally precedes all I/O.
+	auto file = FileReference::FromValue(value, "ai_prompt");
+	if (!media_supported) {
+		result.error = PROMPT_MEDIA_ERROR_UNSUPPORTED;
+		return;
+	}
+	if (file.has_content_type) {
+		result.has_content_type = NormalizePromptContentType(file.content_type, result.content_type);
+		if (!result.has_content_type) {
+			result.error = PROMPT_MEDIA_ERROR_INVALID_MIME;
+			return;
+		}
+	}
+
+	try {
+		result.resolved = ResolvedFile::Open(context, file);
+		result.size = result.resolved->LogicalSize();
+		if (result.size == 0) {
+			result.error = PROMPT_MEDIA_ERROR_EMPTY;
+			result.resolved.reset();
+			return;
+		}
+		if (result.size > MAX_PROMPT_FILE_BYTES) {
+			result.error = PROMPT_MEDIA_ERROR_TOO_LARGE;
+			result.resolved.reset();
+			return;
+		}
+		if (!file.has_content_type) {
+			result.has_content_type = result.resolved->GuessMimeType(result.content_type);
+			if (!result.has_content_type) {
+				result.error = PROMPT_MEDIA_ERROR_MIME;
+				result.resolved.reset();
+				return;
+			}
+		}
+		if (result.size > MAX_PROMPT_MEDIA_VECTOR_BYTES - vector_bytes) {
+			result.error = PROMPT_MEDIA_ERROR_VECTOR_TOO_LARGE;
+			result.resolved.reset();
+			return;
+		}
+		vector_bytes += result.size;
+	} catch (const std::exception &exception) {
+		ErrorData error(exception);
+		if (MustPropagatePromptFileError(error)) {
+			throw;
+		}
+		result.error = PROMPT_MEDIA_ERROR_READ;
+		result.resolved.reset();
+	}
+}
+
+template <bool IS_LIST>
+static void PromptMediaFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto media_type = PromptMediaLogicalType();
+	auto return_type = IS_LIST ? LogicalType::LIST(media_type) : media_type;
+	uint64_t vector_bytes = 0;
+	for (idx_t row_index = 0; row_index < args.size(); row_index++) {
+		auto value = args.data[0].GetValue(row_index);
+		if (value.IsNull()) {
+			result.SetValue(row_index, Value(return_type));
+			continue;
+		}
+		auto media_supported_value = args.data[1].GetValue(row_index);
+		if (media_supported_value.IsNull()) {
+			throw InvalidInputException("ai_prompt media policy cannot be NULL");
+		}
+		auto media_supported = BooleanValue::Get(media_supported_value);
+		if (IS_LIST) {
+			auto &children = ListValue::GetChildren(value);
+			vector<Value> values;
+			values.reserve(children.size());
+			for (auto &child : children) {
+				PreparedPromptMedia item;
+				PreparePromptMedia(state.GetContext(), child, media_supported, vector_bytes, item);
+				values.push_back(item.Materialize());
+			}
+			result.SetValue(row_index, Value::LIST(media_type, std::move(values)));
+		} else {
+			PreparedPromptMedia item;
+			PreparePromptMedia(state.GetContext(), value, media_supported, vector_bytes, item);
+			result.SetValue(row_index, item.Materialize());
+		}
+	}
+}
 
 static bool IsPromptFileList(const LogicalType &type) {
 	return type.id() == LogicalTypeId::LIST && FileLogicalType::IsFile(ListType::GetChildType(type));
@@ -261,6 +468,15 @@ static unique_ptr<Expression> BindScalarFunction(ClientContext &context, const s
 	return result;
 }
 
+static unique_ptr<Expression> BindPromptMedia(ClientContext &context, unique_ptr<Expression> file,
+                                              bool media_supported) {
+	vector<unique_ptr<Expression>> children;
+	children.reserve(2);
+	children.push_back(std::move(file));
+	children.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(media_supported)));
+	return BindScalarFunction(context, HIDDEN_PROMPT_MEDIA_FUNCTION, std::move(children));
+}
+
 static unique_ptr<Expression> CastPromptOutput(ClientContext &context, unique_ptr<Expression> result,
                                                const LogicalType &target_type) {
 	if (result->return_type == target_type) {
@@ -342,6 +558,7 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 	Value native_validation_payload;
 	LogicalType public_return_type;
 	unique_ptr<NativeVLLMSpec> native_vllm;
+	bool supports_prompt_media = true;
 	{
 		PythonGILWrapper acquire;
 		auto spec = BuildAISQLSpec(kind, context, arguments, options_index, prompt_input_kind);
@@ -365,10 +582,27 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 				    BuildAISQLPayload(context, py::reinterpret_borrow<py::dict>(validation_spec));
 			}
 		} else if (execution_kind == "expression_udf") {
+			if (prompt_input_kind == PromptInputKind::FILE || prompt_input_kind == PromptInputKind::FILE_LIST) {
+				auto supports_media_obj = DictGetOrNone(spec, "supports_media_inputs");
+				if (!py::isinstance<py::bool_>(supports_media_obj)) {
+					throw BinderException("ai SQL helper returned invalid supports_media_inputs");
+				}
+				supports_prompt_media = py::cast<bool>(supports_media_obj);
+			}
 			payload = BuildAISQLPayload(context, spec);
 		} else {
 			throw BinderException("ai SQL helper returned unknown execution_kind '%s'", execution_kind);
 		}
+	}
+	if (prompt_input_kind == PromptInputKind::FILE || prompt_input_kind == PromptInputKind::FILE_LIST) {
+		if (arguments[1]->return_type.id() == LogicalTypeId::SQLNULL) {
+			auto file_type = FileLogicalType::Create();
+			auto target_type =
+			    prompt_input_kind == PromptInputKind::FILE_LIST ? LogicalType::LIST(file_type) : file_type;
+			arguments[1] = BoundCastExpression::AddCastToType(context, std::move(arguments[1]), target_type);
+		}
+		arguments[1] = BindPromptMedia(context, std::move(arguments[1]), supports_prompt_media);
+		bound_function.arguments[1] = arguments[1]->return_type;
 	}
 
 	if (native_vllm) {
@@ -491,6 +725,9 @@ static unique_ptr<Expression> LowerAIPromptInput(FunctionBindExpressionInput &in
 	    !IsPromptFileList(input_type)) {
 		throw BinderException("Prompt messages must have type VARCHAR, BLOB, BLOB[], FILE, or FILE[]");
 	}
+	if (FileLogicalType::IsFile(input_type) || IsPromptFileList(input_type)) {
+		return BindPromptMedia(input.context, std::move(message), true);
+	}
 	return std::move(message);
 }
 
@@ -519,10 +756,30 @@ static unique_ptr<Expression> LowerAIPromptTextInput(FunctionBindExpressionInput
 		}
 		throw BinderException("Prompt messages for this provider must have type VARCHAR, FILE, or FILE[]");
 	}
+	if (FileLogicalType::IsFile(message->return_type) || IsPromptFileList(message->return_type)) {
+		return BindPromptMedia(input.context, std::move(message), false);
+	}
 	return std::move(message);
 }
 
 } // namespace
+
+ScalarFunctionSet AISQLFunction::GetPromptMediaFunctions() {
+	ScalarFunctionSet set(HIDDEN_PROMPT_MEDIA_FUNCTION);
+	auto file_type = FileLogicalType::Create();
+	auto media_type = PromptMediaLogicalType();
+	auto add_function = [&](LogicalType input_type, LogicalType return_type, scalar_function_t function) {
+		auto materialize =
+		    ScalarFunction({std::move(input_type), LogicalType::BOOLEAN}, std::move(return_type), std::move(function));
+		materialize.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+		materialize.SetStability(FunctionStability::VOLATILE);
+		materialize.SetFallible();
+		set.AddFunction(std::move(materialize));
+	};
+	add_function(file_type, media_type, PromptMediaFunction<false>);
+	add_function(LogicalType::LIST(file_type), LogicalType::LIST(media_type), PromptMediaFunction<true>);
+	return set;
+}
 
 ScalarFunctionSet AISQLFunction::GetPromptImplementationFunctions() {
 	ScalarFunctionSet set(HIDDEN_PROMPT_FUNCTION);

--- a/src/vane_py/ai_sql_functions.cpp
+++ b/src/vane_py/ai_sql_functions.cpp
@@ -14,6 +14,7 @@
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/function_binder.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/function/scalar_macro_function.hpp"
 #include "duckdb/function/scalar/vllm_functions.hpp"
 #include "duckdb/function/scalar/udf_functions.hpp"
@@ -38,7 +39,10 @@ enum class PromptInputKind : uint8_t { TEXT, BLOB, BLOB_LIST, FILE, FILE_LIST };
 
 static constexpr const char *HIDDEN_EMBED_FUNCTION = "__vane_ai_embed";
 static constexpr const char *HIDDEN_PROMPT_FUNCTION = "__vane_ai_prompt";
-static constexpr const char *HIDDEN_PROMPT_MEDIA_FUNCTION = "__vane_ai_prompt_media";
+static constexpr const char *HIDDEN_PROMPT_PACK_FUNCTION = "__vane_ai_prompt_pack";
+static constexpr idx_t PROMPT_PACK_MEDIA_SUPPORTED_INDEX = 0;
+static constexpr idx_t PROMPT_PACK_SINGLE_MESSAGE_INDEX = 1;
+static constexpr idx_t PROMPT_PACK_MESSAGE_OFFSET = 2;
 
 // Prompt providers receive media inline. Keep both an individual FILE and the
 // materialized input vector bounded before allocating its bytes. The vector
@@ -183,6 +187,11 @@ static void PreparePromptMedia(ClientContext &context, const Value &value, bool 
 			result.resolved.reset();
 			return;
 		}
+		if (result.size > MAX_PROMPT_MEDIA_VECTOR_BYTES - vector_bytes) {
+			result.error = PROMPT_MEDIA_ERROR_VECTOR_TOO_LARGE;
+			result.resolved.reset();
+			return;
+		}
 		if (!file.has_content_type) {
 			result.has_content_type = result.resolved->GuessMimeType(result.content_type);
 			if (!result.has_content_type) {
@@ -190,11 +199,6 @@ static void PreparePromptMedia(ClientContext &context, const Value &value, bool 
 				result.resolved.reset();
 				return;
 			}
-		}
-		if (result.size > MAX_PROMPT_MEDIA_VECTOR_BYTES - vector_bytes) {
-			result.error = PROMPT_MEDIA_ERROR_VECTOR_TOO_LARGE;
-			result.resolved.reset();
-			return;
 		}
 		vector_bytes += result.size;
 	} catch (const std::exception &exception) {
@@ -207,39 +211,188 @@ static void PreparePromptMedia(ClientContext &context, const Value &value, bool 
 	}
 }
 
-template <bool IS_LIST>
-static void PromptMediaFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-	result.SetVectorType(VectorType::FLAT_VECTOR);
+static bool IsPromptFileList(const LogicalType &type);
+
+struct MaterializedPromptFileInput {
+	Value value;
+	bool has_error;
+};
+
+static MaterializedPromptFileInput MaterializePromptFileInput(ClientContext &context, const Value &value,
+                                                              const LogicalType &input_type, bool media_supported,
+                                                              uint64_t &vector_bytes) {
 	auto media_type = PromptMediaLogicalType();
-	auto return_type = IS_LIST ? LogicalType::LIST(media_type) : media_type;
-	uint64_t vector_bytes = 0;
-	for (idx_t row_index = 0; row_index < args.size(); row_index++) {
-		auto value = args.data[0].GetValue(row_index);
-		if (value.IsNull()) {
-			result.SetValue(row_index, Value(return_type));
-			continue;
-		}
-		auto media_supported_value = args.data[1].GetValue(row_index);
-		if (media_supported_value.IsNull()) {
-			throw InvalidInputException("ai_prompt media policy cannot be NULL");
-		}
-		auto media_supported = BooleanValue::Get(media_supported_value);
-		if (IS_LIST) {
-			auto &children = ListValue::GetChildren(value);
-			vector<Value> values;
-			values.reserve(children.size());
-			for (auto &child : children) {
-				PreparedPromptMedia item;
-				PreparePromptMedia(state.GetContext(), child, media_supported, vector_bytes, item);
-				values.push_back(item.Materialize());
+	if (value.IsNull()) {
+		return {Value(FileLogicalType::IsFile(input_type) ? media_type : LogicalType::LIST(media_type)), false};
+	}
+	if (FileLogicalType::IsFile(input_type)) {
+		PreparedPromptMedia item;
+		PreparePromptMedia(context, value, media_supported, vector_bytes, item);
+		auto materialized = item.Materialize();
+		return {std::move(materialized), !item.error.empty()};
+	}
+	if (!IsPromptFileList(input_type)) {
+		throw InternalException("ai_prompt pack received an unexpected input type");
+	}
+
+	auto &children = ListValue::GetChildren(value);
+	vector<Value> values;
+	values.reserve(children.size());
+	for (auto &child : children) {
+		PreparedPromptMedia item;
+		PreparePromptMedia(context, child, media_supported, vector_bytes, item);
+		values.push_back(item.Materialize());
+		if (!item.error.empty()) {
+			// Only the first error is observable by the row wrapper. Drop bytes
+			// already read for this list and do not open its remaining FILEs.
+			for (idx_t index = 0; index + 1 < values.size(); index++) {
+				values[index] = Value(media_type);
 			}
-			result.SetValue(row_index, Value::LIST(media_type, std::move(values)));
-		} else {
-			PreparedPromptMedia item;
-			PreparePromptMedia(state.GetContext(), value, media_supported, vector_bytes, item);
-			result.SetValue(row_index, item.Materialize());
+			while (values.size() < children.size()) {
+				values.push_back(Value(media_type));
+			}
+			return {Value::LIST(media_type, std::move(values)), true};
 		}
 	}
+	return {Value::LIST(media_type, std::move(values)), false};
+}
+
+static bool PromptPackBooleanArgument(DataChunk &args, idx_t argument_index, idx_t row_index,
+                                      const char *argument_name) {
+	auto value = args.data[argument_index].GetValue(row_index);
+	if (value.IsNull()) {
+		throw InvalidInputException("ai_prompt %s cannot be NULL", argument_name);
+	}
+	return BooleanValue::Get(value);
+}
+
+static void PromptPackFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &expression = state.expr.Cast<BoundFunctionExpression>();
+	if (!expression.bind_info) {
+		throw InternalException("ai_prompt pack is missing bind data");
+	}
+	auto &bind_data = expression.bind_info->Cast<VariableReturnBindData>();
+	auto &return_children = StructType::GetChildTypes(bind_data.stype);
+	if (args.ColumnCount() < PROMPT_PACK_MESSAGE_OFFSET + 1 ||
+	    return_children.size() != args.ColumnCount() - PROMPT_PACK_MESSAGE_OFFSET) {
+		throw InternalException("ai_prompt pack received an invalid argument envelope");
+	}
+	auto input_types = args.GetTypes();
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	uint64_t vector_bytes = 0;
+	for (idx_t row_index = 0; row_index < args.size(); row_index++) {
+		auto media_supported =
+		    PromptPackBooleanArgument(args, PROMPT_PACK_MEDIA_SUPPORTED_INDEX, row_index, "media policy");
+		auto single_message =
+		    PromptPackBooleanArgument(args, PROMPT_PACK_SINGLE_MESSAGE_INDEX, row_index, "single-message policy");
+		auto first_value = args.data[PROMPT_PACK_MESSAGE_OFFSET].GetValue(row_index);
+		if (single_message && first_value.IsNull()) {
+			// SQL FILE overloads treat the text prompt as the primary input. A
+			// row-varying NULL must short-circuit before any sibling FILE opens.
+			result.SetValue(row_index, Value(bind_data.stype));
+			continue;
+		}
+
+		auto row_start_bytes = vector_bytes;
+		vector<Value> fields;
+		fields.reserve(return_children.size());
+		vector<idx_t> successful_file_fields;
+		bool row_has_media_error = false;
+		for (idx_t argument_index = PROMPT_PACK_MESSAGE_OFFSET; argument_index < args.ColumnCount(); argument_index++) {
+			auto value = argument_index == PROMPT_PACK_MESSAGE_OFFSET ? std::move(first_value)
+			                                                          : args.data[argument_index].GetValue(row_index);
+			auto &input_type = input_types[argument_index];
+			if (FileLogicalType::IsFile(input_type) || IsPromptFileList(input_type)) {
+				auto field_index = fields.size();
+				if (row_has_media_error) {
+					fields.push_back(Value(return_children[field_index].second));
+					continue;
+				}
+				auto materialized =
+				    MaterializePromptFileInput(state.GetContext(), value, input_type, media_supported, vector_bytes);
+				fields.push_back(std::move(materialized.value));
+				if (materialized.has_error) {
+					// A failed row never reaches the provider. Release successful
+					// FILE payloads from this row and restore their vector budget so
+					// later rows are not rejected because of discarded bytes.
+					for (auto successful_index : successful_file_fields) {
+						fields[successful_index] = Value(return_children[successful_index].second);
+					}
+					vector_bytes = row_start_bytes;
+					row_has_media_error = true;
+				} else {
+					successful_file_fields.push_back(field_index);
+				}
+			} else {
+				fields.push_back(std::move(value));
+			}
+		}
+		result.SetValue(row_index, Value::STRUCT(bind_data.stype, std::move(fields)));
+	}
+}
+
+static unique_ptr<FunctionData> PromptPackBind(ClientContext &context, ScalarFunction &bound_function,
+                                               vector<unique_ptr<Expression>> &arguments) {
+	if (arguments.size() < PROMPT_PACK_MESSAGE_OFFSET + 1) {
+		throw BinderException("ai_prompt pack requires at least one message");
+	}
+	for (idx_t policy_index = 0; policy_index < PROMPT_PACK_MESSAGE_OFFSET; policy_index++) {
+		auto &policy = *arguments[policy_index];
+		if (!policy.IsFoldable()) {
+			throw BinderException("ai_prompt pack policies must be constant BOOLEAN values");
+		}
+		if (policy.HasParameter()) {
+			throw ParameterNotResolvedException();
+		}
+		auto value = ExpressionExecutor::EvaluateScalar(context, policy);
+		if (value.IsNull() || value.type().id() != LogicalTypeId::BOOLEAN) {
+			throw BinderException("ai_prompt pack policies must be non-NULL BOOLEAN values");
+		}
+	}
+	auto media_supported =
+	    BooleanValue::Get(ExpressionExecutor::EvaluateScalar(context, *arguments[PROMPT_PACK_MEDIA_SUPPORTED_INDEX]));
+
+	child_list_t<LogicalType> fields;
+	fields.reserve(arguments.size() - PROMPT_PACK_MESSAGE_OFFSET);
+	for (idx_t argument_index = PROMPT_PACK_MESSAGE_OFFSET; argument_index < arguments.size(); argument_index++) {
+		auto &argument = arguments[argument_index];
+		auto input_type = argument->return_type;
+		if (input_type.id() == LogicalTypeId::UNKNOWN) {
+			throw ParameterNotResolvedException();
+		}
+		if (input_type.id() == LogicalTypeId::SQLNULL) {
+			argument = BoundCastExpression::AddCastToType(context, std::move(argument), LogicalType::VARCHAR);
+			input_type = LogicalType::VARCHAR;
+		}
+
+		LogicalType output_type;
+		if (input_type == LogicalType::VARCHAR) {
+			output_type = LogicalType::VARCHAR;
+		} else if (input_type == LogicalType::BLOB) {
+			if (!media_supported) {
+				throw BinderException("Prompt messages for this provider must have type VARCHAR, FILE, or FILE[]");
+			}
+			output_type = LogicalType::BLOB;
+		} else if (input_type == LogicalType::LIST(LogicalType::BLOB)) {
+			if (!media_supported) {
+				throw BinderException("Prompt messages for this provider must have type VARCHAR, FILE, or FILE[]");
+			}
+			output_type = input_type;
+		} else if (FileLogicalType::IsFile(input_type)) {
+			output_type = PromptMediaLogicalType();
+		} else if (IsPromptFileList(input_type)) {
+			output_type = LogicalType::LIST(PromptMediaLogicalType());
+		} else {
+			throw BinderException("Prompt messages must have type VARCHAR, BLOB, BLOB[], FILE, or FILE[]");
+		}
+		fields.emplace_back(StringUtil::Format("message_%d", argument_index - PROMPT_PACK_MESSAGE_OFFSET),
+		                    std::move(output_type));
+	}
+
+	auto return_type = LogicalType::STRUCT(std::move(fields));
+	bound_function.SetReturnType(return_type);
+	return make_uniq<VariableReturnBindData>(std::move(return_type));
 }
 
 static bool IsPromptFileList(const LogicalType &type) {
@@ -468,13 +621,16 @@ static unique_ptr<Expression> BindScalarFunction(ClientContext &context, const s
 	return result;
 }
 
-static unique_ptr<Expression> BindPromptMedia(ClientContext &context, unique_ptr<Expression> file,
-                                              bool media_supported) {
+static unique_ptr<Expression> BindPromptPack(ClientContext &context, vector<unique_ptr<Expression>> messages,
+                                             bool media_supported, bool single_message) {
 	vector<unique_ptr<Expression>> children;
-	children.reserve(2);
-	children.push_back(std::move(file));
+	children.reserve(PROMPT_PACK_MESSAGE_OFFSET + messages.size());
 	children.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(media_supported)));
-	return BindScalarFunction(context, HIDDEN_PROMPT_MEDIA_FUNCTION, std::move(children));
+	children.push_back(make_uniq<BoundConstantExpression>(Value::BOOLEAN(single_message)));
+	for (auto &message : messages) {
+		children.push_back(std::move(message));
+	}
+	return BindScalarFunction(context, HIDDEN_PROMPT_PACK_FUNCTION, std::move(children));
 }
 
 static unique_ptr<Expression> CastPromptOutput(ClientContext &context, unique_ptr<Expression> result,
@@ -601,8 +757,14 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 			    prompt_input_kind == PromptInputKind::FILE_LIST ? LogicalType::LIST(file_type) : file_type;
 			arguments[1] = BoundCastExpression::AddCastToType(context, std::move(arguments[1]), target_type);
 		}
-		arguments[1] = BindPromptMedia(context, std::move(arguments[1]), supports_prompt_media);
-		bound_function.arguments[1] = arguments[1]->return_type;
+		vector<unique_ptr<Expression>> messages;
+		messages.reserve(2);
+		messages.push_back(std::move(arguments[0]));
+		messages.push_back(std::move(arguments[1]));
+		arguments[0] = BindPromptPack(context, std::move(messages), supports_prompt_media, true);
+		bound_function.arguments[0] = arguments[0]->return_type;
+		Function::EraseArgument(bound_function, arguments, 1);
+		runtime_argument_count = 1;
 	}
 
 	if (native_vllm) {
@@ -626,8 +788,8 @@ static unique_ptr<FunctionData> AISQLBind(ClientContext &context, ScalarFunction
 			Function::EraseArgument(bound_function, arguments, index);
 		}
 	} else {
-		// Prompt call-level constants are consumed by the binder. Only the
-		// prompt and optional media expression become row inputs.
+		// Prompt call-level constants are consumed by the binder. FILE inputs
+		// are one packed runtime value; eager BLOB inputs remain two columns.
 		for (idx_t index = arguments.size(); index-- > runtime_argument_count;) {
 			Function::EraseArgument(bound_function, arguments, index);
 		}
@@ -725,9 +887,6 @@ static unique_ptr<Expression> LowerAIPromptInput(FunctionBindExpressionInput &in
 	    !IsPromptFileList(input_type)) {
 		throw BinderException("Prompt messages must have type VARCHAR, BLOB, BLOB[], FILE, or FILE[]");
 	}
-	if (FileLogicalType::IsFile(input_type) || IsPromptFileList(input_type)) {
-		return BindPromptMedia(input.context, std::move(message), true);
-	}
 	return std::move(message);
 }
 
@@ -756,28 +915,22 @@ static unique_ptr<Expression> LowerAIPromptTextInput(FunctionBindExpressionInput
 		}
 		throw BinderException("Prompt messages for this provider must have type VARCHAR, FILE, or FILE[]");
 	}
-	if (FileLogicalType::IsFile(message->return_type) || IsPromptFileList(message->return_type)) {
-		return BindPromptMedia(input.context, std::move(message), false);
-	}
 	return std::move(message);
 }
 
 } // namespace
 
-ScalarFunctionSet AISQLFunction::GetPromptMediaFunctions() {
-	ScalarFunctionSet set(HIDDEN_PROMPT_MEDIA_FUNCTION);
-	auto file_type = FileLogicalType::Create();
-	auto media_type = PromptMediaLogicalType();
-	auto add_function = [&](LogicalType input_type, LogicalType return_type, scalar_function_t function) {
-		auto materialize =
-		    ScalarFunction({std::move(input_type), LogicalType::BOOLEAN}, std::move(return_type), std::move(function));
-		materialize.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
-		materialize.SetStability(FunctionStability::VOLATILE);
-		materialize.SetFallible();
-		set.AddFunction(std::move(materialize));
-	};
-	add_function(file_type, media_type, PromptMediaFunction<false>);
-	add_function(LogicalType::LIST(file_type), LogicalType::LIST(media_type), PromptMediaFunction<true>);
+ScalarFunctionSet AISQLFunction::GetPromptPackFunctions() {
+	ScalarFunctionSet set(HIDDEN_PROMPT_PACK_FUNCTION);
+	auto pack = ScalarFunction({LogicalType::BOOLEAN, LogicalType::BOOLEAN}, LogicalTypeId::STRUCT, PromptPackFunction,
+	                           PromptPackBind);
+	pack.varargs = LogicalType::ANY;
+	pack.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	pack.SetStability(FunctionStability::VOLATILE);
+	pack.SetFallible();
+	pack.SetSerializeCallback(VariableReturnBindData::Serialize);
+	pack.SetDeserializeCallback(VariableReturnBindData::Deserialize);
+	set.AddFunction(std::move(pack));
 	return set;
 }
 

--- a/src/vane_py/include/vane_python/ai_sql_functions.hpp
+++ b/src/vane_py/include/vane_python/ai_sql_functions.hpp
@@ -10,6 +10,7 @@ namespace duckdb {
 struct CreateMacroInfo;
 
 struct AISQLFunction {
+	static ScalarFunctionSet GetPromptMediaFunctions();
 	static ScalarFunctionSet GetPromptImplementationFunctions();
 	static unique_ptr<CreateMacroInfo> GetPromptMacro();
 	static ScalarFunctionSet GetEmbedImplementationFunctions();

--- a/src/vane_py/include/vane_python/ai_sql_functions.hpp
+++ b/src/vane_py/include/vane_python/ai_sql_functions.hpp
@@ -10,7 +10,7 @@ namespace duckdb {
 struct CreateMacroInfo;
 
 struct AISQLFunction {
-	static ScalarFunctionSet GetPromptMediaFunctions();
+	static ScalarFunctionSet GetPromptPackFunctions();
 	static ScalarFunctionSet GetPromptImplementationFunctions();
 	static unique_ptr<CreateMacroInfo> GetPromptMacro();
 	static ScalarFunctionSet GetEmbedImplementationFunctions();

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -3148,10 +3148,10 @@ void InstantiateNewInstance(DuckDB &db) {
 	vllm_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 	system_catalog.CreateFunction(transaction, vllm_info);
 
-	auto ai_prompt_media_set = AISQLFunction::GetPromptMediaFunctions();
-	CreateScalarFunctionInfo ai_prompt_media_info(std::move(ai_prompt_media_set));
-	ai_prompt_media_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
-	system_catalog.CreateFunction(transaction, ai_prompt_media_info);
+	auto ai_prompt_pack_set = AISQLFunction::GetPromptPackFunctions();
+	CreateScalarFunctionInfo ai_prompt_pack_info(std::move(ai_prompt_pack_set));
+	ai_prompt_pack_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+	system_catalog.CreateFunction(transaction, ai_prompt_pack_info);
 
 	auto ai_prompt_implementation_set = AISQLFunction::GetPromptImplementationFunctions();
 	CreateScalarFunctionInfo ai_prompt_implementation_info(std::move(ai_prompt_implementation_set));

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -3148,6 +3148,11 @@ void InstantiateNewInstance(DuckDB &db) {
 	vllm_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 	system_catalog.CreateFunction(transaction, vllm_info);
 
+	auto ai_prompt_media_set = AISQLFunction::GetPromptMediaFunctions();
+	CreateScalarFunctionInfo ai_prompt_media_info(std::move(ai_prompt_media_set));
+	ai_prompt_media_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+	system_catalog.CreateFunction(transaction, ai_prompt_media_info);
+
 	auto ai_prompt_implementation_set = AISQLFunction::GetPromptImplementationFunctions();
 	CreateScalarFunctionInfo ai_prompt_implementation_info(std::move(ai_prompt_implementation_set));
 	ai_prompt_implementation_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -124,6 +124,11 @@ class MockPrompterDescriptor(PrompterDescriptor):
     def supports_image_inputs(self) -> bool:
         return self.model_name != "text-only"
 
+    def supported_media_mime_types(self) -> frozenset[str] | None:
+        if self.model_name == "image-only":
+            return frozenset({"image/png"})
+        return None
+
     def instantiate(self) -> MockPrompter:
         return MockPrompter(self.return_format)
 
@@ -1556,9 +1561,9 @@ def test_ai_prompt_expression_sniffs_missing_file_mime_type(tmp_path):
     path_sql = str(path).replace("'", "''")
     relation = vane.connect().sql(f"SELECT file('{path_sql}', NULL, NULL, NULL, NULL) AS media")
 
-    response = relation.select(vane.ai.prompt(vane.col("media"), provider=MockProvider()).alias("response")).fetchone()[
-        0
-    ]
+    response = relation.select(
+        vane.ai.prompt(vane.col("media"), provider=MockProvider(), model="image-only").alias("response")
+    ).fetchone()[0]
 
     assert response == f"topic:image/png={payload.hex()}"
 
@@ -1606,6 +1611,29 @@ def test_ai_prompt_file_capability_failure_obeys_on_error_before_io():
     )
     with pytest.raises(Exception, match="does not support Prompt media inputs"):
         raised.project("response").fetchall()
+
+
+def test_ai_prompt_expression_rejects_unsupported_file_mime_before_io():
+    relation = vane.connect().sql("""
+        SELECT file('/definitely/missing/file-ai-prompt-audio.bin', 'audio/wav', NULL, NULL, NULL) AS media
+    """)
+
+    ignored = vane.ai.prompt(
+        vane.col("media"),
+        provider=MockProvider(),
+        model="image-only",
+        on_error="ignore",
+    )
+    assert relation.select(ignored).fetchall() == [(None,)]
+
+    raised = vane.ai.prompt(
+        vane.col("media"),
+        provider=MockProvider(),
+        model="image-only",
+        on_error="raise",
+    )
+    with pytest.raises(Exception, match="Prompt FILE MIME type.*not supported"):
+        relation.select(raised).fetchall()
 
 
 def test_prompt_file_read_errors_do_not_expose_locator_values(tmp_path):

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -1587,14 +1587,15 @@ def test_ai_prompt_file_capability_failure_obeys_on_error_before_io():
 
 
 def test_prompt_file_read_errors_do_not_expose_locator_values(tmp_path):
-    from vane.ai.functions import _PromptBatch
-
     secret = "SIGNED_QUERY_SECRET_SENTINEL"
-    value = vane.File(str(tmp_path / f"missing.bin?token={secret}"), "image/png")
-    wrapper = _PromptBatch(MockPrompterDescriptor(), ["message_0"], "response", max_retries=0)
+    path_sql = str(tmp_path / f"missing.bin?token={secret}").replace("'", "''")
+    relation = vane.connect().sql(f"""
+        SELECT file('{path_sql}', 'image/png', NULL, NULL, NULL) AS media
+    """)
+    prompted = vane.ai.prompt(relation, vane.col("media"), provider=MockProvider())
 
-    with pytest.raises(RuntimeError, match="Prompt FILE read") as exc_info:
-        wrapper._read_file_media(value)
+    with pytest.raises(Exception, match="Prompt FILE read") as exc_info:
+        prompted.project("response").fetchall()
 
     assert secret not in str(exc_info.value)
     assert secret not in repr(exc_info.value)

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -1527,6 +1527,28 @@ def test_ai_prompt_expression_reads_strict_file_views_and_preserves_order(tmp_pa
     )
 
 
+def test_ai_prompt_expression_packs_multiple_file_columns_once(tmp_path):
+    first = tmp_path / "first-column.bin"
+    second = tmp_path / "second-column.bin"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    first_sql = str(first).replace("'", "''")
+    second_sql = str(second).replace("'", "''")
+    relation = vane.connect().sql(f"""
+        SELECT
+            'describe'::VARCHAR AS prompt,
+            file('{first_sql}', 'image/png', NULL, NULL, NULL) AS first,
+            file('{second_sql}', 'audio/wav', NULL, NULL, NULL) AS second
+    """)
+
+    expression = vane.ai.prompt(
+        [vane.col("prompt"), vane.col("first"), vane.col("second")],
+        provider=MockProvider(),
+    ).alias("response")
+
+    assert relation.select(expression).fetchone() == ("topic:describe:image/png=6669727374:audio/wav=7365636f6e64",)
+
+
 def test_ai_prompt_expression_sniffs_missing_file_mime_type(tmp_path):
     path = tmp_path / "payload.bin"
     payload = b"\x89PNG\r\n\x1a\nimage"

--- a/tests/ai/test_expression_ai_functions.py
+++ b/tests/ai/test_expression_ai_functions.py
@@ -7,6 +7,7 @@ import asyncio
 import inspect
 import json
 import math
+import traceback
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Literal, get_overloads, get_type_hints
@@ -18,6 +19,7 @@ from typing_extensions import Unpack
 
 import vane
 from vane.ai import provider as provider_registry
+from vane.ai._media import PromptMedia
 from vane.ai.options import EmbedOptions, PromptOptions
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
@@ -73,7 +75,15 @@ class MockPrompter:
         return [f"topic:{item}" for item in text]
 
     async def prompt(self, messages: tuple[object, ...]) -> str:
-        result = f"topic:{messages[0]}"
+        parts = [
+            f"{message.content_type}={bytes(message).hex()}"
+            if isinstance(message, PromptMedia)
+            else bytes(message).hex()
+            if isinstance(message, bytes)
+            else str(message)
+            for message in messages
+        ]
+        result = "topic:" + ":".join(parts)
         if self._return_format is not None:
             return json.dumps({"answer": result})
         return result
@@ -85,12 +95,13 @@ class MockPrompterDescriptor(PrompterDescriptor):
     max_concurrency_per_actor: int | None = None
     num_gpus: float | None = 0
     return_format: dict[str, Any] | None = None
+    model_name: str = "mock-prompt"
 
     def get_provider(self) -> str:
         return "mock"
 
     def get_model(self) -> str:
-        return "mock-prompt"
+        return self.model_name
 
     def get_options(self) -> dict[str, object]:
         return {
@@ -109,6 +120,9 @@ class MockPrompterDescriptor(PrompterDescriptor):
             batch_size=1,
             max_concurrency_per_actor=self.max_concurrency_per_actor,
         )
+
+    def supports_image_inputs(self) -> bool:
+        return self.model_name != "text-only"
 
     def instantiate(self) -> MockPrompter:
         return MockPrompter(self.return_format)
@@ -137,7 +151,7 @@ class MockProvider(Provider):
         *,
         options: dict[str, object] | None = None,
     ) -> PrompterDescriptor:
-        return MockPrompterDescriptor(return_format=return_format)
+        return MockPrompterDescriptor(return_format=return_format, model_name=model or "mock-prompt")
 
 
 def test_prompt_and_embed_ignore_descriptor_execution_defaults():
@@ -1238,7 +1252,7 @@ def test_openai_known_text_only_models_reject_images_during_planning(model, opti
 
     if entry_point == "sql":
         with pytest.raises(ValueError, match="does not support Prompt image inputs"):
-            build_ai_prompt_sql_spec(model=model, image_input=True, options=options)
+            build_ai_prompt_sql_spec(model=model, input_kind="blob", options=options)
         return
 
     relation = vane.connect().sql("select 'question'::VARCHAR as question, '\\x89504e470d0a1a0a'::BLOB as image")
@@ -1447,7 +1461,7 @@ def test_ai_prompt_rejects_invalid_message_lists(messages):
 
 def test_ai_prompt_relation_rejects_unsupported_expression_type():
     relation = vane.connect().sql("select 1::INTEGER as value")
-    with pytest.raises(TypeError, match="VARCHAR, BLOB, or BLOB"):
+    with pytest.raises(TypeError, match=r"VARCHAR, BLOB, BLOB\[\], FILE"):
         vane.ai.prompt(relation, vane.col("value"), provider=MockProvider())
 
 
@@ -1456,7 +1470,7 @@ def test_ai_prompt_expression_rejects_unsupported_type_during_planning(on_error)
     relation = vane.connect().sql("select 1::INTEGER as value")
     expression = vane.ai.prompt(vane.col("value"), provider=MockProvider(), on_error=on_error)
 
-    with pytest.raises(Exception, match="VARCHAR, BLOB, or BLOB"):
+    with pytest.raises(Exception, match=r"VARCHAR, BLOB, BLOB\[\], FILE"):
         relation.select(expression).types
 
 
@@ -1468,9 +1482,127 @@ def test_ai_prompt_expression_accepts_supported_types_during_planning():
             [from_hex('ffd8ff')]::BLOB[] as images
     """)
 
+    file_relation = vane.connect().sql("""
+        select
+            file('memory://one', 'image/png', NULL, NULL, NULL) as file,
+            [file('memory://two', 'image/png', NULL, NULL, NULL)]::FILE[] as files
+    """)
+
     for column in ("text", "image", "images"):
         expression = vane.ai.prompt(vane.col(column), provider=MockProvider())
         assert [str(value) for value in relation.select(expression).types] == ["VARCHAR"]
+    for column in ("file", "files"):
+        expression = vane.ai.prompt(vane.col(column), provider=MockProvider())
+        assert [str(value) for value in file_relation.select(expression).types] == ["VARCHAR"]
+
+
+def test_ai_prompt_expression_reads_strict_file_views_and_preserves_order(tmp_path):
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    third = tmp_path / "third.bin"
+    first.write_bytes(b"prefix-first-suffix")
+    second.write_bytes(b"prefix-second-suffix")
+    third.write_bytes(b"prefix-video-suffix")
+    first_sql = str(first).replace("'", "''")
+    second_sql = str(second).replace("'", "''")
+    third_sql = str(third).replace("'", "''")
+    relation = vane.connect().sql(f"""
+        SELECT
+            'describe'::VARCHAR AS prompt,
+            [
+                file('{first_sql}', 'IMAGE/PNG; source=declared', 7, 5, NULL),
+                NULL::FILE,
+                file('{second_sql}', 'audio/wav', 7, 6, NULL),
+                file('{third_sql}', 'video/mp4', 7, 5, NULL)
+            ]::FILE[] AS files
+    """)
+
+    expression = vane.ai.prompt(
+        [vane.col("prompt"), vane.col("files")],
+        provider=MockProvider(),
+    ).alias("response")
+
+    assert relation.select(expression).fetchone() == (
+        "topic:describe:image/png=6669727374:audio/wav=7365636f6e64:video/mp4=766964656f",
+    )
+
+
+def test_ai_prompt_expression_sniffs_missing_file_mime_type(tmp_path):
+    path = tmp_path / "payload.bin"
+    payload = b"\x89PNG\r\n\x1a\nimage"
+    path.write_bytes(payload)
+    path_sql = str(path).replace("'", "''")
+    relation = vane.connect().sql(f"SELECT file('{path_sql}', NULL, NULL, NULL, NULL) AS media")
+
+    response = relation.select(vane.ai.prompt(vane.col("media"), provider=MockProvider()).alias("response")).fetchone()[
+        0
+    ]
+
+    assert response == f"topic:image/png={payload.hex()}"
+
+
+def test_ai_prompt_expression_ignores_null_and_empty_file_lists():
+    relation = vane.connect().sql("""
+        SELECT
+            'describe'::VARCHAR AS prompt,
+            NULL::FILE[] AS null_files,
+            []::FILE[] AS empty_files
+    """)
+
+    for column in ("null_files", "empty_files"):
+        response = relation.select(
+            vane.ai.prompt(
+                [vane.col("prompt"), vane.col(column)],
+                provider=MockProvider(),
+            ).alias("response")
+        ).fetchone()[0]
+        assert response == "topic:describe"
+
+
+def test_ai_prompt_file_capability_failure_obeys_on_error_before_io():
+    relation = vane.connect().sql("""
+        SELECT
+            'describe'::VARCHAR AS prompt,
+            file('/definitely/missing/file-ai-prompt.bin', 'image/png', NULL, NULL, NULL) AS media
+    """)
+
+    ignored = vane.ai.prompt(
+        relation,
+        [vane.col("prompt"), vane.col("media")],
+        provider=MockProvider(),
+        model="text-only",
+        on_error="ignore",
+    )
+    assert ignored.project("response").fetchall() == [(None,)]
+
+    raised = vane.ai.prompt(
+        relation,
+        [vane.col("prompt"), vane.col("media")],
+        provider=MockProvider(),
+        model="text-only",
+        on_error="raise",
+    )
+    with pytest.raises(Exception, match="does not support Prompt media inputs"):
+        raised.project("response").fetchall()
+
+
+def test_prompt_file_read_errors_do_not_expose_locator_values(tmp_path):
+    from vane.ai.functions import _PromptBatch
+
+    secret = "SIGNED_QUERY_SECRET_SENTINEL"
+    value = vane.File(str(tmp_path / f"missing.bin?token={secret}"), "image/png")
+    wrapper = _PromptBatch(MockPrompterDescriptor(), ["message_0"], "response", max_retries=0)
+
+    with pytest.raises(RuntimeError, match="Prompt FILE read") as exc_info:
+        wrapper._read_file_media(value)
+
+    assert secret not in str(exc_info.value)
+    assert secret not in repr(exc_info.value)
+    assert secret not in "".join(
+        traceback.format_exception(type(exc_info.value), exc_info.value, exc_info.value.__traceback__)
+    )
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__context__ is None
 
 
 @pytest.mark.parametrize(
@@ -1733,7 +1865,7 @@ def test_sglang_prompt_accepts_resource_and_sampling_boundaries():
 
 def test_ai_prompt_vllm_rejects_images_and_execution_backend():
     relation = vane.connect().sql("select 'question'::VARCHAR as question, '\\x89504e470d0a1a0a'::BLOB as image")
-    with pytest.raises(ValueError, match="does not support Prompt image"):
+    with pytest.raises(ValueError, match="does not support Prompt media"):
         vane.ai.prompt(
             relation,
             [vane.col("question"), vane.col("image")],
@@ -1748,12 +1880,19 @@ def test_ai_prompt_vllm_rejects_images_and_execution_backend():
         )
 
 
-@pytest.mark.parametrize("image_type", ["BLOB", "BLOB[]"])
-def test_ai_prompt_expression_vllm_rejects_mixed_image_input_during_planning(image_type):
-    image = "'\\x89504e470d0a1a0a'::BLOB" if image_type == "BLOB" else "['\\x89504e470d0a1a0a'::BLOB]"
-    relation = vane.connect().sql(f"select 'question'::VARCHAR as question, {image} as image")
+@pytest.mark.parametrize(
+    "media",
+    [
+        "'\\x89504e470d0a1a0a'::BLOB",
+        "['\\x89504e470d0a1a0a'::BLOB]::BLOB[]",
+        "file('/not-opened', 'image/png', NULL, NULL, NULL)",
+        "[file('/not-opened', 'image/png', NULL, NULL, NULL)]::FILE[]",
+    ],
+)
+def test_ai_prompt_expression_vllm_rejects_mixed_media_input_during_planning(media):
+    relation = vane.connect().sql(f"select 'question'::VARCHAR as question, {media} as media")
     expression = vane.ai.prompt(
-        [vane.col("question"), vane.col("image")],
+        [vane.col("question"), vane.col("media")],
         provider="vllm",
     )
 

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -782,6 +782,31 @@ def test_ai_prompt_sql_file_read_errors_obey_on_error(tmp_path):
     """).fetchall() == [(None,)]
 
 
+def test_ai_prompt_sql_null_prompt_skips_file_materialization(tmp_path):
+    valid_path = tmp_path / "valid.bin"
+    valid_path.write_bytes(b"media")
+    valid_sql = str(valid_path).replace("'", "''")
+    missing_sql = str(tmp_path / "missing.bin").replace("'", "''")
+
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            prompt,
+            media,
+            provider := 'mock_ai_sql'
+        )
+        FROM (VALUES
+            (NULL::VARCHAR, file('{missing_sql}', 'image/png', NULL, NULL, NULL)),
+            ('describe', file('{valid_sql}', 'image/png', NULL, NULL, NULL))
+        ) AS source(prompt, media)
+    """)
+        .fetchall()
+    )
+
+    assert rows == [(None,), ("topic:describe:image/png=6d65646961",)]
+
+
 def test_ai_prompt_sql_inconclusive_file_mime_obeys_on_error(tmp_path):
     path = tmp_path / "unknown.bin"
     path.write_bytes(b"not-a-recognized-media-format")
@@ -856,6 +881,44 @@ def test_ai_prompt_sql_rejects_file_larger_than_the_materialization_limit(tmp_pa
             on_error := 'ignore'
         )
     """).fetchall() == [(None,)]
+
+
+def test_ai_prompt_pack_enforces_vector_limit_across_file_columns_and_rows(tmp_path):
+    path = tmp_path / "aggregate-limit.bin"
+    with path.open("wb") as file:
+        file.truncate(19 * 1024 * 1024)
+    path_sql = str(path).replace("'", "''")
+    file_value = f"file('{path_sql}', 'image/png', NULL, NULL, NULL)"
+    column_names = [f"message_{index}" for index in range(7)]
+    packed_arguments = ", ".join(column_names)
+    oversized_row = ",\n".join(file_value for _ in column_names)
+    valid_row = ",\n".join([file_value, *("NULL::FILE" for _ in column_names[1:])])
+
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT
+            row_id,
+            packed.message_6.error,
+            octet_length(packed.message_0.data)
+        FROM (
+            SELECT
+                row_id,
+                __vane_ai_prompt_pack(TRUE, FALSE, {packed_arguments}) AS packed
+            FROM (VALUES
+                (0, {oversized_row}),
+                (1, {valid_row})
+            ) AS source(row_id, {packed_arguments})
+        )
+        ORDER BY row_id
+    """)
+        .fetchall()
+    )
+
+    assert rows == [
+        (0, "vector_too_large", None),
+        (1, None, 19 * 1024 * 1024),
+    ]
 
 
 def test_ai_prompt_sql_file_capability_error_obeys_on_error_before_io():
@@ -1038,10 +1101,11 @@ def test_ai_prompt_sql_file_materialization_boundary_survives_plan_round_trip(tm
     table = _execute_ai_physical_plan(target, physical)
 
     assert table.column(0).to_pylist() == ["round-trip-file:describe:image/png=6d65646961"]
-    assert node["payload"]["input_names"] == ["message_0", "message_1"]
-    assert node["payload"]["input_types"][0] == "VARCHAR"
-    assert node["payload"]["input_types"][1] == 'STRUCT(content_type VARCHAR, "data" BLOB, "error" VARCHAR)'
-    assert node["payload"]["input_contract_types"] == [None, None]
+    assert node["payload"]["input_names"] == ["__vane_prompt_messages"]
+    assert node["payload"]["input_types"] == [
+        'STRUCT(message_0 VARCHAR, message_1 STRUCT(content_type VARCHAR, "data" BLOB, "error" VARCHAR))'
+    ]
+    assert node["payload"]["input_contract_types"] == [None]
     assert b"prefix-media-suffix" not in serialized
     assert 0 < len(serialized) < 1_000_000
 
@@ -1403,6 +1467,9 @@ def test_ai_sql_helper_builds_prompt_specs_without_execution():
     assert spec["actor_number"] == 2
     assert spec["batch_size"] == 4
     assert spec["gpus"] == 0
+
+    file_spec = build_ai_prompt_sql_spec("mock_ai_sql", input_kind="file")
+    assert file_spec["input_names"] == ["__vane_prompt_messages"]
 
 
 def test_ai_sql_helper_builds_closed_native_vllm_spec():

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -118,6 +118,11 @@ class MockPrompterDescriptor(PrompterDescriptor):
     def supports_image_inputs(self) -> bool:
         return self.model_name != "text-only"
 
+    def supported_media_mime_types(self) -> frozenset[str] | None:
+        if self.model_name in {"image-only", "round-trip-file"}:
+            return frozenset({"image/gif", "image/jpeg", "image/png", "image/webp"})
+        return None
+
     def instantiate(self) -> MockPrompter:
         return MockPrompter(
             self.model_name,
@@ -644,11 +649,10 @@ def test_ai_prompt_sql_file_media_survives_provider_retry(tmp_path):
 
 def test_ai_prompt_sql_unsupported_file_mime_obeys_on_error(tmp_path):
     path = tmp_path / "audio.bin"
-    path.write_bytes(b"audio")
     path_sql = str(path).replace("'", "''")
     connection = vane.connect()
 
-    with pytest.raises(Exception, match="Prompt execution"):
+    with pytest.raises(Exception, match="Prompt FILE MIME type.*not supported"):
         connection.sql(f"""
             SELECT ai_prompt(
                 'describe',
@@ -904,7 +908,7 @@ def test_ai_prompt_pack_enforces_vector_limit_across_file_columns_and_rows(tmp_p
         FROM (
             SELECT
                 row_id,
-                __vane_ai_prompt_pack(TRUE, FALSE, {packed_arguments}) AS packed
+                __vane_ai_prompt_pack(TRUE, ['image/png'], FALSE, {packed_arguments}) AS packed
             FROM (VALUES
                 (0, {oversized_row}),
                 (1, {valid_row})
@@ -919,6 +923,46 @@ def test_ai_prompt_pack_enforces_vector_limit_across_file_columns_and_rows(tmp_p
         (0, "vector_too_large", None),
         (1, None, 19 * 1024 * 1024),
     ]
+
+
+def test_ai_prompt_pack_rejects_unsupported_mime_before_vector_budget(tmp_path):
+    path = tmp_path / "mime-budget.bin"
+    with path.open("wb") as file:
+        file.truncate(19 * 1024 * 1024)
+    path_sql = str(path).replace("'", "''")
+
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT
+            row_id,
+            packed.message_0.error,
+            octet_length(packed.message_0.data)
+        FROM (
+            SELECT
+                row_id,
+                __vane_ai_prompt_pack(
+                    TRUE,
+                    ['image/png'],
+                    FALSE,
+                    file('{path_sql}', content_type, NULL, NULL, NULL)
+                ) AS packed
+            FROM (VALUES
+                (0, 'audio/wav'),
+                (1, 'audio/wav'),
+                (2, 'audio/wav'),
+                (3, 'audio/wav'),
+                (4, 'audio/wav'),
+                (5, 'audio/wav'),
+                (6, 'image/png')
+            ) AS source(row_id, content_type)
+        )
+        ORDER BY row_id
+    """)
+        .fetchall()
+    )
+
+    assert rows == [(row_id, "unsupported_mime", None) for row_id in range(6)] + [(6, None, 19 * 1024 * 1024)]
 
 
 def test_ai_prompt_sql_file_capability_error_obeys_on_error_before_io():
@@ -1470,6 +1514,15 @@ def test_ai_sql_helper_builds_prompt_specs_without_execution():
 
     file_spec = build_ai_prompt_sql_spec("mock_ai_sql", input_kind="file")
     assert file_spec["input_names"] == ["__vane_prompt_messages"]
+    assert file_spec["supported_media_mime_types"] == []
+
+    image_only_spec = build_ai_prompt_sql_spec("mock_ai_sql", model="image-only", input_kind="file")
+    assert image_only_spec["supported_media_mime_types"] == [
+        "image/gif",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    ]
 
 
 def test_ai_sql_helper_builds_closed_native_vllm_spec():

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -447,6 +447,36 @@ def test_ai_prompt_sql_exact_file_overload_reads_strict_view(tmp_path):
     assert rows == [("topic:describe:image/png=7061796c6f6164",)]
 
 
+def test_ai_prompt_sql_file_composes_with_structured_output(tmp_path):
+    schema = json.dumps(
+        {
+            "type": "object",
+            "properties": {
+                "answer": {"type": "string"},
+                "score": {"type": "integer"},
+            },
+            "required": ["answer", "score"],
+            "additionalProperties": False,
+        }
+    )
+    path = tmp_path / "structured.bin"
+    path.write_bytes(b"media")
+    path_sql = str(path).replace("'", "''")
+    relation = vane.connect().sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'image/png', NULL, NULL, NULL),
+            return_format := json '{schema}',
+            provider := 'mock_ai_sql',
+            model := 'structured'
+        ) AS response
+    """)
+
+    answer = "structured:describe:image/png=6d65646961"
+    assert str(relation.types[0]) == "STRUCT(answer VARCHAR, score BIGINT)"
+    assert relation.fetchone() == ({"answer": answer, "score": len(answer)},)
+
+
 def test_ai_prompt_sql_exact_file_list_overload_preserves_order_and_ignores_nulls(tmp_path):
     first = tmp_path / "first.bin"
     second = tmp_path / "second.bin"
@@ -493,6 +523,101 @@ def test_ai_prompt_sql_file_without_content_type_uses_bounded_detection(tmp_path
     )
 
     assert row == (f"topic:describe:image/png={payload.hex()}",)
+
+
+@pytest.mark.parametrize("entry_point", ["sql", "relation"])
+def test_ai_prompt_file_uses_the_query_connection_secret(entry_point):
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    payload = b"prefix-media-suffix"
+    expected_authorization = "Bearer query-token"
+
+    class ObjectHandler(BaseHTTPRequestHandler):
+        def _send_object(self, include_body):
+            if self.path.split("?", 1)[0] != "/object.bin":
+                self.send_response(404)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            if self.headers.get("Authorization") != expected_authorization:
+                self.send_response(401)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
+            body = payload
+            status = 200
+            content_range = None
+            range_header = self.headers.get("Range")
+            if range_header is not None:
+                start_text, end_text = range_header.removeprefix("bytes=").split("-", 1)
+                start = int(start_text)
+                end = len(payload) - 1 if not end_text else min(int(end_text), len(payload) - 1)
+                body = payload[start : end + 1]
+                status = 206
+                content_range = f"bytes {start}-{end}/{len(payload)}"
+
+            self.send_response(status)
+            self.send_header("Accept-Ranges", "bytes")
+            self.send_header("Content-Length", str(len(body)))
+            if content_range is not None:
+                self.send_header("Content-Range", content_range)
+            self.end_headers()
+            if include_body:
+                self.wfile.write(body)
+
+        def do_HEAD(self):
+            self._send_object(False)
+
+        def do_GET(self):
+            self._send_object(True)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ObjectHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_port}/object.bin"
+    scope = f"http://127.0.0.1:{server.server_port}/"
+
+    connection = None
+    try:
+        connection = vane.connect()
+        connection.execute("LOAD httpfs")
+        connection.execute(f"CREATE SECRET prompt_http (TYPE HTTP, BEARER_TOKEN 'query-token', SCOPE '{scope}')")
+        if entry_point == "sql":
+            rows = connection.sql(f"""
+                SELECT ai_prompt(
+                    'describe',
+                    file('{url}', 'audio/wav', 7, 5, NULL),
+                    provider := 'mock_ai_sql'
+                )
+            """).fetchall()
+        else:
+            source = connection.sql(f"""
+                SELECT
+                    'describe'::VARCHAR AS prompt,
+                    file('{url}', 'audio/wav', 7, 5, NULL) AS media
+            """)
+            rows = (
+                vane.ai.prompt(
+                    source,
+                    [vane.col("prompt"), vane.col("media")],
+                    provider=MockProvider(),
+                )
+                .project("response")
+                .fetchall()
+            )
+    finally:
+        if connection is not None:
+            connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+    assert rows == [("topic:describe:audio/wav=6d65646961",)]
 
 
 def test_ai_prompt_sql_file_media_survives_provider_retry(tmp_path):
@@ -657,6 +782,31 @@ def test_ai_prompt_sql_file_read_errors_obey_on_error(tmp_path):
     """).fetchall() == [(None,)]
 
 
+def test_ai_prompt_sql_inconclusive_file_mime_obeys_on_error(tmp_path):
+    path = tmp_path / "unknown.bin"
+    path.write_bytes(b"not-a-recognized-media-format")
+    path_sql = str(path).replace("'", "''")
+    connection = vane.connect()
+
+    with pytest.raises(Exception, match="content detection was inconclusive"):
+        connection.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                file('{path_sql}', NULL, NULL, NULL, NULL),
+                provider := 'mock_ai_sql'
+            )
+        """).fetchall()
+
+    assert connection.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', NULL, NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
 def test_ai_prompt_sql_zero_length_file_obeys_on_error(tmp_path):
     path = tmp_path / "empty.bin"
     path.write_bytes(b"")
@@ -676,6 +826,32 @@ def test_ai_prompt_sql_zero_length_file_obeys_on_error(tmp_path):
         SELECT ai_prompt(
             'describe',
             file('{path_sql}', 'image/png', NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
+def test_ai_prompt_sql_rejects_file_larger_than_the_materialization_limit(tmp_path):
+    path = tmp_path / "oversized.bin"
+    with path.open("wb") as file:
+        file.truncate(20 * 1024 * 1024 + 1)
+    path_sql = str(path).replace("'", "''")
+    connection = vane.connect()
+
+    with pytest.raises(Exception, match="20 MiB materialization limit"):
+        connection.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                file('{path_sql}', 'video/mp4', NULL, NULL, NULL),
+                provider := 'mock_ai_sql'
+            )
+        """).fetchall()
+
+    assert connection.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'video/mp4', NULL, NULL, NULL),
             provider := 'mock_ai_sql',
             on_error := 'ignore'
         )
@@ -747,7 +923,7 @@ def test_ai_prompt_sql_validates_malformed_file_before_opening():
         )
     """)
 
-    with pytest.raises(Exception, match="invalid FILE value"):
+    with pytest.raises(Exception, match=r"ai_prompt\(\) url cannot be NULL"):
         connection.sql("""
             SELECT ai_prompt(
                 'describe',
@@ -842,7 +1018,7 @@ def test_ai_prompt_sql_expression_udf_survives_plan_round_trip():
     assert 0 < len(serialized) < 1_000_000
 
 
-def test_ai_prompt_sql_file_contract_survives_plan_round_trip(tmp_path):
+def test_ai_prompt_sql_file_materialization_boundary_survives_plan_round_trip(tmp_path):
     path = tmp_path / "round-trip.bin"
     path.write_bytes(b"prefix-media-suffix")
     path_sql = str(path).replace("'", "''")
@@ -863,8 +1039,9 @@ def test_ai_prompt_sql_file_contract_survives_plan_round_trip(tmp_path):
 
     assert table.column(0).to_pylist() == ["round-trip-file:describe:image/png=6d65646961"]
     assert node["payload"]["input_names"] == ["message_0", "message_1"]
-    assert node["payload"]["input_types"] == ["VARCHAR", "FILE"]
-    assert node["payload"]["input_contract_types"] == [None, "FILE"]
+    assert node["payload"]["input_types"][0] == "VARCHAR"
+    assert node["payload"]["input_types"][1] == 'STRUCT(content_type VARCHAR, "data" BLOB, "error" VARCHAR)'
+    assert node["payload"]["input_contract_types"] == [None, None]
     assert b"prefix-media-suffix" not in serialized
     assert 0 < len(serialized) < 1_000_000
 

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -1524,6 +1524,9 @@ def test_ai_sql_helper_builds_prompt_specs_without_execution():
         "image/webp",
     ]
 
+    google_file_spec = build_ai_prompt_sql_spec("google", model="gemini-test", input_kind="file")
+    assert google_file_spec["supported_media_mime_types"] == []
+
 
 def test_ai_sql_helper_builds_closed_native_vllm_spec():
     from vane.ai._sql import build_ai_prompt_sql_spec

--- a/tests/ai/test_expression_ai_sql.py
+++ b/tests/ai/test_expression_ai_sql.py
@@ -19,6 +19,8 @@ import pytest
 
 import vane
 from vane.ai import provider as provider_registry
+from vane.ai._media import PromptMedia
+from vane.ai.functions import RetryAfterError
 from vane.ai.protocols import PrompterDescriptor, TextEmbedderDescriptor
 from vane.ai.provider import Provider
 from vane.ai.typing import UDFOptions
@@ -68,13 +70,24 @@ class MockPrompter:
         self._system_message = system_message
         self._return_format = return_format
         self._return_raw_response = return_raw_response
+        self._calls = 0
 
     async def prompt(self, messages: tuple[object, ...]) -> object:
+        self._calls += 1
+        if self._model == "retry-file" and self._calls == 1:
+            raise RetryAfterError(0, RuntimeError("transient"))
+        if self._model == "image-only" and any(
+            isinstance(message, PromptMedia) and not message.content_type.startswith("image/") for message in messages
+        ):
+            raise ValueError("unsupported test media")
         parts = [self._model]
         if self._system_message is not None:
             parts.append(f"system={self._system_message}")
         for message in messages:
-            parts.append(message if isinstance(message, str) else bytes(message).hex())
+            if isinstance(message, PromptMedia):
+                parts.append(f"{message.content_type}={bytes(message).hex()}")
+            else:
+                parts.append(message if isinstance(message, str) else bytes(message).hex())
         result = ":".join(parts)
         if self._return_raw_response:
             return json.dumps({"id": f"raw-{self._model}", "output": [{"text": result}]})
@@ -101,6 +114,9 @@ class MockPrompterDescriptor(PrompterDescriptor):
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0, batch_size=2, max_retries=0)
+
+    def supports_image_inputs(self) -> bool:
+        return self.model_name != "text-only"
 
     def instantiate(self) -> MockPrompter:
         return MockPrompter(
@@ -411,6 +427,123 @@ def test_ai_prompt_sql_exact_blob_list_overload_flattens_in_place():
     assert rows == [("vision:compare:89504e47:ffd8ff",)]
 
 
+def test_ai_prompt_sql_exact_file_overload_reads_strict_view(tmp_path):
+    path = tmp_path / "media.bin"
+    path.write_bytes(b"prefix-payload-suffix")
+    path_sql = str(path).replace("'", "''")
+
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file := file('{path_sql}', 'IMAGE/PNG; source=declared', 7, 7, NULL),
+            provider := 'mock_ai_sql'
+        )
+    """)
+        .fetchall()
+    )
+
+    assert rows == [("topic:describe:image/png=7061796c6f6164",)]
+
+
+def test_ai_prompt_sql_exact_file_list_overload_preserves_order_and_ignores_nulls(tmp_path):
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    first_sql = str(first).replace("'", "''")
+    second_sql = str(second).replace("'", "''")
+
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            'compare',
+            files := [
+                file('{first_sql}', 'image/png', NULL, NULL, NULL),
+                NULL::FILE,
+                file('{second_sql}', 'audio/wav', NULL, NULL, NULL)
+            ]::FILE[],
+            provider := 'mock_ai_sql'
+        )
+    """)
+        .fetchall()
+    )
+
+    assert rows == [("topic:compare:image/png=6669727374:audio/wav=7365636f6e64",)]
+
+
+def test_ai_prompt_sql_file_without_content_type_uses_bounded_detection(tmp_path):
+    path = tmp_path / "unknown.bin"
+    payload = b"\x89PNG\r\n\x1a\nimage"
+    path.write_bytes(b"prefix" + payload + b"suffix")
+    path_sql = str(path).replace("'", "''")
+
+    row = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', NULL, 6, {len(payload)}, NULL),
+            provider := 'mock_ai_sql'
+        )
+    """)
+        .fetchone()
+    )
+
+    assert row == (f"topic:describe:image/png={payload.hex()}",)
+
+
+def test_ai_prompt_sql_file_media_survives_provider_retry(tmp_path):
+    path = tmp_path / "retry.bin"
+    path.write_bytes(b"payload")
+    path_sql = str(path).replace("'", "''")
+
+    row = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'image/png', NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            model := 'retry-file',
+            options := struct_pack(max_retries := 1)
+        )
+    """)
+        .fetchone()
+    )
+
+    assert row == ("retry-file:describe:image/png=7061796c6f6164",)
+
+
+def test_ai_prompt_sql_unsupported_file_mime_obeys_on_error(tmp_path):
+    path = tmp_path / "audio.bin"
+    path.write_bytes(b"audio")
+    path_sql = str(path).replace("'", "''")
+    connection = vane.connect()
+
+    with pytest.raises(Exception, match="Prompt execution"):
+        connection.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                file('{path_sql}', 'audio/wav', NULL, NULL, NULL),
+                provider := 'mock_ai_sql',
+                model := 'image-only'
+            )
+        """).fetchall()
+
+    assert connection.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'audio/wav', NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            model := 'image-only',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
 @pytest.mark.parametrize("image_argument", ["image := NULL", "images := NULL"])
 def test_ai_prompt_sql_named_untyped_null_image_selects_exact_overload(image_argument):
     conn = vane.connect()
@@ -427,6 +560,23 @@ def test_ai_prompt_sql_named_untyped_null_image_selects_exact_overload(image_arg
     assert rows == [("vision:describe",)]
 
 
+@pytest.mark.parametrize("file_argument", ["file := NULL", "files := NULL"])
+def test_ai_prompt_sql_named_untyped_null_file_selects_exact_overload(file_argument):
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            {file_argument},
+            provider := 'mock_ai_sql'
+        )
+    """)
+        .fetchall()
+    )
+
+    assert rows == [("topic:describe",)]
+
+
 @pytest.mark.parametrize("image", ["NULL::BLOB", "NULL::BLOB[]", "[]::BLOB[]"])
 def test_ai_prompt_sql_null_and_empty_image_inputs_are_omitted(image):
     conn = vane.connect()
@@ -441,6 +591,171 @@ def test_ai_prompt_sql_null_and_empty_image_inputs_are_omitted(image):
     """).fetchall()
 
     assert rows == [("vision:describe",)]
+
+
+@pytest.mark.parametrize("file_value", ["NULL::FILE", "NULL::FILE[]", "[]::FILE[]"])
+def test_ai_prompt_sql_null_and_empty_file_inputs_degrade_to_text(file_value):
+    rows = (
+        vane.connect()
+        .sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            {file_value},
+            provider := 'mock_ai_sql'
+        )
+    """)
+        .fetchall()
+    )
+
+    assert rows == [("topic:describe",)]
+
+
+def test_ai_prompt_sql_file_media_errors_obey_on_error(tmp_path):
+    path = tmp_path / "media.bin"
+    path_sql = str(path).replace("'", "''")
+    conn = vane.connect()
+
+    with pytest.raises(Exception, match="valid MIME type"):
+        conn.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                file('{path_sql}', 'invalid', NULL, NULL, NULL),
+                provider := 'mock_ai_sql'
+            )
+        """).fetchall()
+
+    assert conn.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'invalid', NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
+def test_ai_prompt_sql_file_read_errors_obey_on_error(tmp_path):
+    path_sql = str(tmp_path / "missing.bin").replace("'", "''")
+    connection = vane.connect()
+
+    with pytest.raises(Exception, match="Prompt FILE read"):
+        connection.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                file('{path_sql}', 'image/png', NULL, NULL, NULL),
+                provider := 'mock_ai_sql'
+            )
+        """).fetchall()
+
+    assert connection.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'image/png', NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
+def test_ai_prompt_sql_zero_length_file_obeys_on_error(tmp_path):
+    path = tmp_path / "empty.bin"
+    path.write_bytes(b"")
+    path_sql = str(path).replace("'", "''")
+    connection = vane.connect()
+
+    with pytest.raises(Exception, match="zero length"):
+        connection.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                file('{path_sql}', 'image/png', NULL, NULL, NULL),
+                provider := 'mock_ai_sql'
+            )
+        """).fetchall()
+
+    assert connection.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'image/png', NULL, NULL, NULL),
+            provider := 'mock_ai_sql',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
+def test_ai_prompt_sql_file_capability_error_obeys_on_error_before_io():
+    conn = vane.connect()
+    missing_file = "file('/definitely/missing/file-ai-prompt.bin', 'image/png', NULL, NULL, NULL)"
+
+    with pytest.raises(Exception, match="does not support Prompt media inputs"):
+        conn.sql(f"""
+            SELECT ai_prompt(
+                'describe',
+                {missing_file},
+                provider := 'mock_ai_sql',
+                model := 'text-only'
+            )
+        """).fetchall()
+
+    assert conn.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            {missing_file},
+            provider := 'mock_ai_sql',
+            model := 'text-only',
+            on_error := 'ignore'
+        )
+    """).fetchall() == [(None,)]
+
+
+def test_ai_prompt_sql_rejects_plain_struct_file_fallback():
+    with pytest.raises(Exception, match="No function matches|Binder|FILE"):
+        vane.connect().sql("""
+            SELECT ai_prompt(
+                'describe',
+                CAST(
+                    ROW(
+                        '/tmp/plain-struct',
+                        'image/png',
+                        NULL::BIGINT,
+                        NULL::BIGINT,
+                        NULL::VARCHAR
+                    )
+                    AS STRUCT(
+                        url VARCHAR,
+                        content_type VARCHAR,
+                        "position" BIGINT,
+                        size BIGINT,
+                        checksum VARCHAR
+                    )
+                ),
+                provider := 'mock_ai_sql'
+            )
+        """).fetchall()
+
+
+def test_ai_prompt_sql_validates_malformed_file_before_opening():
+    connection = vane.connect()
+    connection.execute("CREATE TABLE malformed_ai_file(value FILE)")
+    connection.execute("""
+        INSERT INTO malformed_ai_file
+        SELECT struct_pack(
+            url := NULL::VARCHAR,
+            content_type := 'image/png',
+            "position" := NULL::BIGINT,
+            size := NULL::BIGINT,
+            checksum := NULL::VARCHAR
+        )
+    """)
+
+    with pytest.raises(Exception, match="invalid FILE value"):
+        connection.sql("""
+            SELECT ai_prompt(
+                'describe',
+                value,
+                provider := 'mock_ai_sql'
+            )
+            FROM malformed_ai_file
+        """).fetchall()
 
 
 @pytest.mark.parametrize("image", ["''::BLOB", "[''::BLOB]::BLOB[]"])
@@ -524,6 +839,33 @@ def test_ai_prompt_sql_expression_udf_survives_plan_round_trip():
     assert node["payload"]["ai_provider"] == "mock_ai_sql"
     assert node["payload"]["ai_model"] == "round-trip"
     assert node["payload"]["ai_return_type"] == "VARCHAR"
+    assert 0 < len(serialized) < 1_000_000
+
+
+def test_ai_prompt_sql_file_contract_survives_plan_round_trip(tmp_path):
+    path = tmp_path / "round-trip.bin"
+    path.write_bytes(b"prefix-media-suffix")
+    path_sql = str(path).replace("'", "''")
+    source = vane.connect()
+    relation = source.sql(f"""
+        SELECT ai_prompt(
+            'describe',
+            file('{path_sql}', 'image/png', 7, 5, NULL),
+            provider := 'mock_ai_sql',
+            model := 'round-trip-file',
+            options := struct_pack(actor_number := 1)
+        ) AS response
+    """)
+
+    target, physical, serialized = _round_trip_ai_plan(relation)
+    node = physical.collect_udf_nodes()[0]
+    table = _execute_ai_physical_plan(target, physical)
+
+    assert table.column(0).to_pylist() == ["round-trip-file:describe:image/png=6d65646961"]
+    assert node["payload"]["input_names"] == ["message_0", "message_1"]
+    assert node["payload"]["input_types"] == ["VARCHAR", "FILE"]
+    assert node["payload"]["input_contract_types"] == [None, "FILE"]
+    assert b"prefix-media-suffix" not in serialized
     assert 0 < len(serialized) < 1_000_000
 
 
@@ -705,14 +1047,21 @@ def test_ai_prompt_sql_rejects_sensitive_options_recursively(options):
     assert "INLINE_SECRET_SENTINEL" not in str(exc_info.value)
 
 
-def test_ai_prompt_sql_on_error_does_not_hide_planning_capability_errors():
+@pytest.mark.parametrize(
+    "media",
+    [
+        "from_hex('89504e47')",
+        "file('/not-opened', 'image/png', NULL, NULL, NULL)",
+    ],
+)
+def test_ai_prompt_sql_on_error_does_not_hide_planning_capability_errors(media):
     conn = vane.connect()
 
-    with pytest.raises(Exception, match="does not support image inputs"):
-        conn.sql("""
+    with pytest.raises(Exception, match="does not support media inputs"):
+        conn.sql(f"""
             SELECT ai_prompt(
                 'describe',
-                from_hex('89504e47'),
+                {media},
                 provider := 'vllm',
                 on_error := 'ignore'
             )
@@ -868,7 +1217,7 @@ def test_ai_sql_helper_builds_prompt_specs_without_execution():
         "system-a",
         "ignore",
         {"actor_number": Decimal(2), "batch_size": Decimal(4)},
-        True,
+        "blob",
     )
 
     assert spec["name"] == "ai_prompt"

--- a/tests/ai/test_image_mime.py
+++ b/tests/ai/test_image_mime.py
@@ -11,8 +11,11 @@ import pytest
 from vane.ai._media import PromptMedia, normalize_media_content_type
 from vane.ai.providers._mime import ImageMimePolicy, detect_image_mime_type
 from vane.ai.providers.anthropic import _IMAGE_MIME_POLICY as _ANTHROPIC_IMAGE_MIME_POLICY
+from vane.ai.providers.anthropic import AnthropicPrompterDescriptor
 from vane.ai.providers.google import _IMAGE_MIME_POLICY as _GOOGLE_IMAGE_MIME_POLICY
+from vane.ai.providers.google import GooglePrompterDescriptor
 from vane.ai.providers.openai import _IMAGE_MIME_POLICY as _OPENAI_IMAGE_MIME_POLICY
+from vane.ai.providers.openai import OpenAIPrompterDescriptor
 
 
 def _ftyp(
@@ -276,6 +279,16 @@ def test_provider_image_mime_policy_matches_documented_formats(
         else:
             with pytest.raises(ValueError, match=f"not supported by {policy.provider_name}"):
                 policy.require_supported(data)
+
+
+def test_provider_descriptors_expose_only_closed_file_mime_policies():
+    openai = OpenAIPrompterDescriptor()
+    anthropic = AnthropicPrompterDescriptor(model_name="claude-test", options={"max_tokens": 1})
+    google = GooglePrompterDescriptor(model_name="gemini-test")
+
+    assert openai.supported_media_mime_types() == _OPENAI_IMAGE_MIME_POLICY.supported_mime_types
+    assert anthropic.supported_media_mime_types() == _ANTHROPIC_IMAGE_MIME_POLICY.supported_mime_types
+    assert google.supported_media_mime_types() is None
 
 
 @pytest.mark.parametrize(

--- a/tests/ai/test_image_mime.py
+++ b/tests/ai/test_image_mime.py
@@ -8,6 +8,7 @@ import importlib.util
 
 import pytest
 
+from vane.ai._media import PromptMedia, normalize_media_content_type
 from vane.ai.providers._mime import ImageMimePolicy, detect_image_mime_type
 from vane.ai.providers.anthropic import _IMAGE_MIME_POLICY as _ANTHROPIC_IMAGE_MIME_POLICY
 from vane.ai.providers.google import _IMAGE_MIME_POLICY as _GOOGLE_IMAGE_MIME_POLICY
@@ -59,6 +60,33 @@ _DETECTED_IMAGES = {
     "image/png": _PNG,
     "image/webp": _WEBP,
 }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("IMAGE/PNG; charset=binary", "image/png", id="parameters"),
+        pytest.param("audio/wav", "audio/wav", id="audio"),
+        pytest.param("video/mp4", "video/mp4", id="video"),
+    ],
+)
+def test_prompt_media_normalizes_declared_content_type(value, expected):
+    assert normalize_media_content_type(value) == expected
+
+
+@pytest.mark.parametrize("value", ["invalid", "image/*", "*/*", "image/", "/png", "image/p ng"])
+def test_prompt_media_rejects_invalid_declared_content_type(value):
+    with pytest.raises(ValueError, match="valid MIME type"):
+        PromptMedia(b"payload", value)
+
+
+def test_prompt_media_repr_does_not_expose_payload():
+    payload = b"PRIVATE_MEDIA_BYTES"
+    media = PromptMedia(payload, "image/png")
+
+    assert bytes(media) == payload
+    assert repr(media) == "PromptMedia(content_type='image/png', size=19)"
+    assert "PRIVATE_MEDIA_BYTES" not in repr(media)
 
 
 @pytest.mark.parametrize(
@@ -263,6 +291,19 @@ def test_provider_image_mime_policy_rejects_unrecognized_data(policy):
         policy.require_supported(b"not-an-image")
 
 
+@pytest.mark.parametrize(
+    "policy",
+    [
+        pytest.param(_ANTHROPIC_IMAGE_MIME_POLICY, id="anthropic"),
+        pytest.param(_OPENAI_IMAGE_MIME_POLICY, id="openai"),
+    ],
+)
+def test_image_provider_policy_uses_file_metadata_without_sniffing(policy):
+    assert policy.require_supported(PromptMedia(b"not-an-image", "IMAGE/PNG; source=metadata")) == "image/png"
+    with pytest.raises(ValueError, match="FILE MIME type.*not supported"):
+        policy.require_supported(PromptMedia(b"payload", "audio/wav"))
+
+
 def test_anthropic_message_processing_uses_provider_image_policy():
     from vane.ai.providers.anthropic import AnthropicPrompter
 
@@ -275,6 +316,14 @@ def test_anthropic_message_processing_uses_provider_image_policy():
     with pytest.raises(ValueError, match="not supported by Anthropic"):
         AnthropicPrompter._process_message(_HEIC)
 
+    declared = PromptMedia(b"declared-not-sniffed", "image/png")
+    file_image = AnthropicPrompter._process_message(declared)
+    assert file_image["source"] == {
+        "type": "base64",
+        "media_type": "image/png",
+        "data": base64.b64encode(bytes(declared)).decode("ascii"),
+    }
+
 
 def test_openai_message_processing_uses_provider_image_policy():
     from vane.ai.providers.openai import OpenAIPrompter
@@ -286,6 +335,10 @@ def test_openai_message_processing_uses_provider_image_policy():
     assert image["image_url"].startswith("data:image/png;base64,")
     with pytest.raises(ValueError, match="not supported by OpenAI"):
         prompter._process_bytes(_HEIC)
+
+    declared = prompter._process_bytes(PromptMedia(b"declared-not-sniffed", "image/png"))
+    assert declared["type"] == "input_image"
+    assert declared["image_url"].startswith("data:image/png;base64,")
 
 
 @pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
@@ -300,3 +353,15 @@ def test_google_message_processing_uses_provider_image_policy():
         prompter._process_message(_GIF)
     with pytest.raises(ValueError, match="not supported by Google"):
         prompter._process_message(_AVIF)
+
+
+@pytest.mark.skipif(not _has_module("google.genai"), reason="google-genai not installed")
+@pytest.mark.parametrize("content_type", ["audio/wav", "video/mp4", "application/pdf"])
+def test_google_message_processing_routes_declared_file_media(content_type):
+    from vane.ai.providers.google import GooglePrompter
+
+    prompter = GooglePrompter.__new__(GooglePrompter)
+    media = prompter._process_message(PromptMedia(b"provider-payload", content_type))
+
+    assert media.inline_data.mime_type == content_type
+    assert media.inline_data.data == b"provider-payload"

--- a/tests/fast/test_file_ray.py
+++ b/tests/fast/test_file_ray.py
@@ -1,9 +1,61 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+from dataclasses import dataclass
+from typing import Any
+
 import pytest
 
 import vane
+from vane.ai._media import PromptMedia
+from vane.ai.protocols import PrompterDescriptor
+from vane.ai.provider import Provider
+from vane.ai.typing import UDFOptions
+
+
+class _RayFilePrompter:
+    async def prompt(self, messages: tuple[Any, ...]) -> str:
+        rendered = [
+            f"{message.content_type}={bytes(message).hex()}" if isinstance(message, PromptMedia) else str(message)
+            for message in messages
+        ]
+        return f"{os.getpid()}:" + ":".join(rendered)
+
+
+@dataclass
+class _RayFilePrompterDescriptor(PrompterDescriptor):
+    def get_provider(self) -> str:
+        return "ray-file-test"
+
+    def get_model(self) -> str:
+        return "ray-file-test"
+
+    def get_options(self) -> dict[str, object]:
+        return {}
+
+    def get_udf_options(self) -> UDFOptions:
+        return UDFOptions(num_gpus=0, batch_size=1, max_retries=0)
+
+    def instantiate(self) -> _RayFilePrompter:
+        return _RayFilePrompter()
+
+
+class _RayFileProvider(Provider):
+    @property
+    def name(self) -> str:
+        return "ray-file-test"
+
+    def get_prompter(
+        self,
+        model: str | None = None,
+        system_message: str | None = None,
+        return_format: dict[str, Any] | None = None,
+        return_raw_response: bool = False,
+        *,
+        options: dict[str, Any] | None = None,
+    ) -> _RayFilePrompterDescriptor:
+        return _RayFilePrompterDescriptor()
 
 
 @pytest.mark.usefixtures("ray_local")
@@ -124,3 +176,37 @@ def test_default_ray_executes_scalar_and_batch_file_udfs(monkeypatch):
     assert sorted(scalar_rows) == expected
     assert sorted(batch_rows) == expected
     assert sorted(nested_rows) == [(index, [vane.File(f"memory://ray-udf/{index}"), None]) for index in range(4)]
+
+
+@pytest.mark.usefixtures("ray_local")
+def test_default_ray_ai_prompt_reads_file_view_on_worker(monkeypatch, tmp_path):
+    path = tmp_path / "ray-ai-media.bin"
+    path.write_bytes(b"prefix-media-suffix")
+    path_sql = str(path).replace("'", "''")
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    vane.teardown_runner()
+    vane.set_runner_ray(noop_if_initialized=True)
+
+    connection = vane.connect()
+    try:
+        source = connection.sql(f"""
+            SELECT
+                'describe'::VARCHAR AS prompt,
+                file('{path_sql}', 'audio/wav', 7, 5, NULL) AS media
+        """)
+        response = (
+            vane.ai.prompt(
+                source,
+                [vane.col("prompt"), vane.col("media")],
+                provider=_RayFileProvider(),
+            )
+            .project("response")
+            .fetchone()[0]
+        )
+    finally:
+        connection.close()
+
+    worker_pid, rendered = response.split(":", 1)
+    assert int(worker_pid) != os.getpid()
+    assert rendered == "describe:audio/wav=6d65646961"

--- a/vane/ai/_media.py
+++ b/vane/ai/_media.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal, worker-local media values used by AI provider adapters."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_MIME_TOKEN = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+
+def normalize_media_content_type(value: object) -> str:
+    """Return a provider-safe base MIME type without optional parameters."""
+    if not isinstance(value, str):
+        raise TypeError(f"FILE content_type must be str, not {type(value).__name__!r}")
+    content_type = value.split(";", 1)[0].strip().lower()
+    if content_type.count("/") != 1:
+        raise ValueError("FILE content_type must be a valid MIME type")
+    media_type, media_subtype = content_type.split("/", 1)
+    if (
+        media_type == "*"
+        or media_subtype == "*"
+        or not _MIME_TOKEN.fullmatch(media_type)
+        or not _MIME_TOKEN.fullmatch(media_subtype)
+    ):
+        raise ValueError("FILE content_type must be a valid MIME type")
+    return content_type
+
+
+@dataclass(frozen=True, repr=False, slots=True)
+class PromptMedia:
+    """Resolved FILE bytes plus their routing MIME type.
+
+    Instances are created only inside the AI execution worker. They contain no
+    locator, checksum, provider configuration, or credentials and are never
+    persisted as FILE values or plan metadata.
+    """
+
+    data: bytes
+    content_type: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.data, bytes):
+            raise TypeError(f"Prompt media data must be bytes, not {type(self.data).__name__!r}")
+        if not self.data:
+            raise ValueError("Prompt FILE content cannot be zero length")
+        object.__setattr__(self, "content_type", normalize_media_content_type(self.content_type))
+
+    def __bytes__(self) -> bytes:
+        return self.data
+
+    def __repr__(self) -> str:
+        return f"PromptMedia(content_type={self.content_type!r}, size={len(self.data)})"

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -16,6 +16,7 @@ from vane.ai.functions import (
     _gpus_or_zero,
     _prepare_embed_call,
     _prepare_prompt_call,
+    _PROMPT_PACKED_INPUT_COLUMN,
     _PromptBatch,
     _resolve_ai_batch_size,
     _ValidateStructuredOutputBatch,
@@ -134,6 +135,7 @@ def build_ai_prompt_sql_spec(
         raise ValueError(f"AI_PROMPT input_kind must be one of: {allowed}")
     media_input = input_kind != "text"
     blob_input = input_kind in {"blob", "blob_list"}
+    file_input = input_kind in {"file", "file_list"}
     opts = _normalize_sql_options(options)
     if isinstance(return_format, str):
         try:
@@ -208,10 +210,11 @@ def build_ai_prompt_sql_spec(
             "does not support Prompt image inputs"
         )
 
-    input_names = ["message_0", "message_1"] if media_input else ["message_0"]
+    message_columns = ["message_0", "message_1"] if media_input else ["message_0"]
+    packed_input_column = _PROMPT_PACKED_INPUT_COLUMN if file_input else None
     wrapper = _PromptBatch(
         descriptor,
-        input_names,
+        message_columns,
         "response",
         udf_opts.max_concurrency_per_actor,
         single_message=True,
@@ -220,6 +223,7 @@ def build_ai_prompt_sql_spec(
         max_retries=udf_opts.max_retries,
         on_error=udf_opts.on_error,
         supports_media_inputs=supports_media_inputs,
+        packed_input_column=packed_input_column,
     )
     actor_callable = _adapt_batch_wrapper_for_backend(wrapper, "subprocess_actor", force_actor=True)
     return {
@@ -231,7 +235,7 @@ def build_ai_prompt_sql_spec(
         "return_type": (
             structured_output.duckdb_type if structured_output is not None and not return_raw_response else "VARCHAR"
         ),
-        "input_names": input_names,
+        "input_names": [packed_input_column] if packed_input_column is not None else message_columns,
         "schema": {"response": "VARCHAR"},
         "batch_size": _resolve_ai_batch_size(udf_opts),
         "row_preserving": True,

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -201,7 +201,8 @@ def build_ai_prompt_sql_spec(
         return spec
     if isinstance(descriptor, NativePrompterPlan):
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
-    if blob_input and not descriptor.supports_image_inputs():
+    supports_media_inputs = bool(descriptor.supports_image_inputs())
+    if blob_input and not supports_media_inputs:
         raise ValueError(
             f"Provider {descriptor.get_provider()!r} model {descriptor.get_model()!r} "
             "does not support Prompt image inputs"
@@ -218,6 +219,7 @@ def build_ai_prompt_sql_spec(
         return_raw_response=return_raw_response,
         max_retries=udf_opts.max_retries,
         on_error=udf_opts.on_error,
+        supports_media_inputs=supports_media_inputs,
     )
     actor_callable = _adapt_batch_wrapper_for_backend(wrapper, "subprocess_actor", force_actor=True)
     return {
@@ -225,6 +227,7 @@ def build_ai_prompt_sql_spec(
         "name": "ai_prompt",
         "provider": descriptor.get_provider(),
         "model": descriptor.get_model(),
+        "supports_media_inputs": supports_media_inputs,
         "return_type": (
             structured_output.duckdb_type if structured_output is not None and not return_raw_response else "VARCHAR"
         ),

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -19,6 +19,7 @@ from vane.ai.functions import (
     _PROMPT_PACKED_INPUT_COLUMN,
     _PromptBatch,
     _resolve_ai_batch_size,
+    _supported_prompt_media_mime_types,
     _ValidateStructuredOutputBatch,
 )
 from vane.ai.protocols import NativePrompterPlan
@@ -232,6 +233,7 @@ def build_ai_prompt_sql_spec(
         "provider": descriptor.get_provider(),
         "model": descriptor.get_model(),
         "supports_media_inputs": supports_media_inputs,
+        "supported_media_mime_types": list(_supported_prompt_media_mime_types(descriptor)),
         "return_type": (
             structured_output.duckdb_type if structured_output is not None and not return_raw_response else "VARCHAR"
         ),

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -10,13 +10,13 @@ from typing import Any
 
 from vane.ai._redaction import is_sensitive_option_key
 from vane.ai.functions import (
+    _PROMPT_PACKED_INPUT_COLUMN,
     _actor_number_or_one,
     _adapt_batch_wrapper_for_backend,
     _EmbedTextBatch,
     _gpus_or_zero,
     _prepare_embed_call,
     _prepare_prompt_call,
-    _PROMPT_PACKED_INPUT_COLUMN,
     _PromptBatch,
     _resolve_ai_batch_size,
     _supported_prompt_media_mime_types,

--- a/vane/ai/_sql.py
+++ b/vane/ai/_sql.py
@@ -48,6 +48,8 @@ _FLOAT_OPTION_NAMES = {
     "top_p",
 }
 
+_PROMPT_INPUT_KINDS = frozenset({"text", "blob", "blob_list", "file", "file_list"})
+
 
 def _reject_inline_credentials(value: Any, path: str = "options") -> None:
     """Reject sensitive-keyed options at any nesting depth (defense layer 1).
@@ -122,11 +124,16 @@ def build_ai_prompt_sql_spec(
     system_message: str | None = None,
     on_error: str = "raise",
     options: dict[str, Any] | None = None,
-    image_input: bool = False,
+    input_kind: str = "text",
     return_format: str | dict[str, Any] | None = None,
     return_raw_response: bool = False,
 ) -> dict[str, Any]:
     """Build the row-preserving SQL prompt UDF specification."""
+    if not isinstance(input_kind, str) or input_kind not in _PROMPT_INPUT_KINDS:
+        allowed = ", ".join(sorted(_PROMPT_INPUT_KINDS))
+        raise ValueError(f"AI_PROMPT input_kind must be one of: {allowed}")
+    media_input = input_kind != "text"
+    blob_input = input_kind in {"blob", "blob_list"}
     opts = _normalize_sql_options(options)
     if isinstance(return_format, str):
         try:
@@ -151,8 +158,8 @@ def build_ai_prompt_sql_spec(
     from vane.ai.providers.vllm import _build_native_vllm_options_argument
 
     if isinstance(descriptor, NativeInferencePlan):
-        if image_input:
-            raise ValueError("native inference ai_prompt does not support image inputs")
+        if media_input:
+            raise ValueError("native inference ai_prompt does not support media inputs")
 
         native_options = descriptor.build_physical_vllm_options()
         options_argument = _build_native_vllm_options_argument(native_options, engine=descriptor.get_engine())
@@ -194,13 +201,13 @@ def build_ai_prompt_sql_spec(
         return spec
     if isinstance(descriptor, NativePrompterPlan):
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
-    if image_input and not descriptor.supports_image_inputs():
+    if blob_input and not descriptor.supports_image_inputs():
         raise ValueError(
             f"Provider {descriptor.get_provider()!r} model {descriptor.get_model()!r} "
             "does not support Prompt image inputs"
         )
 
-    input_names = ["message_0", "message_1"] if image_input else ["message_0"]
+    input_names = ["message_0", "message_1"] if media_input else ["message_0"]
     wrapper = _PromptBatch(
         descriptor,
         input_names,

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -46,6 +46,7 @@ import vane
 from vane._expression_udf import _build_actor_map_batches_expression, _build_map_batches_expression
 from vane._expressions import as_expression, is_expression
 from vane._typing import Expression, Relation
+from vane.ai._media import PromptMedia, normalize_media_content_type
 from vane.ai._schema import (
     OutputValidationError,
     RawResponseSerializationError,
@@ -1088,7 +1089,7 @@ class _EmbedTextBatch:
 
 
 class _PromptBatch:
-    """Actor-local row-preserving wrapper for ordered text/image Prompt parts."""
+    """Actor-local row-preserving wrapper for ordered text/media Prompt parts."""
 
     def __init__(
         self,
@@ -1114,6 +1115,8 @@ class _PromptBatch:
         self._return_raw_response = return_raw_response
         self._max_retries = max_retries
         self._on_error: _OnError = on_error
+        supports_media = getattr(descriptor, "supports_image_inputs", None)
+        self._supports_media_inputs = True if not callable(supports_media) else bool(supports_media())
         self._prompter: Prompter | None = None  # lazy: instantiate on first __call__
         self._run_async: Callable[[Awaitable[Any]], Any] | None = None  # executor-bound capability
         self._prompter_loop_bound = False  # set once the prompter is known loop-bound
@@ -1186,32 +1189,91 @@ class _PromptBatch:
         state["_prompter_loop_bound"] = False  # recomputed on next _ensure_prompter()
         return state
 
+    def _require_media_support(self) -> None:
+        if self._supports_media_inputs:
+            return
+        provider, model = _descriptor_identity(self._descriptor)
+        raise ValueError(f"Provider {provider!r} model {model!r} does not support Prompt media inputs")
+
     @staticmethod
-    def _append_message_value(parts: list[Any], value: Any) -> None:
+    def _materialize_file(value: Any) -> vane.File:
+        if isinstance(value, vane.File):
+            return value
+        # AI prompting is a batch UDF: after the shared FILE contract validates
+        # the Arrow input, a FILE leaf reaches this wrapper as its canonical
+        # five-field STRUCT mapping rather than as the scalar-UDF value object.
+        if not isinstance(value, Mapping):
+            raise TypeError("Prompt FILE input must use the canonical five-field value")
+        expected_fields = {"url", "content_type", "position", "size", "checksum"}
+        if set(value) != expected_fields:
+            raise TypeError("Prompt FILE input must contain exactly the canonical five fields")
+        return vane.File(
+            value["url"],
+            value["content_type"],
+            value["position"],
+            value["size"],
+            value["checksum"],
+        )
+
+    def _read_file_media(self, value: Any) -> PromptMedia:
+        self._require_media_support()
+        file = self._materialize_file(value)
+        content_type = normalize_media_content_type(file.content_type) if file.content_type is not None else None
+        data: bytes | None = None
+        read_error: Exception | None = None
+        try:
+            with file.open() as reader:
+                if content_type is None:
+                    detected_content_type = reader.guess_mime_type()
+                    if detected_content_type is not None:
+                        content_type = normalize_media_content_type(detected_content_type)
+                if content_type is not None:
+                    data = reader.read()
+        except Exception as exc:
+            read_error = exc
+        if read_error is not None:
+            provider, model = _descriptor_identity(self._descriptor)
+            raise _safe_provider_execution_error(provider, model, "Prompt FILE read", read_error) from None
+        if content_type is None:
+            raise ValueError("Prompt FILE MIME type is missing and content detection was inconclusive")
+        if data is None:
+            raise RuntimeError("Prompt FILE reader produced no content result")
+        return PromptMedia(data, content_type)
+
+    def _append_message_value(self, parts: list[Any], value: Any) -> None:
         if value is None:
             return
         if isinstance(value, str):
             parts.append(value)
             return
         if isinstance(value, (bytes, bytearray, memoryview)):
+            self._require_media_support()
             image = bytes(value)
             if not image:
                 raise ValueError("Prompt image BLOB cannot be zero length")
             parts.append(image)
             return
+        if isinstance(value, (vane.File, Mapping)):
+            parts.append(self._read_file_media(value))
+            return
         if isinstance(value, (list, tuple)):
             for item in value:
                 if item is None:
                     continue
-                if not isinstance(item, (bytes, bytearray, memoryview)):
-                    raise TypeError("Prompt BLOB[] content must contain only BLOB or NULL values")
-                image = bytes(item)
-                if not image:
-                    raise ValueError("Prompt image BLOB cannot be zero length")
-                parts.append(image)
+                if isinstance(item, (bytes, bytearray, memoryview)):
+                    self._require_media_support()
+                    image = bytes(item)
+                    if not image:
+                        raise ValueError("Prompt image BLOB cannot be zero length")
+                    parts.append(image)
+                elif isinstance(item, (vane.File, Mapping)):
+                    parts.append(self._read_file_media(item))
+                else:
+                    raise TypeError("Prompt media lists must contain only BLOB, FILE, or NULL values")
             return
         raise TypeError(
-            f"Prompt messages expressions must produce VARCHAR, BLOB, or BLOB[] values; got {type(value).__name__}"
+            "Prompt messages expressions must produce VARCHAR, BLOB, BLOB[], FILE, or FILE[] values; "
+            f"got {type(value).__name__}"
         )
 
     def _build_row_messages(self, columns: list[list[Any]], index: int) -> tuple[Any, ...] | None:
@@ -1243,9 +1305,10 @@ class _PromptBatch:
         for index in range(row_count):
             try:
                 messages = self._build_row_messages(columns, index)
-            except Exception:
+            except Exception as exc:
                 if self._on_error == "raise":
                     raise
+                _log_substituted_failure(exc, on_error=self._on_error)
                 continue
             if messages is not None:
                 row_messages[index] = messages
@@ -1774,17 +1837,23 @@ def _normalize_prompt_messages(messages: Any) -> tuple[list[Expression], bool]:
 
 def _prompt_relation_types(rel: Relation, messages: list[Expression]) -> list[str]:
     types = [str(value).upper() for value in rel.select(*messages).types]
-    allowed = {"VARCHAR", "BLOB", "BLOB[]"}
+    allowed = {"VARCHAR", "BLOB", "BLOB[]", "FILE", "FILE[]"}
     for index, value in enumerate(types):
         if value not in allowed:
-            raise TypeError(f"Prompt messages[{index}] must have type VARCHAR, BLOB, or BLOB[]; got {value}")
+            raise TypeError(
+                f"Prompt messages[{index}] must have type VARCHAR, BLOB, BLOB[], FILE, or FILE[]; got {value}"
+            )
     return types
 
 
-def _validated_prompt_message(message: Any, *, text_only: bool = False) -> Expression:
+def _validated_prompt_message(message: Any, *, media_policy: Literal["all", "file", "text"] = "all") -> Expression:
     """Add a bind-only Prompt type guard that is removed during planning."""
-    if text_only:
+    if media_policy == "text":
+        # The hidden BOOLEAN overload uses TRUE for strict text-only native plans.
         return vane.FunctionExpression("__vane_ai_prompt", message, vane.ConstantExpression(True))
+    if media_policy == "file":
+        # FALSE permits text plus FILE while continuing to reject eager BLOB input.
+        return vane.FunctionExpression("__vane_ai_prompt", message, vane.ConstantExpression(False))
     return vane.FunctionExpression("__vane_ai_prompt", message)
 
 
@@ -1860,7 +1929,7 @@ def _prompt_relation(
 
     if isinstance(descriptor, NativeInferencePlan):
         if any(value != "VARCHAR" for value in message_types):
-            raise ValueError(f"Provider {descriptor.get_provider()!r} does not support Prompt image inputs")
+            raise ValueError(f"Provider {descriptor.get_provider()!r} does not support Prompt media inputs")
         expression = _build_native_vllm_expression(message_expressions, descriptor)
         if structured_output is not None:
             input_column = "__vane_vllm_response"
@@ -1887,7 +1956,7 @@ def _prompt_relation(
         return rel.select(star, expression)
     if isinstance(descriptor, NativePrompterPlan):
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
-    if not descriptor.supports_image_inputs() and any(value != "VARCHAR" for value in message_types):
+    if not descriptor.supports_image_inputs() and any(value in {"BLOB", "BLOB[]"} for value in message_types):
         raise ValueError(
             f"Provider {descriptor.get_provider()!r} model {descriptor.get_model()!r} "
             "does not support Prompt image inputs"
@@ -1946,7 +2015,9 @@ def _prompt_expression(
     )
 
     if isinstance(descriptor, NativeInferencePlan):
-        validated_messages = [_validated_prompt_message(message, text_only=True) for message in message_expressions]
+        validated_messages = [
+            _validated_prompt_message(message, media_policy="text") for message in message_expressions
+        ]
         expression = _build_native_vllm_expression(validated_messages, descriptor)
         if structured_output is None:
             return expression
@@ -1973,9 +2044,9 @@ def _prompt_expression(
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
 
     input_names = [f"message_{index}" for index in range(len(message_expressions))]
+    media_policy: Literal["all", "file", "text"] = "all" if descriptor.supports_image_inputs() else "file"
     validated_messages = [
-        _validated_prompt_message(message, text_only=not descriptor.supports_image_inputs())
-        for message in message_expressions
+        _validated_prompt_message(message, media_policy=media_policy) for message in message_expressions
     ]
     wrapper = _PromptBatch(
         descriptor,
@@ -2092,7 +2163,7 @@ def prompt(
     output_column: str = _PROMPT_OUTPUT_COLUMN_DEFAULT,
     **options: Unpack[PromptOptions],
 ) -> Expression | Relation:
-    """Prompt over ordered VARCHAR, BLOB, or BLOB[] Expressions.
+    """Prompt over ordered VARCHAR, BLOB, BLOB[], FILE, or FILE[] Expressions.
 
     ``return_format`` accepts a Pydantic model class or the portable JSON
     Schema subset and exposes a native STRUCT. ``return_raw_response=True``

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -1870,7 +1870,7 @@ _PROMPT_PACKED_INPUT_COLUMN = "__vane_prompt_messages"
 
 
 def _supported_prompt_media_mime_types(descriptor: Any) -> tuple[str, ...]:
-    """Return the normalized, deterministic native FILE media allowlist."""
+    """Return the normalized closed FILE allowlist; empty defers MIME policy to the provider."""
     values = descriptor.supported_media_mime_types()
     if values is None:
         return ()

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -46,7 +46,7 @@ import vane
 from vane._expression_udf import _build_actor_map_batches_expression, _build_map_batches_expression
 from vane._expressions import as_expression, is_expression
 from vane._typing import Expression, Relation
-from vane.ai._media import PromptMedia, normalize_media_content_type
+from vane.ai._media import PromptMedia
 from vane.ai._schema import (
     OutputValidationError,
     RawResponseSerializationError,
@@ -1102,6 +1102,7 @@ class _PromptBatch:
         return_raw_response: bool = False,
         max_retries: int = 3,
         on_error: _OnError = "raise",
+        supports_media_inputs: bool | None = None,
     ) -> None:
         if not message_columns:
             raise ValueError("Prompt message_columns cannot be empty")
@@ -1115,8 +1116,10 @@ class _PromptBatch:
         self._return_raw_response = return_raw_response
         self._max_retries = max_retries
         self._on_error: _OnError = on_error
-        supports_media = getattr(descriptor, "supports_image_inputs", None)
-        self._supports_media_inputs = True if not callable(supports_media) else bool(supports_media())
+        if supports_media_inputs is None:
+            supports_media = getattr(descriptor, "supports_image_inputs", None)
+            supports_media_inputs = True if not callable(supports_media) else bool(supports_media())
+        self._supports_media_inputs = supports_media_inputs
         self._prompter: Prompter | None = None  # lazy: instantiate on first __call__
         self._run_async: Callable[[Awaitable[Any]], Any] | None = None  # executor-bound capability
         self._prompter_loop_bound = False  # set once the prompter is known loop-bound
@@ -1195,49 +1198,35 @@ class _PromptBatch:
         provider, model = _descriptor_identity(self._descriptor)
         raise ValueError(f"Provider {provider!r} model {model!r} does not support Prompt media inputs")
 
-    @staticmethod
-    def _materialize_file(value: Any) -> vane.File:
-        if isinstance(value, vane.File):
-            return value
-        # AI prompting is a batch UDF: after the shared FILE contract validates
-        # the Arrow input, a FILE leaf reaches this wrapper as its canonical
-        # five-field STRUCT mapping rather than as the scalar-UDF value object.
-        if not isinstance(value, Mapping):
-            raise TypeError("Prompt FILE input must use the canonical five-field value")
-        expected_fields = {"url", "content_type", "position", "size", "checksum"}
-        if set(value) != expected_fields:
-            raise TypeError("Prompt FILE input must contain exactly the canonical five fields")
-        return vane.File(
-            value["url"],
-            value["content_type"],
-            value["position"],
-            value["size"],
-            value["checksum"],
-        )
+    def _materialized_prompt_media(self, value: Any) -> PromptMedia:
+        """Decode the locator-free value produced by the native FILE boundary."""
+        if not isinstance(value, Mapping) or set(value) != {"content_type", "data", "error"}:
+            raise TypeError("Prompt FILE input did not cross the native media boundary")
+        error = value["error"]
+        if error is not None:
+            if error == "unsupported":
+                self._require_media_support()
+                raise RuntimeError("Prompt FILE capability validation produced an invalid result")
+            if error == "read":
+                provider, model = _descriptor_identity(self._descriptor)
+                safe_error = OSError("FILE access failed")
+                raise _safe_provider_execution_error(provider, model, "Prompt FILE read", safe_error) from None
+            if error == "mime":
+                raise ValueError("Prompt FILE MIME type is missing and content detection was inconclusive")
+            if error == "invalid_mime":
+                raise ValueError("FILE content_type must be a valid MIME type")
+            if error == "empty":
+                raise ValueError("Prompt FILE content cannot be zero length")
+            if error == "too_large":
+                raise ValueError("Prompt FILE content exceeds the 20 MiB materialization limit")
+            if error == "vector_too_large":
+                raise ValueError("Prompt FILE inputs exceed the 128 MiB materialization-vector limit")
+            raise RuntimeError("Prompt FILE materialization produced an unknown error")
 
-    def _read_file_media(self, value: Any) -> PromptMedia:
-        self._require_media_support()
-        file = self._materialize_file(value)
-        content_type = normalize_media_content_type(file.content_type) if file.content_type is not None else None
-        data: bytes | None = None
-        read_error: Exception | None = None
-        try:
-            with file.open() as reader:
-                if content_type is None:
-                    detected_content_type = reader.guess_mime_type()
-                    if detected_content_type is not None:
-                        content_type = normalize_media_content_type(detected_content_type)
-                if content_type is not None:
-                    data = reader.read()
-        except Exception as exc:
-            read_error = exc
-        if read_error is not None:
-            provider, model = _descriptor_identity(self._descriptor)
-            raise _safe_provider_execution_error(provider, model, "Prompt FILE read", read_error) from None
-        if content_type is None:
-            raise ValueError("Prompt FILE MIME type is missing and content detection was inconclusive")
-        if data is None:
-            raise RuntimeError("Prompt FILE reader produced no content result")
+        data = value["data"]
+        content_type = value["content_type"]
+        if not isinstance(data, bytes):
+            raise TypeError("Prompt FILE materialization did not produce bytes")
         return PromptMedia(data, content_type)
 
     def _append_message_value(self, parts: list[Any], value: Any) -> None:
@@ -1253,8 +1242,8 @@ class _PromptBatch:
                 raise ValueError("Prompt image BLOB cannot be zero length")
             parts.append(image)
             return
-        if isinstance(value, (vane.File, Mapping)):
-            parts.append(self._read_file_media(value))
+        if isinstance(value, Mapping):
+            parts.append(self._materialized_prompt_media(value))
             return
         if isinstance(value, (list, tuple)):
             for item in value:
@@ -1266,8 +1255,8 @@ class _PromptBatch:
                     if not image:
                         raise ValueError("Prompt image BLOB cannot be zero length")
                     parts.append(image)
-                elif isinstance(item, (vane.File, Mapping)):
-                    parts.append(self._read_file_media(item))
+                elif isinstance(item, Mapping):
+                    parts.append(self._materialized_prompt_media(item))
                 else:
                     raise TypeError("Prompt media lists must contain only BLOB, FILE, or NULL values")
             return
@@ -1847,7 +1836,7 @@ def _prompt_relation_types(rel: Relation, messages: list[Expression]) -> list[st
 
 
 def _validated_prompt_message(message: Any, *, media_policy: Literal["all", "file", "text"] = "all") -> Expression:
-    """Add a bind-only Prompt type guard that is removed during planning."""
+    """Add a bind-only Prompt guard; FILE inputs lower to native materialization."""
     if media_policy == "text":
         # The hidden BOOLEAN overload uses TRUE for strict text-only native plans.
         return vane.FunctionExpression("__vane_ai_prompt", message, vane.ConstantExpression(True))
@@ -1956,13 +1945,18 @@ def _prompt_relation(
         return rel.select(star, expression)
     if isinstance(descriptor, NativePrompterPlan):
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
-    if not descriptor.supports_image_inputs() and any(value in {"BLOB", "BLOB[]"} for value in message_types):
+    supports_media_inputs = bool(descriptor.supports_image_inputs())
+    if not supports_media_inputs and any(value in {"BLOB", "BLOB[]"} for value in message_types):
         raise ValueError(
             f"Provider {descriptor.get_provider()!r} model {descriptor.get_model()!r} "
             "does not support Prompt image inputs"
         )
 
     input_names = [f"message_{index}" for index in range(len(message_expressions))]
+    media_policy: Literal["all", "file", "text"] = "all" if supports_media_inputs else "file"
+    validated_messages = [
+        _validated_prompt_message(message, media_policy=media_policy) for message in message_expressions
+    ]
     wrapper = _PromptBatch(
         descriptor,
         input_names,
@@ -1973,10 +1967,11 @@ def _prompt_relation(
         return_raw_response=return_raw_response,
         max_retries=udf_options.max_retries,
         on_error=udf_options.on_error,
+        supports_media_inputs=supports_media_inputs,
     )
     expression = _build_ai_batch_expression(
         wrapper,
-        inputs=dict(zip(input_names, message_expressions, strict=True)),
+        inputs=dict(zip(input_names, validated_messages, strict=True)),
         output_column=output_column,
         output_type="VARCHAR",
         udf_opts=udf_options,
@@ -2044,7 +2039,8 @@ def _prompt_expression(
         raise ValueError(f"Unsupported native prompt plan {type(descriptor).__name__}")
 
     input_names = [f"message_{index}" for index in range(len(message_expressions))]
-    media_policy: Literal["all", "file", "text"] = "all" if descriptor.supports_image_inputs() else "file"
+    supports_media_inputs = bool(descriptor.supports_image_inputs())
+    media_policy: Literal["all", "file", "text"] = "all" if supports_media_inputs else "file"
     validated_messages = [
         _validated_prompt_message(message, media_policy=media_policy) for message in message_expressions
     ]
@@ -2058,6 +2054,7 @@ def _prompt_expression(
         return_raw_response=return_raw_response,
         max_retries=udf_options.max_retries,
         on_error=udf_options.on_error,
+        supports_media_inputs=supports_media_inputs,
     )
     expression = _build_ai_batch_expression(
         wrapper,

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -46,7 +46,7 @@ import vane
 from vane._expression_udf import _build_actor_map_batches_expression, _build_map_batches_expression
 from vane._expressions import as_expression, is_expression
 from vane._typing import Expression, Relation
-from vane.ai._media import PromptMedia
+from vane.ai._media import PromptMedia, normalize_media_content_type
 from vane.ai._schema import (
     OutputValidationError,
     RawResponseSerializationError,
@@ -1219,6 +1219,12 @@ class _PromptBatch:
                 raise ValueError("Prompt FILE MIME type is missing and content detection was inconclusive")
             if error == "invalid_mime":
                 raise ValueError("FILE content_type must be a valid MIME type")
+            if error == "unsupported_mime":
+                provider, model = _descriptor_identity(self._descriptor)
+                content_type = value["content_type"]
+                raise ValueError(
+                    f"Prompt FILE MIME type {content_type!r} is not supported by provider {provider!r} model {model!r}"
+                )
             if error == "empty":
                 raise ValueError("Prompt FILE content cannot be zero length")
             if error == "too_large":
@@ -1863,13 +1869,28 @@ def _validated_prompt_message(message: Any, *, media_policy: Literal["all", "fil
 _PROMPT_PACKED_INPUT_COLUMN = "__vane_prompt_messages"
 
 
+def _supported_prompt_media_mime_types(descriptor: Any) -> tuple[str, ...]:
+    """Return the normalized, deterministic native FILE media allowlist."""
+    values = descriptor.supported_media_mime_types()
+    if values is None:
+        return ()
+    if not values:
+        raise ValueError("supported_media_mime_types() must return None or a non-empty MIME allowlist")
+    return tuple(sorted({normalize_media_content_type(value) for value in values}))
+
+
 def _packed_prompt_messages(
-    messages: list[Expression], *, supports_media_inputs: bool, single_message: bool
+    messages: list[Expression],
+    *,
+    supports_media_inputs: bool,
+    supported_media_mime_types: tuple[str, ...],
+    single_message: bool,
 ) -> Expression:
     """Pack every message so all FILE inputs share one native byte budget."""
     return vane.FunctionExpression(
         "__vane_ai_prompt_pack",
         vane.ConstantExpression(supports_media_inputs),
+        vane.ConstantExpression(list(supported_media_mime_types)).cast("VARCHAR[]"),
         vane.ConstantExpression(single_message),
         *messages,
     )
@@ -1989,6 +2010,7 @@ def _prompt_relation(
             _PROMPT_PACKED_INPUT_COLUMN: _packed_prompt_messages(
                 message_expressions,
                 supports_media_inputs=supports_media_inputs,
+                supported_media_mime_types=_supported_prompt_media_mime_types(descriptor),
                 single_message=single_message,
             )
         }
@@ -2085,6 +2107,7 @@ def _prompt_expression(
     packed_messages = _packed_prompt_messages(
         message_expressions,
         supports_media_inputs=supports_media_inputs,
+        supported_media_mime_types=_supported_prompt_media_mime_types(descriptor),
         single_message=single_message,
     )
     wrapper = _PromptBatch(

--- a/vane/ai/functions.py
+++ b/vane/ai/functions.py
@@ -1103,12 +1103,16 @@ class _PromptBatch:
         max_retries: int = 3,
         on_error: _OnError = "raise",
         supports_media_inputs: bool | None = None,
+        packed_input_column: str | None = None,
     ) -> None:
         if not message_columns:
             raise ValueError("Prompt message_columns cannot be empty")
+        if packed_input_column is not None and (not isinstance(packed_input_column, str) or not packed_input_column):
+            raise ValueError("Prompt packed_input_column must be a non-empty string or None")
         _validate_on_error(on_error)
         self._descriptor = descriptor
         self._message_columns = list(message_columns)
+        self._packed_input_column = packed_input_column
         self._output_column = output_column
         self._max_concurrency_per_actor = max_concurrency_per_actor
         self._single_message = single_message
@@ -1266,11 +1270,20 @@ class _PromptBatch:
         )
 
     def _build_row_messages(self, columns: list[list[Any]], index: int) -> tuple[Any, ...] | None:
-        if self._single_message and columns[0][index] is None:
+        if self._packed_input_column is not None:
+            packed = columns[0][index]
+            if packed is None:
+                return None
+            if not isinstance(packed, Mapping) or set(packed) != set(self._message_columns):
+                raise TypeError("Prompt messages did not cross the native pack boundary")
+            values = [packed[name] for name in self._message_columns]
+        else:
+            values = [column[index] for column in columns]
+        if self._single_message and values[0] is None:
             return None
         parts: list[Any] = []
-        for column in columns:
-            self._append_message_value(parts, column[index])
+        for value in values:
+            self._append_message_value(parts, value)
         return tuple(parts) if parts else None
 
     def _validate_result(self, result: Any) -> str | None:
@@ -1287,7 +1300,8 @@ class _PromptBatch:
         )
 
     def __call__(self, table: pa.Table) -> pa.Table:
-        columns = [table.column(name).to_pylist() for name in self._message_columns]
+        input_columns = [self._packed_input_column] if self._packed_input_column is not None else self._message_columns
+        columns = [table.column(name).to_pylist() for name in input_columns]
         row_count = table.num_rows
         results: list[str | None] = [None] * row_count
         row_messages: dict[int, tuple[Any, ...]] = {}
@@ -1836,7 +1850,7 @@ def _prompt_relation_types(rel: Relation, messages: list[Expression]) -> list[st
 
 
 def _validated_prompt_message(message: Any, *, media_policy: Literal["all", "file", "text"] = "all") -> Expression:
-    """Add a bind-only Prompt guard; FILE inputs lower to native materialization."""
+    """Add a bind-only Prompt type guard that is removed during planning."""
     if media_policy == "text":
         # The hidden BOOLEAN overload uses TRUE for strict text-only native plans.
         return vane.FunctionExpression("__vane_ai_prompt", message, vane.ConstantExpression(True))
@@ -1844,6 +1858,21 @@ def _validated_prompt_message(message: Any, *, media_policy: Literal["all", "fil
         # FALSE permits text plus FILE while continuing to reject eager BLOB input.
         return vane.FunctionExpression("__vane_ai_prompt", message, vane.ConstantExpression(False))
     return vane.FunctionExpression("__vane_ai_prompt", message)
+
+
+_PROMPT_PACKED_INPUT_COLUMN = "__vane_prompt_messages"
+
+
+def _packed_prompt_messages(
+    messages: list[Expression], *, supports_media_inputs: bool, single_message: bool
+) -> Expression:
+    """Pack every message so all FILE inputs share one native byte budget."""
+    return vane.FunctionExpression(
+        "__vane_ai_prompt_pack",
+        vane.ConstantExpression(supports_media_inputs),
+        vane.ConstantExpression(single_message),
+        *messages,
+    )
 
 
 def _build_native_vllm_expression(messages: list[Any], descriptor: NativeInferencePlan) -> vane.Expression:
@@ -1953,10 +1982,22 @@ def _prompt_relation(
         )
 
     input_names = [f"message_{index}" for index in range(len(message_expressions))]
-    media_policy: Literal["all", "file", "text"] = "all" if supports_media_inputs else "file"
-    validated_messages = [
-        _validated_prompt_message(message, media_policy=media_policy) for message in message_expressions
-    ]
+    has_file_inputs = any(value in {"FILE", "FILE[]"} for value in message_types)
+    packed_input_column = _PROMPT_PACKED_INPUT_COLUMN if has_file_inputs else None
+    if has_file_inputs:
+        udf_inputs = {
+            _PROMPT_PACKED_INPUT_COLUMN: _packed_prompt_messages(
+                message_expressions,
+                supports_media_inputs=supports_media_inputs,
+                single_message=single_message,
+            )
+        }
+    else:
+        media_policy: Literal["all", "file", "text"] = "all" if supports_media_inputs else "file"
+        validated_messages = [
+            _validated_prompt_message(message, media_policy=media_policy) for message in message_expressions
+        ]
+        udf_inputs = dict(zip(input_names, validated_messages, strict=True))
     wrapper = _PromptBatch(
         descriptor,
         input_names,
@@ -1968,10 +2009,11 @@ def _prompt_relation(
         max_retries=udf_options.max_retries,
         on_error=udf_options.on_error,
         supports_media_inputs=supports_media_inputs,
+        packed_input_column=packed_input_column,
     )
     expression = _build_ai_batch_expression(
         wrapper,
-        inputs=dict(zip(input_names, validated_messages, strict=True)),
+        inputs=udf_inputs,
         output_column=output_column,
         output_type="VARCHAR",
         udf_opts=udf_options,
@@ -2040,10 +2082,11 @@ def _prompt_expression(
 
     input_names = [f"message_{index}" for index in range(len(message_expressions))]
     supports_media_inputs = bool(descriptor.supports_image_inputs())
-    media_policy: Literal["all", "file", "text"] = "all" if supports_media_inputs else "file"
-    validated_messages = [
-        _validated_prompt_message(message, media_policy=media_policy) for message in message_expressions
-    ]
+    packed_messages = _packed_prompt_messages(
+        message_expressions,
+        supports_media_inputs=supports_media_inputs,
+        single_message=single_message,
+    )
     wrapper = _PromptBatch(
         descriptor,
         input_names,
@@ -2055,10 +2098,11 @@ def _prompt_expression(
         max_retries=udf_options.max_retries,
         on_error=udf_options.on_error,
         supports_media_inputs=supports_media_inputs,
+        packed_input_column=_PROMPT_PACKED_INPUT_COLUMN,
     )
     expression = _build_ai_batch_expression(
         wrapper,
-        inputs=dict(zip(input_names, validated_messages, strict=True)),
+        inputs={_PROMPT_PACKED_INPUT_COLUMN: packed_messages},
         output_column="response",
         output_type="VARCHAR",
         udf_opts=udf_options,

--- a/vane/ai/protocols.py
+++ b/vane/ai/protocols.py
@@ -67,7 +67,7 @@ class PrompterDescriptor(Descriptor["Prompter"]):
         return True
 
     def supported_media_mime_types(self) -> frozenset[str] | None:
-        """Return a non-empty Prompt MIME allowlist, or ``None`` to allow any valid MIME."""
+        """Return a closed Prompt MIME allowlist, or ``None`` when support is provider/model-dynamic."""
         return None
 
 

--- a/vane/ai/protocols.py
+++ b/vane/ai/protocols.py
@@ -66,6 +66,10 @@ class PrompterDescriptor(Descriptor["Prompter"]):
         """Whether this descriptor's statically selected model accepts images."""
         return True
 
+    def supported_media_mime_types(self) -> frozenset[str] | None:
+        """Return a non-empty Prompt MIME allowlist, or ``None`` to allow any valid MIME."""
+        return None
+
 
 class NativePrompterPlan(ABC):
     """Serializable prompt metadata consumed directly by a native planner.

--- a/vane/ai/providers/_mime.py
+++ b/vane/ai/providers/_mime.py
@@ -158,6 +158,7 @@ class ImageMimePolicy:
 
     def require_supported(self, value: bytes | PromptMedia) -> str:
         """Return a declared/detected MIME type or reject the input locally."""
+        mime_type: str | None
         if isinstance(value, PromptMedia):
             mime_type = value.content_type
         else:

--- a/vane/ai/providers/_mime.py
+++ b/vane/ai/providers/_mime.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
+from vane.ai._media import PromptMedia
+
 _PNG_SIGNATURE: Final = b"\x89PNG\r\n\x1a\n"
 _GIF_SIGNATURES: Final = (b"GIF87a", b"GIF89a")
 _MAX_FTYP_BOX_SIZE: Final = 64 * 1024
@@ -154,13 +156,21 @@ class ImageMimePolicy:
     provider_name: str
     supported_mime_types: frozenset[str]
 
-    def require_supported(self, data: bytes) -> str:
-        """Return the detected MIME type or reject the input locally."""
-        mime_type = detect_image_mime_type(data)
-        if mime_type is None:
-            raise ValueError("Prompt image BLOB has an unrecognized image format")
+    def require_supported(self, value: bytes | PromptMedia) -> str:
+        """Return a declared/detected MIME type or reject the input locally."""
+        if isinstance(value, PromptMedia):
+            mime_type = value.content_type
+        else:
+            mime_type = detect_image_mime_type(value)
+            if mime_type is None:
+                raise ValueError("Prompt image BLOB has an unrecognized image format")
         if mime_type not in self.supported_mime_types:
             supported = ", ".join(sorted(self.supported_mime_types))
+            if isinstance(value, PromptMedia):
+                raise ValueError(
+                    f"Prompt FILE MIME type {mime_type!r} is not supported by "
+                    f"{self.provider_name}; supported MIME types: {supported}"
+                )
             raise ValueError(
                 f"Prompt image BLOB format {mime_type!r} is not supported by "
                 f"{self.provider_name}; supported MIME types: {supported}"

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -171,6 +171,9 @@ class AnthropicPrompterDescriptor(PrompterDescriptor):
     def get_options(self) -> Options:
         return dict(self.options)
 
+    def supported_media_mime_types(self) -> frozenset[str]:
+        return _IMAGE_MIME_POLICY.supported_mime_types
+
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0)
 

--- a/vane/ai/providers/anthropic.py
+++ b/vane/ai/providers/anthropic.py
@@ -9,6 +9,7 @@ import base64
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from vane.ai._media import PromptMedia
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import OutputValidationError, serialize_raw_response
 from vane.ai.options import (
@@ -228,14 +229,14 @@ class AnthropicPrompter:
     def _process_message(message: Any) -> dict[str, Any]:
         if isinstance(message, str):
             return {"type": "text", "text": message}
-        if isinstance(message, bytes):
+        if isinstance(message, (bytes, PromptMedia)):
             media_type = _IMAGE_MIME_POLICY.require_supported(message)
             return {
                 "type": "image",
                 "source": {
                     "type": "base64",
                     "media_type": media_type,
-                    "data": base64.b64encode(message).decode("ascii"),
+                    "data": base64.b64encode(bytes(message)).decode("ascii"),
                 },
             }
         raise TypeError(f"Unsupported Prompt content type: {type(message).__name__}")

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -568,6 +568,9 @@ class GooglePrompterDescriptor(PrompterDescriptor):
     def get_options(self) -> Options:
         return dict(self.options)
 
+    def supported_media_mime_types(self) -> frozenset[str]:
+        return _IMAGE_MIME_POLICY.supported_mime_types
+
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0)
 

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -3,7 +3,7 @@
 
 """Google Generative AI (Gemini) provider for Vane AI.
 
-Supports text embedding via ``embed_content`` and basic text/image Prompt
+Supports text embedding via ``embed_content`` and basic multimodal Prompt
 calls via ``generate_content``.
 
 Prompt calls must name a model, either per call (``model=...``) or through
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 
+from vane.ai._media import PromptMedia
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import serialize_raw_response
 from vane.ai.options import (
@@ -540,7 +541,7 @@ def _validate_google_prompt_options(options: Mapping[str, Any]) -> dict[str, Any
 
 @dataclass
 class GooglePrompterDescriptor(PrompterDescriptor):
-    """Serializable factory for a basic Gemini text/image prompter."""
+    """Serializable factory for a basic Gemini multimodal prompter."""
 
     model_name: str
     provider_name: str = "google"
@@ -582,7 +583,7 @@ class GooglePrompterDescriptor(PrompterDescriptor):
 
 
 class GooglePrompter:
-    """Async basic text/image prompter using Gemini ``generate_content``."""
+    """Async basic multimodal prompter using Gemini ``generate_content``."""
 
     def __init__(
         self,
@@ -620,7 +621,7 @@ class GooglePrompter:
             return "structured Prompt generation"
         if raw:
             return "Prompt raw response body"
-        return "basic Prompt text/image generation"
+        return "basic multimodal Prompt generation"
 
     # --- Multimodal message processing -----------------------------------
 
@@ -633,6 +634,8 @@ class GooglePrompter:
         if isinstance(msg, bytes):
             media_type = _IMAGE_MIME_POLICY.require_supported(msg)
             return types.Part.from_bytes(data=msg, mime_type=media_type)
+        if isinstance(msg, PromptMedia):
+            return types.Part.from_bytes(data=msg.data, mime_type=msg.content_type)
         raise TypeError(f"Unsupported Prompt content type: {type(msg).__name__}")
 
     # --- API call --------------------------------------------------------

--- a/vane/ai/providers/google.py
+++ b/vane/ai/providers/google.py
@@ -568,8 +568,10 @@ class GooglePrompterDescriptor(PrompterDescriptor):
     def get_options(self) -> Options:
         return dict(self.options)
 
-    def supported_media_mime_types(self) -> frozenset[str]:
-        return _IMAGE_MIME_POLICY.supported_mime_types
+    def supported_media_mime_types(self) -> None:
+        # FILE inputs also include audio, video, and documents. Google's
+        # effective set varies by model, so the SDK/provider owns validation.
+        return None
 
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0)

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -791,6 +791,9 @@ class OpenAIPrompterDescriptor(PrompterDescriptor):
             and self.model_name.strip().casefold() in _OPENAI_TEXT_ONLY_PROMPT_MODELS
         )
 
+    def supported_media_mime_types(self) -> frozenset[str]:
+        return _IMAGE_MIME_POLICY.supported_mime_types
+
     def get_udf_options(self) -> UDFOptions:
         return UDFOptions(num_gpus=0)
 

--- a/vane/ai/providers/openai.py
+++ b/vane/ai/providers/openai.py
@@ -20,6 +20,7 @@ from urllib.parse import urlsplit
 
 import numpy as np
 
+from vane.ai._media import PromptMedia
 from vane.ai._redaction import unwrap_sensitive_options, wrap_sensitive_options
 from vane.ai._schema import (
     _is_known_openai_prompt_model,
@@ -867,7 +868,7 @@ class OpenAIPrompter:
         """Convert one validated Vane text/image part to the OpenAI shape."""
         if isinstance(msg, str):
             return self._process_str(msg)
-        if isinstance(msg, bytes):
+        if isinstance(msg, (bytes, PromptMedia)):
             return self._process_bytes(msg)
         raise TypeError(f"Unsupported Prompt content type: {type(msg).__name__}")
 
@@ -876,11 +877,11 @@ class OpenAIPrompter:
             return {"type": "text", "text": msg}
         return {"type": "input_text", "text": msg}
 
-    def _process_bytes(self, msg: bytes) -> dict[str, Any]:
+    def _process_bytes(self, msg: bytes | PromptMedia) -> dict[str, Any]:
         import base64
 
         mime_type = _IMAGE_MIME_POLICY.require_supported(msg)
-        b64 = base64.b64encode(msg).decode("utf-8")
+        b64 = base64.b64encode(bytes(msg)).decode("utf-8")
         data_url = f"data:{mime_type};base64,{b64}"
         return self._build_image_part(data_url)
 


### PR DESCRIPTION
## Summary

- Add Python and SQL AI prompt support for FILE and FILE[] expressions without adding FILE outputs.
- Validate FILE logical contracts without I/O, then materialize each logical byte view at one native query-execution boundary using the active connection FileSystem/Secret context; only locator-free MIME/data/error values cross into the provider UDF.
- Pack every prompt message into one dynamically typed STRUCT so all FILE columns and FILE[] elements share the 128 MiB vector budget; a NULL primary SQL prompt performs no FILE I/O, and failed rows release their materialized bytes before later rows execute.
- Carry closed provider MIME allowlists into the native pack so unsupported declared MIME types fail before FILE I/O and sniffed unsupported types fail before charging the vector budget; providers with model-dynamic multimodal contracts defer MIME validation to the provider.
- Enforce a 20 MiB per-FILE limit before full reads while preserving strict ranges, ordered arrays, NULL semantics, provider `on_error`, retries/cancellation, structured output, and credential-safe errors.

## Related issue

close: #664

## Documentation impact

- [ ] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [x] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Follow-up: AstroVela/vane-website#45

## Validation

- `scripts/format root --changed`
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)" VANE_NATIVE_BUILD_JOBS="$(nproc)" uv pip install . --no-build-isolation`
- Targeted provider MIME, SQL spec, dynamic-routing, and native budget regressions (`80 passed`)
- Complete AI suite (`782 passed, 7 deselected`)
- `tests/fast/test_file_ray.py` (`5 passed`, local CPU Ray cluster; worker PID and exact range asserted)
- Ruff and mypy checks for the changed Python files
- `scripts/run_release_tests.sh` (`813 passed, 20 deselected`; real-Ray shard `14 passed, 819 deselected`)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. (No new dependencies or copied assets.)
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
