### PR TITLE
[feat](extensions) Load installed providers by name

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -265,36 +265,24 @@ size-checked before it is compared with the generated wheel in bounded chunks.
 The complete generated member set is checked against the total uncompressed
 limit before a temporary wheel is created, including a second check after its
 RECORD is generated.
-Load locally by passing the wheel's provider explicitly to
-`DynamicExtensionResolver`:
+Load an installed provider and its exact dependency closure by canonical
+extension name:
 
 ```python
-from importlib import import_module
-from importlib.metadata import entry_points
-
 import vane
-from vane.extensions import DynamicExtensionResolver
 
-matches = [
-    candidate
-    for candidate in entry_points(group="vane.dynamic_extension_providers")
-    if candidate.name == "<extension>"
-]
-if len(matches) != 1:
-    raise RuntimeError(f"expected one installed provider, found {matches!r}")
-installed_extension = import_module(matches[0].module)
-local_provider = matches[0].load()()
 connection = vane.connect()
-DynamicExtensionResolver(
-    trusted_identities={local_provider.trust_identity},
-    providers=(local_provider,),
-).load(connection, installed_extension.descriptor())
+vane.load_installed_extension("<extension>", connection=connection)
 ```
 
-For an extension with dependencies, resolve each dependency provider through
-the same entry-point group and include all of them in `providers` and
-`trusted_identities`. Pass the same complete dependency-wheel closure to the
-verifier in load order with repeated `--dependency-wheel` arguments.
+The named entry point must provide exactly one root artifact. Vane initializes
+only that provider and the providers named by its exact descriptor dependency
+identities, verifies the complete closure before loading native code, and
+records dependencies before the root in the connection manifest. Advanced
+callers that already hold explicit descriptors and trust policy can continue to
+use `DynamicExtensionResolver` directly. Pass the same complete
+dependency-wheel closure to the verifier in load order with repeated
+`--dependency-wheel` arguments.
 
 The installed provider and resolver perform no network lookup at runtime.
 Package installation remains standard pip behavior; for an offline deployment,
@@ -326,12 +314,13 @@ extension loading. `tpch` remains an in-tree build/test artifact only: its
 source has additional redistribution terms and it must not be published as an
 extension wheel. #619 tracks the first release-approved Iceberg wheel.
 
-Applications load a trusted local artifact through
-`DynamicExtensionResolver.load()`. After DuckDB accepts the verified cache
-snapshot, Vane records the artifact's canonical `DynamicExtensionDescriptor`
-on the connection session. Ray snapshots preserve that ordered descriptor
-manifest, including each SHA-256 digest and dependency identity, but never a
-local artifact path or binary payload.
+Applications normally load a named installed provider through
+`load_installed_extension()`; callers with an explicit descriptor and trust
+policy can use `DynamicExtensionResolver.load()` directly. After DuckDB accepts
+the verified cache snapshot, Vane records the artifact's canonical
+`DynamicExtensionDescriptor` on the connection session. Ray snapshots preserve
+that ordered descriptor manifest, including each SHA-256 digest and dependency
+identity, but never a local artifact path or binary payload.
 
 Every Ray node must install the same platform extension wheels before queries
 start. Each wheel supplies one provider entry point under

--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -119,6 +119,13 @@ records it only after `DynamicExtensionResolver.load()` verifies the local
 artifact and DuckDB accepts the cached bytes. A non-static extension loaded by
 another route makes snapshot capture fail closed.
 
+Applications can call `vane.load_installed_extension(name, connection=...)` to
+discover exactly one installed root provider by canonical name and resolve only
+the dependency identities declared by that provider. This convenience API uses
+the same resolver and snapshot path; it does not scan extension directories,
+contact a repository, download a wheel, select a compatible version, or fall
+back to another artifact.
+
 Optional platform wheels are the offline deployment transport for these local
 providers. Each wheel contains exactly one self-contained artifact, its
 canonical descriptor, required license files, and one provider entry point,

--- a/scripts/verify_extension_wheel.py
+++ b/scripts/verify_extension_wheel.py
@@ -1051,7 +1051,6 @@ def _verify_extension_wheel_snapshots(
             from pathlib import Path
 
             import vane
-            from vane.extensions import DynamicExtensionResolver
 
             installed_entry_points = tuple(entry_points(group={ENTRY_POINT_GROUP!r}))
             provider_by_name = {{}}
@@ -1098,13 +1097,11 @@ def _verify_extension_wheel_snapshots(
 
             assert set(descriptor_by_name) == set({all_extension_names!r})
 
-            connection = vane.connect()
+            connection = vane.connect(
+                config={{"extension_directory": str(Path.cwd() / "duckdb-extensions")}}
+            )
             try:
-                resolved = DynamicExtensionResolver(
-                    trusted_identities={trusted_identities!r},
-                    providers=tuple(provider_by_name.values()),
-                    cache_directory=Path.cwd() / "extension-cache",
-                ).load(connection, descriptor)
+                resolved = vane.load_installed_extension({extension_name!r}, connection=connection)
                 assert resolved.identity == descriptor.identity
                 assert connection.execute(
                     "SELECT loaded FROM duckdb_extensions() WHERE extension_name = ?", [descriptor.name]

--- a/tests/fast/test_dynamic_extension_resolver.py
+++ b/tests/fast/test_dynamic_extension_resolver.py
@@ -77,8 +77,10 @@ class _InstalledProviderEntryPoint:
     def __init__(self, name, provider):
         self.name = name
         self._provider = provider
+        self.load_calls = 0
 
     def load(self):
+        self.load_calls += 1
         return lambda: self._provider
 
 
@@ -248,6 +250,143 @@ def test_resolver_loads_dependencies_in_order_and_reuses_content_cache(tmp_path,
     snapshot_json = str(extension_module._capture_dynamic_extension_snapshot(connection))
     assert str(dependency_path) not in snapshot_json
     assert str(root_path) not in snapshot_json
+
+
+def test_load_installed_extension_discovers_only_the_exact_dependency_closure(
+    tmp_path,
+    fake_native_loader,
+    monkeypatch,
+):
+    platform = _runtime_platform()
+    dependency_path = _write_extension_artifact(
+        tmp_path / "providers" / "dependency.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    root_path = _write_extension_artifact(
+        tmp_path / "providers" / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+        extension_version="root-version",
+    )
+    unrelated_path = _write_extension_artifact(
+        tmp_path / "providers" / "unrelated.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    dependency = _descriptor(dependency_path, name="dependency", trust_identity="dependency-signer")
+    root = replace(
+        _descriptor(root_path, name="root", trust_identity="root-signer"),
+        dependencies=(DynamicExtensionDependency(dependency.name, dependency.extension_version, dependency.sha256),),
+    )
+    unrelated = _descriptor(unrelated_path, name="unrelated", trust_identity="unrelated-signer")
+    installed_entry_points = (
+        _InstalledProviderEntryPoint(
+            "dependency",
+            LocalExtensionProvider(
+                dependency.trust_identity,
+                (LocalExtensionArtifact(dependency, dependency_path),),
+            ),
+        ),
+        _InstalledProviderEntryPoint(
+            "root",
+            LocalExtensionProvider(root.trust_identity, (LocalExtensionArtifact(root, root_path),)),
+        ),
+        _InstalledProviderEntryPoint(
+            "unrelated",
+            LocalExtensionProvider(unrelated.trust_identity, (LocalExtensionArtifact(unrelated, unrelated_path),)),
+        ),
+    )
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: installed_entry_points if group == "vane.dynamic_extension_providers" else (),
+    )
+    monkeypatch.setattr(extension_module, "_native_extension_directory", lambda _connection: tmp_path / "runtime")
+    connection = RecordingConnection(platform)
+
+    resolved = extension_module.load_installed_extension("root", connection=connection)
+
+    assert resolved.descriptor == root
+    assert [path.name for path in connection.loaded_paths] == [
+        "dependency.duckdb_extension",
+        "root.duckdb_extension",
+    ]
+    assert extension_module._capture_dynamic_extension_snapshot(connection) == [dependency.to_dict(), root.to_dict()]
+    assert [entry_point.load_calls for entry_point in installed_entry_points] == [1, 1, 0]
+
+
+def test_load_installed_extension_rejects_a_missing_dependency_provider_before_loading(
+    tmp_path,
+    fake_native_loader,
+    monkeypatch,
+):
+    platform = _runtime_platform()
+    root_path = _write_extension_artifact(
+        tmp_path / "providers" / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+    )
+    root = replace(
+        _descriptor(root_path, name="root"),
+        dependencies=(DynamicExtensionDependency("dependency", "missing-version", "1" * 64),),
+    )
+    root_entry_point = _InstalledProviderEntryPoint(
+        "root",
+        LocalExtensionProvider(root.trust_identity, (LocalExtensionArtifact(root, root_path),)),
+    )
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: (root_entry_point,) if group == "vane.dynamic_extension_providers" else (),
+    )
+    connection = RecordingConnection(platform)
+
+    with pytest.raises(DynamicExtensionError, match="PROVIDER_NOT_FOUND"):
+        extension_module.load_installed_extension("root", connection=connection)
+
+    assert connection.loaded_paths == []
+
+
+def test_load_installed_extension_rejects_multiple_root_artifacts_without_selecting_latest(
+    tmp_path,
+    fake_native_loader,
+    monkeypatch,
+):
+    platform = _runtime_platform()
+    first_path = _write_extension_artifact(
+        tmp_path / "first" / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+        extension_version="first-version",
+    )
+    second_path = _write_extension_artifact(
+        tmp_path / "second" / "root.duckdb_extension",
+        platform=platform,
+        source_id=vane.__git_revision__,
+        extension_version="second-version",
+    )
+    first = _descriptor(first_path, name="root")
+    second = _descriptor(second_path, name="root")
+    provider = LocalExtensionProvider(
+        first.trust_identity,
+        (
+            LocalExtensionArtifact(first, first_path),
+            LocalExtensionArtifact(second, second_path),
+        ),
+    )
+    root_entry_point = _InstalledProviderEntryPoint("root", provider)
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: (root_entry_point,) if group == "vane.dynamic_extension_providers" else (),
+    )
+    connection = RecordingConnection(platform)
+
+    with pytest.raises(DynamicExtensionError, match="PROVIDER_AMBIGUOUS"):
+        extension_module.load_installed_extension("root", connection=connection)
+
+    assert connection.loaded_paths == []
 
 
 def test_vane_connection_cursors_share_dynamic_snapshot_state():

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -43,6 +43,7 @@ def test_vane_public_exports_are_unique_and_resolvable():
         "file_type",
         "func",
         "lit",
+        "load_installed_extension",
         "sql_expr",
     }
     assert expected_vane_exports <= set(vane.__all__)

--- a/tests/fast/test_ray_dynamic_extension_replay.py
+++ b/tests/fast/test_ray_dynamic_extension_replay.py
@@ -13,7 +13,7 @@ from typing import Any
 import pytest
 
 import vane
-from vane.extensions import DynamicExtensionResolver, LocalExtensionProvider
+from vane.extensions import LocalExtensionProvider
 
 
 def _configured_signed_provider():
@@ -148,7 +148,7 @@ def test_real_ray_prepares_and_reuses_explicit_signed_extension_without_driver_p
     from vane.runners.ray.runner import RayRunner
     from vane.runners.ray.worker import RayWorkerActor
 
-    provider, artifact = _configured_signed_provider()
+    _, artifact = _configured_signed_provider()
     connection = vane.connect(
         config={
             "allow_unsigned_extensions": "true",
@@ -156,11 +156,7 @@ def test_real_ray_prepares_and_reuses_explicit_signed_extension_without_driver_p
             "autoload_known_extensions": "true",
         }
     )
-    resolver = DynamicExtensionResolver(
-        trusted_identities={provider.trust_identity},
-        providers=(provider,),
-    )
-    resolver.load(connection, artifact.descriptor)
+    vane.load_installed_extension(artifact.descriptor.name, connection=connection)
     extension_security_settings = """
         SELECT
             CAST(current_setting('allow_unsigned_extensions') AS BOOLEAN),

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -241,6 +241,7 @@ from vane.extensions import (
     LocalExtensionProvider,
     ResolvedDynamicExtension,
     create_dynamic_extension_descriptor,
+    load_installed_extension,
 )
 from vane.value.constant import (
     BinaryValue,
@@ -541,6 +542,7 @@ __all__: list[str] = [
     "list_filesystems",
     "list_type",
     "load_extension",
+    "load_installed_extension",
     "map_type",
     "order",
     "open_file",

--- a/vane/extensions.py
+++ b/vane/extensions.py
@@ -566,31 +566,11 @@ def _load_installed_dynamic_extension_providers(
     descriptor_by_name = {descriptor.name: descriptor for descriptor in descriptors}
     if not descriptor_by_name:
         return ()
-    try:
-        installed_entry_points = tuple(entry_points(group=_DYNAMIC_EXTENSION_PROVIDER_ENTRY_POINT_GROUP))
-    except Exception as exception:
-        raise DynamicExtensionError(
-            "PROVIDER_DISCOVERY_FAILED", "could not enumerate installed dynamic extension providers"
-        ) from exception
+    installed_entry_points = _installed_dynamic_extension_provider_entry_points()
 
     providers: list[LocalExtensionProvider] = []
     for name, descriptor in sorted(descriptor_by_name.items()):
-        matches = [installed for installed in installed_entry_points if installed.name == name]
-        if not matches:
-            _fail("PROVIDER_NOT_FOUND", f"no installed local provider entry point exists for {name}")
-        if len(matches) != 1:
-            _fail("PROVIDER_AMBIGUOUS", f"multiple installed local provider entry points exist for {name}")
-        try:
-            provider_factory = matches[0].load()
-            provider = provider_factory()
-        except DynamicExtensionError:
-            raise
-        except Exception as exception:
-            raise DynamicExtensionError(
-                "PROVIDER_INVALID", f"could not initialize installed local provider for {name}"
-            ) from exception
-        if not isinstance(provider, LocalExtensionProvider):
-            _fail("PROVIDER_INVALID", f"installed local provider for {name} did not return LocalExtensionProvider")
+        provider = _load_installed_dynamic_extension_provider(name, installed_entry_points)
         artifact = provider.find(descriptor.identity)
         if artifact is None or artifact.descriptor != descriptor:
             _fail(
@@ -608,6 +588,136 @@ def _load_installed_dynamic_extension_providers(
             )
         )
     return tuple(providers)
+
+
+def _installed_dynamic_extension_provider_entry_points() -> tuple[object, ...]:
+    """Enumerate installed provider metadata without initializing providers."""
+    try:
+        return tuple(entry_points(group=_DYNAMIC_EXTENSION_PROVIDER_ENTRY_POINT_GROUP))
+    except Exception as exception:
+        raise DynamicExtensionError(
+            "PROVIDER_DISCOVERY_FAILED", "could not enumerate installed dynamic extension providers"
+        ) from exception
+
+
+def _load_installed_dynamic_extension_provider(
+    name: str,
+    installed_entry_points: tuple[object, ...],
+) -> LocalExtensionProvider:
+    """Initialize the one installed provider authorized for a canonical name."""
+    matches = [installed for installed in installed_entry_points if getattr(installed, "name", None) == name]
+    if not matches:
+        _fail("PROVIDER_NOT_FOUND", f"no installed local provider entry point exists for {name}")
+    if len(matches) != 1:
+        _fail("PROVIDER_AMBIGUOUS", f"multiple installed local provider entry points exist for {name}")
+    try:
+        provider_factory = matches[0].load()  # type: ignore[attr-defined]
+        provider = provider_factory()
+    except DynamicExtensionError:
+        raise
+    except Exception as exception:
+        raise DynamicExtensionError(
+            "PROVIDER_INVALID", f"could not initialize installed local provider for {name}"
+        ) from exception
+    if not isinstance(provider, LocalExtensionProvider):
+        _fail("PROVIDER_INVALID", f"installed local provider for {name} did not return LocalExtensionProvider")
+    return provider
+
+
+def load_installed_extension(
+    name: str,
+    *,
+    connection: DuckDBPyConnection,
+) -> ResolvedDynamicExtension:
+    """Load one named installed provider and its exact dependency closure.
+
+    Provider discovery is limited to the canonical entry-point name and the
+    dependency identities declared by its descriptor. The installed provider
+    packages form the local trust boundary; this helper performs no repository,
+    directory, download, compatibility, or fallback lookup.
+    """
+    canonical_name = _validate_extension_name(name, "provider name")
+    installed_entry_points = _installed_dynamic_extension_provider_entry_points()
+    provider_by_name: dict[str, LocalExtensionProvider] = {}
+
+    def installed_provider(provider_name: str) -> LocalExtensionProvider:
+        provider = provider_by_name.get(provider_name)
+        if provider is None:
+            provider = _load_installed_dynamic_extension_provider(provider_name, installed_entry_points)
+            provider_by_name[provider_name] = provider
+        return provider
+
+    root_provider = installed_provider(canonical_name)
+    root_artifacts = tuple(
+        artifact
+        for artifact in root_provider._artifact_by_identity.values()
+        if artifact.descriptor.name == canonical_name
+    )
+    if not root_artifacts:
+        _fail(
+            "PROVIDER_DESCRIPTOR_MISMATCH",
+            f"installed local provider entry point {canonical_name} does not provide that extension",
+        )
+    if len(root_artifacts) != 1:
+        _fail(
+            "PROVIDER_AMBIGUOUS",
+            f"installed local provider entry point {canonical_name} provides multiple artifact identities",
+        )
+
+    root_descriptor = root_artifacts[0].descriptor
+    descriptor_by_identity: dict[str, DynamicExtensionDescriptor] = {}
+    descriptor_by_name: dict[str, DynamicExtensionDescriptor] = {}
+    scoped_provider_by_identity: dict[str, LocalExtensionProvider] = {}
+    pending = [root_descriptor]
+    while pending:
+        descriptor = pending.pop()
+        existing_identity = descriptor_by_identity.get(descriptor.identity)
+        if existing_identity is not None:
+            if existing_identity != descriptor:
+                _fail(
+                    "RESOLVED_IDENTITY_CONFLICT",
+                    f"{descriptor.identity} resolves to conflicting descriptors",
+                )
+            continue
+        existing_name = descriptor_by_name.get(descriptor.name)
+        if existing_name is not None and existing_name.identity != descriptor.identity:
+            _fail(
+                "RESOLVED_NAME_CONFLICT",
+                f"dependency graph resolves {descriptor.name} as both "
+                f"{existing_name.identity} and {descriptor.identity}",
+            )
+
+        provider = installed_provider(descriptor.name)
+        artifact = provider.find(descriptor.identity)
+        if artifact is None or artifact.descriptor != descriptor:
+            _fail(
+                "PROVIDER_DESCRIPTOR_MISMATCH",
+                f"installed local provider descriptor does not exactly match {descriptor.identity}",
+            )
+        descriptor_by_identity[descriptor.identity] = descriptor
+        descriptor_by_name[descriptor.name] = descriptor
+        scoped_provider_by_identity[descriptor.identity] = LocalExtensionProvider(
+            provider.trust_identity,
+            (artifact,),
+        )
+
+        dependency_descriptors: list[DynamicExtensionDescriptor] = []
+        for dependency in descriptor.dependencies:
+            dependency_provider = installed_provider(dependency.name)
+            dependency_artifact = dependency_provider.find(dependency.identity)
+            if dependency_artifact is None:
+                _fail(
+                    "DEPENDENCY_NOT_FOUND",
+                    f"installed local provider does not contain {dependency.identity}",
+                )
+            dependency_descriptors.append(dependency_artifact.descriptor)
+        pending.extend(reversed(dependency_descriptors))
+
+    resolver = DynamicExtensionResolver(
+        trusted_identities={descriptor.trust_identity for descriptor in descriptor_by_identity.values()},
+        providers=tuple(scoped_provider_by_identity.values()),
+    )
+    return resolver.load(connection, root_descriptor)
 
 
 def _prepare_dynamic_extension_snapshot(connection: DuckDBPyConnection, snapshot: object) -> None:
@@ -1477,4 +1587,5 @@ __all__ = [
     "LocalExtensionProvider",
     "ResolvedDynamicExtension",
     "create_dynamic_extension_descriptor",
+    "load_installed_extension",
 ]


### PR DESCRIPTION
## Summary

- add `vane.load_installed_extension(name, connection=...)` for loading an installed dynamic-extension provider by canonical name
- discover only the requested provider and its exact declared dependency closure
- reuse the existing resolver for signature, digest, SourceID, platform, dependency-order, and native-load checks
- fail closed on missing or ambiguous installed providers; do not scan repositories, download artifacts, select versions, or fall back
- use the public API in clean extension-wheel verification and isolate its DuckDB extension cache

## Related issue

Part of #619

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Updated `DEVELOPMENT.md` and `DISTRIBUTED_EXTENSIONS.md`.

## Validation

- `scripts/format root --changed --check`
- Ruff checks for all changed Python files
- `pre-commit run mypy --all-files`
- `python3 -m compileall` for changed Python files
- `git diff --check`
- incremental Release wheel build and install with `SKBUILD_BUILD_DIR=build/python-release`
- installed-package smoke check from outside the source tree
- targeted installed-package tests: 50 passed, 2 skipped
- real-Ray signed-provider replay target: 1 skipped because no signed provider is configured locally

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.