### PR TITLE
[feat](file) Add AudioFile metadata and decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ pip install 'vane-ai[openai]'   # OpenAI provider (anthropic / google / transfor
 pip install 'vane-ai[vllm]'     # Native vLLM inference on Linux x86-64
 pip install 'vane-ai[sglang]'   # Native SGLang 0.5.17 inference on Linux x86-64
 pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
+pip install 'vane-ai[audio]'    # AudioFile metadata and waveform decoding (SoundFile)
 pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
 pip install 'vane-ai[milvus]'   # distributed full-row Milvus upserts
 pip install 'vane-ai[qdrant]'   # distributed full-point Qdrant upserts

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ pip install 'vane-ai[openai]'   # OpenAI provider (anthropic / google / transfor
 pip install 'vane-ai[vllm]'     # Native vLLM inference on Linux x86-64
 pip install 'vane-ai[sglang]'   # Native SGLang 0.5.17 inference on Linux x86-64
 pip install 'vane-ai[image]'    # ndarray image inputs for AI providers (Pillow)
-pip install 'vane-ai[audio]'    # AudioFile metadata and waveform decoding (SoundFile)
 pip install 'vane-ai[video]'    # video data source (Pillow, psutil, decord)
 pip install 'vane-ai[milvus]'   # distributed full-row Milvus upserts
 pip install 'vane-ai[qdrant]'   # distributed full-point Qdrant upserts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ sglang = [
 image = [ # ImageFile metadata/decoding and ndarray image inputs for AI providers
     "pillow>=10",
 ]
+audio = [ # AudioFile metadata and float64 waveform decoding
+    "soundfile>=0.14",
+]
 video = [ # video data source; decord is gated to Vane's supported native platform (it lacks modern macOS/ARM wheels)
     "pillow>=10",
     "psutil>=5.9",
@@ -101,6 +104,7 @@ all = [ # Cloud providers and dataframe/filesystem integrations; local model run
     "pillow>=10", # used for image inputs and video frames
     "pymilvus>=3.0.1,<4", # Milvus DataSink
     "qdrant-client>=1.19.0,<2", # Qdrant DataSink
+    "soundfile>=0.14", # AudioFile metadata and waveform decoding
 ]
 
 ######################################################################################################
@@ -451,6 +455,7 @@ test = [ # dependencies used for running the complete test suite
     "pyspark",
     "pytz",
     "requests",
+    "soundfile>=0.14",
     "urllib3",
     "fsspec>=2022.11.0; sys_platform != 'win32' or platform_machine != 'ARM64'",
     "torch>=2.2.2; sys_platform != 'win32' or platform_machine != 'ARM64' or python_version > '3.11'",

--- a/src/vane_py/CMakeLists.txt
+++ b/src/vane_py/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   importer.cpp
   merge_relation.cpp
   ai_sql_functions.cpp
+  audio_file_functions.cpp
   image_file_functions.cpp
   path_like.cpp
   pyconnection.cpp

--- a/src/vane_py/audio_file_functions.cpp
+++ b/src/vane_py/audio_file_functions.cpp
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "vane_python/audio_file_functions.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/expression.hpp"
+#include "file_resolver.hpp"
+#include "file_value.hpp"
+#include "vane_python/pybind11/gil_wrapper.hpp"
+
+#include <cmath>
+#include <exception>
+
+namespace duckdb {
+
+namespace {
+
+static constexpr uint64_t DEFAULT_AUDIO_METADATA_BYTES = 8 * 1024 * 1024;
+static constexpr uint64_t MAX_AUDIO_METADATA_BYTES = 64 * 1024 * 1024;
+
+static LogicalType AudioMetadataType() {
+	child_list_t<LogicalType> fields;
+	fields.emplace_back("sample_rate", LogicalType::BIGINT);
+	fields.emplace_back("channels", LogicalType::BIGINT);
+	fields.emplace_back("frames", LogicalType::BIGINT);
+	fields.emplace_back("duration", LogicalType::DOUBLE);
+	fields.emplace_back("format", LogicalType::VARCHAR);
+	fields.emplace_back("subtype", LogicalType::VARCHAR);
+	return LogicalType::STRUCT(std::move(fields));
+}
+
+struct AudioMetadataResult {
+	int64_t sample_rate;
+	int64_t channels;
+	bool has_frames;
+	int64_t frames;
+	bool has_duration;
+	double duration;
+	string format;
+	bool has_subtype;
+	string subtype;
+
+	Value ToValue() const {
+		vector<Value> fields;
+		fields.reserve(6);
+		fields.push_back(Value::BIGINT(sample_rate));
+		fields.push_back(Value::BIGINT(channels));
+		fields.push_back(has_frames ? Value::BIGINT(frames) : Value(LogicalType::BIGINT));
+		fields.push_back(has_duration ? Value::DOUBLE(duration) : Value(LogicalType::DOUBLE));
+		fields.push_back(Value(format));
+		fields.push_back(has_subtype ? Value(subtype) : Value(LogicalType::VARCHAR));
+		return Value::STRUCT(AudioMetadataType(), std::move(fields));
+	}
+};
+
+static unique_ptr<FunctionData> BindAudioMetadata(ClientContext &, ScalarFunction &bound_function,
+                                                  vector<unique_ptr<Expression>> &arguments) {
+	auto audio_type = FileLogicalType::Create(FileMediaType::AUDIO);
+	auto input_type = arguments[0]->return_type;
+	if (input_type.id() == LogicalTypeId::UNKNOWN || input_type.id() == LogicalTypeId::SQLNULL) {
+		input_type = audio_type;
+	}
+	if (!FileLogicalType::IsFile(input_type) || FileLogicalType::GetMediaType(input_type) != FileMediaType::AUDIO) {
+		throw BinderException("audio_metadata() requires AUDIOFILE, not %s", input_type.ToString());
+	}
+	bound_function.arguments[0] = std::move(input_type);
+	return nullptr;
+}
+
+static void RequireAudioDependency() {
+	PythonGILWrapper gil;
+	try {
+		py::module_::import("vane._audio_file").attr("_load_soundfile")();
+	} catch (py::error_already_set &error) {
+		if (!error.matches(PyExc_Exception)) {
+			throw InterruptException();
+		}
+		if (error.matches(PyExc_MemoryError)) {
+			throw OutOfMemoryException("Audio dependency preflight ran out of memory");
+		}
+		if (error.matches(PyExc_ImportError)) {
+			throw InvalidInputException("audio_metadata() failed: %s", error.what());
+		}
+		throw InternalException("audio_metadata() dependency preflight failed unexpectedly: %s", error.what());
+	}
+}
+
+[[noreturn]] static void RethrowAudioReadError(const std::exception_ptr &read_error) {
+	try {
+		std::rethrow_exception(read_error);
+	} catch (py::error_already_set &error) {
+		// Registered Python filesystems execute beneath ResolvedFile. Preserve
+		// Python control-flow and resource failures when their virtual-I/O
+		// exceptions have been parked across the libsndfile callback boundary.
+		if (!error.matches(PyExc_Exception)) {
+			throw InterruptException();
+		}
+		if (error.matches(PyExc_MemoryError)) {
+			throw OutOfMemoryException("Audio metadata source read ran out of memory");
+		}
+		throw;
+	}
+}
+
+static AudioMetadataResult ProbeAudioMetadata(ResolvedFile &resolved, const FileReference &file,
+                                              uint64_t max_metadata_bytes) {
+	PythonGILWrapper gil;
+	py::object audio_file_error_type;
+	std::exception_ptr read_error;
+	try {
+		auto module = py::module_::import("vane._audio_file");
+		audio_file_error_type = module.attr("AudioFileError");
+		auto helper = module.attr("_probe_audio_metadata");
+		auto read_at = py::cpp_function([&resolved, &read_error](uint64_t offset, uint64_t size) {
+			string bytes;
+			try {
+				bytes.resize(NumericCast<idx_t>(size));
+				if (size > 0) {
+					py::gil_scoped_release release;
+					resolved.ReadExact(reinterpret_cast<data_ptr_t>(bytes.data()), size, offset);
+				}
+			} catch (...) {
+				read_error = std::current_exception();
+				return py::bytes();
+			}
+			return py::bytes(bytes);
+		});
+		py::object content_type = file.has_content_type ? py::cast(file.content_type) : py::none();
+		auto value = helper(std::move(read_at), py::int_(resolved.LogicalSize()), std::move(content_type),
+		                    py::int_(max_metadata_bytes));
+		if (read_error) {
+			RethrowAudioReadError(read_error);
+		}
+		if (!py::isinstance<py::tuple>(value)) {
+			throw InternalException("Audio metadata helper returned a non-tuple value");
+		}
+		auto fields = py::reinterpret_borrow<py::tuple>(value);
+		if (fields.size() != 6 || !py::isinstance<py::int_>(fields[0]) || !py::isinstance<py::int_>(fields[1]) ||
+		    (!fields[2].is_none() && !py::isinstance<py::int_>(fields[2])) ||
+		    (!fields[3].is_none() && !py::isinstance<py::float_>(fields[3]) && !py::isinstance<py::int_>(fields[3])) ||
+		    !py::isinstance<py::str>(fields[4]) || (!fields[5].is_none() && !py::isinstance<py::str>(fields[5]))) {
+			throw InternalException("Audio metadata helper returned an invalid value");
+		}
+		auto sample_rate = py::cast<int64_t>(fields[0]);
+		auto channels = py::cast<int64_t>(fields[1]);
+		auto has_frames = !fields[2].is_none();
+		auto has_duration = !fields[3].is_none();
+		if (has_frames != has_duration) {
+			throw InternalException("Audio metadata helper returned inconsistent frame and duration values");
+		}
+		auto frames = has_frames ? py::cast<int64_t>(fields[2]) : 0;
+		auto duration = has_duration ? py::cast<double>(fields[3]) : 0;
+		if (sample_rate <= 0 || channels <= 0 || frames < 0 || !std::isfinite(duration) || duration < 0) {
+			throw InternalException("Audio metadata helper returned out-of-range numeric values");
+		}
+		if (fields[5].is_none()) {
+			return {sample_rate, channels, has_frames, frames, has_duration, duration, py::cast<string>(fields[4]),
+			        false,       string()};
+		}
+		return {sample_rate,
+		        channels,
+		        has_frames,
+		        frames,
+		        has_duration,
+		        duration,
+		        py::cast<string>(fields[4]),
+		        true,
+		        py::cast<string>(fields[5])};
+	} catch (py::error_already_set &error) {
+		// A currently propagating interpreter-control exception takes priority
+		// over any earlier ordinary connector failure captured by read_at.
+		if (!error.matches(PyExc_Exception)) {
+			throw InterruptException();
+		}
+		if (read_error) {
+			RethrowAudioReadError(read_error);
+		}
+		if (error.matches(PyExc_MemoryError)) {
+			throw OutOfMemoryException("Audio metadata inspection ran out of memory");
+		}
+		if (error.matches(PyExc_ImportError) ||
+		    (audio_file_error_type.ptr() && error.matches(audio_file_error_type.ptr()))) {
+			throw InvalidInputException("audio_metadata() failed: %s", error.what());
+		}
+		throw InternalException("audio_metadata() Python helper failed unexpectedly: %s", error.what());
+	}
+}
+
+static void AudioMetadataFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	bool dependency_ready = false;
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto file_value = args.data[0].GetValue(row);
+		if (file_value.IsNull()) {
+			result.SetValue(row, Value(AudioMetadataType()));
+			continue;
+		}
+
+		uint64_t max_metadata_bytes = DEFAULT_AUDIO_METADATA_BYTES;
+		if (args.ColumnCount() == 2) {
+			auto max_metadata_value = args.data[1].GetValue(row);
+			if (max_metadata_value.IsNull()) {
+				result.SetValue(row, Value(AudioMetadataType()));
+				continue;
+			}
+			max_metadata_bytes = max_metadata_value.GetValue<uint64_t>();
+		}
+		if (max_metadata_bytes == 0 || max_metadata_bytes > MAX_AUDIO_METADATA_BYTES) {
+			throw InvalidInputException("audio_metadata() max_bytes must be between 1 and %llu",
+			                            static_cast<unsigned long long>(MAX_AUDIO_METADATA_BYTES));
+		}
+
+		auto &context = state.GetContext();
+		try {
+			// Fail with the actionable optional-dependency error before resolving a
+			// local or remote URL. The Python value API follows the same ordering.
+			if (!dependency_ready) {
+				RequireAudioDependency();
+				dependency_ready = true;
+			}
+			auto file = FileReference::FromValue(file_value, "audio_metadata");
+			auto resolved = ResolvedFile::Open(context, file);
+			auto metadata = ProbeAudioMetadata(*resolved, file, max_metadata_bytes);
+			if (context.IsInterrupted()) {
+				throw InterruptException();
+			}
+			result.SetValue(row, metadata.ToValue());
+		} catch (...) {
+			// Cancellation wins over a competing connector, dependency, media, or
+			// resource-limit failure raised while this row was being inspected.
+			if (context.IsInterrupted()) {
+				throw InterruptException();
+			}
+			throw;
+		}
+	}
+}
+
+static ScalarFunction MakeAudioMetadataFunction(vector<LogicalType> arguments) {
+	ScalarFunction function("audio_metadata", std::move(arguments), AudioMetadataType(), AudioMetadataFunction,
+	                        BindAudioMetadata);
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	function.SetStability(FunctionStability::VOLATILE);
+	function.SetFallible();
+	return function;
+}
+
+} // namespace
+
+ScalarFunctionSet AudioFileFunctions::GetFunctions() {
+	ScalarFunctionSet result("audio_metadata");
+	result.AddFunction(MakeAudioMetadataFunction({LogicalType::ANY}));
+	result.AddFunction(MakeAudioMetadataFunction({LogicalType::ANY, LogicalType::UBIGINT}));
+	return result;
+}
+
+} // namespace duckdb

--- a/src/vane_py/include/vane_python/audio_file_functions.hpp
+++ b/src/vane_py/include/vane_python/audio_file_functions.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "duckdb/function/function_set.hpp"
+
+namespace duckdb {
+
+struct AudioFileFunctions {
+	static ScalarFunctionSet GetFunctions();
+};
+
+} // namespace duckdb

--- a/src/vane_py/native/file.cpp
+++ b/src/vane_py/native/file.cpp
@@ -24,6 +24,11 @@ static constexpr uint64_t DEFAULT_IMAGE_MAX_PIXELS = 100000000;
 static constexpr uint64_t DEFAULT_IMAGE_BUFFER_SIZE = 1024 * 1024;
 static constexpr uint64_t DEFAULT_IMAGE_MAX_INPUT_BYTES = 256 * 1024 * 1024;
 static constexpr uint64_t DEFAULT_IMAGE_MAX_DECODED_BYTES = 512 * 1024 * 1024;
+static constexpr uint64_t DEFAULT_AUDIO_METADATA_BYTES = 8 * 1024 * 1024;
+static constexpr uint64_t DEFAULT_AUDIO_BUFFER_SIZE = 1024 * 1024;
+static constexpr uint64_t DEFAULT_AUDIO_MAX_INPUT_BYTES = 512 * 1024 * 1024;
+static constexpr uint64_t DEFAULT_AUDIO_MAX_FRAMES = 100000000;
+static constexpr uint64_t DEFAULT_AUDIO_MAX_DECODED_BYTES = 512 * 1024 * 1024;
 
 static string PythonTypeName(const py::handle &value) {
 	return py::str(py::type::of(value)).cast<string>();
@@ -157,6 +162,34 @@ static void BindMediaFileClass(py::handle &m, const char *class_name) {
 		    py::arg("max_input_bytes") = DEFAULT_IMAGE_MAX_INPUT_BYTES,
 		    py::arg("max_pixels") = DEFAULT_IMAGE_MAX_PIXELS,
 		    py::arg("max_decoded_bytes") = DEFAULT_IMAGE_MAX_DECODED_BYTES, py::arg("connection") = py::none());
+	} else if constexpr (std::is_same_v<FILE_TYPE, PythonAudioFile>) {
+		file.def(
+		    "metadata",
+		    [](const FILE_TYPE &value, const py::object &max_bytes, shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._audio_file")
+			        .attr("_audio_file_metadata_value")(py::cast(value, py::return_value_policy::copy),
+			                                            py::arg("max_bytes") = max_bytes,
+			                                            py::arg("connection") = std::move(connection));
+		    },
+		    "Inspect bounded encoded audio metadata without decoding samples", py::kw_only(),
+		    py::arg("max_bytes") = DEFAULT_AUDIO_METADATA_BYTES, py::arg("connection") = py::none());
+		file.def(
+		    "to_numpy",
+		    [](const FILE_TYPE &value, const py::object &buffer_size, const py::object &max_input_bytes,
+		       const py::object &max_frames, const py::object &max_decoded_bytes,
+		       shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._audio_file")
+			        .attr("_decode_audio_file")(py::cast(value, py::return_value_policy::copy), buffer_size,
+			                                    py::arg("max_input_bytes") = max_input_bytes,
+			                                    py::arg("max_frames") = max_frames,
+			                                    py::arg("max_decoded_bytes") = max_decoded_bytes,
+			                                    py::arg("connection") = std::move(connection));
+		    },
+		    "Decode audio samples into a detached float64 (frames, channels) NumPy array",
+		    py::arg("buffer_size") = DEFAULT_AUDIO_BUFFER_SIZE, py::kw_only(),
+		    py::arg("max_input_bytes") = DEFAULT_AUDIO_MAX_INPUT_BYTES,
+		    py::arg("max_frames") = DEFAULT_AUDIO_MAX_FRAMES,
+		    py::arg("max_decoded_bytes") = DEFAULT_AUDIO_MAX_DECODED_BYTES, py::arg("connection") = py::none());
 	}
 }
 

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -5,6 +5,7 @@
 // Modified by Vane contributors.
 
 #include "vane_python/pyconnection/pyconnection.hpp"
+#include "vane_python/audio_file_functions.hpp"
 #include "vane_python/image_file_functions.hpp"
 #include "datasource_function.hpp"
 #include "vane_python/ai_sql_functions.hpp"
@@ -3148,6 +3149,11 @@ void InstantiateNewInstance(DuckDB &db) {
 	CreateScalarFunctionInfo image_file_info(std::move(image_file_set));
 	image_file_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 	system_catalog.CreateFunction(transaction, image_file_info);
+
+	auto audio_file_set = AudioFileFunctions::GetFunctions();
+	CreateScalarFunctionInfo audio_file_info(std::move(audio_file_set));
+	audio_file_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+	system_catalog.CreateFunction(transaction, audio_file_info);
 
 	auto vllm_set = VLLMFunction::GetFunctions();
 	CreateScalarFunctionInfo vllm_info(std::move(vllm_set));

--- a/src/vane_py/pyexpression/initialize.cpp
+++ b/src/vane_py/pyexpression/initialize.cpp
@@ -472,6 +472,8 @@ void DuckDBPyExpression::Initialize(py::module_ &m) {
 	expression.def("file_mime_type", &DuckDBPyExpression::FileMimeType, py::arg("detect") = "metadata");
 	expression.def("image_file_metadata",
 	               [](const DuckDBPyExpression &self) { return self.FileFunction("image_file_metadata"); });
+	expression.def("audio_metadata",
+	               [](const DuckDBPyExpression &self) { return self.FileFunction("audio_metadata"); });
 }
 
 } // namespace duckdb

--- a/tests/fast/test_audio_file.py
+++ b/tests/fast/test_audio_file.py
@@ -242,6 +242,43 @@ def test_audio_metadata_probe_preserves_cancellation_after_budget_exhaustion(mon
         )
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        MemoryError("allocation failed"),
+        RuntimeError("decoder invariant failed"),
+        _audio_file.AudioFileFormatError("classified media failure"),
+    ],
+    ids=["memory", "internal", "classified-media"],
+)
+def test_audio_metadata_probe_preserves_non_decoder_errors_after_budget_exhaustion(monkeypatch, failure):
+    class FakeSoundFileError(Exception):
+        pass
+
+    class FailingSoundFile:
+        def __init__(self, stream, *, mode, closefd):
+            assert mode == "r"
+            assert closefd is False
+            assert stream.read(1) == b"x"
+            assert stream.read(1) == b""
+            raise failure
+
+    class FakeSoundFileModule:
+        SoundFile = FailingSoundFile
+        SoundFileError = FakeSoundFileError
+
+    monkeypatch.setattr(_audio_file, "_load_soundfile", lambda: FakeSoundFileModule)
+
+    with pytest.raises(type(failure)) as raised:
+        _audio_file._probe_audio_metadata(
+            lambda offset, size: b"x" * size,
+            logical_size=2,
+            content_type=None,
+            max_bytes=1,
+        )
+    assert raised.value is failure
+
+
 def test_audio_operations_preserve_current_cancellation_over_stored_reader_error(
     duckdb_cursor,
     tmp_path,
@@ -585,31 +622,6 @@ def test_audio_file_preserves_unknown_flac_frame_count_and_decodes_incrementally
         value.to_numpy(max_frames=63, connection=duckdb_cursor)
     with pytest.raises(vane.AudioFileLimitError, match="max_decoded_bytes"):
         value.to_numpy(max_decoded_bytes=63 * 2 * 8, connection=duckdb_cursor)
-
-
-def test_audio_file_rejects_decoder_output_beyond_finite_frame_count(duckdb_cursor, tmp_path, monkeypatch):
-    payload, _ = _encoded_audio("FLAC", "PCM_16", frames=64, channels=2)
-    path = tmp_path / "underreported-total.flac"
-    path.write_bytes(_flac_with_total_samples(payload, 63))
-    value = vane.AudioFile(str(path), "audio/flac")
-
-    assert value.metadata(connection=duckdb_cursor).frames == 63
-
-    original_buffer_read_into = soundfile.SoundFile.buffer_read_into
-    read_count = 0
-
-    def expose_extra_frame(self, buffer, dtype):
-        nonlocal read_count
-        read_count += 1
-        decoded_frames = original_buffer_read_into(self, buffer, dtype=dtype)
-        if read_count == 2:
-            assert decoded_frames == 0
-            return 1
-        return decoded_frames
-
-    monkeypatch.setattr(soundfile.SoundFile, "buffer_read_into", expose_extra_frame)
-    with pytest.raises(vane.AudioFileFormatError, match="more frames after reporting 63"):
-        value.to_numpy(connection=duckdb_cursor)
 
 
 def test_soundfile_cleanup_does_not_replace_primary_audio_errors(duckdb_cursor, tmp_path, monkeypatch):

--- a/tests/fast/test_audio_file.py
+++ b/tests/fast/test_audio_file.py
@@ -587,13 +587,27 @@ def test_audio_file_preserves_unknown_flac_frame_count_and_decodes_incrementally
         value.to_numpy(max_decoded_bytes=63 * 2 * 8, connection=duckdb_cursor)
 
 
-def test_audio_file_rejects_finite_underreported_flac_frame_count(duckdb_cursor, tmp_path):
+def test_audio_file_rejects_decoder_output_beyond_finite_frame_count(duckdb_cursor, tmp_path, monkeypatch):
     payload, _ = _encoded_audio("FLAC", "PCM_16", frames=64, channels=2)
     path = tmp_path / "underreported-total.flac"
     path.write_bytes(_flac_with_total_samples(payload, 63))
     value = vane.AudioFile(str(path), "audio/flac")
 
     assert value.metadata(connection=duckdb_cursor).frames == 63
+
+    original_buffer_read_into = soundfile.SoundFile.buffer_read_into
+    read_count = 0
+
+    def expose_extra_frame(self, buffer, dtype):
+        nonlocal read_count
+        read_count += 1
+        decoded_frames = original_buffer_read_into(self, buffer, dtype=dtype)
+        if read_count == 2:
+            assert decoded_frames == 0
+            return 1
+        return decoded_frames
+
+    monkeypatch.setattr(soundfile.SoundFile, "buffer_read_into", expose_extra_frame)
     with pytest.raises(vane.AudioFileFormatError, match="more frames after reporting 63"):
         value.to_numpy(connection=duckdb_cursor)
 

--- a/tests/fast/test_audio_file.py
+++ b/tests/fast/test_audio_file.py
@@ -207,6 +207,63 @@ def test_empty_audio_decodes_under_sub_frame_byte_limit(duckdb_cursor, tmp_path,
     assert decoded.nbytes == 0
 
 
+@pytest.mark.parametrize(
+    ("channels", "decoded_frames"),
+    [(1, 0), (2, 0), (1, 1)],
+    ids=["empty-mono", "empty-stereo", "nonempty"],
+)
+def test_unknown_length_audio_probes_eof_under_sub_frame_byte_limit(
+    duckdb_cursor,
+    tmp_path,
+    monkeypatch,
+    channels,
+    decoded_frames,
+):
+    probes = []
+
+    class FakeSoundFileError(Exception):
+        pass
+
+    class UnknownLengthSoundFile:
+        samplerate = 8000
+        frames = _audio_file._MAX_BIGINT
+        format = "FLAC"
+        subtype = "PCM_16"
+
+        def __init__(self, stream, *, mode, closefd):
+            assert mode == "r"
+            assert closefd is False
+            self.channels = channels
+
+        def buffer_read_into(self, buffer, *, dtype):
+            assert dtype == "float64"
+            probes.append(len(buffer))
+            return decoded_frames
+
+        def close(self):
+            pass
+
+    class FakeSoundFileModule:
+        SoundFile = UnknownLengthSoundFile
+        SoundFileError = FakeSoundFileError
+
+    path = tmp_path / "unknown-total.flac"
+    path.write_bytes(b"encoded-audio")
+    value = vane.AudioFile(str(path), "audio/flac")
+    monkeypatch.setattr(_audio_file, "_load_soundfile", lambda: FakeSoundFileModule)
+
+    if decoded_frames:
+        with pytest.raises(vane.AudioFileLimitError, match="one decoded audio frame requires"):
+            value.to_numpy(max_decoded_bytes=1, connection=duckdb_cursor)
+    else:
+        decoded = value.to_numpy(max_decoded_bytes=1, connection=duckdb_cursor)
+        assert decoded.dtype == np.float64
+        assert decoded.shape == (0, channels)
+        assert decoded.nbytes == 0
+
+    assert probes == [channels * 8]
+
+
 def test_audio_metadata_can_use_header_without_reading_complete_waveform(duckdb_cursor, tmp_path):
     payload, _ = _encoded_audio("WAV", "PCM_16", frames=100_000, channels=2)
     path = tmp_path / "large.wav"

--- a/tests/fast/test_audio_file.py
+++ b/tests/fast/test_audio_file.py
@@ -190,6 +190,23 @@ def test_audio_to_numpy_returns_detached_frame_major_float64(duckdb_cursor, tmp_
     np.testing.assert_allclose(decoded, expected, rtol=0, atol=1e-7)
 
 
+@pytest.mark.parametrize("channels", [1, 2])
+def test_empty_audio_decodes_under_sub_frame_byte_limit(duckdb_cursor, tmp_path, channels):
+    payload, _ = _encoded_audio("WAV", "PCM_16", frames=0, channels=channels)
+    path = tmp_path / f"empty-{channels}.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+
+    metadata = value.metadata(connection=duckdb_cursor)
+    decoded = value.to_numpy(max_decoded_bytes=1, connection=duckdb_cursor)
+
+    assert metadata.frames == 0
+    assert metadata.duration == 0
+    assert decoded.dtype == np.float64
+    assert decoded.shape == (0, channels)
+    assert decoded.nbytes == 0
+
+
 def test_audio_metadata_can_use_header_without_reading_complete_waveform(duckdb_cursor, tmp_path):
     payload, _ = _encoded_audio("WAV", "PCM_16", frames=100_000, channels=2)
     path = tmp_path / "large.wav"

--- a/tests/fast/test_audio_file.py
+++ b/tests/fast/test_audio_file.py
@@ -1,0 +1,738 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import io
+
+import numpy as np
+import pytest
+import soundfile
+
+import vane
+from vane import _audio_file
+
+
+def _encoded_audio(
+    audio_format: str = "WAV",
+    subtype: str = "PCM_16",
+    *,
+    sample_rate: int = 8000,
+    frames: int = 32,
+    channels: int = 2,
+) -> tuple[bytes, np.ndarray]:
+    samples = np.linspace(-0.75, 0.75, frames * channels, dtype=np.float64).reshape(frames, channels)
+    buffer = io.BytesIO()
+    soundfile.write(buffer, samples, sample_rate, format=audio_format, subtype=subtype)
+    return buffer.getvalue(), samples
+
+
+def _flac_with_total_samples(payload: bytes, total_samples: int) -> bytes:
+    assert payload[:4] == b"fLaC"
+    assert payload[4] & 0x7F == 0
+    assert int.from_bytes(payload[5:8], "big") == 34
+    assert 0 <= total_samples < 1 << 36
+    result = bytearray(payload)
+    stream_info = int.from_bytes(result[18:26], "big")
+    result[18:26] = ((stream_info & ~((1 << 36) - 1)) | total_samples).to_bytes(8, "big")
+    return bytes(result)
+
+
+def _flac_with_unknown_total_samples(payload: bytes) -> bytes:
+    return _flac_with_total_samples(payload, 0)
+
+
+@pytest.mark.parametrize(
+    ("audio_format", "subtype", "content_type"),
+    [
+        ("WAV", "PCM_16", "audio/wav"),
+        ("FLAC", "PCM_16", "audio/flac"),
+        ("MP3", "MPEG_LAYER_III", "audio/mpeg"),
+        ("OGG", "VORBIS", "audio/ogg"),
+        ("OGG", "OPUS", "audio/ogg; codecs=opus"),
+    ],
+)
+def test_audio_metadata_sql_and_python_value(duckdb_cursor, tmp_path, audio_format, subtype, content_type):
+    payload, _ = _encoded_audio(audio_format, subtype, sample_rate=16000, frames=40, channels=2)
+    path = tmp_path / f"audio.{audio_format.lower()}"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), content_type)
+
+    result_type, metadata, null_metadata = duckdb_cursor.execute(
+        """
+        SELECT
+            typeof(audio_metadata($1)),
+            audio_metadata($1),
+            audio_metadata(NULL::AUDIOFILE)
+        """,
+        [value],
+    ).fetchone()
+
+    assert result_type == (
+        "STRUCT(sample_rate BIGINT, channels BIGINT, frames BIGINT, duration DOUBLE, format VARCHAR, subtype VARCHAR)"
+    )
+    assert metadata == {
+        "sample_rate": 16000,
+        "channels": 2,
+        "frames": 40,
+        "duration": pytest.approx(40 / 16000),
+        "format": audio_format,
+        "subtype": subtype,
+    }
+    assert null_metadata is None
+    assert value.metadata(connection=duckdb_cursor) == vane.AudioMetadata(
+        16000,
+        2,
+        40,
+        40 / 16000,
+        audio_format,
+        subtype,
+    )
+
+
+def test_audio_metadata_facades(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio(frames=16, channels=1)
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+
+    function_result = duckdb_cursor.sql("SELECT 1").select(vane.audio_metadata(value, max_bytes=4096)).fetchone()[0]
+    method_result = duckdb_cursor.sql("SELECT 1").select(vane.audio_file(value).audio_metadata()).fetchone()[0]
+
+    assert function_result == method_result
+    assert function_result["sample_rate"] == 8000
+    assert function_result["channels"] == 1
+    assert function_result["frames"] == 16
+
+
+def test_audio_metadata_and_decode_honor_logical_range(duckdb_cursor, tmp_path):
+    payload, expected = _encoded_audio("WAV", "FLOAT", frames=24, channels=2)
+    prefix = b"not-an-audio-prefix"
+    suffix = b"not-an-audio-suffix"
+    path = tmp_path / "ranged.bin"
+    path.write_bytes(prefix + payload + suffix)
+    value = vane.AudioFile(str(path), "audio/wav", len(prefix), len(payload))
+
+    assert duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()[0]["frames"] == 24
+    assert value.metadata(connection=duckdb_cursor).format == "WAV"
+    decoded = value.to_numpy(buffer_size=64, connection=duckdb_cursor)
+
+    assert decoded.dtype == np.float64
+    assert decoded.shape == (24, 2)
+    np.testing.assert_allclose(decoded, expected, rtol=0, atol=1e-7)
+
+
+@pytest.mark.parametrize(
+    ("audio_format", "subtype", "content_type"),
+    [
+        ("MP3", "MPEG_LAYER_III", "audio/mpeg"),
+        ("OGG", "OPUS", "audio/ogg; codecs=opus"),
+    ],
+)
+def test_compressed_audio_metadata_and_decode_honor_logical_range(
+    duckdb_cursor,
+    tmp_path,
+    audio_format,
+    subtype,
+    content_type,
+):
+    payload, _ = _encoded_audio(audio_format, subtype, sample_rate=16000, frames=240, channels=2)
+    prefix = b"not-an-audio-prefix"
+    suffix = b"not-an-audio-suffix"
+    path = tmp_path / "compressed-range.bin"
+    path.write_bytes(prefix + payload + suffix)
+    value = vane.AudioFile(str(path), content_type, len(prefix), len(payload))
+
+    sql_metadata = duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()[0]
+    python_metadata = value.metadata(connection=duckdb_cursor)
+    decoded = value.to_numpy(buffer_size=64, connection=duckdb_cursor)
+
+    assert sql_metadata["format"] == audio_format
+    assert sql_metadata["subtype"] == subtype
+    assert python_metadata.frames == 240
+    assert decoded.dtype == np.float64
+    assert decoded.shape == (240, 2)
+    assert decoded.flags.c_contiguous
+    assert np.isfinite(decoded).all()
+    assert np.any(decoded != 0)
+
+
+def test_mp3_metadata_uses_bounded_random_access(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("MP3", "MPEG_LAYER_III", sample_rate=16000, frames=64_000, channels=2)
+    assert len(payload) > 4096
+    prefix = b"not-an-audio-prefix"
+    suffix = b"not-an-audio-suffix"
+    path = tmp_path / "large-ranged-mp3.bin"
+    path.write_bytes(prefix + payload + suffix)
+    value = vane.AudioFile(str(path), "audio/mpeg", len(prefix), len(payload))
+
+    python_metadata = value.metadata(max_bytes=4096, connection=duckdb_cursor)
+    sql_metadata = duckdb_cursor.execute("SELECT audio_metadata($1, 4096)", [value]).fetchone()[0]
+
+    assert python_metadata.frames == 64_000
+    assert python_metadata.format == "MP3"
+    assert sql_metadata["frames"] == 64_000
+    assert sql_metadata["format"] == "MP3"
+
+
+@pytest.mark.parametrize("channels", [1, 2, 4])
+def test_audio_to_numpy_returns_detached_frame_major_float64(duckdb_cursor, tmp_path, channels):
+    payload, expected = _encoded_audio("WAV", "FLOAT", frames=20, channels=channels)
+    path = tmp_path / f"audio-{channels}.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/x-wav")
+
+    decoded = value.to_numpy(connection=duckdb_cursor)
+    path.unlink()
+
+    assert decoded.dtype == np.float64
+    assert decoded.shape == (20, channels)
+    assert decoded.flags.c_contiguous
+    np.testing.assert_allclose(decoded, expected, rtol=0, atol=1e-7)
+
+
+def test_audio_metadata_can_use_header_without_reading_complete_waveform(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("WAV", "PCM_16", frames=100_000, channels=2)
+    path = tmp_path / "large.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+
+    metadata = value.metadata(max_bytes=64, connection=duckdb_cursor)
+    sql_metadata = duckdb_cursor.execute("SELECT audio_metadata($1, 64)", [value]).fetchone()[0]
+
+    assert metadata.frames == 100_000
+    assert sql_metadata["frames"] == 100_000
+
+
+def test_audio_metadata_limit_is_reported_when_parser_reads_past_budget(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("OGG", "VORBIS", frames=64, channels=2)
+    path = tmp_path / "audio.ogg"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/ogg")
+
+    with pytest.raises(vane.AudioFileLimitError, match="max_bytes=16"):
+        value.metadata(max_bytes=16, connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="max_bytes=16"):
+        duckdb_cursor.execute("SELECT audio_metadata($1, 16)", [value]).fetchone()
+
+
+def test_audio_metadata_probe_preserves_cancellation_after_budget_exhaustion(monkeypatch):
+    class FakeSoundFileError(Exception):
+        pass
+
+    class InterruptingSoundFile:
+        def __init__(self, stream, *, mode, closefd):
+            assert mode == "r"
+            assert closefd is False
+            assert stream.read(1) == b"x"
+            assert stream.read(1) == b""
+            raise KeyboardInterrupt
+
+    class FakeSoundFileModule:
+        SoundFile = InterruptingSoundFile
+        SoundFileError = FakeSoundFileError
+
+    monkeypatch.setattr(_audio_file, "_load_soundfile", lambda: FakeSoundFileModule)
+
+    with pytest.raises(KeyboardInterrupt):
+        _audio_file._probe_audio_metadata(
+            lambda offset, size: b"x" * size,
+            logical_size=2,
+            content_type=None,
+            max_bytes=1,
+        )
+
+
+def test_audio_operations_preserve_current_cancellation_over_stored_reader_error(
+    duckdb_cursor,
+    tmp_path,
+    monkeypatch,
+):
+    class FakeSoundFileError(Exception):
+        pass
+
+    class InterruptingSoundFile:
+        def __init__(self, stream, *, mode, closefd):
+            assert mode == "r"
+            assert closefd is False
+            assert stream.read(1) == b""
+            raise KeyboardInterrupt
+
+    class FakeSoundFileModule:
+        SoundFile = InterruptingSoundFile
+        SoundFileError = FakeSoundFileError
+
+    path = tmp_path / "audio.bin"
+    path.write_bytes(b"audio")
+    value = vane.AudioFile(str(path))
+
+    def fail_read(self, size=-1):
+        raise OSError("earlier connector read failed")
+
+    monkeypatch.setattr(_audio_file, "_load_soundfile", lambda: FakeSoundFileModule)
+    monkeypatch.setattr(vane.VaneFileReader, "read", fail_read)
+
+    with pytest.raises(KeyboardInterrupt):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(KeyboardInterrupt):
+        value.to_numpy(connection=duckdb_cursor)
+
+
+def test_audio_metadata_sql_maps_non_exception_control_flow_to_interrupt(duckdb_cursor, tmp_path, monkeypatch):
+    class StopAudioMetadata(BaseException):
+        pass
+
+    path = tmp_path / "audio.bin"
+    path.write_bytes(b"audio")
+    value = vane.AudioFile(str(path))
+
+    def stop_metadata(*args, **kwargs):
+        raise StopAudioMetadata
+
+    monkeypatch.setattr(_audio_file, "_probe_audio_metadata", stop_metadata)
+
+    with pytest.raises(vane.InterruptException):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+def test_audio_metadata_sql_prioritizes_connection_interrupt_over_probe_error(duckdb_cursor, tmp_path, monkeypatch):
+    path = tmp_path / "audio.bin"
+    path.write_bytes(b"audio")
+    value = vane.AudioFile(str(path))
+
+    def interrupt_then_fail(*args, **kwargs):
+        duckdb_cursor.interrupt()
+        raise _audio_file.AudioFileFormatError("competing format failure")
+
+    monkeypatch.setattr(_audio_file, "_probe_audio_metadata", interrupt_then_fail)
+
+    with pytest.raises(vane.InterruptException):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+def test_audio_metadata_sql_maps_python_memory_error_to_out_of_memory(duckdb_cursor, tmp_path, monkeypatch):
+    path = tmp_path / "audio.bin"
+    path.write_bytes(b"audio")
+    value = vane.AudioFile(str(path))
+
+    def exhaust_memory(*args, **kwargs):
+        raise MemoryError("allocation failed")
+
+    monkeypatch.setattr(_audio_file, "_probe_audio_metadata", exhaust_memory)
+
+    with pytest.raises(vane.OutOfMemoryException, match="ran out of memory"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+def test_audio_metadata_view_serves_one_large_request_with_one_source_read():
+    payload = b"x" * (7 * 1024 * 1024)
+    requests = []
+
+    def read_at(offset, size):
+        requests.append((offset, size))
+        return payload[offset : offset + size]
+
+    stream = _audio_file._AudioMetadataView(read_at, logical_size=len(payload), max_bytes=len(payload))
+
+    assert stream.read(len(payload)) == payload
+    assert requests == [(0, len(payload))]
+
+
+def test_audio_metadata_view_preserves_cache_failures(monkeypatch):
+    stream = _audio_file._AudioMetadataView(lambda offset, size: b"x" * size, logical_size=4, max_bytes=4)
+
+    def fail_cache(offset, data):
+        raise RuntimeError("metadata cache insertion failed")
+
+    monkeypatch.setattr(stream, "_cache_bytes", fail_cache)
+
+    assert stream.read(1) == b""
+    with pytest.raises(RuntimeError, match="metadata cache insertion failed"):
+        stream.raise_if_error()
+
+
+def test_audio_metadata_view_bounds_reverse_adjacent_fetches():
+    payload = bytes(range(256)) * 256
+    requests = []
+
+    def read_at(offset, size):
+        requests.append((offset, size))
+        return payload[offset : offset + size]
+
+    stream = _audio_file._AudioMetadataView(read_at, logical_size=len(payload), max_bytes=len(payload))
+    for offset in range(len(payload) - 1, -1, -1):
+        stream.seek(offset)
+        assert stream.read(1) == payload[offset : offset + 1]
+
+    assert len(requests) <= len(payload) // stream._fetch_size + 1
+    assert not stream.fetch_limit_exhausted
+
+
+def test_audio_decode_limits_are_enforced(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("WAV", "FLOAT", frames=16, channels=2)
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+
+    with pytest.raises(vane.AudioFileLimitError, match="max_input_bytes"):
+        value.to_numpy(max_input_bytes=len(payload) - 1, connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileLimitError, match="max_frames=15"):
+        value.to_numpy(max_frames=15, connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileLimitError, match="requires 256 bytes"):
+        value.to_numpy(max_decoded_bytes=255, connection=duckdb_cursor)
+    assert value.to_numpy(max_frames=16, max_decoded_bytes=256, connection=duckdb_cursor).shape == (16, 2)
+
+
+@pytest.mark.parametrize(
+    ("content_type", "message"),
+    [("video/mp4", "contradicts"), ("audio/flac", "detected MIME type")],
+)
+def test_audio_file_rejects_contradictory_content_type(duckdb_cursor, tmp_path, content_type, message):
+    payload, _ = _encoded_audio("WAV", "PCM_16")
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), content_type)
+
+    with pytest.raises(vane.AudioFileFormatError, match=message):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match=message):
+        value.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match=message):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+@pytest.mark.parametrize("content_type", ["audio/wave", "audio/vnd.wave", "application/octet-stream", "audio/*"])
+def test_audio_file_accepts_mime_aliases_and_generic_types(duckdb_cursor, tmp_path, content_type):
+    payload, _ = _encoded_audio("WAV", "PCM_16")
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), content_type)
+
+    assert value.metadata(connection=duckdb_cursor).format == "WAV"
+    assert value.to_numpy(connection=duckdb_cursor).shape == (32, 2)
+
+
+def test_audio_file_accepts_ogg_container_and_codec_mimes(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("OGG", "VORBIS")
+    path = tmp_path / "audio.ogg"
+    path.write_bytes(payload)
+
+    for content_type in ("application/ogg", "audio/ogg; codecs=vorbis"):
+        assert vane.AudioFile(str(path), content_type).metadata(connection=duckdb_cursor).subtype == "VORBIS"
+
+
+@pytest.mark.parametrize(
+    ("subtype", "content_type"),
+    [("OPUS", "audio/opus"), ("VORBIS", "audio/vorbis")],
+)
+def test_audio_file_rejects_rtp_mime_for_ogg_container(duckdb_cursor, tmp_path, subtype, content_type):
+    payload, _ = _encoded_audio("OGG", subtype)
+    path = tmp_path / "audio.ogg"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), content_type)
+
+    with pytest.raises(vane.AudioFileFormatError, match="detected MIME type"):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match="detected MIME type"):
+        value.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="detected MIME type"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+def test_audio_file_validates_wave_codec_parameter(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("WAV", "PCM_16")
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+
+    valid = vane.AudioFile(str(path), "audio/vnd.wave; codec=1")
+    assert valid.metadata(connection=duckdb_cursor).subtype == "PCM_16"
+    assert valid.to_numpy(connection=duckdb_cursor).shape == (32, 2)
+    assert duckdb_cursor.execute("SELECT audio_metadata($1)", [valid]).fetchone()[0]["subtype"] == "PCM_16"
+
+    contradictory = vane.AudioFile(str(path), "audio/vnd.wave; codec=55")
+    with pytest.raises(vane.AudioFileFormatError, match="detected audio codec"):
+        contradictory.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match="detected audio codec"):
+        contradictory.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="detected audio codec"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [contradictory]).fetchone()
+
+
+@pytest.mark.parametrize(
+    ("subtype", "codec"),
+    [
+        ("G721_32", "40"),
+        ("NMS_ADPCM_16", "38"),
+        ("NMS_ADPCM_24", "38"),
+        ("NMS_ADPCM_32", "38"),
+    ],
+)
+def test_audio_file_validates_additional_wave_codec_parameters(duckdb_cursor, tmp_path, subtype, codec):
+    payload, _ = _encoded_audio("WAV", subtype, frames=1024, channels=1)
+    path = tmp_path / f"audio-{subtype}.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), f"audio/vnd.wave; codec={codec}")
+
+    assert value.metadata(connection=duckdb_cursor).subtype == subtype
+    assert duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()[0]["subtype"] == subtype
+
+
+def test_audio_file_validates_waveformatextensible_codec_parameter(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("WAVEX", "PCM_16", frames=32, channels=2)
+    path = tmp_path / "audio-wavex.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/vnd.wave; codec=1")
+
+    assert value.metadata(connection=duckdb_cursor).format == "WAVEX"
+    assert value.to_numpy(connection=duckdb_cursor).shape == (32, 2)
+    assert duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()[0]["format"] == "WAVEX"
+
+
+@pytest.mark.parametrize("content_type", ["audio/x-au", "audio/au", "audio/vnd.sun.audio"])
+def test_audio_file_accepts_au_container_mime_aliases(duckdb_cursor, tmp_path, content_type):
+    payload, _ = _encoded_audio("AU", "ULAW", sample_rate=8000, frames=32, channels=1)
+    path = tmp_path / "audio.au"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), content_type)
+
+    assert value.metadata(connection=duckdb_cursor) == vane.AudioMetadata(8000, 1, 32, 0.004, "AU", "ULAW")
+    assert value.to_numpy(connection=duckdb_cursor).shape == (32, 1)
+    assert duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()[0]["subtype"] == "ULAW"
+
+
+@pytest.mark.parametrize(
+    ("subtype", "sample_rate", "channels"),
+    [
+        ("ULAW", 8000, 1),
+        ("PCM_16", 8000, 1),
+        ("ULAW", 16000, 1),
+        ("ULAW", 8000, 2),
+    ],
+)
+def test_audio_file_rejects_audio_basic_for_au_container(
+    duckdb_cursor,
+    tmp_path,
+    subtype,
+    sample_rate,
+    channels,
+):
+    payload, _ = _encoded_audio("AU", subtype, sample_rate=sample_rate, frames=32, channels=channels)
+    path = tmp_path / "audio.au"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/basic")
+
+    with pytest.raises(vane.AudioFileFormatError, match="detected MIME type"):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match="detected MIME type"):
+        value.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="detected MIME type"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+@pytest.mark.parametrize(
+    ("subtype", "content_type"),
+    [
+        ("VORBIS", "audio/ogg; codecs=opus"),
+        ("OPUS", "audio/ogg; codecs=vorbis"),
+    ],
+)
+def test_audio_file_rejects_contradictory_ogg_codec_parameter(duckdb_cursor, tmp_path, subtype, content_type):
+    payload, _ = _encoded_audio("OGG", subtype)
+    path = tmp_path / "audio.ogg"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), content_type)
+
+    with pytest.raises(vane.AudioFileFormatError, match="detected audio codec"):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match="detected audio codec"):
+        value.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="detected audio codec"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+def test_audio_file_rejects_specific_mime_for_unmapped_decoder_format(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("MAT5", "DOUBLE")
+    path = tmp_path / "audio.mat"
+    path.write_bytes(payload)
+
+    declared = vane.AudioFile(str(path), "audio/wav")
+    with pytest.raises(vane.AudioFileFormatError, match="cannot be validated.*MAT5"):
+        declared.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match="cannot be validated.*MAT5"):
+        declared.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match="cannot be validated.*MAT5"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [declared]).fetchone()
+
+    assert vane.AudioFile(str(path)).metadata(connection=duckdb_cursor).format == "MAT5"
+
+
+def test_audio_file_preserves_unknown_flac_frame_count_and_decodes_incrementally(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("FLAC", "PCM_16", frames=64, channels=2)
+    path = tmp_path / "unknown-total.flac"
+    path.write_bytes(_flac_with_unknown_total_samples(payload))
+    value = vane.AudioFile(str(path), "audio/flac")
+
+    metadata = value.metadata(connection=duckdb_cursor)
+    sql_metadata = duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()[0]
+    decoded = value.to_numpy(max_frames=64, max_decoded_bytes=64 * 2 * 8, connection=duckdb_cursor)
+
+    assert metadata.frames is None
+    assert metadata.duration is None
+    assert sql_metadata["frames"] is None
+    assert sql_metadata["duration"] is None
+    assert decoded.shape == (64, 2)
+
+    with pytest.raises(vane.AudioFileLimitError, match="max_frames=63"):
+        value.to_numpy(max_frames=63, connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileLimitError, match="max_decoded_bytes"):
+        value.to_numpy(max_decoded_bytes=63 * 2 * 8, connection=duckdb_cursor)
+
+
+def test_audio_file_rejects_finite_underreported_flac_frame_count(duckdb_cursor, tmp_path):
+    payload, _ = _encoded_audio("FLAC", "PCM_16", frames=64, channels=2)
+    path = tmp_path / "underreported-total.flac"
+    path.write_bytes(_flac_with_total_samples(payload, 63))
+    value = vane.AudioFile(str(path), "audio/flac")
+
+    assert value.metadata(connection=duckdb_cursor).frames == 63
+    with pytest.raises(vane.AudioFileFormatError, match="more frames after reporting 63"):
+        value.to_numpy(connection=duckdb_cursor)
+
+
+def test_soundfile_cleanup_does_not_replace_primary_audio_errors(duckdb_cursor, tmp_path, monkeypatch):
+    payload, _ = _encoded_audio("WAV", "PCM_16", frames=16, channels=1)
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+    original_close = soundfile.SoundFile.close
+    original_metadata = _audio_file._metadata_from_sound_file
+
+    def fail_first_close(self):
+        was_open = not self.closed
+        original_close(self)
+        if was_open:
+            raise RuntimeError("competing close failure")
+
+    def interrupt_metadata(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(soundfile.SoundFile, "close", fail_first_close)
+    monkeypatch.setattr(_audio_file, "_metadata_from_sound_file", interrupt_metadata)
+    with pytest.raises(KeyboardInterrupt):
+        value.metadata(connection=duckdb_cursor)
+
+    monkeypatch.setattr(_audio_file, "_metadata_from_sound_file", original_metadata)
+    with pytest.raises(vane.AudioFileLimitError, match="max_frames=15"):
+        value.to_numpy(max_frames=15, connection=duckdb_cursor)
+
+
+def test_audio_file_classifies_invalid_media_but_propagates_io(duckdb_cursor, tmp_path):
+    corrupt = tmp_path / "corrupt.wav"
+    corrupt.write_bytes(b"not an audio file")
+    corrupt_value = vane.AudioFile(str(corrupt), "audio/wav")
+
+    with pytest.raises(vane.AudioFileFormatError, match="supported encoded audio"):
+        corrupt_value.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.AudioFileFormatError, match="supported encoded audio"):
+        corrupt_value.to_numpy(connection=duckdb_cursor)
+
+    missing = vane.AudioFile(str(tmp_path / "missing.wav"), "audio/wav")
+    with pytest.raises(vane.IOException):
+        missing.metadata(connection=duckdb_cursor)
+    with pytest.raises(vane.IOException):
+        missing.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.IOException):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [missing]).fetchone()
+
+
+def test_audio_operations_propagate_reader_failures_from_virtual_io(duckdb_cursor, tmp_path, monkeypatch):
+    payload, _ = _encoded_audio("WAV", "FLOAT")
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+
+    def fail_read(self, size=-1):
+        raise OSError("connector read failed")
+
+    monkeypatch.setattr(vane.VaneFileReader, "read", fail_read)
+    with pytest.raises(OSError, match="connector read failed"):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(OSError, match="connector read failed"):
+        value.to_numpy(connection=duckdb_cursor)
+
+
+def test_audio_metadata_requires_audiofile(duckdb_cursor):
+    with pytest.raises(vane.BinderException, match="requires AUDIOFILE, not FILE"):
+        duckdb_cursor.sql("SELECT audio_metadata(file('memory://generic', NULL, NULL, NULL, NULL))")
+    with pytest.raises(vane.BinderException, match="requires AUDIOFILE, not IMAGEFILE"):
+        duckdb_cursor.sql("SELECT audio_metadata(image_file('memory://image'))")
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs", "error_type", "message"),
+    [
+        ("metadata", {"max_bytes": True}, TypeError, "max_bytes must be int"),
+        ("metadata", {"max_bytes": 0}, ValueError, "greater than zero"),
+        ("metadata", {"max_bytes": 64 * 1024 * 1024 + 1}, ValueError, "at most"),
+        ("to_numpy", {"buffer_size": True}, TypeError, "buffer_size must be int"),
+        ("to_numpy", {"buffer_size": 0}, ValueError, "greater than zero"),
+        ("to_numpy", {"max_input_bytes": 0}, ValueError, "greater than zero"),
+        ("to_numpy", {"max_frames": 0}, ValueError, "greater than zero"),
+        ("to_numpy", {"max_decoded_bytes": 0}, ValueError, "greater than zero"),
+    ],
+)
+def test_audio_file_python_argument_validation(method, kwargs, error_type, message):
+    value = vane.AudioFile("memory://not-opened")
+
+    with pytest.raises(error_type, match=message):
+        getattr(value, method)(**kwargs)
+
+
+def test_audio_file_optional_dependency_is_lazy(monkeypatch):
+    original_import = importlib.import_module
+
+    def fail_soundfile(name, package=None):
+        if name == "soundfile":
+            raise ImportError("missing soundfile")
+        return original_import(name, package)
+
+    monkeypatch.setattr(_audio_file.importlib, "import_module", fail_soundfile)
+
+    value = vane.AudioFile("memory://not-opened")
+    with pytest.raises(ImportError, match=r"vane-ai\[audio\]"):
+        value.metadata()
+    with pytest.raises(ImportError, match=r"vane-ai\[audio\]"):
+        value.to_numpy()
+
+
+def test_audio_file_unusable_native_dependency_is_actionable(duckdb_cursor, tmp_path, monkeypatch):
+    payload, _ = _encoded_audio()
+    path = tmp_path / "audio.wav"
+    path.write_bytes(payload)
+    value = vane.AudioFile(str(path), "audio/wav")
+    original_import = importlib.import_module
+
+    def fail_libsndfile(name, package=None):
+        if name == "soundfile":
+            raise OSError("libsndfile cannot be loaded")
+        return original_import(name, package)
+
+    monkeypatch.setattr(_audio_file.importlib, "import_module", fail_libsndfile)
+
+    with pytest.raises(ImportError, match=r"usable libsndfile.*vane-ai\[audio\]"):
+        value.metadata(connection=duckdb_cursor)
+    with pytest.raises(ImportError, match=r"usable libsndfile.*vane-ai\[audio\]"):
+        value.to_numpy(connection=duckdb_cursor)
+    with pytest.raises(vane.InvalidInputException, match=r"usable libsndfile.*vane-ai\[audio\]"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [value]).fetchone()
+
+
+def test_audio_metadata_sql_preflights_dependency_before_opening_file(duckdb_cursor, tmp_path, monkeypatch):
+    missing = vane.AudioFile(str(tmp_path / "missing.wav"), "audio/wav")
+
+    def fail_soundfile():
+        raise ImportError("install vane-ai[audio]")
+
+    monkeypatch.setattr(_audio_file, "_load_soundfile", fail_soundfile)
+
+    with pytest.raises(vane.InvalidInputException, match=r"install vane-ai\[audio\]"):
+        duckdb_cursor.execute("SELECT audio_metadata($1)", [missing]).fetchone()

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -16,11 +16,18 @@ import vane
 FILE_FIELDS = ("url", "content_type", "position", "size", "checksum")
 FILE_METHODS = ("exists", "mime_type", "open", "stat", "to_tempfile")
 IMAGE_FILE_METHODS = FILE_METHODS + ("decode", "metadata")
+AUDIO_FILE_METHODS = FILE_METHODS + ("metadata", "to_numpy")
 MEDIA_FILE_CASES = (
     ("image", "IMAGEFILE", vane.ImageFile, vane.image_file),
     ("audio", "AUDIOFILE", vane.AudioFile, vane.audio_file),
     ("video", "VIDEOFILE", vane.VideoFile, vane.video_file),
 )
+FILE_METHODS_BY_CLASS = {
+    vane.File: FILE_METHODS,
+    vane.ImageFile: IMAGE_FILE_METHODS,
+    vane.AudioFile: AUDIO_FILE_METHODS,
+    vane.VideoFile: FILE_METHODS,
+}
 
 
 def test_file_value_contract():
@@ -207,7 +214,7 @@ def test_media_file_python_value_contract(media, type_name, value_class, _constr
     generic = vane.File(value.url, value.content_type, value.position, value.size, value.checksum)
     assert value != generic
     assert len({value, generic}) == 2
-    expected_methods = IMAGE_FILE_METHODS if value_class is vane.ImageFile else FILE_METHODS
+    expected_methods = FILE_METHODS_BY_CLASS[value_class]
     assert {name for name in dir(value) if not name.startswith("_")} == set(FILE_FIELDS + expected_methods)
 
 

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -494,6 +494,10 @@ def test_image_extra_installs_pillow():
     assert _requirements_for_extra("image") == {"pillow"}
 
 
+def test_audio_extra_installs_soundfile():
+    assert _requirements_for_extra("audio") == {"soundfile"}
+
+
 def test_video_extra_installs_video_dependencies():
     selected = _requirements_for_extra("video")
     assert {"pillow", "psutil"} <= selected
@@ -501,11 +505,11 @@ def test_video_extra_installs_video_dependencies():
     assert ("decord" in selected) is supports_decord
 
 
-def test_base_distribution_keeps_video_dependencies_optional():
+def test_base_distribution_keeps_media_dependencies_optional():
     base_requirements = set()
     for raw_requirement in requires("vane-ai") or []:
         requirement = Requirement(raw_requirement)
         if requirement.marker is None or requirement.marker.evaluate({"extra": ""}):
             base_requirements.add(canonicalize_name(requirement.name))
 
-    assert {"pillow", "psutil", "decord"}.isdisjoint(base_requirements)
+    assert {"pillow", "psutil", "decord", "soundfile"}.isdisjoint(base_requirements)

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -15,6 +15,13 @@ the two distributions do not share Python modules or extension names.
 import importlib as _importlib
 import typing as _typing
 
+from vane._audio_file import (
+    AudioFileError,
+    AudioFileFormatError,
+    AudioFileLimitError,
+    AudioMetadata,
+    audio_metadata,
+)
 from vane._dbapi_type_object import (
     BINARY,
     DATETIME,
@@ -363,6 +370,10 @@ def __dir__() -> list[str]:
 
 __all__: list[str] = [
     "AudioFile",
+    "AudioFileError",
+    "AudioFileFormatError",
+    "AudioFileLimitError",
+    "AudioMetadata",
     "BINARY",
     "BinaryValue",
     "BinderException",
@@ -499,6 +510,7 @@ __all__: list[str] = [
     "apilevel",
     "append",
     "audio_file",
+    "audio_metadata",
     "array_type",
     "arrow",
     "begin",

--- a/vane/_audio_file.py
+++ b/vane/_audio_file.py
@@ -571,7 +571,7 @@ def _decode_audio_file(
     soundfile = _load_soundfile()
     numpy = importlib.import_module("numpy")
 
-    class _AudioDecoder(soundfile.SoundFile):
+    class _AudioDecoder(soundfile.SoundFile):  # type: ignore[name-defined]
         def seekable(self) -> bool:
             # libsndfile reports SF_COUNT_MAX when a container omits its
             # total frame count. The encoded stream can still seek while

--- a/vane/_audio_file.py
+++ b/vane/_audio_file.py
@@ -600,65 +600,76 @@ def _decode_audio_file(
                     decoded_frame_limit = normalized_max_decoded // frame_bytes
                     frame_limit = min(normalized_max_frames, decoded_frame_limit)
                     if frame_limit == 0:
-                        raise AudioFileLimitError(
-                            f"one decoded audio frame requires {frame_bytes} bytes, "
-                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
-                        )
+                        # A stream with an unknown total can still be empty. A
+                        # one-frame probe distinguishes EOF from a non-empty
+                        # result that cannot fit the requested output budget.
+                        probe = bytearray(frame_bytes)
+                        probe_frames = audio.buffer_read_into(probe, dtype="float64")
+                        proxy.raise_if_error()
+                        del probe
+                        if probe_frames < 0 or probe_frames > 1:
+                            raise AudioFileFormatError("audio decoder returned an invalid frame count")
+                        if probe_frames:
+                            raise AudioFileLimitError(
+                                f"one decoded audio frame requires {frame_bytes} bytes, "
+                                f"exceeding max_decoded_bytes={normalized_max_decoded}"
+                            )
+                        samples = numpy.empty((0, metadata.channels), dtype=numpy.float64)
+                    else:
+                        # Unknown-length streams cannot accumulate both a decoded
+                        # output and a same-sized scratch buffer without violating
+                        # max_decoded_bytes. Spool bounded chunks, release the
+                        # scratch allocation, then materialize the exact ndarray
+                        # directly from the temporary file.
+                        with tempfile.TemporaryFile(mode="w+b", buffering=0, prefix="vane_audio_") as decoded_file:
+                            decoded_frames = 0
+                            while decoded_frames < frame_limit:
+                                requested_frames = min(64 * 1024, frame_limit - decoded_frames)
+                                chunk = bytearray(requested_frames * frame_bytes)
+                                chunk_frames = audio.buffer_read_into(chunk, dtype="float64")
+                                proxy.raise_if_error()
+                                if chunk_frames < 0 or chunk_frames > requested_frames:
+                                    raise AudioFileFormatError("audio decoder returned an invalid frame count")
+                                chunk_bytes = chunk_frames * frame_bytes
+                                chunk_view = memoryview(chunk)[:chunk_bytes]
+                                while chunk_view:
+                                    written = decoded_file.write(chunk_view)
+                                    if written is None or written <= 0:
+                                        raise OSError("temporary audio spool made no write progress")
+                                    chunk_view = chunk_view[written:]
+                                decoded_frames += chunk_frames
+                                reached_end = chunk_frames < requested_frames
+                                del chunk_view
+                                del chunk
+                                if reached_end:
+                                    break
 
-                    # Unknown-length streams cannot accumulate both a decoded
-                    # output and a same-sized scratch buffer without violating
-                    # max_decoded_bytes. Spool bounded chunks, release the
-                    # scratch allocation, then materialize the exact ndarray
-                    # directly from the temporary file.
-                    with tempfile.TemporaryFile(mode="w+b", buffering=0, prefix="vane_audio_") as decoded_file:
-                        decoded_frames = 0
-                        while decoded_frames < frame_limit:
-                            requested_frames = min(64 * 1024, frame_limit - decoded_frames)
-                            chunk = bytearray(requested_frames * frame_bytes)
-                            chunk_frames = audio.buffer_read_into(chunk, dtype="float64")
-                            proxy.raise_if_error()
-                            if chunk_frames < 0 or chunk_frames > requested_frames:
-                                raise AudioFileFormatError("audio decoder returned an invalid frame count")
-                            chunk_bytes = chunk_frames * frame_bytes
-                            chunk_view = memoryview(chunk)[:chunk_bytes]
-                            while chunk_view:
-                                written = decoded_file.write(chunk_view)
-                                if written is None or written <= 0:
-                                    raise OSError("temporary audio spool made no write progress")
-                                chunk_view = chunk_view[written:]
-                            decoded_frames += chunk_frames
-                            reached_end = chunk_frames < requested_frames
-                            del chunk_view
-                            del chunk
-                            if reached_end:
-                                break
-
-                        if decoded_frames == frame_limit:
-                            extra = bytearray(frame_bytes)
-                            extra_frames = audio.buffer_read_into(extra, dtype="float64")
-                            proxy.raise_if_error()
-                            del extra
-                            if extra_frames < 0 or extra_frames > 1:
-                                raise AudioFileFormatError("audio decoder returned an invalid frame count")
-                            if extra_frames:
-                                if normalized_max_frames <= decoded_frame_limit:
+                            if decoded_frames == frame_limit:
+                                extra = bytearray(frame_bytes)
+                                extra_frames = audio.buffer_read_into(extra, dtype="float64")
+                                proxy.raise_if_error()
+                                del extra
+                                if extra_frames < 0 or extra_frames > 1:
+                                    raise AudioFileFormatError("audio decoder returned an invalid frame count")
+                                if extra_frames:
+                                    if normalized_max_frames <= decoded_frame_limit:
+                                        raise AudioFileLimitError(
+                                            f"audio contains more than max_frames={normalized_max_frames} frames"
+                                        )
                                     raise AudioFileLimitError(
-                                        f"audio contains more than max_frames={normalized_max_frames} frames"
+                                        f"audio decode requires more than max_decoded_bytes={normalized_max_decoded}"
                                     )
-                                raise AudioFileLimitError(
-                                    f"audio decode requires more than max_decoded_bytes={normalized_max_decoded}"
-                                )
 
-                        samples = numpy.empty((decoded_frames, metadata.channels), dtype=numpy.float64)
-                        output_view = memoryview(samples).cast("B")
-                        decoded_file.seek(0)
-                        output_offset = 0
-                        while output_offset < len(output_view):
-                            read_count = decoded_file.readinto(output_view[output_offset:])
-                            if read_count is None or read_count <= 0:
-                                raise OSError("temporary audio spool ended before the decoded output")
-                            output_offset += read_count
-                        del output_view
+                            samples = numpy.empty((decoded_frames, metadata.channels), dtype=numpy.float64)
+                            output_view = memoryview(samples).cast("B")
+                            decoded_file.seek(0)
+                            output_offset = 0
+                            while output_offset < len(output_view):
+                                read_count = decoded_file.readinto(output_view[output_offset:])
+                                if read_count is None or read_count <= 0:
+                                    raise OSError("temporary audio spool ended before the decoded output")
+                                output_offset += read_count
+                            del output_view
                 else:
                     decoded_bytes = metadata.frames * metadata.channels * 8
                     if decoded_bytes > normalized_max_decoded:

--- a/vane/_audio_file.py
+++ b/vane/_audio_file.py
@@ -660,12 +660,6 @@ def _decode_audio_file(
                             output_offset += read_count
                         del output_view
                 else:
-                    frame_bytes = metadata.channels * 8
-                    if frame_bytes > normalized_max_decoded:
-                        raise AudioFileLimitError(
-                            f"one decoded audio frame requires {frame_bytes} bytes, "
-                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
-                        )
                     decoded_bytes = metadata.frames * metadata.channels * 8
                     if decoded_bytes > normalized_max_decoded:
                         raise AudioFileLimitError(

--- a/vane/_audio_file.py
+++ b/vane/_audio_file.py
@@ -1,0 +1,734 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Encoded AUDIOFILE metadata and Python waveform decoding helpers."""
+
+from __future__ import annotations
+
+import importlib
+import io
+import math
+import tempfile
+from bisect import bisect_left, bisect_right
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from email.message import EmailMessage
+from email.policy import default as default_email_policy
+from typing import TYPE_CHECKING, Any
+
+import vane
+from vane._expressions import as_expression
+from vane._file import _positive_buffer_size
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+DEFAULT_AUDIO_METADATA_BYTES = 8 * 1024 * 1024
+DEFAULT_AUDIO_BUFFER_SIZE = 1024 * 1024
+DEFAULT_AUDIO_MAX_INPUT_BYTES = 512 * 1024 * 1024
+DEFAULT_AUDIO_MAX_FRAMES = 100_000_000
+DEFAULT_AUDIO_MAX_DECODED_BYTES = 512 * 1024 * 1024
+MAX_AUDIO_METADATA_BYTES = 64 * 1024 * 1024
+_MAX_AUDIO_METADATA_FETCH_BYTES = 64 * 1024
+_AUDIO_METADATA_FETCHES_PER_BUDGET = 8
+_MAX_AUDIO_METADATA_FETCHES = 1024
+_MAX_BIGINT = (1 << 63) - 1
+_MAX_UBIGINT = (1 << 64) - 1
+
+_MIME_ALIASES = {
+    "application/ogg": "audio/ogg",
+    "audio/aif": "audio/aiff",
+    "audio/au": "audio/x-au",
+    "audio/mp3": "audio/mpeg",
+    "audio/vnd.sun.audio": "audio/x-au",
+    "audio/vnd.wave": "audio/wav",
+    "audio/wave": "audio/wav",
+    "audio/x-aiff": "audio/aiff",
+    "audio/x-flac": "audio/flac",
+    "audio/x-mp3": "audio/mpeg",
+    "audio/x-wav": "audio/wav",
+}
+_GENERIC_MIME_TYPES = frozenset({"application/octet-stream", "audio/*", "binary/octet-stream"})
+_FORMAT_MIME_TYPES = {
+    "AIFF": "audio/aiff",
+    "AU": "audio/x-au",
+    "CAF": "audio/x-caf",
+    "FLAC": "audio/flac",
+    "MP3": "audio/mpeg",
+    "NIST": "audio/x-nist",
+    "OGG": "audio/ogg",
+    "RF64": "audio/wav",
+    "SVX": "audio/x-iff",
+    "VOC": "audio/x-voc",
+    "W64": "audio/x-w64",
+    "WAV": "audio/wav",
+    "WAVEX": "audio/wav",
+}
+_FORMAT_SUBTYPE_CODECS: dict[tuple[str, str | None], frozenset[str]] = {
+    ("OGG", "OPUS"): frozenset({"opus"}),
+    ("OGG", "VORBIS"): frozenset({"vorbis"}),
+}
+_WAVE_SUBTYPE_CODECS = {
+    "ALAW": "6",
+    "DOUBLE": "3",
+    "FLOAT": "3",
+    "GSM610": "31",
+    "G721_32": "40",
+    "IMA_ADPCM": "11",
+    "MPEG_LAYER_III": "55",
+    "MS_ADPCM": "2",
+    "NMS_ADPCM_16": "38",
+    "NMS_ADPCM_24": "38",
+    "NMS_ADPCM_32": "38",
+    "PCM_16": "1",
+    "PCM_24": "1",
+    "PCM_32": "1",
+    "PCM_U8": "1",
+    "ULAW": "7",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AudioMetadata:
+    """Decoder-reported metadata for an encoded :class:`vane.AudioFile`."""
+
+    sample_rate: int
+    channels: int
+    frames: int | None
+    duration: float | None
+    format: str
+    subtype: str | None
+
+
+class AudioFileError(RuntimeError):
+    """Base class for failures caused by encoded audio content."""
+
+
+class AudioFileFormatError(AudioFileError):
+    """The logical FILE view could not be opened or decoded as supported audio."""
+
+
+class AudioFileLimitError(AudioFileError):
+    """An AudioFile operation exceeded an explicit resource limit."""
+
+
+@contextmanager
+def _close_sound_file(audio: Any) -> Iterator[Any]:
+    """Close a decoder without replacing an exception from its operation."""
+    try:
+        yield audio
+    except BaseException:
+        try:
+            audio.close()
+        except BaseException:
+            pass
+        raise
+    else:
+        audio.close()
+
+
+class _AudioMetadataView:
+    """Expose bounded, range-aware reads over a logical FILE view."""
+
+    def __init__(
+        self,
+        read_at: Callable[[int, int], bytes],
+        *,
+        logical_size: int,
+        max_bytes: int,
+    ) -> None:
+        self._read_at = read_at
+        self._logical_size = logical_size
+        self._max_bytes = max_bytes
+        self._fetch_size = min(
+            _MAX_AUDIO_METADATA_FETCH_BYTES,
+            max(1, max_bytes // _AUDIO_METADATA_FETCHES_PER_BUDGET),
+        )
+        self._position = 0
+        self._bytes_read = 0
+        self._fetches = 0
+        self._cache_starts: list[int] = []
+        self._cache: list[tuple[int, bytes]] = []
+        self._error: BaseException | None = None
+        self.budget_exhausted = False
+        self.fetch_limit_exhausted = False
+
+    def _cached_at(self, position: int) -> tuple[int, bytes] | None:
+        index = bisect_right(self._cache_starts, position) - 1
+        if index >= 0:
+            start, data = self._cache[index]
+            if position < start + len(data):
+                return start, data
+        return None
+
+    def _next_cached_start(self, position: int) -> int:
+        index = bisect_right(self._cache_starts, position)
+        return self._cache_starts[index] if index < len(self._cache_starts) else self._logical_size
+
+    def _previous_cached_end(self, position: int) -> int:
+        index = bisect_right(self._cache_starts, position) - 1
+        if index < 0:
+            return 0
+        start, data = self._cache[index]
+        return min(position, start + len(data))
+
+    def _cache_bytes(self, start: int, data: bytes) -> None:
+        insert_at = bisect_left(self._cache_starts, start)
+        if insert_at > 0:
+            previous_start, previous_data = self._cache[insert_at - 1]
+            if previous_start + len(previous_data) > start:
+                raise RuntimeError("audio metadata cache received overlapping ranges")
+        if insert_at < len(self._cache) and start + len(data) > self._cache[insert_at][0]:
+            raise RuntimeError("audio metadata cache received overlapping ranges")
+        self._cache_starts.insert(insert_at, start)
+        self._cache.insert(insert_at, (start, data))
+
+    def _remember(self, error: BaseException) -> None:
+        if self._error is None:
+            self._error = error
+
+    def _read(self, size: int | None) -> bytes:
+        if size == 0 or self._position >= self._logical_size:
+            return b""
+        if size is None or size < 0:
+            requested_end = self._logical_size
+        else:
+            requested_end = min(self._logical_size, self._position + size)
+
+        result = bytearray()
+        position = self._position
+        while position < requested_end:
+            cached = self._cached_at(position)
+            if cached is not None:
+                cached_start, cached_data = cached
+                cached_offset = position - cached_start
+                copy_size = min(requested_end - position, len(cached_data) - cached_offset)
+                result.extend(cached_data[cached_offset : cached_offset + copy_size])
+                position += copy_size
+                continue
+
+            remaining_budget = self._max_bytes - self._bytes_read
+            if remaining_budget <= 0:
+                self.budget_exhausted = True
+                break
+            if self._fetches >= _MAX_AUDIO_METADATA_FETCHES:
+                self.fetch_limit_exhausted = True
+                break
+
+            block_start = position - position % self._fetch_size
+            fetch_start = max(block_start, self._previous_cached_end(position))
+            fetch_end = min(
+                self._logical_size,
+                self._next_cached_start(position),
+                max(requested_end, block_start + self._fetch_size),
+            )
+            if remaining_budget <= position - fetch_start:
+                fetch_start = position
+            fetch_size = min(fetch_end - fetch_start, remaining_budget)
+            if fetch_size <= 0:
+                self.budget_exhausted = True
+                break
+            fetched = self._read_at(fetch_start, fetch_size)
+            if not isinstance(fetched, bytes) or len(fetched) != fetch_size:
+                raise OSError(
+                    f"audio metadata source returned {len(fetched) if isinstance(fetched, bytes) else 0} bytes "
+                    f"after requesting {fetch_size}"
+                )
+            self._bytes_read += len(fetched)
+            self._fetches += 1
+            self._cache_bytes(fetch_start, fetched)
+
+        self._position = position
+        return bytes(result)
+
+    def read(self, size: int | None = -1, /) -> bytes:
+        if self._error is not None:
+            return b""
+        try:
+            return self._read(size)
+        except BaseException as error:
+            self._remember(error)
+            return b""
+
+    def _seek(self, offset: int, whence: int) -> int:
+        if whence == io.SEEK_SET:
+            position = offset
+        elif whence == io.SEEK_CUR:
+            position = self._position + offset
+        elif whence == io.SEEK_END:
+            position = self._logical_size + offset
+        else:
+            raise ValueError(f"invalid whence {whence}")
+        if position < 0:
+            raise ValueError("negative seek position")
+        self._position = position
+        return position
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET, /) -> int:
+        if self._error is not None:
+            return -1
+        try:
+            return self._seek(offset, whence)
+        except BaseException as error:
+            self._remember(error)
+            return -1
+
+    def tell(self) -> int:
+        if self._error is not None:
+            return -1
+        try:
+            return self._position
+        except BaseException as error:
+            self._remember(error)
+            return -1
+
+    def raise_if_error(self) -> None:
+        if self._error is not None:
+            raise self._error.with_traceback(self._error.__traceback__)
+
+
+class _AudioReaderProxy:
+    """Keep reader failures from being swallowed by CFFI virtual-I/O callbacks."""
+
+    def __init__(self, reader: vane.VaneFileReader) -> None:
+        self._reader = reader
+        self._error: BaseException | None = None
+
+    def _remember(self, error: BaseException) -> None:
+        if self._error is None:
+            self._error = error
+
+    def read(self, size: int = -1, /) -> bytes:
+        if self._error is not None:
+            return b""
+        try:
+            return self._reader.read(size)
+        except BaseException as error:
+            self._remember(error)
+            return b""
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET, /) -> int:
+        if self._error is not None:
+            return -1
+        try:
+            return self._reader.seek(offset, whence)
+        except BaseException as error:
+            self._remember(error)
+            return -1
+
+    def tell(self) -> int:
+        if self._error is not None:
+            return -1
+        try:
+            return self._reader.tell()
+        except BaseException as error:
+            self._remember(error)
+            return -1
+
+    def raise_if_error(self) -> None:
+        if self._error is not None:
+            raise self._error.with_traceback(self._error.__traceback__)
+
+
+def _load_soundfile() -> Any:
+    try:
+        soundfile = importlib.import_module("soundfile")
+        soundfile.SoundFile
+        soundfile.SoundFileError
+    except (AttributeError, ImportError, OSError) as error:
+        raise ImportError(
+            "AudioFile metadata and decoding require the 'soundfile' package and a usable libsndfile library. "
+            "Please `pip install 'vane-ai[audio]'`."
+        ) from error
+    return soundfile
+
+
+def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be int, not {type(value).__name__!r}")
+    if value <= 0:
+        raise ValueError(f"{name} must be greater than zero")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return value
+
+
+def _limit_expression(value: int | vane.Expression, *, name: str, maximum: int | None = None) -> vane.Expression:
+    if isinstance(value, vane.Expression):
+        return value
+    return as_expression(_positive_limit(value, name=name, maximum=maximum))
+
+
+def _canonical_mime_type(value: str) -> str:
+    normalized = value.strip().lower()
+    return _MIME_ALIASES.get(normalized, normalized)
+
+
+def _parse_content_type(value: str) -> tuple[str, str | None, frozenset[str] | None]:
+    message = EmailMessage(policy=default_email_policy)
+    try:
+        message["Content-Type"] = value
+        header = message["Content-Type"]
+        if header is None or getattr(header, "defects", False):
+            raise ValueError("invalid Content-Type syntax")
+        parameters = message.get_params(header="content-type", unquote=True)
+    except (TypeError, ValueError) as error:
+        raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} is invalid") from error
+    if not parameters:
+        raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} is invalid")
+
+    declared = _canonical_mime_type(message.get_content_type())
+    codec_values = [parameter for name, parameter in parameters[1:] if name.lower() == "codec"]
+    if len(codec_values) > 1 or (codec_values and not isinstance(codec_values[0], str)):
+        raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} has an invalid codec parameter")
+    declared_codec = codec_values[0].strip().lower() if codec_values else None
+    if declared_codec == "" or (declared_codec is not None and "," in declared_codec):
+        raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} has an invalid codec parameter")
+
+    codec_values = [parameter for name, parameter in parameters[1:] if name.lower() == "codecs"]
+    if not codec_values:
+        return declared, declared_codec, None
+
+    codecs: set[str] = set()
+    for codec_value in codec_values:
+        if not isinstance(codec_value, str):
+            raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} has an invalid codecs parameter")
+        parsed = [codec.strip().lower() for codec in codec_value.split(",")]
+        if not parsed or any(not codec for codec in parsed):
+            raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} has an invalid codecs parameter")
+        codecs.update(parsed)
+    if declared_codec is not None:
+        raise AudioFileFormatError(f"AUDIOFILE content_type {value!r} cannot declare both codec and codecs")
+    return declared, None, frozenset(codecs)
+
+
+def _detected_audio_mime_type(audio_format: str) -> str | None:
+    return _FORMAT_MIME_TYPES.get(audio_format)
+
+
+def _validate_content_type(
+    content_type: str | None,
+    audio_format: str,
+    subtype: str | None,
+    detected_mime_type: str | None,
+) -> None:
+    if content_type is None:
+        return
+    declared, declared_codec, declared_codecs = _parse_content_type(content_type)
+    is_generic = declared in _GENERIC_MIME_TYPES
+    if not is_generic and not declared.startswith("audio/"):
+        raise AudioFileFormatError(f"AUDIOFILE content_type {content_type!r} contradicts the decoded audio content")
+    if not is_generic:
+        if detected_mime_type is None:
+            raise AudioFileFormatError(
+                f"AUDIOFILE content_type {content_type!r} cannot be validated against detected audio format "
+                f"{audio_format!r}"
+            )
+        detected = _canonical_mime_type(detected_mime_type)
+        if declared != detected:
+            raise AudioFileFormatError(
+                f"AUDIOFILE content_type {content_type!r} contradicts detected MIME type {detected_mime_type!r}"
+            )
+    if declared_codec is not None:
+        detected_codec = (
+            _WAVE_SUBTYPE_CODECS.get(subtype)
+            if audio_format in {"RF64", "WAV", "WAVEX"} and subtype is not None
+            else None
+        )
+        if declared != "audio/wav" or detected_codec is None:
+            raise AudioFileFormatError(
+                f"AUDIOFILE content_type {content_type!r} codec parameter cannot be validated against "
+                f"detected audio format {audio_format!r}"
+            )
+        if declared_codec != detected_codec:
+            raise AudioFileFormatError(
+                f"AUDIOFILE content_type {content_type!r} contradicts detected audio codec {subtype!r}"
+            )
+    if declared_codecs is not None:
+        detected_codecs = _FORMAT_SUBTYPE_CODECS.get((audio_format, subtype))
+        if declared_codecs != detected_codecs:
+            raise AudioFileFormatError(
+                f"AUDIOFILE content_type {content_type!r} contradicts detected audio codec {subtype!r}"
+            )
+
+
+def _metadata_from_sound_file(audio: Any, *, content_type: str | None) -> AudioMetadata:
+    sample_rate = int(audio.samplerate)
+    channels = int(audio.channels)
+    reported_frames = int(audio.frames)
+    if sample_rate <= 0 or sample_rate > _MAX_BIGINT:
+        raise AudioFileFormatError(f"audio sample rate must be between 1 and {_MAX_BIGINT}, found {sample_rate}")
+    if channels <= 0 or channels > _MAX_BIGINT:
+        raise AudioFileFormatError(f"audio channel count must be between 1 and {_MAX_BIGINT}, found {channels}")
+    if reported_frames < 0 or reported_frames > _MAX_BIGINT:
+        raise AudioFileFormatError(f"audio frame count must be between 0 and {_MAX_BIGINT}, found {reported_frames}")
+    frames = None if reported_frames == _MAX_BIGINT else reported_frames
+
+    audio_format = audio.format
+    if not isinstance(audio_format, str) or not audio_format:
+        raise AudioFileFormatError("audio decoder did not report an encoded format")
+    audio_format = audio_format.upper()
+    subtype = audio.subtype
+    if subtype is not None:
+        if not isinstance(subtype, str):
+            raise AudioFileFormatError("audio decoder reported an invalid subtype")
+        subtype = subtype.upper() or None
+
+    detected_mime_type = _detected_audio_mime_type(audio_format)
+    _validate_content_type(
+        content_type,
+        audio_format,
+        subtype,
+        detected_mime_type,
+    )
+    duration = None if frames is None else frames / sample_rate
+    if duration is not None and (not math.isfinite(duration) or duration < 0):
+        raise AudioFileFormatError("audio decoder reported an invalid duration")
+    return AudioMetadata(sample_rate, channels, frames, duration, audio_format, subtype)
+
+
+def _probe_audio_metadata(
+    read_at: Callable[[int, int], bytes],
+    logical_size: int,
+    content_type: str | None,
+    max_bytes: int,
+) -> tuple[int, int, int | None, float | None, str, str | None]:
+    """Bounded helper called by the native SQL scalar function."""
+    soundfile = _load_soundfile()
+    stream = _AudioMetadataView(read_at, logical_size=logical_size, max_bytes=max_bytes)
+    try:
+        # libsndfile owns container parsing. Vane only supplies a bounded,
+        # range-aware logical FILE view and classifies the library's result.
+        with _close_sound_file(soundfile.SoundFile(stream, mode="r", closefd=False)) as audio:
+            stream.raise_if_error()
+            metadata = _metadata_from_sound_file(audio, content_type=content_type)
+            stream.raise_if_error()
+    except BaseException as error:
+        # Cancellation and interpreter-control exceptions must never be
+        # rewritten as a media or resource-limit failure.
+        if not isinstance(error, Exception):
+            raise
+        stream.raise_if_error()
+        if stream.budget_exhausted:
+            raise AudioFileLimitError(f"audio metadata requires more than max_bytes={max_bytes}") from error
+        if stream.fetch_limit_exhausted:
+            raise AudioFileLimitError(
+                f"audio metadata requires more than {_MAX_AUDIO_METADATA_FETCHES} source ranges"
+            ) from error
+        if isinstance(error, AudioFileError):
+            raise
+        if isinstance(error, soundfile.SoundFileError):
+            raise AudioFileFormatError("logical FILE view is not a supported encoded audio file") from error
+        raise
+    if stream.budget_exhausted:
+        raise AudioFileLimitError(f"audio metadata requires more than max_bytes={max_bytes}")
+    if stream.fetch_limit_exhausted:
+        raise AudioFileLimitError(f"audio metadata requires more than {_MAX_AUDIO_METADATA_FETCHES} source ranges")
+    return (
+        metadata.sample_rate,
+        metadata.channels,
+        metadata.frames,
+        metadata.duration,
+        metadata.format,
+        metadata.subtype,
+    )
+
+
+def _audio_file_metadata_value(
+    value: vane.AudioFile,
+    *,
+    max_bytes: int = DEFAULT_AUDIO_METADATA_BYTES,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> AudioMetadata:
+    normalized_max_bytes = _positive_limit(max_bytes, name="max_bytes", maximum=MAX_AUDIO_METADATA_BYTES)
+    _load_soundfile()
+    with value.open(buffer_size=1, connection=connection) as reader:
+        logical_size = reader.size()
+
+        def read_at(offset: int, size: int) -> bytes:
+            reader.seek(offset)
+            return reader.read(size)
+
+        fields = _probe_audio_metadata(read_at, logical_size, value.content_type, normalized_max_bytes)
+    return AudioMetadata(*fields)
+
+
+def _decode_audio_file(
+    value: vane.AudioFile,
+    buffer_size: int = DEFAULT_AUDIO_BUFFER_SIZE,
+    *,
+    max_input_bytes: int = DEFAULT_AUDIO_MAX_INPUT_BYTES,
+    max_frames: int = DEFAULT_AUDIO_MAX_FRAMES,
+    max_decoded_bytes: int = DEFAULT_AUDIO_MAX_DECODED_BYTES,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> np.ndarray[Any, np.dtype[np.float64]]:
+    normalized_buffer_size = _positive_buffer_size(buffer_size, none_default=None, name="buffer_size")
+    normalized_max_input = _positive_limit(max_input_bytes, name="max_input_bytes", maximum=_MAX_UBIGINT)
+    normalized_max_frames = _positive_limit(max_frames, name="max_frames", maximum=_MAX_BIGINT)
+    normalized_max_decoded = _positive_limit(max_decoded_bytes, name="max_decoded_bytes", maximum=_MAX_UBIGINT)
+    soundfile = _load_soundfile()
+    numpy = importlib.import_module("numpy")
+
+    class _AudioDecoder(soundfile.SoundFile):
+        def seekable(self) -> bool:
+            # libsndfile reports SF_COUNT_MAX when a container omits its
+            # total frame count. The encoded stream can still seek while
+            # probing, but frame-based seeks are unavailable. SoundFile's
+            # read wrapper otherwise performs such a seek after every read.
+            return int(self.frames) != _MAX_BIGINT and super().seekable()
+
+    with value.open(buffer_size=normalized_buffer_size, connection=connection) as reader:
+        input_size = reader.size()
+        if input_size > normalized_max_input:
+            raise AudioFileLimitError(
+                f"encoded audio contains {input_size} bytes, exceeding max_input_bytes={normalized_max_input}"
+            )
+
+        proxy = _AudioReaderProxy(reader)
+        try:
+            with _close_sound_file(_AudioDecoder(proxy, mode="r", closefd=False)) as audio:
+                proxy.raise_if_error()
+                metadata = _metadata_from_sound_file(audio, content_type=value.content_type)
+                if metadata.frames is not None and metadata.frames > normalized_max_frames:
+                    raise AudioFileLimitError(
+                        f"audio contains {metadata.frames} frames, exceeding max_frames={normalized_max_frames}"
+                    )
+                if metadata.frames is None:
+                    frame_bytes = metadata.channels * 8
+                    decoded_frame_limit = normalized_max_decoded // frame_bytes
+                    frame_limit = min(normalized_max_frames, decoded_frame_limit)
+                    if frame_limit == 0:
+                        raise AudioFileLimitError(
+                            f"one decoded audio frame requires {frame_bytes} bytes, "
+                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
+                        )
+
+                    # Unknown-length streams cannot accumulate both a decoded
+                    # output and a same-sized scratch buffer without violating
+                    # max_decoded_bytes. Spool bounded chunks, release the
+                    # scratch allocation, then materialize the exact ndarray
+                    # directly from the temporary file.
+                    with tempfile.TemporaryFile(mode="w+b", buffering=0, prefix="vane_audio_") as decoded_file:
+                        decoded_frames = 0
+                        while decoded_frames < frame_limit:
+                            requested_frames = min(64 * 1024, frame_limit - decoded_frames)
+                            chunk = bytearray(requested_frames * frame_bytes)
+                            chunk_frames = audio.buffer_read_into(chunk, dtype="float64")
+                            proxy.raise_if_error()
+                            if chunk_frames < 0 or chunk_frames > requested_frames:
+                                raise AudioFileFormatError("audio decoder returned an invalid frame count")
+                            chunk_bytes = chunk_frames * frame_bytes
+                            chunk_view = memoryview(chunk)[:chunk_bytes]
+                            while chunk_view:
+                                written = decoded_file.write(chunk_view)
+                                if written is None or written <= 0:
+                                    raise OSError("temporary audio spool made no write progress")
+                                chunk_view = chunk_view[written:]
+                            decoded_frames += chunk_frames
+                            reached_end = chunk_frames < requested_frames
+                            del chunk_view
+                            del chunk
+                            if reached_end:
+                                break
+
+                        if decoded_frames == frame_limit:
+                            extra = bytearray(frame_bytes)
+                            extra_frames = audio.buffer_read_into(extra, dtype="float64")
+                            proxy.raise_if_error()
+                            del extra
+                            if extra_frames < 0 or extra_frames > 1:
+                                raise AudioFileFormatError("audio decoder returned an invalid frame count")
+                            if extra_frames:
+                                if normalized_max_frames <= decoded_frame_limit:
+                                    raise AudioFileLimitError(
+                                        f"audio contains more than max_frames={normalized_max_frames} frames"
+                                    )
+                                raise AudioFileLimitError(
+                                    f"audio decode requires more than max_decoded_bytes={normalized_max_decoded}"
+                                )
+
+                        samples = numpy.empty((decoded_frames, metadata.channels), dtype=numpy.float64)
+                        output_view = memoryview(samples).cast("B")
+                        decoded_file.seek(0)
+                        output_offset = 0
+                        while output_offset < len(output_view):
+                            read_count = decoded_file.readinto(output_view[output_offset:])
+                            if read_count is None or read_count <= 0:
+                                raise OSError("temporary audio spool ended before the decoded output")
+                            output_offset += read_count
+                        del output_view
+                else:
+                    frame_bytes = metadata.channels * 8
+                    if frame_bytes > normalized_max_decoded:
+                        raise AudioFileLimitError(
+                            f"one decoded audio frame requires {frame_bytes} bytes, "
+                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
+                        )
+                    decoded_bytes = metadata.frames * metadata.channels * 8
+                    if decoded_bytes > normalized_max_decoded:
+                        raise AudioFileLimitError(
+                            f"audio decode requires {decoded_bytes} bytes, "
+                            f"exceeding max_decoded_bytes={normalized_max_decoded}"
+                        )
+                    if metadata.frames == 0:
+                        samples = numpy.empty((0, metadata.channels), dtype=numpy.float64)
+                    else:
+                        decoded = bytearray(decoded_bytes)
+                        decoded_frames = audio.buffer_read_into(decoded, dtype="float64")
+                        proxy.raise_if_error()
+                        if decoded_frames != metadata.frames:
+                            raise AudioFileFormatError(
+                                f"audio decoder returned {decoded_frames} frames after reporting {metadata.frames}"
+                            )
+                        samples = numpy.frombuffer(decoded, dtype=numpy.float64).reshape(
+                            metadata.frames,
+                            metadata.channels,
+                        )
+                    extra = bytearray(frame_bytes)
+                    extra_frames = audio.buffer_read_into(extra, dtype="float64")
+                    proxy.raise_if_error()
+                    del extra
+                    if extra_frames < 0 or extra_frames > 1:
+                        raise AudioFileFormatError("audio decoder returned an invalid frame count")
+                    if extra_frames:
+                        raise AudioFileFormatError(
+                            f"audio decoder produced more frames after reporting {metadata.frames}"
+                        )
+                proxy.raise_if_error()
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            proxy.raise_if_error()
+            if isinstance(error, AudioFileError):
+                raise
+            if isinstance(error, soundfile.SoundFileError):
+                raise AudioFileFormatError("logical FILE view is not a supported encoded audio file") from error
+            raise
+
+    # The backing bytearray (when present) is owned by the returned array and
+    # is independent of the reader, which has already been closed.
+    return samples
+
+
+def audio_metadata(
+    value: vane.AudioFile | vane.Expression,
+    *,
+    max_bytes: int | vane.Expression = DEFAULT_AUDIO_METADATA_BYTES,
+) -> vane.Expression:
+    """Inspect bounded encoded AUDIOFILE metadata without decoding samples."""
+    return vane.FunctionExpression(
+        "audio_metadata",
+        as_expression(value),
+        _limit_expression(max_bytes, name="max_bytes", maximum=MAX_AUDIO_METADATA_BYTES),
+    )
+
+
+__all__ = [
+    "AudioFileError",
+    "AudioFileFormatError",
+    "AudioFileLimitError",
+    "AudioMetadata",
+    "audio_metadata",
+]

--- a/vane/_audio_file.py
+++ b/vane/_audio_file.py
@@ -511,17 +511,17 @@ def _probe_audio_metadata(
         if not isinstance(error, Exception):
             raise
         stream.raise_if_error()
+        if isinstance(error, AudioFileError):
+            raise
+        if not isinstance(error, soundfile.SoundFileError):
+            raise
         if stream.budget_exhausted:
             raise AudioFileLimitError(f"audio metadata requires more than max_bytes={max_bytes}") from error
         if stream.fetch_limit_exhausted:
             raise AudioFileLimitError(
                 f"audio metadata requires more than {_MAX_AUDIO_METADATA_FETCHES} source ranges"
             ) from error
-        if isinstance(error, AudioFileError):
-            raise
-        if isinstance(error, soundfile.SoundFileError):
-            raise AudioFileFormatError("logical FILE view is not a supported encoded audio file") from error
-        raise
+        raise AudioFileFormatError("logical FILE view is not a supported encoded audio file") from error
     if stream.budget_exhausted:
         raise AudioFileLimitError(f"audio metadata requires more than max_bytes={max_bytes}")
     if stream.fetch_limit_exhausted:
@@ -685,16 +685,6 @@ def _decode_audio_file(
                         samples = numpy.frombuffer(decoded, dtype=numpy.float64).reshape(
                             metadata.frames,
                             metadata.channels,
-                        )
-                    extra = bytearray(frame_bytes)
-                    extra_frames = audio.buffer_read_into(extra, dtype="float64")
-                    proxy.raise_if_error()
-                    del extra
-                    if extra_frames < 0 or extra_frames > 1:
-                        raise AudioFileFormatError("audio decoder returned an invalid frame count")
-                    if extra_frames:
-                        raise AudioFileFormatError(
-                            f"audio decoder produced more frames after reporting {metadata.frames}"
                         )
                 proxy.raise_if_error()
         except BaseException as error:

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -27,6 +27,7 @@ if typing.TYPE_CHECKING:
 
     import vane.sqltypes as sqltypes
     import vane.udf as func
+    from vane._audio_file import AudioMetadata
     from vane._file import VaneFileReader
     from vane._image_file import ImageMetadata
     from vane.ai.options import EmbedOptions, PromptOptions
@@ -933,6 +934,7 @@ class Expression:
     def file_path(self) -> Expression: ...
     def file_size(self) -> Expression: ...
     def file_stat(self) -> Expression: ...
+    def audio_metadata(self) -> Expression: ...
     def image_file_metadata(self) -> Expression: ...
     def get_name(self) -> str: ...
     def isin(self, *args: _ExpressionLike) -> Expression: ...
@@ -1024,7 +1026,22 @@ class ImageFile(File):
     ) -> ImageMetadata: ...
 
 @typing.final
-class AudioFile(File): ...
+class AudioFile(File):
+    def metadata(
+        self,
+        *,
+        max_bytes: int = 8388608,
+        connection: DuckDBPyConnection | None = None,
+    ) -> AudioMetadata: ...
+    def to_numpy(
+        self,
+        buffer_size: int = 1048576,
+        *,
+        max_input_bytes: int = 536870912,
+        max_frames: int = 100000000,
+        max_decoded_bytes: int = 536870912,
+        connection: DuckDBPyConnection | None = None,
+    ) -> np.ndarray[typing.Any, np.dtype[np.float64]]: ...
 
 @typing.final
 class VideoFile(File): ...


### PR DESCRIPTION
## Summary

- Add the native SQL audio_metadata(AUDIOFILE [, max_bytes]) scalar and Python expression facade.
- Add AudioMetadata, AudioFile.metadata(), and bounded, range-aware AudioFile.to_numpy() decoding to detached float64 frame-major arrays.
- Use SoundFile/libsndfile for encoded-audio parsing while preserving Vane FILE resolution, cancellation, resource limits, MIME validation, and error contracts.
- Add the optional audio dependency extra and focused SQL/Python regression coverage.

## Related issue

Refs #713. This PR implements the metadata and bounded Python decode subset; resampling and the engine decoded-audio/Arrow/distributed contract remain follow-up work.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in AstroVela/vane-website.

The public contract is captured in docstrings, type stubs, and tests. README is intentionally unchanged for this focused subset.

## Validation

- scripts/format root --changed
- Ruff check on the changed Python files
- Incremental non-editable Release install with CMAKE_BUILD_PARALLEL_LEVEL=12
- Installed-package targeted suite: 73 passed across tests/fast/test_audio_file.py, the media value contract, and audio package metadata checks
- git diff --check

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.