### PR TITLE
[feat](release) Trust TestPyPI extension candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,6 +212,8 @@ jobs:
 
       - name: Build wheels from the source package
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        env:
+          CIBW_CONFIG_SETTINGS: "cmake.define.VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY=${{ inputs.operation == 'testpypi-dev' && 'ON' || 'OFF' }}"
         with:
           package-dir: ${{ steps.sdist.outputs.path }}
           output-dir: wheelhouse

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -345,6 +345,14 @@ Python 3.12 wheel used to build the test artifact explicitly enables
 `VANE_ENABLE_TEST_EXTENSION_SIGNING_KEY`; the option is off by default and must
 never be enabled for release artifacts.
 
+No-tag TestPyPI development candidates instead enable
+`VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY`. That key is independent of the
+public integration-test key; official artifacts enable it only in
+`testpypi-dev` base wheels. It must never be enabled for a tagged release or
+build-only qualification. Its private key belongs only in the protected
+provider-publishing environment; source, logs, workflow artifacts, and Vane's
+release environments contain only the public key.
+
 ## Native C++ tests
 
 The complete native gate builds DuckDB, distributed exchange, and the test

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,6 +95,12 @@ tag, or create or modify a GitHub Release. A development candidate is
 immutable and is never promoted; if it is unsuitable, merge a fix and publish
 the new commit's development version.
 
+Only these no-tag candidate wheels trust the dedicated AstroVela TestPyPI
+extension-signing key. Build-only and tagged release wheels explicitly leave
+that key disabled. Provider candidates signed by it are therefore qualification
+artifacts only: never promote them to PyPI, and never reuse the candidate key
+as the production extension-signing key.
+
 ## Prepare the release pull request
 
 1. Choose a final canonical PEP 440 version with an `X.Y.Z` release segment.

--- a/external/duckdb/CMakeLists.txt
+++ b/external/duckdb/CMakeLists.txt
@@ -217,6 +217,8 @@ option(FORCE_WARN_UNUSED "Unused code objects lead to compiler warnings." FALSE)
 option(ENABLE_EXTENSION_AUTOLOADING "Enable extension auto-loading by default." FALSE)
 option(ENABLE_EXTENSION_AUTOINSTALL "Enable extension auto-installing by default." FALSE)
 option(EXTENSION_TESTS_ONLY "Only load the tests for extensions, don't actually build them; useful for testing loadable extensions" FALSE)
+option(VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY
+       "Trust AstroVela's candidate-only TestPyPI extension signing key." FALSE)
 option(VANE_ENABLE_TEST_EXTENSION_SIGNING_KEY
        "Trust DuckDB's committed test key for Vane integration fixtures." FALSE)
 set(EXTENSION_DIRECTORIES "~/.duckdb/extensions" CACHE STRING "Default extension directories (;-separated list on win, : on unix)")

--- a/external/duckdb/src/main/extension/CMakeLists.txt
+++ b/external/duckdb/src/main/extension/CMakeLists.txt
@@ -10,6 +10,10 @@ string(REPLACE ";" "\;" EXT_DIR_ESCAPED "${EXTENSION_DIRECTORIES}")
 target_compile_definitions(
   duckdb_main_extension
   PRIVATE "DUCKDB_EXTENSION_DIRECTORIES=\"${EXT_DIR_ESCAPED}\"")
+if(VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY)
+  target_compile_definitions(duckdb_main_extension
+                             PRIVATE VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY)
+endif()
 if(VANE_ENABLE_TEST_EXTENSION_SIGNING_KEY)
   target_compile_definitions(duckdb_main_extension
                              PRIVATE VANE_ENABLE_TEST_EXTENSION_SIGNING_KEY)

--- a/external/duckdb/src/main/extension/extension_helper.cpp
+++ b/external/duckdb/src/main/extension/extension_helper.cpp
@@ -418,6 +418,22 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 }
 
 static const char *const public_keys[] = {
+#ifdef VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY
+    // Candidate-only AstroVela TestPyPI key. Its DER-encoded SubjectPublicKeyInfo
+    // has SHA-256 f02108bc37439677d8ade5c6e0efd90314d5ac7308b8d972d2271f41791b4941.
+    // Production releases must use an independently managed signing key.
+    R"(
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7zuFv8bsD9U0YboZXyIx
+KNe99EktVJewYMTFSTMmLyRH3Ldn3yLTQCk1kciABjT8o556ZtviuGeo5pWXN/Gl
+a2BF0lftvrrU6mJTrY+Hwggk33JSXA46puTrCOlRuREDe2pcAIUela3ktpaqxfXQ
+l1yuIeoFO3tyGRMyvevEZ3Bx5MSdSr9ooLdvhKEm5uW/gb4yVx9QbZ4WVvHLn+Sq
+YyBVHLxB9c1k0MDRFfwpZOnq8r1VFD6ULkAQEgAM8NHZnZsHfmetoemuZmpLx/AB
+mh+FqYTeIb8dIGVBWyCkQa5/0fvhTVuZ+iImLqdbLbDDIYgwKmylrKDoY77n640C
+UQIDAQAB
+-----END PUBLIC KEY-----
+)",
+#endif
 #ifdef VANE_ENABLE_TEST_EXTENSION_SIGNING_KEY
     // This public key matches test/mbedtls/private.pem and is intentionally
     // available only in builds that opt into Vane's integration-test fixture.
@@ -652,7 +668,8 @@ SLWQo0+/ciQ21Zwz5SwimX8ep1YpqYirO04gcyGZzAfGboXRvdUwA+1bZvuUXdKC
 EMS5gLv50CzQqJXK9mNzPuYXNUIc4Pw4ssVWe0OfN3Od90gl5uFUwk/G9lWSYnBN
 3wIDAQAB
 -----END PUBLIC KEY-----
-)", nullptr};
+)",
+    nullptr};
 
 static const char *const community_public_keys[] = {
     R"(

--- a/tests/fast/test_testpypi_candidate.py
+++ b/tests/fast/test_testpypi_candidate.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import re
 import urllib.error
+from pathlib import Path
 
 import pytest
 from packaging.version import Version
@@ -13,6 +17,9 @@ from scripts.validate_testpypi_candidate import (
     require_testpypi_version_absent,
     validate_development_version,
 )
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+TESTPYPI_EXTENSION_KEY_FINGERPRINT = "f02108bc37439677d8ade5c6e0efd90314d5ac7308b8d972d2271f41791b4941"
 
 
 @pytest.mark.parametrize("raw_version", ["0.2.0.dev601", "0.2.0rc2.dev3"])
@@ -63,3 +70,42 @@ def test_require_testpypi_version_absent_rejects_existing_or_indeterminate_versi
     expected = "already exists" if status == 200 else "query failed"
     with pytest.raises(CandidateValidationError, match=expected):
         require_testpypi_version_absent(Version("0.2.0.dev601"), open_url=open_url)
+
+
+def test_testpypi_extension_signing_key_is_candidate_only():
+    option_name = "VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY"
+    duckdb_cmake = (REPOSITORY_ROOT / "external/duckdb/CMakeLists.txt").read_text(encoding="utf-8")
+    extension_cmake = (REPOSITORY_ROOT / "external/duckdb/src/main/extension/CMakeLists.txt").read_text(
+        encoding="utf-8"
+    )
+    extension_helper = (REPOSITORY_ROOT / "external/duckdb/src/main/extension/extension_helper.cpp").read_text(
+        encoding="utf-8"
+    )
+
+    option = re.search(rf"option\({option_name}\s+\"[^\"]+\"\s+(\w+)\)", duckdb_cmake)
+    assert option is not None
+    assert option.group(1) == "FALSE"
+    assert extension_cmake.count(f"if({option_name})") == 1
+    assert extension_cmake.count(f"PRIVATE {option_name}") == 1
+
+    key_block = re.search(
+        rf"#ifdef {option_name}.*?R\"\(\n"
+        r"(-----BEGIN PUBLIC KEY-----\n.+?\n-----END PUBLIC KEY-----)\n"
+        r"\)\",\n#endif",
+        extension_helper,
+        flags=re.DOTALL,
+    )
+    assert key_block is not None
+    public_key_lines = key_block.group(1).splitlines()
+    public_key_der = base64.b64decode("".join(public_key_lines[1:-1]), validate=True)
+    assert hashlib.sha256(public_key_der).hexdigest() == TESTPYPI_EXTENSION_KEY_FINGERPRINT
+    assert TESTPYPI_EXTENSION_KEY_FINGERPRINT in key_block.group(0)
+
+    workflow_setting = (
+        'CIBW_CONFIG_SETTINGS: "cmake.define.'
+        f"{option_name}=${{{{ inputs.operation == 'testpypi-dev' && 'ON' || 'OFF' }}}}\""
+    )
+    workflows = sorted((REPOSITORY_ROOT / ".github/workflows").glob("*.yml"))
+    workflow_contents = [path.read_text(encoding="utf-8") for path in workflows]
+    assert sum(content.count(workflow_setting) for content in workflow_contents) == 1
+    assert sum(content.count(option_name) for content in workflow_contents) == 1


### PR DESCRIPTION
## Summary

- add a dedicated AstroVela TestPyPI extension-signing public key to DuckDB's native signature verifier behind a default-off CMake option;
- enable that trust anchor only for no-tag `testpypi-dev` base wheels, while build-only and tagged release wheels explicitly keep it disabled;
- pin the public-key fingerprint and the single allowed workflow use in a regression test, and document that candidate artifacts and keys are never promoted to production.

The matching private key is held only by the protected `testpypi` environment in `AstroVela/duckdb-iceberg`; no private key enters Vane source, logs, artifacts, or release environments.

## Related issue

Related to #619.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`DEVELOPMENT.md` and `RELEASE.md` document the candidate-only trust boundary and production-key separation.

## Validation

- `PATH="/home/kaka/astrovela_vane-extension-write-core/.venv/bin:$PATH" scripts/format workspace --changed --check`
- Release native install with `SKBUILD_BUILD_DIR="$PWD/build/python-release"`, `SKBUILD_CMAKE_BUILD_TYPE=Release`, `CMAKE_BUILD_PARALLEL_LEVEL=20`, and `-Ccmake.define.VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY=ON`
- installed-native smoke: CMake option is `ON`, candidate public key is embedded, public integration-test key is absent, and `SELECT 42` succeeds
- `scripts/run_installed_pytest.sh tests/fast/test_testpypi_candidate.py` (`11 passed`)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
