### PR TITLE
[feat](release) Publish development candidates to TestPyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Build only, or publish an existing draft release
+        description: Build only, publish a main-branch dev candidate, or publish an existing draft release
         type: choice
         options:
           - build-only
+          - testpypi-dev
           - release
         default: build-only
         required: true
@@ -150,6 +151,10 @@ jobs:
           )"
           if test "$OPERATION" = "release"; then
             test "$GITHUB_REF_NAME" = "v$version"
+          elif test "$OPERATION" = "testpypi-dev"; then
+            python scripts/validate_testpypi_candidate.py \
+              --version "$version" \
+              --github-ref "$GITHUB_REF"
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           python scripts/check_release_artifacts.py --expected-version "$version" "$path"
@@ -358,7 +363,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: inputs.operation == 'release'
+    if: inputs.operation == 'release' || inputs.operation == 'testpypi-dev'
     needs: assemble
     runs-on: ubuntu-24.04
     environment:
@@ -382,10 +387,11 @@ jobs:
 
   verify-testpypi:
     name: Verify the TestPyPI candidate
-    if: inputs.operation == 'release'
+    if: inputs.operation == 'release' || inputs.operation == 'testpypi-dev'
     needs:
       - assemble
       - publish-testpypi
+      - source-package
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Python
@@ -401,10 +407,11 @@ jobs:
 
       - name: Download and install the indexed candidate
         env:
+          EXPECTED_VERSION: ${{ needs['source-package'].outputs.version }}
           INDEX_URL: https://test.pypi.org/simple/
         run: |
           python -m pip install --upgrade pip
-          version="${GITHUB_REF_NAME#v}"
+          version="$EXPECTED_VERSION"
           indexed_wheel=""
           for attempt in 1 2 3 4 5; do
             candidate_dir="$RUNNER_TEMP/testpypi-candidate-$attempt"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,8 +59,10 @@ Repository administrators must:
    scanning.
 4. Configure the `RELEASE_ARTIFACT_CONTENT_RULES` repository secret used by
    trusted artifact validation.
-5. Create protected `testpypi` and `pypi` GitHub environments. Both accept only
-   `v*` tags, require maintainer approval, and disallow administrator bypass.
+5. Create protected `testpypi` and `pypi` GitHub environments. The `testpypi`
+   environment accepts only the protected `main` branch and `v*` tags; the
+   `pypi` environment accepts only `v*` tags. Both require maintainer approval
+   and disallow administrator bypass.
 6. Register `.github/workflows/release.yml` as a trusted publisher for the
    `vane-ai` project on TestPyPI and PyPI, using the matching `testpypi` and
    `pypi` environment names. Publishing intentionally has no API-token fallback.
@@ -70,6 +72,28 @@ Repository administrators must:
 
 Review these settings before every release rather than assuming the one-time
 configuration has remained unchanged.
+
+## Publish a TestPyPI development candidate
+
+Use a development candidate to qualify exact cross-package dependencies before
+the next Vane release exists. Dispatch the release workflow from the protected
+`main` branch without creating a tag:
+
+```bash
+gh workflow run release.yml \
+  --repo AstroVela/vane \
+  --ref main \
+  -f operation=testpypi-dev
+```
+
+The workflow accepts only the canonical PEP 440 development version derived
+from that exact `main` commit and rejects a version already present on
+TestPyPI. It builds, validates, attests, and signs the same complete
+distribution set as a release, then publishes and clean-installs it through
+the protected `testpypi` environment. It does not publish to PyPI, create a
+tag, or create or modify a GitHub Release. A development candidate is
+immutable and is never promoted; if it is unsuitable, merge a fix and publish
+the new commit's development version.
 
 ## Prepare the release pull request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ include = [
     "/scripts/resolve_duckdb_fork_version.py",
     "/scripts/sync_duckdb_source_id.py",
     "/scripts/sync_vcpkg_licenses.py",
+    "/scripts/validate_testpypi_candidate.py",
     "/scripts/verify_base_install.py",
     "/scripts/verify_duckdb_coexistence.py",
     "/scripts/verify_extension_wheel.py",

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -767,6 +767,7 @@ def _check_sdist(artifact: SdistArtifact, layout: DistributionLayout) -> None:
         "scripts/run_installed_pytest.sh",
         "scripts/run_release_tests.sh",
         "scripts/sync_duckdb_source_id.py",
+        "scripts/validate_testpypi_candidate.py",
         "scripts/verify_duckdb_coexistence.py",
         "scripts/verify_extension_wheel.py",
         "tests/ray_test_profile.py",

--- a/scripts/validate_testpypi_candidate.py
+++ b/scripts/validate_testpypi_candidate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate one no-tag Vane development candidate before TestPyPI publication."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+
+from packaging.version import InvalidVersion, Version
+
+_MAIN_REF = "refs/heads/main"
+_TESTPYPI_JSON_BASE = "https://test.pypi.org/pypi"
+
+
+class CandidateValidationError(RuntimeError):
+    """Raised when a requested development candidate is unsafe to publish."""
+
+
+def validate_development_version(raw_version: str, github_ref: str) -> Version:
+    """Return a canonical main-branch PEP 440 development version."""
+    if github_ref != _MAIN_REF:
+        raise CandidateValidationError(f"TestPyPI development candidates require {_MAIN_REF}, not {github_ref!r}")
+    try:
+        version = Version(raw_version)
+    except InvalidVersion:
+        raise CandidateValidationError(
+            f"development candidate is not a valid PEP 440 version: {raw_version!r}"
+        ) from None
+    if str(version) != raw_version:
+        raise CandidateValidationError(f"development candidate must use canonical PEP 440 spelling: {version}")
+    if version.epoch != 0 or len(version.release) != 3:
+        raise CandidateValidationError("development candidate must use an X.Y.Z version without an epoch")
+    if not version.is_devrelease or version.local is not None:
+        raise CandidateValidationError("TestPyPI development candidates must have a .devN suffix and no local version")
+    return version
+
+
+def require_testpypi_version_absent(
+    version: Version,
+    *,
+    open_url: Callable[..., AbstractContextManager[object]] = urllib.request.urlopen,
+) -> None:
+    """Fail unless TestPyPI reports that the immutable version is unused."""
+    encoded_version = urllib.parse.quote(str(version), safe="")
+    url = f"{_TESTPYPI_JSON_BASE}/vane-ai/{encoded_version}/json"
+    try:
+        with open_url(url, timeout=30):
+            pass
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return
+        raise CandidateValidationError(f"TestPyPI version query failed with HTTP {error.code}") from error
+    except urllib.error.URLError as error:
+        raise CandidateValidationError(f"TestPyPI version query failed: {error.reason}") from error
+    raise CandidateValidationError(f"vane-ai {version} already exists on TestPyPI")
+
+
+def main() -> int:
+    """Validate CLI arguments and TestPyPI availability."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Exact version read from the built source distribution")
+    parser.add_argument("--github-ref", required=True, help="Exact GitHub Actions ref for this workflow run")
+    arguments = parser.parse_args()
+    try:
+        version = validate_development_version(arguments.version, arguments.github_ref)
+        require_testpypi_version_absent(version)
+    except CandidateValidationError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fast/test_testpypi_candidate.py
+++ b/tests/fast/test_testpypi_candidate.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+from packaging.version import Version
+
+from scripts.validate_testpypi_candidate import (
+    CandidateValidationError,
+    require_testpypi_version_absent,
+    validate_development_version,
+)
+
+
+@pytest.mark.parametrize("raw_version", ["0.2.0.dev601", "0.2.0rc2.dev3"])
+def test_validate_development_version_accepts_canonical_main_versions(raw_version):
+    assert validate_development_version(raw_version, "refs/heads/main") == Version(raw_version)
+
+
+@pytest.mark.parametrize(
+    ("raw_version", "github_ref", "message"),
+    [
+        ("0.2.0.dev601", "refs/heads/feature/candidate", "require refs/heads/main"),
+        ("0.2.0", "refs/heads/main", "must have a .devN suffix"),
+        ("0.2.0.dev601+local", "refs/heads/main", "no local version"),
+        ("0.2.dev601", "refs/heads/main", "must use an X.Y.Z version"),
+        ("0.2.0.dev0601", "refs/heads/main", "canonical PEP 440 spelling"),
+    ],
+)
+def test_validate_development_version_rejects_unsafe_candidates(raw_version, github_ref, message):
+    with pytest.raises(CandidateValidationError, match=message):
+        validate_development_version(raw_version, github_ref)
+
+
+def test_require_testpypi_version_absent_accepts_only_an_explicit_404():
+    requested: list[tuple[str, int]] = []
+
+    def missing(url, *, timeout):
+        requested.append((url, timeout))
+        raise urllib.error.HTTPError(url, 404, "missing", {}, None)
+
+    require_testpypi_version_absent(Version("0.2.0.dev601"), open_url=missing)
+    assert requested == [("https://test.pypi.org/pypi/vane-ai/0.2.0.dev601/json", 30)]
+
+
+@pytest.mark.parametrize("status", [200, 500])
+def test_require_testpypi_version_absent_rejects_existing_or_indeterminate_versions(status):
+    class ExistingResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    def open_url(url, *, timeout):
+        if status == 500:
+            raise urllib.error.HTTPError(url, status, "failed", {}, None)
+        return ExistingResponse()
+
+    expected = "already exists" if status == 200 else "query failed"
+    with pytest.raises(CandidateValidationError, match=expected):
+        require_testpypi_version_absent(Version("0.2.0.dev601"), open_url=open_url)


### PR DESCRIPTION
## Summary

- add a manual `testpypi-dev` operation to the existing release workflow
- allow publication only from `refs/heads/main` and only for canonical PEP 440 development versions
- reject versions already present on TestPyPI and fail closed on index errors
- publish and verify the normal release distribution set on TestPyPI without continuing to PyPI or GitHub Releases
- document the no-tag candidate workflow and required protected-environment branch policy

## Related issue

Part of #619

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Updated `RELEASE.md`.

## Validation

- `pre-commit run --files .github/workflows/release.yml RELEASE.md pyproject.toml scripts/check_release_artifacts.py scripts/validate_testpypi_candidate.py tests/fast/test_testpypi_candidate.py`
- `scripts/format root --changed --check`
- `python -m compileall` for the changed Python files
- targeted installed-package tests: 10 passed
- built and validated `vane_ai-0.2.0.dev601.tar.gz`
- confirmed the validation script is present in the sdist
- exercised the live TestPyPI availability check for `0.2.0.dev601`
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.