### PR TITLE
[fix](release) Rotate TestPyPI extension signing key

### DIFF
--- a/external/duckdb/src/main/extension/extension_helper.cpp
+++ b/external/duckdb/src/main/extension/extension_helper.cpp
@@ -420,17 +420,17 @@ void ExtensionHelper::AutoLoadExtension(DatabaseInstance &db, const string &exte
 static const char *const public_keys[] = {
 #ifdef VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY
     // Candidate-only AstroVela TestPyPI key. Its DER-encoded SubjectPublicKeyInfo
-    // has SHA-256 f02108bc37439677d8ade5c6e0efd90314d5ac7308b8d972d2271f41791b4941.
+    // has SHA-256 53779fb8f9c97e9dec9c66ff838839eb234d1a64d4b105671304820e627b5e32.
     // Production releases must use an independently managed signing key.
     R"(
 -----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7zuFv8bsD9U0YboZXyIx
-KNe99EktVJewYMTFSTMmLyRH3Ldn3yLTQCk1kciABjT8o556ZtviuGeo5pWXN/Gl
-a2BF0lftvrrU6mJTrY+Hwggk33JSXA46puTrCOlRuREDe2pcAIUela3ktpaqxfXQ
-l1yuIeoFO3tyGRMyvevEZ3Bx5MSdSr9ooLdvhKEm5uW/gb4yVx9QbZ4WVvHLn+Sq
-YyBVHLxB9c1k0MDRFfwpZOnq8r1VFD6ULkAQEgAM8NHZnZsHfmetoemuZmpLx/AB
-mh+FqYTeIb8dIGVBWyCkQa5/0fvhTVuZ+iImLqdbLbDDIYgwKmylrKDoY77n640C
-UQIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1NVtTvTBmZsTT34Hg066
+yJeo+rYT1VRROdr7WEY/kuT5CLdGnuEynG69w3HBFakhz5oTnd+bODCecgpQ83K5
+aYYF8KKlI3a62Tg3lOZvd7gVhwxE7np2z4aBZn5/BtvHAdyqMnCP2k9veZFan2GJ
+/xsCLeTvEJPBBy831gCrfwJriCKE7uE9Ck4/n1lztLbxIelz8e5MZ7KDuK76jNuI
+i/q3XQkDf5+5eIoKBsMVL+m3Au+McjhjvzoCZaghT8wsks5cLiQtrvTxeX8WkDrV
+luem0uNYeof25pwgGiUunWBXYhkUVysDqLmDjoBQLP+WoOsND/QeEepwpzu8+1/Y
+9wIDAQAB
 -----END PUBLIC KEY-----
 )",
 #endif

--- a/tests/fast/test_testpypi_candidate.py
+++ b/tests/fast/test_testpypi_candidate.py
@@ -19,7 +19,7 @@ from scripts.validate_testpypi_candidate import (
 )
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-TESTPYPI_EXTENSION_KEY_FINGERPRINT = "f02108bc37439677d8ade5c6e0efd90314d5ac7308b8d972d2271f41791b4941"
+TESTPYPI_EXTENSION_KEY_FINGERPRINT = "53779fb8f9c97e9dec9c66ff838839eb234d1a64d4b105671304820e627b5e32"
 
 
 @pytest.mark.parametrize("raw_version", ["0.2.0.dev601", "0.2.0rc2.dev3"])


### PR DESCRIPTION
## Summary

- replace the unrecoverable TestPyPI candidate extension trust root with the newly managed shared public key
- remove the old public key instead of retaining a compatibility fallback
- keep the candidate key opt-in and compiled only into `testpypi-dev` base wheels
- pin the new DER SubjectPublicKeyInfo SHA-256 in the candidate release contract test

The old TestPyPI provider candidates are intentionally incompatible with base wheels built from this change. Official and ordinary build-only Vane wheels remain unaffected because the candidate-key CMake option stays disabled.

## Related issue

Part of #619

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

This rotates qualification-only signing material and does not change the public installation API.

## Validation

- two clean review passes over key integrity, build isolation, diff scope, and private-key exclusion
- `scripts/format workspace --changed --check`
- `python -m pytest --confcutdir=tests/fast tests/fast/test_testpypi_candidate.py` (`11 passed`)
- Release wheel build and non-editable install with `SKBUILD_BUILD_DIR=build/python-release`
- incremental Release rebuild with `VANE_ENABLE_TESTPYPI_EXTENSION_SIGNING_KEY=ON`
- installed native binary inspection: new public key present and old public key absent
- installed-package smoke query from outside the checkout (`SELECT 42`)

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
