### PR TITLE
[fix](packaging) Separate extension artifact size budgets

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -207,11 +207,15 @@ policy, fixed UCRT API-set contracts, the exact CPython runtime DLL, and the VC
 runtime shipped with CPython are accepted; publisher-local, lookalike API-set,
 or path-qualified imports are rejected. Clean verification applies the same
 checks to every PE member of the base wheel. The builder and verifier reject
-extension wheels above the project's 100 MiB publication limit, any archive
-member above a 100 MiB uncompressed limit, or an archive whose total decompressed
-contents exceed that limit. The preflight runs before reading
-dependency, root, or base wheel members. Before constructing Python's ZIP
-reader, every supplied wheel also receives a streaming central-directory
+extension wheels above the project's 128 MiB publication limit, any archive
+member above a 384 MiB per-member uncompressed limit, or an archive whose total
+decompressed contents exceed 512 MiB. These independent budgets bound bytes in
+transport, one large native artifact, and aggregate decompression amplification
+without requiring them to share the same value. These are Vane's safety budgets;
+an external package index may impose a smaller project-specific upload limit.
+The preflight runs before reading dependency, root, or base wheel members.
+Before constructing Python's ZIP reader, every supplied wheel also receives a
+streaming central-directory
 preflight capped at 10,000 members. Archives with comments, spanning, ZIP64 end records, or
 internally inconsistent counts and bounds are rejected. Untrusted release and
 extension-wheel archive paths are opened once, confirmed to name regular
@@ -257,14 +261,15 @@ each decompressed TAR header and bounded PAX or GNU extension-header payload,
 including matches split across streaming chunks. They also scan the
 bounded raw artifact stream, including ZIP gaps and other bytes not exposed as
 archive members; text-only rules retain their archive-member binary filter.
-The staged `.duckdb_extension` must also be a regular file within the 100 MiB
-uncompressed limit. The builder checks it before descriptor inspection and
+The staged `.duckdb_extension` must also be a regular file within the 384 MiB
+extension-artifact limit. The builder checks it before descriptor inspection and
 performs a second file-descriptor check plus a bounded read before packaging.
-License inputs use the same bounded reader, and an existing output wheel is
-size-checked before it is compared with the generated wheel in bounded chunks.
-The complete generated member set is checked against the total uncompressed
-limit before a temporary wheel is created, including a second check after its
-RECORD is generated.
+License inputs use the 384 MiB per-member bounded reader, and an existing output
+wheel is size-checked before it is compared with the generated wheel in bounded
+chunks.
+The complete generated member set is checked against the 512 MiB total
+uncompressed limit before a temporary wheel is created, including a second check
+after its RECORD is generated.
 Load an installed provider and its exact dependency closure by canonical
 extension name:
 

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -54,14 +54,23 @@ try:
         open_zip_snapshot,
         snapshot_archive,
     )
+    from vane_packaging.artifact_limits import (
+        ARCHIVE_MEMBER_LIMIT_DESCRIPTION,
+        ARCHIVE_TOTAL_LIMIT_DESCRIPTION,
+        MAX_ARCHIVE_MEMBER_BYTES,
+        MAX_ARCHIVE_UNCOMPRESSED_BYTES,
+        MAX_PUBLICATION_FILE_BYTES,
+        PUBLICATION_FILE_LIMIT_DESCRIPTION,
+    )
 finally:
     sys.path[:] = _ORIGINAL_SYS_PATH
     del _ORIGINAL_SYS_PATH
 
 PROJECT_METADATA = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
 EXPECTED_NAME = str(PROJECT_METADATA["name"])
-MAX_ARTIFACT_BYTES = 100 * 1024 * 1024
-MAX_ARTIFACT_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
+MAX_ARTIFACT_BYTES = MAX_PUBLICATION_FILE_BYTES
+MAX_ARTIFACT_MEMBER_BYTES = MAX_ARCHIVE_MEMBER_BYTES
+MAX_ARTIFACT_UNCOMPRESSED_BYTES = MAX_ARCHIVE_UNCOMPRESSED_BYTES
 MAX_ARTIFACT_MEMBERS = 10_000
 MAX_CORE_METADATA_BYTES = 1024 * 1024
 MAX_CORE_METADATA_HEADERS = 1024
@@ -218,7 +227,7 @@ class WheelArtifact:
                         archive_input,
                         max_bytes=MAX_ARTIFACT_BYTES,
                         description="artifact",
-                        size_limit_description="the project's 100 MiB publication limit",
+                        size_limit_description=PUBLICATION_FILE_LIMIT_DESCRIPTION,
                     )
                 )
             self.raw_content_match = _detect_raw_archive_content(self.snapshot, content_rules)
@@ -267,7 +276,7 @@ class SdistArtifact:
                         archive_input,
                         max_bytes=MAX_ARTIFACT_BYTES,
                         description="artifact",
-                        size_limit_description="the project's 100 MiB publication limit",
+                        size_limit_description=PUBLICATION_FILE_LIMIT_DESCRIPTION,
                     )
                 )
             self.raw_content_match = _detect_raw_archive_content(self.snapshot, content_rules)
@@ -276,9 +285,10 @@ class SdistArtifact:
                 open_tar_snapshot(
                     self.snapshot,
                     max_members=MAX_ARTIFACT_MEMBERS,
-                    max_member_bytes=MAX_ARTIFACT_UNCOMPRESSED_BYTES,
+                    max_member_bytes=MAX_ARTIFACT_MEMBER_BYTES,
                     max_total_bytes=MAX_ARTIFACT_UNCOMPRESSED_BYTES,
-                    uncompressed_limit_description="the project's 100 MiB uncompressed limit",
+                    member_limit_description=ARCHIVE_MEMBER_LIMIT_DESCRIPTION,
+                    total_limit_description=ARCHIVE_TOTAL_LIMIT_DESCRIPTION,
                     description="sdist",
                     metadata_chunk_callback=metadata_scanner if content_rules else None,
                     mode="r:gz",
@@ -444,7 +454,7 @@ def _detect_raw_archive_content(
         while chunk := snapshot.file.read(_RAW_ARCHIVE_SCAN_CHUNK_BYTES):
             total_size += len(chunk)
             if total_size > MAX_ARTIFACT_BYTES:
-                raise ValueError(f"{path}: artifact exceeds the project's 100 MiB publication limit")
+                raise ValueError(f"{path}: artifact exceeds {PUBLICATION_FILE_LIMIT_DESCRIPTION}")
             window = overlap + chunk
             for rule in content_rules:
                 if rule.matches(window):
@@ -757,6 +767,7 @@ def _check_sdist(artifact: SdistArtifact, layout: DistributionLayout) -> None:
         "build_backend.py",
         "vane_packaging/__init__.py",
         "vane_packaging/archive_safety.py",
+        "vane_packaging/artifact_limits.py",
         "vane_packaging/extension_wheel.py",
         "vane_packaging/manylinux_policy.py",
         "vane_packaging/setuptools_scm_version.py",
@@ -910,15 +921,13 @@ def _validate_artifact_contents_size(artifact: Artifact) -> None:
     for member_name, member_size in artifact.member_sizes():
         if member_size < 0:
             raise ValueError(f"{artifact.path}: archive member {member_name!r} has an invalid negative size")
-        if member_size > MAX_ARTIFACT_UNCOMPRESSED_BYTES:
+        if member_size > MAX_ARTIFACT_MEMBER_BYTES:
             raise ValueError(
-                f"{artifact.path}: archive member {member_name!r} exceeds the project's 100 MiB uncompressed limit"
+                f"{artifact.path}: archive member {member_name!r} exceeds {ARCHIVE_MEMBER_LIMIT_DESCRIPTION}"
             )
         total_size += member_size
         if total_size > MAX_ARTIFACT_UNCOMPRESSED_BYTES:
-            raise ValueError(
-                f"{artifact.path}: archive decompressed contents exceed the project's 100 MiB uncompressed limit"
-            )
+            raise ValueError(f"{artifact.path}: archive decompressed contents exceed {ARCHIVE_TOTAL_LIMIT_DESCRIPTION}")
 
 
 def _open_artifact(

--- a/scripts/verify_extension_wheel.py
+++ b/scripts/verify_extension_wheel.py
@@ -33,6 +33,7 @@ try:
     sys.path.insert(0, str(REPOSITORY_ROOT))
     from scripts.check_release_artifacts import check_artifact as _check_release_artifact
     from vane_packaging.archive_safety import ArchiveSnapshot, open_zip_snapshot, snapshot_archive
+    from vane_packaging.artifact_limits import PUBLICATION_FILE_LIMIT_DESCRIPTION
     from vane_packaging.extension_wheel import (
         _ELF_MAGIC,
         _MAX_EXTENSION_DESCRIPTOR_DEPENDENCIES,
@@ -106,7 +107,7 @@ def _wheel_snapshot(
         wheel,
         max_bytes=_MAX_EXTENSION_WHEEL_BYTES,
         description=description,
-        size_limit_description="the project's 100 MiB publication limit",
+        size_limit_description=PUBLICATION_FILE_LIMIT_DESCRIPTION,
     ) as snapshot:
         yield snapshot
 
@@ -875,7 +876,7 @@ def _enter_verification_snapshot(
 ) -> tuple[ArchiveSnapshot, int]:
     max_bytes = min(_MAX_EXTENSION_WHEEL_BYTES, remaining_bytes)
     size_limit_description = (
-        "the project's 100 MiB publication limit"
+        PUBLICATION_FILE_LIMIT_DESCRIPTION
         if max_bytes == _MAX_EXTENSION_WHEEL_BYTES
         else _CLEAN_VERIFICATION_SNAPSHOT_LIMIT_DESCRIPTION
     )

--- a/tests/fast/test_extension_wheel.py
+++ b/tests/fast/test_extension_wheel.py
@@ -29,6 +29,7 @@ from packaging.version import Version
 import scripts.verify_extension_wheel as verify_extension_wheel_module
 import vane
 import vane_packaging.archive_safety as archive_safety_module
+import vane_packaging.artifact_limits as artifact_limits_module
 import vane_packaging.extension_wheel as extension_wheel_module
 import vane_packaging.manylinux_policy as manylinux_policy_module
 from scripts import check_release_artifacts
@@ -38,6 +39,16 @@ from vane_packaging.extension_wheel import ENTRY_POINT_GROUP, build_extension_wh
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 TEST_TRUST_IDENTITY = "vane-tests"
+
+
+def test_extension_wheel_uses_the_shared_layered_size_budgets() -> None:
+    assert extension_wheel_module._MAX_EXTENSION_WHEEL_BYTES == artifact_limits_module.MAX_PUBLICATION_FILE_BYTES
+    assert extension_wheel_module._MAX_EXTENSION_WHEEL_MEMBER_BYTES == artifact_limits_module.MAX_ARCHIVE_MEMBER_BYTES
+    assert (
+        extension_wheel_module._MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES
+        == artifact_limits_module.MAX_ARCHIVE_UNCOMPRESSED_BYTES
+    )
+    assert extension_wheel_module._MAX_EXTENSION_ARTIFACT_BYTES == artifact_limits_module.MAX_EXTENSION_ARTIFACT_BYTES
 
 
 def _runtime_platform() -> str:
@@ -3071,7 +3082,7 @@ def test_platform_wheel_rejects_oversized_dependency_wheels(
     )
     monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_BYTES", 0)
 
-    with pytest.raises(ValueError, match="100 MiB publication limit"):
+    with pytest.raises(ValueError, match="128 MiB publication limit"):
         _build_sample_wheel(tmp_path, output_name="root-dist", dependencies=(dependency.path,))
 
 
@@ -4646,7 +4657,7 @@ def test_platform_wheel_rejects_an_oversized_archive_before_publication(
 ):
     monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_BYTES", 0)
 
-    with pytest.raises(ValueError, match="100 MiB publication limit"):
+    with pytest.raises(ValueError, match="128 MiB publication limit"):
         _build_sample_wheel(tmp_path)
 
     assert not list((tmp_path / "dist").glob("*.whl"))
@@ -4657,14 +4668,14 @@ def test_platform_wheel_rejects_an_oversized_artifact_before_descriptor_inspecti
     monkeypatch,
 ):
     artifact_path = _write_artifact(tmp_path / "sample.duckdb_extension")
-    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES", 0)
+    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_ARTIFACT_BYTES", 0)
 
     def reject_descriptor_inspection(*args, **kwargs):
         raise AssertionError("oversized artifact reached descriptor inspection")
 
     monkeypatch.setattr(extension_wheel_module, "_create_descriptor", reject_descriptor_inspection)
 
-    with pytest.raises(ValueError, match="extension artifact exceeds.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="extension artifact exceeds.*384 MiB extension-artifact limit"):
         _build_sample_wheel(tmp_path, artifact_path=artifact_path)
 
 
@@ -4680,7 +4691,7 @@ def test_platform_wheel_rechecks_the_artifact_bound_immediately_before_descripto
     def reject_descriptor_inspection(*args, **kwargs):
         raise AssertionError("expanded artifact reached descriptor inspection")
 
-    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES", len(b"initial"))
+    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_ARTIFACT_BYTES", len(b"initial"))
     monkeypatch.setattr(
         extension_wheel_module,
         "_validate_dependency_wheel_requirements",
@@ -4688,7 +4699,7 @@ def test_platform_wheel_rechecks_the_artifact_bound_immediately_before_descripto
     )
     monkeypatch.setattr(extension_wheel_module, "_create_descriptor", reject_descriptor_inspection)
 
-    with pytest.raises(ValueError, match="extension artifact exceeds.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="extension artifact exceeds.*384 MiB extension-artifact limit"):
         _build_sample_wheel(tmp_path, artifact_path=artifact_path)
 
 
@@ -4705,10 +4716,10 @@ def test_platform_wheel_rechecks_the_artifact_bound_after_descriptor_inspection(
         path.write_bytes(b"expanded")
         return descriptor
 
-    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES", len(b"initial"))
+    monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_ARTIFACT_BYTES", len(b"initial"))
     monkeypatch.setattr(extension_wheel_module, "_create_descriptor", create_then_expand)
 
-    with pytest.raises(ValueError, match="extension artifact exceeds.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="extension artifact exceeds.*384 MiB extension-artifact limit"):
         _build_sample_wheel(tmp_path, artifact_path=artifact_path)
 
 
@@ -4720,11 +4731,11 @@ def test_platform_wheel_rejects_an_oversized_license_before_reading_it(
     artifact_path = _write_artifact(tmp_path / "sample.duckdb_extension")
     monkeypatch.setattr(
         extension_wheel_module,
-        "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES",
-        artifact_path.stat().st_size,
+        "_MAX_EXTENSION_WHEEL_MEMBER_BYTES",
+        0,
     )
 
-    with pytest.raises(ValueError, match="license file exceeds.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="license file exceeds.*384 MiB per-member uncompressed limit"):
         _build_sample_wheel(tmp_path, artifact_path=artifact_path)
 
 
@@ -4735,7 +4746,7 @@ def test_platform_wheel_rejects_oversized_decompressed_contents_before_publicati
 ):
     monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES", 0)
 
-    with pytest.raises(ValueError, match="100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="512 MiB total uncompressed limit"):
         _build_sample_wheel(tmp_path)
 
     assert not list((tmp_path / "dist").glob("*.whl"))
@@ -4756,7 +4767,7 @@ def test_platform_wheel_rejects_oversized_aggregate_contents_before_creating_arc
 
     monkeypatch.setattr(extension_wheel_module.tempfile, "mkstemp", reject_archive_creation)
 
-    with pytest.raises(ValueError, match="decompressed contents exceed.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="decompressed contents exceed.*512 MiB total uncompressed limit"):
         build_extension_wheel(
             artifact=artifact_path,
             extension_name="sample",
@@ -4791,12 +4802,12 @@ def test_platform_wheel_rejects_oversized_decompressed_dependency_before_reading
 
     monkeypatch.setattr(
         extension_wheel_module,
-        "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES",
+        "_MAX_EXTENSION_WHEEL_MEMBER_BYTES",
         root_artifact.stat().st_size,
     )
     monkeypatch.setattr(extension_wheel_module.zipfile.ZipFile, "read", require_size_check_before_read)
 
-    with pytest.raises(ValueError, match="dependency extension wheel.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="dependency extension wheel.*384 MiB per-member uncompressed limit"):
         _build_sample_wheel(
             tmp_path,
             artifact_path=root_artifact,
@@ -5016,7 +5027,7 @@ def test_platform_wheel_rejects_oversized_total_decompressed_dependency_contents
         largest_member,
     )
 
-    with pytest.raises(ValueError, match="decompressed contents exceed.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="decompressed contents exceed.*512 MiB total uncompressed limit"):
         _build_sample_wheel(tmp_path, output_name="root-dist", dependencies=(dependency.path,))
 
 
@@ -5031,13 +5042,13 @@ def test_clean_verifier_rejects_an_oversized_extension_wheel(
     @contextmanager
     def reject_extension(path, **kwargs):
         if kwargs["description"] == "extension wheel":
-            raise ValueError("extension wheel exceeds the project's 100 MiB publication limit")
+            raise ValueError("extension wheel exceeds the project's 128 MiB publication limit")
         with snapshot_archive(path, **kwargs) as snapshot:
             yield snapshot
 
     monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", reject_extension)
 
-    with pytest.raises(RuntimeError, match="100 MiB publication limit"):
+    with pytest.raises(RuntimeError, match="128 MiB publication limit"):
         verify_extension_wheel(
             base_wheel=_write_minimal_base_wheel(tmp_path),
             extension_wheel=built.path,
@@ -5121,7 +5132,7 @@ def test_clean_verifier_rejects_oversized_decompressed_extension_contents(
     built = _build_sample_wheel(tmp_path)
     monkeypatch.setattr(extension_wheel_module, "_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES", 0)
 
-    with pytest.raises(RuntimeError, match="100 MiB uncompressed limit"):
+    with pytest.raises(RuntimeError, match="512 MiB total uncompressed limit"):
         verify_extension_wheel(
             base_wheel=_write_minimal_base_wheel(tmp_path),
             extension_wheel=built.path,
@@ -5142,13 +5153,13 @@ def test_clean_verifier_rejects_an_oversized_base_wheel_before_opening_it(
     @contextmanager
     def reject_base(path, **kwargs):
         if kwargs["description"] == "base Vane wheel":
-            raise ValueError("base Vane wheel exceeds the project's 100 MiB publication limit")
+            raise ValueError("base Vane wheel exceeds the project's 128 MiB publication limit")
         with snapshot_archive(path, **kwargs) as snapshot:
             yield snapshot
 
     monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", reject_base)
 
-    with pytest.raises(RuntimeError, match="base Vane wheel exceeds.*100 MiB publication limit"):
+    with pytest.raises(RuntimeError, match="base Vane wheel exceeds.*128 MiB publication limit"):
         verify_extension_wheel(
             base_wheel=base_wheel,
             extension_wheel=root.path,
@@ -5177,13 +5188,13 @@ def test_clean_verifier_rejects_an_oversized_dependency_before_opening_it(
     @contextmanager
     def reject_dependency(path, **kwargs):
         if kwargs["description"] == "dependency extension wheel":
-            raise ValueError("dependency extension wheel exceeds the project's 100 MiB publication limit")
+            raise ValueError("dependency extension wheel exceeds the project's 128 MiB publication limit")
         with snapshot_archive(path, **kwargs) as snapshot:
             yield snapshot
 
     monkeypatch.setattr(verify_extension_wheel_module, "snapshot_archive", reject_dependency)
 
-    with pytest.raises(RuntimeError, match="100 MiB publication limit"):
+    with pytest.raises(RuntimeError, match="128 MiB publication limit"):
         verify_extension_wheel(
             base_wheel=_write_minimal_base_wheel(tmp_path),
             extension_wheel=root.path,

--- a/tests/fast/test_release_artifact_security.py
+++ b/tests/fast/test_release_artifact_security.py
@@ -22,7 +22,7 @@ import pytest
 from packaging.version import Version
 
 from scripts import check_release_artifacts, verify_duckdb_coexistence
-from vane_packaging import archive_safety
+from vane_packaging import archive_safety, artifact_limits
 
 TEST_VERSION = Version("0.2.0.dev14")
 TEST_LAYOUT = check_release_artifacts.distribution_layout(TEST_VERSION)
@@ -39,6 +39,21 @@ REQUIRED_WHEEL_PATHS = (
     f"{TEST_LAYOUT.dist_info_root}/WHEEL",
     f"{TEST_LAYOUT.dist_info_root}/RECORD",
 )
+
+
+def test_release_artifact_size_budgets_are_independent() -> None:
+    assert artifact_limits.MAX_PUBLICATION_FILE_BYTES == 128 * artifact_limits.MEBIBYTE
+    assert artifact_limits.MAX_ARCHIVE_MEMBER_BYTES == 384 * artifact_limits.MEBIBYTE
+    assert artifact_limits.MAX_ARCHIVE_UNCOMPRESSED_BYTES == 512 * artifact_limits.MEBIBYTE
+    assert artifact_limits.MAX_EXTENSION_ARTIFACT_BYTES == artifact_limits.MAX_ARCHIVE_MEMBER_BYTES
+    assert check_release_artifacts.MAX_ARTIFACT_BYTES == artifact_limits.MAX_PUBLICATION_FILE_BYTES
+    assert check_release_artifacts.MAX_ARTIFACT_MEMBER_BYTES == artifact_limits.MAX_ARCHIVE_MEMBER_BYTES
+    assert check_release_artifacts.MAX_ARTIFACT_UNCOMPRESSED_BYTES == artifact_limits.MAX_ARCHIVE_UNCOMPRESSED_BYTES
+    assert (
+        artifact_limits.MAX_PUBLICATION_FILE_BYTES
+        < artifact_limits.MAX_ARCHIVE_MEMBER_BYTES
+        < artifact_limits.MAX_ARCHIVE_UNCOMPRESSED_BYTES
+    )
 
 
 class _NamesOnlyArtifact:
@@ -110,9 +125,9 @@ def _write_archive_members(path: Path, members: dict[str, bytes]) -> None:
 def _validate_tar_member_count(path: Path, **kwargs) -> int:
     with archive_safety.snapshot_archive(
         path,
-        max_bytes=100 * 1024 * 1024,
+        max_bytes=artifact_limits.MAX_PUBLICATION_FILE_BYTES,
         description="sdist",
-        size_limit_description="the test archive limit",
+        size_limit_description=artifact_limits.PUBLICATION_FILE_LIMIT_DESCRIPTION,
     ) as snapshot:
         return archive_safety.validate_tar_member_count(
             snapshot.file,
@@ -591,7 +606,7 @@ def test_content_scan_rejects_an_oversized_decompressed_member_before_reading_it
     contents = b"a" * 1024
     _write_archive(artifact, "project/oversized.bin", contents)
     assert artifact.stat().st_size < len(contents)
-    monkeypatch.setattr(check_release_artifacts, "MAX_ARTIFACT_UNCOMPRESSED_BYTES", 512)
+    monkeypatch.setattr(check_release_artifacts, "MAX_ARTIFACT_MEMBER_BYTES", 512)
     artifact_type = (
         check_release_artifacts.SdistArtifact if suffix == ".tar.gz" else check_release_artifacts.WheelArtifact
     )
@@ -601,7 +616,7 @@ def test_content_scan_rejects_an_oversized_decompressed_member_before_reading_it
 
     monkeypatch.setattr(artifact_type, "read", reject_member_read)
 
-    with pytest.raises(ValueError, match="archive member.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="archive member.*384 MiB per-member uncompressed limit"):
         check_release_artifacts.check_artifact_contents(artifact)
 
 
@@ -629,7 +644,7 @@ def test_content_scan_rejects_oversized_total_decompressed_contents_before_readi
 
     monkeypatch.setattr(artifact_type, "read", reject_member_read)
 
-    with pytest.raises(ValueError, match="decompressed contents exceed.*100 MiB uncompressed limit"):
+    with pytest.raises(ValueError, match="decompressed contents exceed.*512 MiB total uncompressed limit"):
         check_release_artifacts.check_artifact_contents(artifact)
 
 
@@ -886,7 +901,8 @@ def test_uncompressed_tar_preflight_and_parser_use_the_same_snapshot(tmp_path, m
             max_members=1,
             max_member_bytes=1024,
             max_total_bytes=1024,
-            uncompressed_limit_description="the test limit",
+            member_limit_description="the test member limit",
+            total_limit_description="the test total limit",
             description="test TAR",
         ) as archive:
             members = archive.getmembers()
@@ -941,7 +957,8 @@ def test_sdist_streaming_preflight_normalizes_corrupt_deflate_errors(tmp_path, m
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
 
@@ -975,7 +992,8 @@ def test_sdist_streaming_preflight_rejects_oversized_header_before_advancing(
             max_members=10,
             max_member_bytes=512,
             max_total_bytes=2048,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
 
@@ -1002,7 +1020,8 @@ def test_sdist_streaming_preflight_bounds_extension_header_payloads(tmp_path, mo
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
 
@@ -1026,7 +1045,8 @@ def test_sdist_streaming_preflight_rejects_gnu_sparse_before_special_parsing(tmp
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
 
@@ -1048,7 +1068,8 @@ def test_sdist_streaming_preflight_matches_tarfile_for_nonzero_directory_sizes(t
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
         == 2
@@ -1078,7 +1099,8 @@ def test_sdist_streaming_preflight_matches_tarfile_local_pax_size_precedence(tmp
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
         == 3
@@ -1101,7 +1123,8 @@ def test_sdist_streaming_preflight_rejects_ambiguous_global_pax_size(tmp_path):
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
 
@@ -1119,7 +1142,8 @@ def test_sdist_streaming_preflight_rejects_a_concatenated_gzip_payload_after_the
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
 
@@ -1141,7 +1165,8 @@ def test_sdist_streaming_preflight_accepts_bounded_zero_padding_after_the_termin
             max_members=10,
             max_member_bytes=2048,
             max_total_bytes=4096,
-            uncompressed_limit_description="the uncompressed test limit",
+            member_limit_description="the uncompressed test limit",
+            total_limit_description="the uncompressed test limit",
             description="sdist",
         )
         == 1

--- a/vane_packaging/archive_safety.py
+++ b/vane_packaging/archive_safety.py
@@ -230,7 +230,8 @@ def validate_tar_member_count(
     max_members: int,
     max_member_bytes: int,
     max_total_bytes: int,
-    uncompressed_limit_description: str,
+    member_limit_description: str,
+    total_limit_description: str,
     description: str,
     metadata_chunk_callback: Callable[[bytes, bool], None] | None = None,
 ) -> int:
@@ -255,7 +256,8 @@ def validate_tar_member_count(
                     max_members=max_members,
                     max_member_bytes=max_member_bytes,
                     max_total_bytes=max_total_bytes,
-                    uncompressed_limit_description=uncompressed_limit_description,
+                    member_limit_description=member_limit_description,
+                    total_limit_description=total_limit_description,
                     description=description,
                     metadata_chunk_callback=metadata_chunk_callback,
                 )
@@ -265,7 +267,8 @@ def validate_tar_member_count(
             max_members=max_members,
             max_member_bytes=max_member_bytes,
             max_total_bytes=max_total_bytes,
-            uncompressed_limit_description=uncompressed_limit_description,
+            member_limit_description=member_limit_description,
+            total_limit_description=total_limit_description,
             description=description,
             metadata_chunk_callback=metadata_chunk_callback,
         )
@@ -300,7 +303,8 @@ def open_tar_snapshot(
     max_members: int,
     max_member_bytes: int,
     max_total_bytes: int,
-    uncompressed_limit_description: str,
+    member_limit_description: str,
+    total_limit_description: str,
     description: str,
     metadata_chunk_callback: Callable[[bytes, bool], None] | None = None,
     mode: str = "r:*",
@@ -312,7 +316,8 @@ def open_tar_snapshot(
         max_members=max_members,
         max_member_bytes=max_member_bytes,
         max_total_bytes=max_total_bytes,
-        uncompressed_limit_description=uncompressed_limit_description,
+        member_limit_description=member_limit_description,
+        total_limit_description=total_limit_description,
         description=description,
         metadata_chunk_callback=metadata_chunk_callback,
     )
@@ -328,7 +333,8 @@ def _validate_tar_stream(
     max_members: int,
     max_member_bytes: int,
     max_total_bytes: int,
-    uncompressed_limit_description: str,
+    member_limit_description: str,
+    total_limit_description: str,
     description: str,
     metadata_chunk_callback: Callable[[bytes, bool], None] | None,
 ) -> int:
@@ -368,7 +374,7 @@ def _validate_tar_stream(
             member_name=member.name,
             archive_path=archive_path,
             max_member_bytes=max_member_bytes,
-            uncompressed_limit_description=uncompressed_limit_description,
+            member_limit_description=member_limit_description,
         )
 
         if member.type in _PAX_HEADER_TYPES | _GNU_LONG_HEADER_TYPES:
@@ -382,7 +388,7 @@ def _validate_tar_stream(
                 member.size,
                 archive_path=archive_path,
                 max_total_bytes=max_total_bytes,
-                uncompressed_limit_description=uncompressed_limit_description,
+                total_limit_description=total_limit_description,
             )
             payload = _read_tar_payload(
                 tar_stream,
@@ -413,14 +419,14 @@ def _validate_tar_stream(
             member_name=member.name,
             archive_path=archive_path,
             max_member_bytes=max_member_bytes,
-            uncompressed_limit_description=uncompressed_limit_description,
+            member_limit_description=member_limit_description,
         )
         total_size = _add_tar_payload_size(
             total_size,
             effective_size,
             archive_path=archive_path,
             max_total_bytes=max_total_bytes,
-            uncompressed_limit_description=uncompressed_limit_description,
+            total_limit_description=total_limit_description,
         )
         physical_size = effective_size if member.type in _REGULAR_TAR_MEMBER_TYPES else 0
         _read_tar_payload(tar_stream, physical_size, collect=False)
@@ -432,12 +438,12 @@ def _validate_tar_payload_size(
     member_name: str,
     archive_path: Path,
     max_member_bytes: int,
-    uncompressed_limit_description: str,
+    member_limit_description: str,
 ) -> None:
     if size < 0:
         raise ValueError(f"{archive_path}: archive member {member_name!r} has an invalid negative size")
     if size > max_member_bytes:
-        raise ValueError(f"{archive_path}: archive member {member_name!r} exceeds {uncompressed_limit_description}")
+        raise ValueError(f"{archive_path}: archive member {member_name!r} exceeds {member_limit_description}")
 
 
 def _add_tar_payload_size(
@@ -446,11 +452,11 @@ def _add_tar_payload_size(
     *,
     archive_path: Path,
     max_total_bytes: int,
-    uncompressed_limit_description: str,
+    total_limit_description: str,
 ) -> int:
     updated_size = total_size + member_size
     if updated_size > max_total_bytes:
-        raise ValueError(f"{archive_path}: archive decompressed contents exceed {uncompressed_limit_description}")
+        raise ValueError(f"{archive_path}: archive decompressed contents exceed {total_limit_description}")
     return updated_size
 
 

--- a/vane_packaging/artifact_limits.py
+++ b/vane_packaging/artifact_limits.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared byte budgets for release archives and extension-provider wheels."""
+
+MEBIBYTE = 1024 * 1024
+
+# Bound bytes copied from an untrusted publication artifact before an archive
+# parser sees them. This limit also keeps provider wheels within a practical
+# index-upload and worker-install envelope.
+MAX_PUBLICATION_FILE_BYTES = 128 * MEBIBYTE
+
+# Bound one decompressed member separately from the complete archive. Native
+# extension artifacts may legitimately be much larger than their compressed
+# wheels, while the aggregate budget still limits decompression amplification.
+MAX_ARCHIVE_MEMBER_BYTES = 384 * MEBIBYTE
+MAX_ARCHIVE_UNCOMPRESSED_BYTES = 512 * MEBIBYTE
+MAX_EXTENSION_ARTIFACT_BYTES = MAX_ARCHIVE_MEMBER_BYTES
+
+
+def _mibibytes(value: int) -> int:
+    if value % MEBIBYTE:
+        raise ValueError("artifact byte budgets must be whole MiB values")
+    return value // MEBIBYTE
+
+
+PUBLICATION_FILE_LIMIT_DESCRIPTION = f"the project's {_mibibytes(MAX_PUBLICATION_FILE_BYTES)} MiB publication limit"
+ARCHIVE_MEMBER_LIMIT_DESCRIPTION = (
+    f"the project's {_mibibytes(MAX_ARCHIVE_MEMBER_BYTES)} MiB per-member uncompressed limit"
+)
+ARCHIVE_TOTAL_LIMIT_DESCRIPTION = (
+    f"the project's {_mibibytes(MAX_ARCHIVE_UNCOMPRESSED_BYTES)} MiB total uncompressed limit"
+)
+EXTENSION_ARTIFACT_LIMIT_DESCRIPTION = (
+    f"the project's {_mibibytes(MAX_EXTENSION_ARTIFACT_BYTES)} MiB extension-artifact limit"
+)
+
+__all__ = [
+    "ARCHIVE_MEMBER_LIMIT_DESCRIPTION",
+    "ARCHIVE_TOTAL_LIMIT_DESCRIPTION",
+    "EXTENSION_ARTIFACT_LIMIT_DESCRIPTION",
+    "MAX_ARCHIVE_MEMBER_BYTES",
+    "MAX_ARCHIVE_UNCOMPRESSED_BYTES",
+    "MAX_EXTENSION_ARTIFACT_BYTES",
+    "MAX_PUBLICATION_FILE_BYTES",
+    "MEBIBYTE",
+    "PUBLICATION_FILE_LIMIT_DESCRIPTION",
+]

--- a/vane_packaging/extension_wheel.py
+++ b/vane_packaging/extension_wheel.py
@@ -43,6 +43,16 @@ from packaging.utils import InvalidWheelFilename, canonicalize_name, parse_wheel
 from packaging.version import InvalidVersion, Version
 
 from vane_packaging.archive_safety import ArchiveSnapshot, open_zip_snapshot, snapshot_archive
+from vane_packaging.artifact_limits import (
+    ARCHIVE_MEMBER_LIMIT_DESCRIPTION,
+    ARCHIVE_TOTAL_LIMIT_DESCRIPTION,
+    EXTENSION_ARTIFACT_LIMIT_DESCRIPTION,
+    MAX_ARCHIVE_MEMBER_BYTES,
+    MAX_ARCHIVE_UNCOMPRESSED_BYTES,
+    MAX_EXTENSION_ARTIFACT_BYTES,
+    MAX_PUBLICATION_FILE_BYTES,
+    PUBLICATION_FILE_LIMIT_DESCRIPTION,
+)
 from vane_packaging.manylinux_policy import ManylinuxPolicy, manylinux_policy
 
 if TYPE_CHECKING:
@@ -54,8 +64,10 @@ _EXTENSION_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
 _EXTENSION_INTERPRETER_TAG_RE = re.compile(r"^cp3(?:10|11|12|13|14)$")
 _WHEEL_PLATFORM_TAG_RE = re.compile(r"^[a-z0-9_]+$")
 _MAX_WHEEL_PATH_COMPONENT_BYTES = 255
-_MAX_EXTENSION_WHEEL_BYTES = 100 * 1024 * 1024
-_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
+_MAX_EXTENSION_WHEEL_BYTES = MAX_PUBLICATION_FILE_BYTES
+_MAX_EXTENSION_WHEEL_MEMBER_BYTES = MAX_ARCHIVE_MEMBER_BYTES
+_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES = MAX_ARCHIVE_UNCOMPRESSED_BYTES
+_MAX_EXTENSION_ARTIFACT_BYTES = MAX_EXTENSION_ARTIFACT_BYTES
 _MAX_EXTENSION_WHEEL_MEMBERS = 10_000
 _MAX_CORE_METADATA_BYTES = 1024 * 1024
 _MAX_CORE_METADATA_HEADERS = 1024
@@ -654,7 +666,7 @@ def _read_dependency_wheel(path: Path) -> _DependencyWheel:
         path,
         max_bytes=_MAX_EXTENSION_WHEEL_BYTES,
         description="dependency extension wheel",
-        size_limit_description="the project's 100 MiB publication limit",
+        size_limit_description=PUBLICATION_FILE_LIMIT_DESCRIPTION,
     ) as snapshot:
         return _read_dependency_wheel_snapshot(snapshot)
 
@@ -3251,7 +3263,7 @@ def _normalize_extension_wheel_permissions(path: Path) -> None:
 
 def _validate_extension_wheel_size(path: Path, *, description: str = "extension wheel") -> None:
     if path.stat().st_size > _MAX_EXTENSION_WHEEL_BYTES:
-        raise ValueError(f"{description} exceeds the project's 100 MiB publication limit")
+        raise ValueError(f"{description} exceeds {PUBLICATION_FILE_LIMIT_DESCRIPTION}")
 
 
 def _validate_extension_wheel_archive_size(
@@ -3293,18 +3305,25 @@ def _validate_extension_wheel_member_sizes(
 ) -> None:
     total_size = 0
     for member_name, member_size in members:
-        if member_size > _MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES:
-            raise ValueError(f"{description} member {member_name!r} exceeds the project's 100 MiB uncompressed limit")
+        if member_size > _MAX_EXTENSION_WHEEL_MEMBER_BYTES:
+            raise ValueError(f"{description} member {member_name!r} exceeds {ARCHIVE_MEMBER_LIMIT_DESCRIPTION}")
         total_size += member_size
         if total_size > _MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES:
-            raise ValueError(f"{description} decompressed contents exceed the project's 100 MiB uncompressed limit")
+            raise ValueError(f"{description} decompressed contents exceed {ARCHIVE_TOTAL_LIMIT_DESCRIPTION}")
 
 
-def _validate_bounded_file_metadata(path: Path, metadata: os.stat_result, *, description: str) -> None:
+def _validate_bounded_file_metadata(
+    path: Path,
+    metadata: os.stat_result,
+    *,
+    description: str,
+    max_bytes: int,
+    limit_description: str,
+) -> None:
     if not stat.S_ISREG(metadata.st_mode):
         raise ValueError(f"{description} must be a regular file: {path}")
-    if metadata.st_size > _MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES:
-        raise ValueError(f"{description} exceeds the project's 100 MiB uncompressed limit: {path}")
+    if metadata.st_size > max_bytes:
+        raise ValueError(f"{description} exceeds {limit_description}: {path}")
 
 
 def _validate_extension_artifact_size(path: Path) -> None:
@@ -3312,27 +3331,46 @@ def _validate_extension_artifact_size(path: Path) -> None:
         metadata = path.stat()
     except OSError as exception:
         raise ValueError(f"could not inspect extension artifact: {path}") from exception
-    _validate_bounded_file_metadata(path, metadata, description="extension artifact")
+    _validate_bounded_file_metadata(
+        path,
+        metadata,
+        description="extension artifact",
+        max_bytes=_MAX_EXTENSION_ARTIFACT_BYTES,
+        limit_description=EXTENSION_ARTIFACT_LIMIT_DESCRIPTION,
+    )
 
 
-def _read_bounded_file(path: Path, *, description: str) -> bytes:
+def _read_bounded_file(
+    path: Path,
+    *,
+    description: str,
+    max_bytes: int,
+    limit_description: str,
+) -> bytes:
     try:
         with path.open("rb") as artifact_file:
             _validate_bounded_file_metadata(
                 path,
                 os.fstat(artifact_file.fileno()),
                 description=description,
+                max_bytes=max_bytes,
+                limit_description=limit_description,
             )
-            contents = artifact_file.read(_MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES + 1)
+            contents = artifact_file.read(max_bytes + 1)
     except OSError as exception:
         raise ValueError(f"could not read {description}: {path}") from exception
-    if len(contents) > _MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES:
-        raise ValueError(f"{description} exceeds the project's 100 MiB uncompressed limit: {path}")
+    if len(contents) > max_bytes:
+        raise ValueError(f"{description} exceeds {limit_description}: {path}")
     return contents
 
 
 def _read_extension_artifact(path: Path) -> bytes:
-    return _read_bounded_file(path, description="extension artifact")
+    return _read_bounded_file(
+        path,
+        description="extension artifact",
+        max_bytes=_MAX_EXTENSION_ARTIFACT_BYTES,
+        limit_description=EXTENSION_ARTIFACT_LIMIT_DESCRIPTION,
+    )
 
 
 def _bounded_files_equal(first: Path, second: Path) -> bool:
@@ -3342,7 +3380,7 @@ def _bounded_files_equal(first: Path, second: Path) -> bool:
         if not stat.S_ISREG(first_metadata.st_mode) or not stat.S_ISREG(second_metadata.st_mode):
             return False
         if first_metadata.st_size > _MAX_EXTENSION_WHEEL_BYTES:
-            raise ValueError("existing extension wheel exceeds the project's 100 MiB publication limit")
+            raise ValueError(f"existing extension wheel exceeds {PUBLICATION_FILE_LIMIT_DESCRIPTION}")
         if first_metadata.st_size != second_metadata.st_size:
             return False
         remaining = first_metadata.st_size
@@ -3379,9 +3417,14 @@ def _license_entries(
                 f"{colliding_path!r} and {relative_path!r}"
             )
         casefolded_paths[member_name.casefold()] = relative_path
-        entries[member_name] = _read_bounded_file(path, description="license file")
+        entries[member_name] = _read_bounded_file(
+            path,
+            description="license file",
+            max_bytes=_MAX_EXTENSION_WHEEL_MEMBER_BYTES,
+            limit_description=ARCHIVE_MEMBER_LIMIT_DESCRIPTION,
+        )
         if sum(map(len, entries.values())) > _MAX_EXTENSION_WHEEL_UNCOMPRESSED_BYTES:
-            raise ValueError("license files exceed the project's 100 MiB total uncompressed limit")
+            raise ValueError(f"license files exceed {ARCHIVE_TOTAL_LIMIT_DESCRIPTION}")
     if not entries:
         raise ValueError("license_files must contain every license required by the extension artifact")
     for member_name, relative_path in sorted(casefolded_paths.items()):


### PR DESCRIPTION
## Summary

- replace the coupled 100 MiB archive policy with shared 128 MiB publication-file, 384 MiB per-member/native-artifact, and 512 MiB total-uncompressed budgets
- apply the same limits and distinct failure descriptions in provider-wheel construction, dependency/clean verification, and generic wheel/sdist release validation
- retain the 1 GiB clean-verification multi-wheel snapshot aggregate, require the shared policy module in sdists, and document external package-index quotas as independent
- validate the policy against current Vane builds: DuckLake is 39.0 MiB raw, Vortex is 68.7 MiB raw, and the stripped Lance artifact is 252.1 MiB raw / about 90 MiB compressed

## Related issue

close: #740

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`DEVELOPMENT.md` documents the layered budgets, their safety purpose, and the independent external-index quota boundary.

## Validation

- `scripts/format root --changed --check`
- `PATH=/home/kaka/astrovela_vane-testpypi-signing-rotation-20260902/.venv/bin:$PATH scripts/run_installed_pytest.sh -n 24 tests/fast/test_release_artifact_security.py tests/fast/test_extension_wheel.py` (`403 passed, 1 skipped`; the skipped test requires externally supplied signed-extension and base-wheel artifacts)
- `uv build --sdist --python <matching Python 3.12 environment> --out-dir <temporary directory> .`
- `python scripts/check_release_artifacts.py <temporary directory>/vane_ai-0.2.0.dev612.tar.gz`
- confirmed the validated sdist contains `vane_packaging/artifact_limits.py`
- no native rebuild was required because the change is limited to Python, tests, and documentation

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No dependency or copied-code changes are included.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. The independent bounds preserve preflight validation before archive-member reads.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks. No native sources changed.
