### PR TITLE
[fix](distributed) Handle missing S3 markers during force abort

### DIFF
--- a/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
+++ b/external/duckdb/src/include/duckdb/execution/distributed/copy_finalize.hpp
@@ -46,7 +46,8 @@ inline bool DistributedCopyExceptionIsNotFound(const std::exception &ex) {
 		return true;
 	}
 	auto error_number = extra_info.find("errno");
-	if (error_number != extra_info.end() && error_number->second == std::to_string(ENOENT)) {
+	if (error_number != extra_info.end() &&
+	    (error_number->second == std::to_string(ENOENT) || error_number->second == "404")) {
 		return true;
 	}
 

--- a/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
+++ b/external/duckdb/test/execution/distributed/test_copy_finalize.cpp
@@ -291,6 +291,23 @@ private:
 	string phantom_directory;
 };
 
+class MissingRemoteMarkerRemovalFileSystem : public MappedRemoteFileSystem {
+public:
+	MissingRemoteMarkerRemovalFileSystem(string local_root, string missing_marker_path)
+	    : MappedRemoteFileSystem(std::move(local_root)), missing_marker_path(std::move(missing_marker_path)) {
+	}
+
+	void RemoveFile(const string &path, optional_ptr<FileOpener> opener = nullptr) override {
+		if (path == missing_marker_path && !MappedRemoteFileSystem::FileExists(path, opener)) {
+			throw IOException({{"errno", "404"}}, "injected missing remote object");
+		}
+		MappedRemoteFileSystem::RemoveFile(path, opener);
+	}
+
+private:
+	string missing_marker_path;
+};
+
 class WindowsPathFileSystem : public LocalFileSystem {
 public:
 	string PathSeparator(const string &) override {
@@ -885,6 +902,8 @@ TEST_CASE("Distributed COPY treats only not-found list failures as empty",
 
 	std::runtime_error python_missing("FileNotFoundError: /missing");
 	REQUIRE(DistributedCopyExceptionIsNotFound(python_missing));
+	IOException s3_missing({{"errno", "404"}}, "injected missing S3 object");
+	REQUIRE(DistributedCopyExceptionIsNotFound(s3_missing));
 
 	ErrnoListFileSystem partial_missing_fs(ENOENT, true);
 	auto partial_missing_res = ListDistributedCopyFilesUnderPrefix(partial_missing_fs, "/partial");
@@ -1181,6 +1200,29 @@ TEST_CASE("Direct-write force abort cleans shared remote output before reporting
 	REQUIRE(fs.FileExists(paths.lifecycle_path));
 
 	fs.AllowRemoval();
+	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
+
+	REQUIRE(abort_res.is_ok());
+	REQUIRE_FALSE(abort_res.value().skipped_committed);
+	REQUIRE_FALSE(fs.FileExists(paths.committed_marker_path));
+	REQUIRE_FALSE(fs.FileExists(data_file));
+	REQUIRE_FALSE(fs.FileExists(paths.lifecycle_path));
+	REQUIRE_FALSE(fs.DirectoryExists(paths.commit_dir));
+}
+
+TEST_CASE("Direct-write force abort tolerates an absent remote committed marker",
+          "[distributed][copy][lifecycle][object-storage]") {
+	CopyFinalizeTestDirectory test_dir("copy_finalize_force_abort_missing_remote_marker");
+	const string base_path = "s3://bucket/out";
+	const string run_id = "run-force-abort-missing-remote-marker";
+	auto paths = BuildDistributedCopyFinalizeCommitPaths(test_dir.fs, base_path, run_id);
+	MissingRemoteMarkerRemovalFileSystem fs(test_dir.fs.JoinPath(test_dir.path, "remote"), paths.committed_marker_path);
+	auto data_file = BuildCopyDirectTargetFilePath(base_path, run_id, "w_selected", "part.parquet");
+	WriteTestFile(fs, data_file, "discard me");
+	REQUIRE(WriteDistributedCopyDirectWriteLifecycle(fs, base_path, run_id, 1).is_ok());
+	WriteTestFile(fs, paths.manifest_path, "manifest");
+	REQUIRE_FALSE(fs.FileExists(paths.committed_marker_path));
+
 	auto abort_res = ForceAbortDistributedCopyDirectWriteRun(fs, base_path, run_id);
 
 	REQUIRE(abort_res.is_ok());


### PR DESCRIPTION
## Summary

Treat the `errno=404` metadata emitted by S3-compatible DuckDB filesystems as a not-found result during distributed COPY recovery. This keeps `force_abort_copy_direct_write_run` idempotent when the committed marker is already absent while continuing to fail closed for authorization, transport, and server errors.

The regression coverage exercises both the shared not-found classifier and the complete remote force-abort cleanup path with an absent committed marker.

## Related issue

N/A — discovered while qualifying AstroVela/duckdb-vortex#8.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

## Validation

- `PATH=/home/kaka/vane-format-tools/bin:$PATH scripts/format duckdb --changed --check`
- `VANE_NATIVE_BUILD_JOBS=36 VCPKG_INSTALLED_DIR=/home/kaka/vane/vcpkg_installed scripts/run_native_tests.sh 'Direct-write force abort tolerates an absent remote committed marker' -s` — 1 test case, 10 assertions passed
- `build/native-cxx20/test/unittest '[distributed][copy][lifecycle][object-storage]'` — 16 test cases, 188 assertions passed

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.
