### PR TITLE
[feat](file) Add ImageFile metadata and decoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ vllm = [
 sglang = [
     "sglang==0.5.17; platform_system == 'Linux' and platform_machine == 'x86_64'", # validated public async Engine API and lifecycle target
 ]
-image = [ # ndarray image inputs for AI providers
+image = [ # ImageFile metadata/decoding and ndarray image inputs for AI providers
     "pillow>=10",
 ]
 video = [ # video data source; decord is gated to Vane's supported native platform (it lacks modern macOS/ARM wheels)

--- a/src/vane_py/CMakeLists.txt
+++ b/src/vane_py/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   vane_python.cpp
   importer.cpp
   ai_sql_functions.cpp
+  image_file_functions.cpp
   path_like.cpp
   pyconnection.cpp
   datasource_function.cpp

--- a/src/vane_py/image_file_functions.cpp
+++ b/src/vane_py/image_file_functions.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "vane_python/image_file_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/expression.hpp"
+#include "file_resolver.hpp"
+#include "file_value.hpp"
+#include "vane_python/pybind11/gil_wrapper.hpp"
+
+namespace duckdb {
+
+namespace {
+
+static constexpr uint64_t DEFAULT_IMAGE_METADATA_BYTES = 1024 * 1024;
+static constexpr uint64_t DEFAULT_IMAGE_PIXELS = 100000000;
+static constexpr uint64_t MAX_IMAGE_METADATA_BYTES = 64 * 1024 * 1024;
+
+static LogicalType ImageMetadataType() {
+	child_list_t<LogicalType> fields;
+	fields.emplace_back("width", LogicalType::UINTEGER);
+	fields.emplace_back("height", LogicalType::UINTEGER);
+	fields.emplace_back("format", LogicalType::VARCHAR);
+	fields.emplace_back("mode", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(fields));
+}
+
+struct ImageMetadataResult {
+	uint32_t width;
+	uint32_t height;
+	string format;
+	string mode;
+
+	Value ToValue() const {
+		vector<Value> fields;
+		fields.reserve(4);
+		fields.push_back(Value::UINTEGER(width));
+		fields.push_back(Value::UINTEGER(height));
+		fields.push_back(Value(format));
+		fields.push_back(Value(mode));
+		return Value::STRUCT(ImageMetadataType(), std::move(fields));
+	}
+};
+
+static unique_ptr<FunctionData> BindImageFileMetadata(ClientContext &, ScalarFunction &bound_function,
+                                                      vector<unique_ptr<Expression>> &arguments) {
+	auto image_type = FileLogicalType::Create(FileMediaType::IMAGE);
+	auto input_type = arguments[0]->return_type;
+	if (input_type.id() == LogicalTypeId::UNKNOWN || input_type.id() == LogicalTypeId::SQLNULL) {
+		input_type = image_type;
+	}
+	if (!FileLogicalType::IsFile(input_type) || FileLogicalType::GetMediaType(input_type) != FileMediaType::IMAGE) {
+		throw BinderException("image_file_metadata() requires IMAGEFILE, not %s", input_type.ToString());
+	}
+	bound_function.arguments[0] = std::move(input_type);
+	return nullptr;
+}
+
+static ImageMetadataResult ProbeImageMetadata(const string &bytes, uint64_t max_pixels, bool truncated,
+                                              const FileReference &file, uint64_t max_metadata_bytes) {
+	PythonGILWrapper gil;
+	py::object image_file_error_type;
+	try {
+		auto module = py::module_::import("vane._image_file");
+		image_file_error_type = module.attr("ImageFileError");
+		auto helper = module.attr("_probe_image_metadata");
+		py::object content_type = file.has_content_type ? py::cast(file.content_type) : py::none();
+		auto value = helper(py::bytes(bytes), py::int_(max_pixels), py::bool_(truncated), std::move(content_type),
+		                    py::int_(max_metadata_bytes));
+		if (!py::isinstance<py::tuple>(value)) {
+			throw InternalException("Image metadata helper returned a non-tuple value");
+		}
+		auto fields = py::reinterpret_borrow<py::tuple>(value);
+		if (fields.size() != 4 || !py::isinstance<py::int_>(fields[0]) || !py::isinstance<py::int_>(fields[1]) ||
+		    !py::isinstance<py::str>(fields[2]) || !py::isinstance<py::str>(fields[3])) {
+			throw InternalException("Image metadata helper returned an invalid value");
+		}
+		auto width = py::cast<uint64_t>(fields[0]);
+		auto height = py::cast<uint64_t>(fields[1]);
+		if (width > NumericLimits<uint32_t>::Maximum() || height > NumericLimits<uint32_t>::Maximum()) {
+			throw OutOfRangeException("Image dimensions do not fit the image_file_metadata() result type");
+		}
+		return {NumericCast<uint32_t>(width), NumericCast<uint32_t>(height), py::cast<string>(fields[2]),
+		        py::cast<string>(fields[3])};
+	} catch (py::error_already_set &error) {
+		if (error.matches(PyExc_KeyboardInterrupt)) {
+			throw InterruptException();
+		}
+		if (error.matches(PyExc_MemoryError)) {
+			throw OutOfMemoryException("Image metadata inspection ran out of memory");
+		}
+		if (error.matches(PyExc_ImportError) ||
+		    (image_file_error_type.ptr() && error.matches(image_file_error_type.ptr()))) {
+			throw InvalidInputException("image_file_metadata() failed: %s", error.what());
+		}
+		throw InternalException("image_file_metadata() Python helper failed unexpectedly: %s", error.what());
+	}
+}
+
+static void ImageFileMetadataFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto file_value = args.data[0].GetValue(row);
+		if (file_value.IsNull()) {
+			result.SetValue(row, Value(ImageMetadataType()));
+			continue;
+		}
+
+		uint64_t max_metadata_bytes = DEFAULT_IMAGE_METADATA_BYTES;
+		uint64_t max_pixels = DEFAULT_IMAGE_PIXELS;
+		if (args.ColumnCount() == 3) {
+			auto max_metadata_value = args.data[1].GetValue(row);
+			auto max_pixels_value = args.data[2].GetValue(row);
+			if (max_metadata_value.IsNull() || max_pixels_value.IsNull()) {
+				result.SetValue(row, Value(ImageMetadataType()));
+				continue;
+			}
+			max_metadata_bytes = max_metadata_value.GetValue<uint64_t>();
+			max_pixels = max_pixels_value.GetValue<uint64_t>();
+		}
+		if (max_metadata_bytes == 0 || max_metadata_bytes > MAX_IMAGE_METADATA_BYTES) {
+			throw InvalidInputException("image_file_metadata() max_bytes must be between 1 and %llu",
+			                            static_cast<unsigned long long>(MAX_IMAGE_METADATA_BYTES));
+		}
+		if (max_pixels == 0) {
+			throw InvalidInputException("image_file_metadata() max_pixels must be greater than zero");
+		}
+
+		auto file = FileReference::FromValue(file_value, "image_file_metadata");
+		auto resolved = ResolvedFile::Open(state.GetContext(), file);
+		auto logical_size = resolved->LogicalSize();
+		auto read_size = MinValue<uint64_t>(logical_size, max_metadata_bytes);
+		string bytes(NumericCast<idx_t>(read_size), '\0');
+		if (read_size > 0) {
+			resolved->ReadExact(reinterpret_cast<data_ptr_t>(bytes.data()), read_size);
+		}
+		auto metadata = ProbeImageMetadata(bytes, max_pixels, logical_size > read_size, file, max_metadata_bytes);
+		if (state.GetContext().IsInterrupted()) {
+			throw InterruptException();
+		}
+		result.SetValue(row, metadata.ToValue());
+	}
+}
+
+static ScalarFunction MakeImageMetadataFunction(vector<LogicalType> arguments) {
+	ScalarFunction function("image_file_metadata", std::move(arguments), ImageMetadataType(), ImageFileMetadataFunction,
+	                        BindImageFileMetadata);
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	function.SetStability(FunctionStability::VOLATILE);
+	function.SetFallible();
+	return function;
+}
+
+} // namespace
+
+ScalarFunctionSet ImageFileFunctions::GetFunctions() {
+	ScalarFunctionSet result("image_file_metadata");
+	result.AddFunction(MakeImageMetadataFunction({LogicalType::ANY}));
+	result.AddFunction(MakeImageMetadataFunction({LogicalType::ANY, LogicalType::UBIGINT, LogicalType::UBIGINT}));
+	return result;
+}
+
+} // namespace duckdb

--- a/src/vane_py/include/vane_python/image_file_functions.hpp
+++ b/src/vane_py/include/vane_python/image_file_functions.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+
+namespace duckdb {
+
+struct ImageFileFunctions {
+	static ScalarFunctionSet GetFunctions();
+};
+
+} // namespace duckdb

--- a/src/vane_py/native/file.cpp
+++ b/src/vane_py/native/file.cpp
@@ -12,11 +12,18 @@
 #include "vane_python/python_objects.hpp"
 
 #include <mutex>
+#include <type_traits>
 #include <utility>
 
 namespace duckdb {
 
 namespace {
+
+static constexpr uint64_t DEFAULT_IMAGE_METADATA_BYTES = 1024 * 1024;
+static constexpr uint64_t DEFAULT_IMAGE_MAX_PIXELS = 100000000;
+static constexpr uint64_t DEFAULT_IMAGE_BUFFER_SIZE = 1024 * 1024;
+static constexpr uint64_t DEFAULT_IMAGE_MAX_INPUT_BYTES = 256 * 1024 * 1024;
+static constexpr uint64_t DEFAULT_IMAGE_MAX_DECODED_BYTES = 512 * 1024 * 1024;
 
 static string PythonTypeName(const py::handle &value) {
 	return py::str(py::type::of(value)).cast<string>();
@@ -120,6 +127,37 @@ static void BindMediaFileClass(py::handle &m, const char *class_name) {
 	file.def(
 	    py::pickle([](const FILE_TYPE &value) { return value.State(); },
 	               [class_name](const py::tuple &state) { return FileFromPickleState<FILE_TYPE>(state, class_name); }));
+	if constexpr (std::is_same_v<FILE_TYPE, PythonImageFile>) {
+		file.def(
+		    "metadata",
+		    [](const FILE_TYPE &value, const py::object &max_bytes, const py::object &max_pixels,
+		       shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._image_file")
+			        .attr("_image_file_metadata_value")(
+			            py::cast(value, py::return_value_policy::copy), py::arg("max_bytes") = max_bytes,
+			            py::arg("max_pixels") = max_pixels, py::arg("connection") = std::move(connection));
+		    },
+		    "Inspect bounded encoded image headers without decoding pixels", py::kw_only(),
+		    py::arg("max_bytes") = DEFAULT_IMAGE_METADATA_BYTES, py::arg("max_pixels") = DEFAULT_IMAGE_MAX_PIXELS,
+		    py::arg("connection") = py::none());
+		file.def(
+		    "decode",
+		    [](const FILE_TYPE &value, const py::object &mode, const py::object &buffer_size,
+		       const py::object &max_input_bytes, const py::object &max_pixels, const py::object &max_decoded_bytes,
+		       shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._image_file")
+			        .attr("_decode_image_file")(py::cast(value, py::return_value_policy::copy), mode, buffer_size,
+			                                    py::arg("max_input_bytes") = max_input_bytes,
+			                                    py::arg("max_pixels") = max_pixels,
+			                                    py::arg("max_decoded_bytes") = max_decoded_bytes,
+			                                    py::arg("connection") = std::move(connection));
+		    },
+		    "Decode frame zero into a fully loaded, detached Pillow image", py::arg("mode") = py::none(),
+		    py::arg("buffer_size") = DEFAULT_IMAGE_BUFFER_SIZE, py::kw_only(),
+		    py::arg("max_input_bytes") = DEFAULT_IMAGE_MAX_INPUT_BYTES,
+		    py::arg("max_pixels") = DEFAULT_IMAGE_MAX_PIXELS,
+		    py::arg("max_decoded_bytes") = DEFAULT_IMAGE_MAX_DECODED_BYTES, py::arg("connection") = py::none());
+	}
 }
 
 static py::object ExecuteFileScalar(const PythonFile &file, shared_ptr<DuckDBPyConnection> connection,

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -5,6 +5,7 @@
 // Modified by Vane contributors.
 
 #include "vane_python/pyconnection/pyconnection.hpp"
+#include "vane_python/image_file_functions.hpp"
 #include "datasource_function.hpp"
 #include "vane_python/ai_sql_functions.hpp"
 #include "vane_python/pybind11/gil_wrapper.hpp"
@@ -3142,6 +3143,11 @@ void InstantiateNewInstance(DuckDB &db) {
 	auto transaction = CatalogTransaction::GetSystemTransaction(db_instance);
 
 	system_catalog.CreateFunction(transaction, scan_info);
+
+	auto image_file_set = ImageFileFunctions::GetFunctions();
+	CreateScalarFunctionInfo image_file_info(std::move(image_file_set));
+	image_file_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+	system_catalog.CreateFunction(transaction, image_file_info);
 
 	auto vllm_set = VLLMFunction::GetFunctions();
 	CreateScalarFunctionInfo vllm_info(std::move(vllm_set));

--- a/src/vane_py/pyexpression/initialize.cpp
+++ b/src/vane_py/pyexpression/initialize.cpp
@@ -470,6 +470,8 @@ void DuckDBPyExpression::Initialize(py::module_ &m) {
 	expression.def("file_exists", [](const DuckDBPyExpression &self) { return self.FileFunction("file_exists"); });
 	expression.def("file_stat", [](const DuckDBPyExpression &self) { return self.FileFunction("file_stat"); });
 	expression.def("file_mime_type", &DuckDBPyExpression::FileMimeType, py::arg("detect") = "metadata");
+	expression.def("image_file_metadata",
+	               [](const DuckDBPyExpression &self) { return self.FileFunction("image_file_metadata"); });
 }
 
 } // namespace duckdb

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -15,6 +15,7 @@ import vane
 
 FILE_FIELDS = ("url", "content_type", "position", "size", "checksum")
 FILE_METHODS = ("exists", "mime_type", "open", "stat", "to_tempfile")
+IMAGE_FILE_METHODS = FILE_METHODS + ("decode", "metadata")
 MEDIA_FILE_CASES = (
     ("image", "IMAGEFILE", vane.ImageFile, vane.image_file),
     ("audio", "AUDIOFILE", vane.AudioFile, vane.audio_file),
@@ -206,7 +207,8 @@ def test_media_file_python_value_contract(media, type_name, value_class, _constr
     generic = vane.File(value.url, value.content_type, value.position, value.size, value.checksum)
     assert value != generic
     assert len({value, generic}) == 2
-    assert {name for name in dir(value) if not name.startswith("_")} == set(FILE_FIELDS + FILE_METHODS)
+    expected_methods = IMAGE_FILE_METHODS if value_class is vane.ImageFile else FILE_METHODS
+    assert {name for name in dir(value) if not name.startswith("_")} == set(FILE_FIELDS + expected_methods)
 
 
 def test_media_file_value_inherits_reader_and_metadata_behavior(tmp_path):

--- a/tests/fast/test_image_file.py
+++ b/tests/fast/test_image_file.py
@@ -3,6 +3,7 @@
 
 import importlib
 import io
+import threading
 
 import pytest
 from PIL import Image
@@ -74,6 +75,42 @@ def test_image_file_metadata_facades(duckdb_cursor, tmp_path):
     expected = {"width": 3, "height": 2, "format": "PNG", "mode": "RGB"}
     assert function_result == expected
     assert method_result == expected
+
+
+def test_image_file_accepts_raw_jpeg2000_mime(duckdb_cursor, tmp_path):
+    buffer = io.BytesIO()
+    image = Image.new("L", (3, 2), 100)
+    try:
+        image.save(buffer, format="JPEG2000", no_jp2=True)
+    except OSError as error:
+        pytest.skip(f"Pillow build does not support JPEG 2000: {error}")
+    finally:
+        image.close()
+    payload = buffer.getvalue()
+    assert payload.startswith(b"\xff\x4f\xff\x51")
+    path = tmp_path / "image.j2c"
+    path.write_bytes(payload)
+    value = vane.ImageFile(str(path), "image/j2c")
+
+    assert value.metadata(connection=duckdb_cursor).format == "JPEG2000"
+    assert duckdb_cursor.execute("SELECT image_file_metadata($1)", [value]).fetchone()[0]["mode"] == "L"
+    decoded = value.decode(connection=duckdb_cursor)
+    assert decoded.size == (3, 2)
+    decoded.close()
+    with pytest.raises(vane.ImageFileFormatError, match="detected MIME type"):
+        vane.ImageFile(str(path), "image/jp2").metadata(connection=duckdb_cursor)
+
+
+def test_image_file_accepts_precise_and_family_portable_anymap_mimes(duckdb_cursor, tmp_path):
+    path = tmp_path / "image.pgm"
+    path.write_bytes(b"P5\n2 1\n255\n\x00\xff")
+
+    precise = vane.ImageFile(str(path), "image/x-portable-graymap")
+    family = vane.ImageFile(str(path), "image/x-portable-anymap")
+    assert precise.metadata(connection=duckdb_cursor).mode == "L"
+    assert duckdb_cursor.execute("SELECT image_file_metadata($1)", [family]).fetchone()[0]["format"] == "PPM"
+    with pytest.raises(vane.ImageFileFormatError, match="detected MIME type"):
+        vane.ImageFile(str(path), "image/x-portable-pixmap").metadata(connection=duckdb_cursor)
 
 
 def test_image_file_preserves_high_bit_depth_mode(duckdb_cursor, tmp_path):
@@ -159,7 +196,7 @@ def test_image_file_metadata_limits_are_enforced(duckdb_cursor, tmp_path):
         duckdb_cursor.execute("SELECT image_file_metadata($1, 1024, 11)", [value]).fetchone()
 
 
-def test_image_file_per_call_pixel_limit_overrides_and_restores_pillow_global_limit(
+def test_image_file_per_call_pixel_limit_does_not_change_pillow_global_limit(
     duckdb_cursor,
     tmp_path,
     monkeypatch,
@@ -173,8 +210,8 @@ def test_image_file_per_call_pixel_limit_overrides_and_restores_pillow_global_li
     assert Image.MAX_IMAGE_PIXELS == 1
     assert duckdb_cursor.execute("SELECT image_file_metadata($1, 1024, 12)", [value]).fetchone()[0]["height"] == 3
     assert Image.MAX_IMAGE_PIXELS == 1
-    # TIFF checks the global limit again while allocating its decode tile, so
-    # this also verifies that the per-call limit covers the complete load.
+    # TIFF repeats Pillow's bomb check while allocating its decode tile, so
+    # this also verifies that the per-call context covers the complete load.
     decode_path = tmp_path / "image.tiff"
     decode_path.write_bytes(_encoded_image("TIFF", size=(4, 3)))
     decoded = vane.ImageFile(str(decode_path), "image/tiff").decode(
@@ -184,6 +221,48 @@ def test_image_file_per_call_pixel_limit_overrides_and_restores_pillow_global_li
     assert decoded.size == (4, 3)
     decoded.close()
     assert Image.MAX_IMAGE_PIXELS == 1
+
+
+def test_image_file_pixel_limit_is_isolated_from_unrelated_pillow_threads(monkeypatch):
+    payload = _encoded_image("PNG", size=(4, 3))
+    entered = threading.Event()
+    release = threading.Event()
+    worker_sizes: list[tuple[int, int]] = []
+    worker_errors: list[BaseException] = []
+    original_check = Image._decompression_bomb_check
+    monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 1)
+
+    class BlockingBytesIO(io.BytesIO):
+        def read(self, size=-1, /):
+            entered.set()
+            if not release.wait(timeout=5):
+                raise TimeoutError("test did not release the ImageFile reader")
+            return super().read(size)
+
+    def open_with_vane_limit():
+        try:
+            with _image_file._open_image_with_limit(Image, BlockingBytesIO(payload), max_pixels=12) as image:
+                image.load()
+                worker_sizes.append(image.size)
+        except BaseException as error:
+            worker_errors.append(error)
+
+    worker = threading.Thread(target=open_with_vane_limit)
+    worker.start()
+    try:
+        assert entered.wait(timeout=5)
+        with pytest.raises(Image.DecompressionBombError):
+            with Image.open(io.BytesIO(payload)) as unrelated:
+                unrelated.load()
+    finally:
+        release.set()
+        worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert worker_errors == []
+    assert worker_sizes == [(4, 3)]
+    assert Image.MAX_IMAGE_PIXELS == 1
+    assert Image._decompression_bomb_check is original_check
 
 
 def test_image_file_decode_limits_are_enforced(duckdb_cursor, tmp_path):

--- a/tests/fast/test_image_file.py
+++ b/tests/fast/test_image_file.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import io
+
+import pytest
+from PIL import Image
+
+import vane
+from vane import _image_file
+
+
+def _encoded_image(image_format: str, *, size: tuple[int, int] = (7, 5), color: str = "red") -> bytes:
+    buffer = io.BytesIO()
+    image = Image.new("RGB", size, color)
+    try:
+        image.save(buffer, format=image_format)
+    except OSError as error:
+        pytest.skip(f"Pillow build does not support {image_format}: {error}")
+    finally:
+        image.close()
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("image_format", "expected_mode", "expected_mime"),
+    [
+        ("PNG", "RGB", "image/png"),
+        ("JPEG", "RGB", "image/jpeg"),
+        ("WEBP", "RGB", "image/webp"),
+        ("GIF", "P", "image/gif"),
+    ],
+)
+def test_image_file_metadata_sql_and_python_value(
+    duckdb_cursor,
+    tmp_path,
+    image_format,
+    expected_mode,
+    expected_mime,
+):
+    path = tmp_path / f"image.{image_format.lower()}"
+    path.write_bytes(_encoded_image(image_format))
+    value = vane.ImageFile(str(path), expected_mime)
+
+    result_type, metadata, null_metadata = duckdb_cursor.execute(
+        """
+        SELECT
+            typeof(image_file_metadata($1)),
+            image_file_metadata($1),
+            image_file_metadata(NULL::IMAGEFILE)
+        """,
+        [value],
+    ).fetchone()
+
+    assert result_type == 'STRUCT(width UINTEGER, height UINTEGER, format VARCHAR, "mode" VARCHAR)'
+    assert metadata == {"width": 7, "height": 5, "format": image_format, "mode": expected_mode}
+    assert null_metadata is None
+    assert value.metadata(connection=duckdb_cursor) == vane.ImageMetadata(7, 5, image_format, expected_mode)
+
+
+def test_image_file_metadata_facades(duckdb_cursor, tmp_path):
+    path = tmp_path / "image.png"
+    path.write_bytes(_encoded_image("PNG", size=(3, 2)))
+    value = vane.ImageFile(str(path), "image/png")
+
+    function_result = (
+        duckdb_cursor.sql("SELECT 1")
+        .select(vane.image_file_metadata(value, max_bytes=4096, max_pixels=6))
+        .fetchone()[0]
+    )
+    method_result = duckdb_cursor.sql("SELECT 1").select(vane.image_file(value).image_file_metadata()).fetchone()[0]
+
+    expected = {"width": 3, "height": 2, "format": "PNG", "mode": "RGB"}
+    assert function_result == expected
+    assert method_result == expected
+
+
+def test_image_file_preserves_high_bit_depth_mode(duckdb_cursor, tmp_path):
+    path = tmp_path / "high-depth.png"
+    image = Image.new("I;16", (2, 3), 1000)
+    try:
+        image.save(path, format="PNG")
+    finally:
+        image.close()
+    value = vane.ImageFile(str(path), "image/png")
+
+    assert value.metadata(connection=duckdb_cursor) == vane.ImageMetadata(2, 3, "PNG", "I;16")
+    decoded = value.decode(connection=duckdb_cursor)
+    assert decoded.mode == "I;16"
+    assert decoded.getpixel((0, 0)) == 1000
+    decoded.close()
+
+
+def test_image_file_metadata_and_decode_honor_logical_range(duckdb_cursor, tmp_path):
+    payload = _encoded_image("PNG", size=(4, 3), color="blue")
+    prefix = b"not-an-image-prefix"
+    suffix = b"not-an-image-suffix"
+    path = tmp_path / "ranged.bin"
+    path.write_bytes(prefix + payload + suffix)
+    value = vane.ImageFile(str(path), "image/png", len(prefix), len(payload))
+
+    assert duckdb_cursor.execute("SELECT image_file_metadata($1)", [value]).fetchone()[0] == {
+        "width": 4,
+        "height": 3,
+        "format": "PNG",
+        "mode": "RGB",
+    }
+    assert value.metadata(connection=duckdb_cursor) == vane.ImageMetadata(4, 3, "PNG", "RGB")
+    decoded = value.decode(connection=duckdb_cursor)
+    assert decoded.size == (4, 3)
+    assert decoded.mode == "RGB"
+    assert decoded.getpixel((0, 0)) == (0, 0, 255)
+    decoded.close()
+
+
+def test_image_file_decode_returns_detached_image_and_converts_mode(duckdb_cursor, tmp_path):
+    path = tmp_path / "image.png"
+    path.write_bytes(_encoded_image("PNG", size=(2, 3)))
+    value = vane.ImageFile(str(path), "image/png")
+
+    decoded = value.decode("L", buffer_size=64, connection=duckdb_cursor)
+    path.unlink()
+
+    assert decoded.size == (2, 3)
+    assert decoded.mode == "L"
+    assert isinstance(decoded.getpixel((0, 0)), int)
+    decoded.close()
+
+
+def test_image_file_decode_uses_first_animated_frame(duckdb_cursor, tmp_path):
+    path = tmp_path / "animated.gif"
+    first = Image.new("RGB", (2, 2), "red")
+    second = Image.new("RGB", (2, 2), "blue")
+    try:
+        first.save(path, format="GIF", save_all=True, append_images=[second], duration=10, loop=0)
+    finally:
+        first.close()
+        second.close()
+
+    decoded = vane.ImageFile(str(path), "image/gif").decode("RGB", connection=duckdb_cursor)
+
+    assert decoded.getpixel((0, 0)) == (255, 0, 0)
+    decoded.close()
+
+
+def test_image_file_metadata_limits_are_enforced(duckdb_cursor, tmp_path):
+    path = tmp_path / "image.png"
+    path.write_bytes(_encoded_image("PNG", size=(4, 3)))
+    value = vane.ImageFile(str(path), "image/png")
+
+    with pytest.raises(vane.ImageFileLimitError, match="max_bytes=8"):
+        value.metadata(max_bytes=8, connection=duckdb_cursor)
+    with pytest.raises(vane.ImageFileLimitError, match="max_pixels=11"):
+        value.metadata(max_pixels=11, connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="max_bytes=8"):
+        duckdb_cursor.execute("SELECT image_file_metadata($1, 8, 100)", [value]).fetchone()
+    with pytest.raises(vane.InvalidInputException, match="max_pixels=11"):
+        duckdb_cursor.execute("SELECT image_file_metadata($1, 1024, 11)", [value]).fetchone()
+
+
+def test_image_file_decode_limits_are_enforced(duckdb_cursor, tmp_path):
+    path = tmp_path / "image.png"
+    payload = _encoded_image("PNG", size=(4, 3))
+    path.write_bytes(payload)
+    value = vane.ImageFile(str(path), "image/png")
+
+    with pytest.raises(vane.ImageFileLimitError, match="max_input_bytes"):
+        value.decode(max_input_bytes=len(payload) - 1, connection=duckdb_cursor)
+    with pytest.raises(vane.ImageFileLimitError, match="max_pixels=11"):
+        value.decode(max_pixels=11, connection=duckdb_cursor)
+    with pytest.raises(vane.ImageFileLimitError, match="max_decoded_bytes=35"):
+        value.decode(max_decoded_bytes=35, connection=duckdb_cursor)
+
+
+@pytest.mark.parametrize(
+    ("content_type", "message"),
+    [("audio/mpeg", "contradicts"), ("image/jpeg", "detected MIME type")],
+)
+def test_image_file_rejects_contradictory_content_type(duckdb_cursor, tmp_path, content_type, message):
+    path = tmp_path / "image.png"
+    path.write_bytes(_encoded_image("PNG"))
+    value = vane.ImageFile(str(path), content_type)
+
+    with pytest.raises(vane.ImageFileFormatError, match=message):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.ImageFileFormatError, match=message):
+        value.decode(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match=message):
+        duckdb_cursor.execute("SELECT image_file_metadata($1)", [value]).fetchone()
+
+
+def test_image_file_classifies_invalid_media_but_propagates_io(duckdb_cursor, tmp_path):
+    corrupt = tmp_path / "corrupt.png"
+    corrupt.write_bytes(b"not an image")
+    corrupt_value = vane.ImageFile(str(corrupt), "image/png")
+
+    with pytest.raises(vane.ImageFileFormatError, match="supported encoded image"):
+        corrupt_value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.ImageFileFormatError, match="supported encoded image"):
+        corrupt_value.decode(connection=duckdb_cursor)
+
+    large_corrupt = tmp_path / "large-corrupt.png"
+    large_corrupt.write_bytes(b"not an image" * 1024)
+    # Once every allowed header byte has been consumed, more bytes could still
+    # contain a late format marker; the bounded probe must report the budget,
+    # not claim that it inspected the complete logical view.
+    with pytest.raises(vane.ImageFileLimitError, match="max_bytes=1024"):
+        vane.ImageFile(str(large_corrupt), "image/png").metadata(max_bytes=1024, connection=duckdb_cursor)
+
+    missing = vane.ImageFile(str(tmp_path / "missing.png"), "image/png")
+    with pytest.raises(vane.IOException):
+        missing.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.IOException):
+        missing.decode(connection=duckdb_cursor)
+    with pytest.raises(vane.IOException):
+        duckdb_cursor.execute("SELECT image_file_metadata($1)", [missing]).fetchone()
+
+
+def test_image_file_metadata_requires_imagefile(duckdb_cursor):
+    with pytest.raises(vane.BinderException, match="requires IMAGEFILE, not FILE"):
+        duckdb_cursor.sql("SELECT image_file_metadata(file('memory://generic', NULL, NULL, NULL, NULL))")
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs", "error_type", "message"),
+    [
+        ("metadata", {"max_bytes": True}, TypeError, "max_bytes must be int"),
+        ("metadata", {"max_bytes": 0}, ValueError, "greater than zero"),
+        ("metadata", {"max_bytes": 64 * 1024 * 1024 + 1}, ValueError, "at most"),
+        ("decode", {"mode": 1}, TypeError, "mode must be str or None"),
+        ("decode", {"mode": "XYZ"}, ValueError, "unsupported image decode mode"),
+        ("decode", {"max_pixels": 0}, ValueError, "greater than zero"),
+    ],
+)
+def test_image_file_python_argument_validation(method, kwargs, error_type, message):
+    value = vane.ImageFile("memory://not-opened")
+
+    with pytest.raises(error_type, match=message):
+        getattr(value, method)(**kwargs)
+
+
+def test_image_file_optional_dependency_is_lazy(monkeypatch):
+    original_import = importlib.import_module
+
+    def fail_pillow(name, package=None):
+        if name == "PIL.Image":
+            raise ImportError("missing pillow")
+        return original_import(name, package)
+
+    monkeypatch.setattr(_image_file.importlib, "import_module", fail_pillow)
+
+    value = vane.ImageFile("memory://not-opened")
+    with pytest.raises(ImportError, match=r"vane-ai\[image\]"):
+        value.metadata()
+    with pytest.raises(ImportError, match=r"vane-ai\[image\]"):
+        value.decode()

--- a/tests/fast/test_image_file.py
+++ b/tests/fast/test_image_file.py
@@ -159,6 +159,33 @@ def test_image_file_metadata_limits_are_enforced(duckdb_cursor, tmp_path):
         duckdb_cursor.execute("SELECT image_file_metadata($1, 1024, 11)", [value]).fetchone()
 
 
+def test_image_file_per_call_pixel_limit_overrides_and_restores_pillow_global_limit(
+    duckdb_cursor,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "image.png"
+    path.write_bytes(_encoded_image("PNG", size=(4, 3)))
+    value = vane.ImageFile(str(path), "image/png")
+    monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 1)
+
+    assert value.metadata(max_pixels=12, connection=duckdb_cursor).width == 4
+    assert Image.MAX_IMAGE_PIXELS == 1
+    assert duckdb_cursor.execute("SELECT image_file_metadata($1, 1024, 12)", [value]).fetchone()[0]["height"] == 3
+    assert Image.MAX_IMAGE_PIXELS == 1
+    # TIFF checks the global limit again while allocating its decode tile, so
+    # this also verifies that the per-call limit covers the complete load.
+    decode_path = tmp_path / "image.tiff"
+    decode_path.write_bytes(_encoded_image("TIFF", size=(4, 3)))
+    decoded = vane.ImageFile(str(decode_path), "image/tiff").decode(
+        max_pixels=12,
+        connection=duckdb_cursor,
+    )
+    assert decoded.size == (4, 3)
+    decoded.close()
+    assert Image.MAX_IMAGE_PIXELS == 1
+
+
 def test_image_file_decode_limits_are_enforced(duckdb_cursor, tmp_path):
     path = tmp_path / "image.png"
     payload = _encoded_image("PNG", size=(4, 3))
@@ -169,8 +196,14 @@ def test_image_file_decode_limits_are_enforced(duckdb_cursor, tmp_path):
         value.decode(max_input_bytes=len(payload) - 1, connection=duckdb_cursor)
     with pytest.raises(vane.ImageFileLimitError, match="max_pixels=11"):
         value.decode(max_pixels=11, connection=duckdb_cursor)
-    with pytest.raises(vane.ImageFileLimitError, match="max_decoded_bytes=35"):
-        value.decode(max_decoded_bytes=35, connection=duckdb_cursor)
+    for mode in (None, "LA", "YCbCr"):
+        with pytest.raises(
+            vane.ImageFileLimitError,
+            match="requires up to 96 bytes, exceeding max_decoded_bytes=95",
+        ):
+            value.decode(mode, max_decoded_bytes=95, connection=duckdb_cursor)
+        decoded = value.decode(mode, max_decoded_bytes=96, connection=duckdb_cursor)
+        decoded.close()
 
 
 @pytest.mark.parametrize(

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -49,6 +49,13 @@ from vane._file import (
     try_to_file,
     video_file,
 )
+from vane._image_file import (
+    ImageFileError,
+    ImageFileFormatError,
+    ImageFileLimitError,
+    ImageMetadata,
+    image_file_metadata,
+)
 
 if _typing.TYPE_CHECKING:
     from vane import ai as ai
@@ -407,6 +414,10 @@ __all__: list[str] = [
     "HugeIntegerValue",
     "IOException",
     "ImageFile",
+    "ImageFileError",
+    "ImageFileFormatError",
+    "ImageFileLimitError",
+    "ImageMetadata",
     "IntegerValue",
     "IntegrityError",
     "InternalError",
@@ -548,6 +559,7 @@ __all__: list[str] = [
     "get_table_names",
     "guess_mime_type",
     "image_file",
+    "image_file_metadata",
     "install_extension",
     "interrupt",
     "limit",

--- a/vane/_image_file.py
+++ b/vane/_image_file.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Encoded IMAGEFILE metadata and Python decoding helpers."""
+
+from __future__ import annotations
+
+import importlib
+import io
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import vane
+from vane._expressions import as_expression
+from vane._file import _positive_buffer_size
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage  # type: ignore[import-not-found]
+
+
+DEFAULT_IMAGE_METADATA_BYTES = 1024 * 1024
+DEFAULT_IMAGE_MAX_PIXELS = 100_000_000
+DEFAULT_IMAGE_BUFFER_SIZE = 1024 * 1024
+DEFAULT_IMAGE_MAX_INPUT_BYTES = 256 * 1024 * 1024
+DEFAULT_IMAGE_MAX_DECODED_BYTES = 512 * 1024 * 1024
+MAX_IMAGE_METADATA_BYTES = 64 * 1024 * 1024
+_MAX_UBIGINT = (1 << 64) - 1
+
+_EXPLICIT_IMAGE_MODES = frozenset({"1", "L", "LA", "P", "RGB", "RGBA", "CMYK", "YCbCr", "I", "F"})
+_MIME_ALIASES = {
+    "image/jpg": "image/jpeg",
+    "image/pjpeg": "image/jpeg",
+    "image/x-png": "image/png",
+    "image/x-icon": "image/vnd.microsoft.icon",
+}
+_GENERIC_MIME_TYPES = frozenset({"application/octet-stream", "binary/octet-stream", "image/*"})
+
+
+@dataclass(frozen=True, slots=True)
+class ImageMetadata:
+    """Header metadata for an encoded :class:`vane.ImageFile`."""
+
+    width: int
+    height: int
+    format: str
+    mode: str
+
+
+class ImageFileError(RuntimeError):
+    """Base class for failures caused by encoded image content."""
+
+
+class ImageFileFormatError(ImageFileError):
+    """The logical FILE view is not a supported, internally consistent image."""
+
+
+class ImageFileLimitError(ImageFileError):
+    """An ImageFile operation exceeded an explicit resource limit."""
+
+
+class _ImageReaderError(Exception):
+    def __init__(self, cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+
+
+class _ImageReaderProxy:
+    """Keep reader failures distinct from Pillow's OSError media failures."""
+
+    def __init__(self, reader: vane.VaneFileReader) -> None:
+        self._reader = reader
+
+    def read(self, size: int = -1, /) -> bytes:
+        try:
+            return self._reader.read(size)
+        except Exception as error:
+            raise _ImageReaderError(error) from error
+
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        try:
+            return self._reader.seek(offset, whence)
+        except Exception as error:
+            raise _ImageReaderError(error) from error
+
+    def tell(self) -> int:
+        try:
+            return self._reader.tell()
+        except Exception as error:
+            raise _ImageReaderError(error) from error
+
+
+class _MetadataBuffer(io.BytesIO):
+    """Record whether a parser actually attempted to read past the budget."""
+
+    def __init__(self, data: bytes, *, truncated: bool) -> None:
+        super().__init__(data)
+        self._length = len(data)
+        self._truncated = truncated
+        self.budget_exhausted = False
+
+    def read(self, size: int | None = -1, /) -> bytes:
+        result = super().read(size)
+        if self._truncated and self.tell() >= self._length:
+            self.budget_exhausted = True
+        return result
+
+    def readline(self, size: int | None = -1, /) -> bytes:
+        result = super().readline(size)
+        if self._truncated and self.tell() >= self._length:
+            self.budget_exhausted = True
+        return result
+
+
+def _load_pillow() -> tuple[Any, type[Exception]]:
+    try:
+        image_module = importlib.import_module("PIL.Image")
+        unidentified_error = importlib.import_module("PIL").UnidentifiedImageError
+    except (ImportError, AttributeError) as error:
+        raise ImportError(
+            "ImageFile metadata and decoding require the 'pillow' package. Please `pip install 'vane-ai[image]'`."
+        ) from error
+    return image_module, unidentified_error
+
+
+def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be int, not {type(value).__name__!r}")
+    if value <= 0:
+        raise ValueError(f"{name} must be greater than zero")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return value
+
+
+def _limit_expression(value: int | vane.Expression, *, name: str, maximum: int | None = None) -> vane.Expression:
+    if isinstance(value, vane.Expression):
+        return value
+    return as_expression(_positive_limit(value, name=name, maximum=maximum))
+
+
+def _canonical_mime_type(value: str) -> str:
+    normalized = value.partition(";")[0].strip().lower()
+    return _MIME_ALIASES.get(normalized, normalized)
+
+
+def _validate_content_type(content_type: str | None, detected_mime_type: str | None) -> None:
+    if content_type is None:
+        return
+    declared = _canonical_mime_type(content_type)
+    if declared in _GENERIC_MIME_TYPES:
+        return
+    if not declared.startswith("image/"):
+        raise ImageFileFormatError(f"IMAGEFILE content_type {content_type!r} contradicts the decoded image content")
+    if detected_mime_type is None:
+        return
+    detected = _canonical_mime_type(detected_mime_type)
+    if declared != detected:
+        raise ImageFileFormatError(
+            f"IMAGEFILE content_type {content_type!r} contradicts detected MIME type {detected_mime_type!r}"
+        )
+
+
+def _validate_dimensions(width: int, height: int, max_pixels: int) -> None:
+    if width <= 0 or height <= 0:
+        raise ImageFileFormatError(f"image dimensions must be positive, found {width}x{height}")
+    pixels = width * height
+    if pixels > max_pixels:
+        raise ImageFileLimitError(f"image contains {pixels} pixels, exceeding max_pixels={max_pixels}")
+
+
+def _metadata_from_image(
+    image: Any,
+    image_module: Any,
+    *,
+    max_pixels: int,
+    content_type: str | None,
+) -> ImageMetadata:
+    width, height = image.size
+    width = int(width)
+    height = int(height)
+    _validate_dimensions(width, height, max_pixels)
+
+    image_format = image.format
+    if not isinstance(image_format, str) or not image_format:
+        raise ImageFileFormatError("image decoder did not report an encoded format")
+    mode = image.mode
+    if not isinstance(mode, str) or not mode:
+        raise ImageFileFormatError("image decoder did not report a pixel mode")
+    detected_mime_type = image_module.MIME.get(image_format.upper())
+    _validate_content_type(content_type, detected_mime_type)
+    return ImageMetadata(width=width, height=height, format=image_format.upper(), mode=mode)
+
+
+def _classified_image_errors(unidentified_error: type[Exception]) -> tuple[type[Exception], ...]:
+    return (unidentified_error, OSError, SyntaxError, ValueError, EOFError)
+
+
+def _probe_image_metadata(
+    data: bytes,
+    max_pixels: int,
+    truncated: bool,
+    content_type: str | None,
+    max_bytes: int,
+) -> tuple[int, int, str, str]:
+    """Bounded helper called by the native SQL scalar function."""
+    image_module, unidentified_error = _load_pillow()
+    stream = _MetadataBuffer(data, truncated=truncated)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", image_module.DecompressionBombWarning)
+            with image_module.open(stream) as image:
+                metadata = _metadata_from_image(
+                    image,
+                    image_module,
+                    max_pixels=max_pixels,
+                    content_type=content_type,
+                )
+    except ImageFileError:
+        raise
+    except image_module.DecompressionBombError as error:
+        raise ImageFileLimitError(f"image dimensions exceed max_pixels={max_pixels}") from error
+    except _classified_image_errors(unidentified_error) as error:
+        if stream.budget_exhausted:
+            raise ImageFileLimitError(f"image metadata requires more than max_bytes={max_bytes}") from error
+        raise ImageFileFormatError("logical FILE view is not a supported encoded image") from error
+    return metadata.width, metadata.height, metadata.format, metadata.mode
+
+
+def _image_file_metadata_value(
+    value: vane.ImageFile,
+    *,
+    max_bytes: int = DEFAULT_IMAGE_METADATA_BYTES,
+    max_pixels: int = DEFAULT_IMAGE_MAX_PIXELS,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> ImageMetadata:
+    normalized_max_bytes = _positive_limit(max_bytes, name="max_bytes", maximum=MAX_IMAGE_METADATA_BYTES)
+    normalized_max_pixels = _positive_limit(max_pixels, name="max_pixels", maximum=_MAX_UBIGINT)
+    _load_pillow()
+    with value.open(connection=connection) as reader:
+        logical_size = reader.size()
+        read_size = min(logical_size, normalized_max_bytes)
+        data = reader.read(read_size)
+    fields = _probe_image_metadata(
+        data,
+        normalized_max_pixels,
+        logical_size > read_size,
+        value.content_type,
+        normalized_max_bytes,
+    )
+    return ImageMetadata(*fields)
+
+
+def _decoded_bytes(image: Any, output_mode: str) -> int:
+    if output_mode == "1":
+        bytes_per_pixel = 1
+    elif output_mode in {"L", "P"}:
+        bytes_per_pixel = 1
+    elif output_mode in {"LA"} or output_mode.startswith("I;16"):
+        bytes_per_pixel = 2
+    elif output_mode in {"RGB", "YCbCr"}:
+        bytes_per_pixel = 3
+    elif output_mode in {"RGBA", "CMYK", "I", "F"}:
+        bytes_per_pixel = 4
+    else:
+        bytes_per_pixel = max(1, len(image.getbands()))
+    return int(image.width) * int(image.height) * bytes_per_pixel
+
+
+def _validate_decode_mode(mode: object) -> str | None:
+    if mode is None:
+        return None
+    if not isinstance(mode, str):
+        raise TypeError(f"mode must be str or None, not {type(mode).__name__!r}")
+    if mode not in _EXPLICIT_IMAGE_MODES:
+        choices = ", ".join(sorted(_EXPLICIT_IMAGE_MODES))
+        raise ValueError(f"unsupported image decode mode {mode!r}; expected one of: {choices}")
+    return mode
+
+
+def _decode_image_file(
+    value: vane.ImageFile,
+    mode: str | None = None,
+    buffer_size: int = DEFAULT_IMAGE_BUFFER_SIZE,
+    *,
+    max_input_bytes: int = DEFAULT_IMAGE_MAX_INPUT_BYTES,
+    max_pixels: int = DEFAULT_IMAGE_MAX_PIXELS,
+    max_decoded_bytes: int = DEFAULT_IMAGE_MAX_DECODED_BYTES,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> PILImage:
+    normalized_mode = _validate_decode_mode(mode)
+    normalized_buffer_size = _positive_buffer_size(buffer_size, none_default=None, name="buffer_size")
+    normalized_max_input = _positive_limit(max_input_bytes, name="max_input_bytes", maximum=_MAX_UBIGINT)
+    normalized_max_pixels = _positive_limit(max_pixels, name="max_pixels", maximum=_MAX_UBIGINT)
+    normalized_max_decoded = _positive_limit(max_decoded_bytes, name="max_decoded_bytes", maximum=_MAX_UBIGINT)
+    image_module, unidentified_error = _load_pillow()
+
+    try:
+        with value.open(buffer_size=normalized_buffer_size, connection=connection) as reader:
+            input_size = reader.size()
+            if input_size > normalized_max_input:
+                raise ImageFileLimitError(
+                    f"encoded image contains {input_size} bytes, exceeding max_input_bytes={normalized_max_input}"
+                )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", image_module.DecompressionBombWarning)
+                with image_module.open(_ImageReaderProxy(reader)) as source:
+                    metadata = _metadata_from_image(
+                        source,
+                        image_module,
+                        max_pixels=normalized_max_pixels,
+                        content_type=value.content_type,
+                    )
+                    output_mode = normalized_mode or metadata.mode
+                    decoded_bytes = _decoded_bytes(source, output_mode)
+                    if decoded_bytes > normalized_max_decoded:
+                        raise ImageFileLimitError(
+                            f"decoded image requires {decoded_bytes} bytes, "
+                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
+                        )
+
+                    if normalized_mode is not None and normalized_mode != source.mode:
+                        converted = source.convert(normalized_mode)
+                        try:
+                            converted.load()
+                            return converted.copy()
+                        finally:
+                            converted.close()
+                    source.load()
+                    return source.copy()
+    except _ImageReaderError as error:
+        raise error.cause.with_traceback(error.cause.__traceback__)
+    except ImageFileError:
+        raise
+    except image_module.DecompressionBombError as error:
+        raise ImageFileLimitError(f"image dimensions exceed max_pixels={normalized_max_pixels}") from error
+    except _classified_image_errors(unidentified_error) as error:
+        raise ImageFileFormatError("logical FILE view is not a supported encoded image") from error
+
+
+def image_file_metadata(
+    value: vane.ImageFile | vane.Expression,
+    *,
+    max_bytes: int | vane.Expression = DEFAULT_IMAGE_METADATA_BYTES,
+    max_pixels: int | vane.Expression = DEFAULT_IMAGE_MAX_PIXELS,
+) -> vane.Expression:
+    """Inspect bounded encoded IMAGEFILE headers without decoding pixels."""
+    return vane.FunctionExpression(
+        "image_file_metadata",
+        as_expression(value),
+        _limit_expression(max_bytes, name="max_bytes", maximum=MAX_IMAGE_METADATA_BYTES),
+        _limit_expression(max_pixels, name="max_pixels", maximum=_MAX_UBIGINT),
+    )
+
+
+__all__ = [
+    "ImageFileError",
+    "ImageFileFormatError",
+    "ImageFileLimitError",
+    "ImageMetadata",
+    "image_file_metadata",
+]

--- a/vane/_image_file.py
+++ b/vane/_image_file.py
@@ -5,9 +5,12 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import io
+import threading
 import warnings
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -35,6 +38,7 @@ _MIME_ALIASES = {
     "image/x-icon": "image/vnd.microsoft.icon",
 }
 _GENERIC_MIME_TYPES = frozenset({"application/octet-stream", "binary/octet-stream", "image/*"})
+_PILLOW_LIMIT_LOCK = threading.RLock()
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,6 +78,12 @@ class _ImageReaderProxy:
     def read(self, size: int = -1, /) -> bytes:
         try:
             return self._reader.read(size)
+        except Exception as error:
+            raise _ImageReaderError(error) from error
+
+    def readline(self, size: int = -1, /) -> bytes:
+        try:
+            return self._reader.readline(size)
         except Exception as error:
             raise _ImageReaderError(error) from error
 
@@ -121,6 +131,30 @@ def _load_pillow() -> tuple[Any, type[Exception]]:
             "ImageFile metadata and decoding require the 'pillow' package. Please `pip install 'vane-ai[image]'`."
         ) from error
     return image_module, unidentified_error
+
+
+@contextlib.contextmanager
+def _open_image_with_limit(image_module: Any, stream: Any, *, max_pixels: int) -> Iterator[Any]:
+    # Pillow consults a process-global limit while opening and, for some
+    # formats, again while loading pixels. Serialize the complete operation,
+    # loosen the global cap only as far as this call requires, and restore it
+    # afterwards. Vane's per-call validation remains the authoritative limit.
+    with _PILLOW_LIMIT_LOCK:
+        previous_limit = image_module.MAX_IMAGE_PIXELS
+        pillow_limit = previous_limit
+        # Pillow raises only above twice MAX_IMAGE_PIXELS; the warning between
+        # the two thresholds is redundant with Vane's exact validation below.
+        minimum_pillow_limit = (max_pixels + 1) // 2
+        if previous_limit is not None and previous_limit < minimum_pillow_limit:
+            pillow_limit = minimum_pillow_limit
+        image_module.MAX_IMAGE_PIXELS = pillow_limit
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", image_module.DecompressionBombWarning)
+                with image_module.open(stream) as image:
+                    yield image
+        finally:
+            image_module.MAX_IMAGE_PIXELS = previous_limit
 
 
 def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> int:
@@ -207,15 +241,13 @@ def _probe_image_metadata(
     image_module, unidentified_error = _load_pillow()
     stream = _MetadataBuffer(data, truncated=truncated)
     try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", image_module.DecompressionBombWarning)
-            with image_module.open(stream) as image:
-                metadata = _metadata_from_image(
-                    image,
-                    image_module,
-                    max_pixels=max_pixels,
-                    content_type=content_type,
-                )
+        with _open_image_with_limit(image_module, stream, max_pixels=max_pixels) as image:
+            metadata = _metadata_from_image(
+                image,
+                image_module,
+                max_pixels=max_pixels,
+                content_type=content_type,
+            )
     except ImageFileError:
         raise
     except image_module.DecompressionBombError as error:
@@ -252,18 +284,14 @@ def _image_file_metadata_value(
 
 
 def _decoded_bytes(image: Any, output_mode: str) -> int:
-    if output_mode == "1":
+    if output_mode in {"1", "L", "P"}:
         bytes_per_pixel = 1
-    elif output_mode in {"L", "P"}:
-        bytes_per_pixel = 1
-    elif output_mode in {"LA"} or output_mode.startswith("I;16"):
+    elif output_mode.startswith("I;16"):
         bytes_per_pixel = 2
-    elif output_mode in {"RGB", "YCbCr"}:
-        bytes_per_pixel = 3
-    elif output_mode in {"RGBA", "CMYK", "I", "F"}:
+    elif output_mode in {"LA", "RGB", "RGBA", "CMYK", "YCbCr", "I", "F"}:
         bytes_per_pixel = 4
     else:
-        bytes_per_pixel = max(1, len(image.getbands()))
+        bytes_per_pixel = max(4, len(image.getbands()))
     return int(image.width) * int(image.height) * bytes_per_pixel
 
 
@@ -302,32 +330,37 @@ def _decode_image_file(
                 raise ImageFileLimitError(
                     f"encoded image contains {input_size} bytes, exceeding max_input_bytes={normalized_max_input}"
                 )
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", image_module.DecompressionBombWarning)
-                with image_module.open(_ImageReaderProxy(reader)) as source:
-                    metadata = _metadata_from_image(
-                        source,
-                        image_module,
-                        max_pixels=normalized_max_pixels,
-                        content_type=value.content_type,
+            with _open_image_with_limit(
+                image_module,
+                _ImageReaderProxy(reader),
+                max_pixels=normalized_max_pixels,
+            ) as source:
+                metadata = _metadata_from_image(
+                    source,
+                    image_module,
+                    max_pixels=normalized_max_pixels,
+                    content_type=value.content_type,
+                )
+                output_mode = normalized_mode or metadata.mode
+                source_bytes = _decoded_bytes(source, metadata.mode)
+                output_bytes = _decoded_bytes(source, output_mode)
+                decoded_working_bytes = source_bytes + output_bytes
+                if decoded_working_bytes > normalized_max_decoded:
+                    raise ImageFileLimitError(
+                        f"image decode requires up to {decoded_working_bytes} bytes, "
+                        f"exceeding max_decoded_bytes={normalized_max_decoded}"
                     )
-                    output_mode = normalized_mode or metadata.mode
-                    decoded_bytes = _decoded_bytes(source, output_mode)
-                    if decoded_bytes > normalized_max_decoded:
-                        raise ImageFileLimitError(
-                            f"decoded image requires {decoded_bytes} bytes, "
-                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
-                        )
 
-                    if normalized_mode is not None and normalized_mode != source.mode:
-                        converted = source.convert(normalized_mode)
-                        try:
-                            converted.load()
-                            return converted.copy()
-                        finally:
-                            converted.close()
-                    source.load()
-                    return source.copy()
+                if normalized_mode is not None and normalized_mode != source.mode:
+                    converted = source.convert(normalized_mode)
+                    try:
+                        converted.load()
+                    except BaseException:
+                        converted.close()
+                        raise
+                    return converted
+                source.load()
+                return source.copy()
     except _ImageReaderError as error:
         raise error.cause.with_traceback(error.cause.__traceback__)
     except ImageFileError:

--- a/vane/_image_file.py
+++ b/vane/_image_file.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 
 import contextlib
+import contextvars
+import functools
 import importlib
 import io
 import threading
-import warnings
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -32,13 +33,17 @@ _MAX_UBIGINT = (1 << 64) - 1
 
 _EXPLICIT_IMAGE_MODES = frozenset({"1", "L", "LA", "P", "RGB", "RGBA", "CMYK", "YCbCr", "I", "F"})
 _MIME_ALIASES = {
+    "image/j2k": "image/j2c",
+    "image/jpc": "image/j2c",
     "image/jpg": "image/jpeg",
     "image/pjpeg": "image/jpeg",
+    "image/x-portable-greymap": "image/x-portable-graymap",
     "image/x-png": "image/png",
     "image/x-icon": "image/vnd.microsoft.icon",
 }
 _GENERIC_MIME_TYPES = frozenset({"application/octet-stream", "binary/octet-stream", "image/*"})
-_PILLOW_LIMIT_LOCK = threading.RLock()
+_PILLOW_PIXEL_LIMIT = contextvars.ContextVar[int | None]("vane_image_file_max_pixels", default=None)
+_PILLOW_HOOK_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +66,17 @@ class ImageFileFormatError(ImageFileError):
 
 class ImageFileLimitError(ImageFileError):
     """An ImageFile operation exceeded an explicit resource limit."""
+
+
+@dataclass(slots=True)
+class _PillowLimitHook:
+    image_module: Any
+    original: Callable[[tuple[int, int]], None]
+    wrapper: Callable[[tuple[int, int]], None]
+    users: int = 0
+
+
+_PILLOW_HOOK: _PillowLimitHook | None = None
 
 
 class _ImageReaderError(Exception):
@@ -133,28 +149,62 @@ def _load_pillow() -> tuple[Any, type[Exception]]:
     return image_module, unidentified_error
 
 
+def _pillow_limit_wrapper(
+    original: Callable[[tuple[int, int]], None],
+) -> Callable[[tuple[int, int]], None]:
+    @functools.wraps(original)
+    def check(size: tuple[int, int]) -> None:
+        max_pixels = _PILLOW_PIXEL_LIMIT.get()
+        if max_pixels is None:
+            original(size)
+            return
+        pixels = max(1, int(size[0])) * max(1, int(size[1]))
+        if pixels > max_pixels:
+            raise ImageFileLimitError(f"image contains {pixels} pixels, exceeding max_pixels={max_pixels}")
+
+    return check
+
+
+@contextlib.contextmanager
+def _pillow_pixel_limit(image_module: Any, max_pixels: int) -> Iterator[None]:
+    """Scope Pillow's process-global check through a context-local limit."""
+    global _PILLOW_HOOK
+
+    token = _PILLOW_PIXEL_LIMIT.set(max_pixels)
+    try:
+        with _PILLOW_HOOK_LOCK:
+            hook = _PILLOW_HOOK
+            if hook is None:
+                original = image_module._decompression_bomb_check
+                wrapper = _pillow_limit_wrapper(original)
+                hook = _PillowLimitHook(image_module, original, wrapper)
+                image_module._decompression_bomb_check = wrapper
+                _PILLOW_HOOK = hook
+            elif hook.image_module is not image_module or image_module._decompression_bomb_check is not hook.wrapper:
+                raise RuntimeError("Pillow decompression check changed during an ImageFile operation")
+            hook.users += 1
+        try:
+            yield
+        finally:
+            with _PILLOW_HOOK_LOCK:
+                hook.users -= 1
+                if hook.users == 0:
+                    if hook.image_module._decompression_bomb_check is hook.wrapper:
+                        hook.image_module._decompression_bomb_check = hook.original
+                    if _PILLOW_HOOK is hook:
+                        _PILLOW_HOOK = None
+    finally:
+        _PILLOW_PIXEL_LIMIT.reset(token)
+
+
 @contextlib.contextmanager
 def _open_image_with_limit(image_module: Any, stream: Any, *, max_pixels: int) -> Iterator[Any]:
-    # Pillow consults a process-global limit while opening and, for some
-    # formats, again while loading pixels. Serialize the complete operation,
-    # loosen the global cap only as far as this call requires, and restore it
-    # afterwards. Vane's per-call validation remains the authoritative limit.
-    with _PILLOW_LIMIT_LOCK:
-        previous_limit = image_module.MAX_IMAGE_PIXELS
-        pillow_limit = previous_limit
-        # Pillow raises only above twice MAX_IMAGE_PIXELS; the warning between
-        # the two thresholds is redundant with Vane's exact validation below.
-        minimum_pillow_limit = (max_pixels + 1) // 2
-        if previous_limit is not None and previous_limit < minimum_pillow_limit:
-            pillow_limit = minimum_pillow_limit
-        image_module.MAX_IMAGE_PIXELS = pillow_limit
-        try:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", image_module.DecompressionBombWarning)
-                with image_module.open(stream) as image:
-                    yield image
-        finally:
-            image_module.MAX_IMAGE_PIXELS = previous_limit
+    # Pillow has no per-open pixel limit and some plugins repeat its private
+    # check while loading. The scoped hook delegates unchanged outside this
+    # context, so unrelated threads retain their own global Pillow policy.
+    with _pillow_pixel_limit(image_module, max_pixels):
+        with image_module.open(stream) as image:
+            yield image
 
 
 def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> int:
@@ -178,7 +228,11 @@ def _canonical_mime_type(value: str) -> str:
     return _MIME_ALIASES.get(normalized, normalized)
 
 
-def _validate_content_type(content_type: str | None, detected_mime_type: str | None) -> None:
+def _validate_content_type(
+    content_type: str | None,
+    detected_mime_type: str | None,
+    compatible_mime_types: frozenset[str],
+) -> None:
     if content_type is None:
         return
     declared = _canonical_mime_type(content_type)
@@ -189,10 +243,30 @@ def _validate_content_type(content_type: str | None, detected_mime_type: str | N
     if detected_mime_type is None:
         return
     detected = _canonical_mime_type(detected_mime_type)
-    if declared != detected:
+    if declared != detected and declared not in compatible_mime_types:
         raise ImageFileFormatError(
             f"IMAGEFILE content_type {content_type!r} contradicts detected MIME type {detected_mime_type!r}"
         )
+
+
+def _detected_image_mime_types(image: Any) -> tuple[str | None, frozenset[str]]:
+    detected_mime_type = image.get_format_mimetype()
+    compatible_mime_types: set[str] = set()
+
+    if image.format == "JPEG2000" and getattr(image, "codec", None) == "j2k":
+        # Pillow uses its JPEG2000-wide image/jp2 registry entry for raw J2K
+        # codestreams, whose registered media type is image/j2c.
+        detected_mime_type = "image/j2c"
+    elif image.format == "PPM":
+        # Pillow reports the precise PBM/PGM/PPM subtype when available. The
+        # portable-anymap type remains a compatible family-level declaration.
+        compatible_mime_types.add("image/x-portable-anymap")
+        if image.mode == "F":
+            compatible_mime_types.add("image/x-portable-floatmap")
+
+    if detected_mime_type is not None:
+        compatible_mime_types.add(_canonical_mime_type(detected_mime_type))
+    return detected_mime_type, frozenset(compatible_mime_types)
 
 
 def _validate_dimensions(width: int, height: int, max_pixels: int) -> None:
@@ -205,7 +279,6 @@ def _validate_dimensions(width: int, height: int, max_pixels: int) -> None:
 
 def _metadata_from_image(
     image: Any,
-    image_module: Any,
     *,
     max_pixels: int,
     content_type: str | None,
@@ -221,8 +294,8 @@ def _metadata_from_image(
     mode = image.mode
     if not isinstance(mode, str) or not mode:
         raise ImageFileFormatError("image decoder did not report a pixel mode")
-    detected_mime_type = image_module.MIME.get(image_format.upper())
-    _validate_content_type(content_type, detected_mime_type)
+    detected_mime_type, compatible_mime_types = _detected_image_mime_types(image)
+    _validate_content_type(content_type, detected_mime_type, compatible_mime_types)
     return ImageMetadata(width=width, height=height, format=image_format.upper(), mode=mode)
 
 
@@ -244,7 +317,6 @@ def _probe_image_metadata(
         with _open_image_with_limit(image_module, stream, max_pixels=max_pixels) as image:
             metadata = _metadata_from_image(
                 image,
-                image_module,
                 max_pixels=max_pixels,
                 content_type=content_type,
             )
@@ -337,7 +409,6 @@ def _decode_image_file(
             ) as source:
                 metadata = _metadata_from_image(
                     source,
-                    image_module,
                     max_pixels=normalized_max_pixels,
                     content_type=value.content_type,
                 )

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -20,6 +20,7 @@ if typing.TYPE_CHECKING:
     import fsspec  # type: ignore[import-not-found, import-untyped, unused-ignore]
     import numpy as np
     import pandas  # type: ignore[import-not-found, import-untyped, unused-ignore]
+    import PIL.Image  # type: ignore[import-not-found, unused-ignore]
     import polars  # type: ignore[import-not-found, import-untyped, unused-ignore]
     import pyarrow.lib  # type: ignore[import-untyped, unused-ignore]
     from pydantic import BaseModel as _PydanticModel  # type: ignore[import-not-found, import-untyped, unused-ignore]
@@ -27,6 +28,7 @@ if typing.TYPE_CHECKING:
     import vane.sqltypes as sqltypes
     import vane.udf as func
     from vane._file import VaneFileReader
+    from vane._image_file import ImageMetadata
     from vane.ai.options import EmbedOptions, PromptOptions
     from vane.ai.provider import Provider
     from vane.ai.typing import JSONSchema
@@ -922,6 +924,7 @@ class Expression:
     def file_path(self) -> Expression: ...
     def file_size(self) -> Expression: ...
     def file_stat(self) -> Expression: ...
+    def image_file_metadata(self) -> Expression: ...
     def get_name(self) -> str: ...
     def isin(self, *args: _ExpressionLike) -> Expression: ...
     def isnotin(self, *args: _ExpressionLike) -> Expression: ...
@@ -992,7 +995,24 @@ class File:
     def url(self) -> str: ...
 
 @typing.final
-class ImageFile(File): ...
+class ImageFile(File):
+    def decode(
+        self,
+        mode: str | None = None,
+        buffer_size: int = 1048576,
+        *,
+        max_input_bytes: int = 268435456,
+        max_pixels: int = 100000000,
+        max_decoded_bytes: int = 536870912,
+        connection: DuckDBPyConnection | None = None,
+    ) -> PIL.Image.Image: ...
+    def metadata(
+        self,
+        *,
+        max_bytes: int = 1048576,
+        max_pixels: int = 100000000,
+        connection: DuckDBPyConnection | None = None,
+    ) -> ImageMetadata: ...
 
 @typing.final
 class AudioFile(File): ...


### PR DESCRIPTION
## Summary

- Register `image_file_metadata(IMAGEFILE)` with bounded header reads through the existing FILE resolver, exact logical-range handling, NULL semantics, and IMAGEFILE-only binding.
- Add `ImageMetadata`, `ImageFile.metadata()`, the function/expression metadata facades, and `ImageFile.decode()` for a fully loaded detached Pillow image using frame zero.
- Enforce metadata, encoded-input, pixel-count, and decoded-working-set limits; isolate per-call pixel policy from unrelated Pillow threads and recognize content-derived MIME variants.
- Keep Pillow lazy and distinguish media/limit failures from resolver, interruption, memory, and internal failures.
- Keep decoded engine `IMAGE` and `decode_image_file()` out of this phase so no temporary untyped representation is introduced. No DuckDB core or provider-specific filesystem code is changed.

## Related issue

Part of #712

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Public API docstrings, exported symbols, and typing stubs are included in this PR. The decoded IMAGE expression API remains documented in #712 until its logical contract is implemented.

## Validation

- Two consecutive clean code-review passes before native compilation.
- Two consecutive clean external Codex reviews on final commit `4326dcf5bb`.
- `pre-commit run --files ...` plus manual Ruff, clang-format, CMake-format, mypy, and `git diff --check` gates.
- Release native install with `CMAKE_BUILD_PARALLEL_LEVEL=36` and `SKBUILD_BUILD_DIR=$PWD/build/python-release`.
- `scripts/run_installed_pytest.sh tests/fast/test_image_file.py tests/fast/test_file.py` — 143 passed.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.