### PR TITLE
[feat](file) Stream VideoFile frames

### DIFF
--- a/src/vane_py/include/vane_python/file_reader.hpp
+++ b/src/vane_py/include/vane_python/file_reader.hpp
@@ -27,20 +27,26 @@ public:
 	                                               shared_ptr<DuckDBPyConnection> connection);
 
 	py::bytes Read(int64_t size);
+	py::bytes ReadAndCheckInterrupted(int64_t size);
 	int64_t Seek(int64_t offset, int whence);
 	int64_t Tell();
 	int64_t Size();
+	void CheckInterrupted();
 	py::object GuessMimeType();
 	void Close();
+	void CloseAndCheckInterrupted();
 	bool Closed() const;
 	string ToString() const;
 	string Repr() const;
 
 private:
 	PythonFileReaderHandle(string url, idx_t buffer_size, shared_ptr<DuckDBPyConnection> connection,
-	                       shared_ptr<ClientContext> context, unique_ptr<ResolvedFile> resolved);
+	                       shared_ptr<ClientContext> context, unique_ptr<ResolvedFile> resolved,
+	                       uint64_t interrupt_generation);
 
 	void RequireOpen() const;
+	void CloseInternal(bool check_interrupted);
+	py::bytes ReadInternal(int64_t size, bool check_retained_interrupt);
 	idx_t ReadLocked(data_ptr_t target, idx_t requested_size);
 	void FillBufferLocked();
 
@@ -49,10 +55,12 @@ private:
 	shared_ptr<DuckDBPyConnection> connection;
 	shared_ptr<ClientContext> context;
 	unique_ptr<ResolvedFile> resolved;
+	const uint64_t interrupt_generation;
 	vector<data_t> buffer;
 	uint64_t buffer_start = 0;
 	uint64_t position = 0;
 	std::atomic<bool> closed {false};
+	mutable std::mutex close_lock;
 	mutable std::mutex lock;
 };
 

--- a/src/vane_py/native/file.cpp
+++ b/src/vane_py/native/file.cpp
@@ -30,6 +30,10 @@ static constexpr uint64_t DEFAULT_AUDIO_MAX_INPUT_BYTES = 512 * 1024 * 1024;
 static constexpr uint64_t DEFAULT_AUDIO_MAX_FRAMES = 100000000;
 static constexpr uint64_t DEFAULT_AUDIO_MAX_DECODED_BYTES = 512 * 1024 * 1024;
 static constexpr uint64_t DEFAULT_VIDEO_METADATA_BYTES = 8 * 1024 * 1024;
+static constexpr uint64_t DEFAULT_VIDEO_BUFFER_SIZE = 1024 * 1024;
+static constexpr uint64_t DEFAULT_VIDEO_MAX_INPUT_BYTES = 8ULL * 1024 * 1024 * 1024;
+static constexpr uint64_t DEFAULT_VIDEO_MAX_FRAMES = 1000000;
+static constexpr uint64_t DEFAULT_VIDEO_MAX_PIXELS = 32 * 1024 * 1024;
 
 static string PythonTypeName(const py::handle &value) {
 	return py::str(py::type::of(value)).cast<string>();
@@ -202,6 +206,49 @@ static void BindMediaFileClass(py::handle &m, const char *class_name) {
 		    },
 		    "Inspect the first video stream with bounded reads and no frame decoding", py::kw_only(),
 		    py::arg("max_bytes") = DEFAULT_VIDEO_METADATA_BYTES, py::arg("connection") = py::none());
+		file.def(
+		    "frames",
+		    [](const FILE_TYPE &value, const py::object &start_time, const py::object &end_time,
+		       const py::object &width, const py::object &height, const py::object &is_key_frame,
+		       const py::object &sample_interval_seconds, const py::object &buffer_size,
+		       const py::object &max_input_bytes, const py::object &max_frames, const py::object &max_pixels,
+		       shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._video_file")
+			        .attr("_video_file_frames_value")(
+			            py::cast(value, py::return_value_policy::copy), start_time, end_time, width, height,
+			            is_key_frame, sample_interval_seconds, buffer_size,
+			            py::arg("max_input_bytes") = max_input_bytes, py::arg("max_frames") = max_frames,
+			            py::arg("max_pixels") = max_pixels, py::arg("connection") = std::move(connection));
+		    },
+		    "Stream decoded RGB frames with exact temporal provenance; native decode calls are atomic and limits are "
+		    "observed at packet/frame boundaries",
+		    py::arg("start_time") = 0, py::arg("end_time") = py::none(), py::arg("width") = py::none(),
+		    py::arg("height") = py::none(), py::arg("is_key_frame") = py::none(),
+		    py::arg("sample_interval_seconds") = py::none(), py::arg("buffer_size") = DEFAULT_VIDEO_BUFFER_SIZE,
+		    py::kw_only(), py::arg("max_input_bytes") = DEFAULT_VIDEO_MAX_INPUT_BYTES,
+		    py::arg("max_frames") = DEFAULT_VIDEO_MAX_FRAMES, py::arg("max_pixels") = DEFAULT_VIDEO_MAX_PIXELS,
+		    py::arg("connection") = py::none());
+		file.def(
+		    "keyframes",
+		    [](const FILE_TYPE &value, const py::object &start_time, const py::object &end_time,
+		       const py::object &width, const py::object &height, const py::object &sample_interval_seconds,
+		       const py::object &buffer_size, const py::object &max_input_bytes, const py::object &max_frames,
+		       const py::object &max_pixels, shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._video_file")
+			        .attr("_video_file_keyframes_value")(
+			            py::cast(value, py::return_value_policy::copy), start_time, end_time, width, height,
+			            sample_interval_seconds, buffer_size, py::arg("max_input_bytes") = max_input_bytes,
+			            py::arg("max_frames") = max_frames, py::arg("max_pixels") = max_pixels,
+			            py::arg("connection") = std::move(connection));
+		    },
+		    "Stream decoded RGB keyframes as detached Pillow images; native decode calls are atomic and limits are "
+		    "observed at packet/frame boundaries",
+		    py::arg("start_time") = 0, py::arg("end_time") = py::none(), py::arg("width") = py::none(),
+		    py::arg("height") = py::none(), py::arg("sample_interval_seconds") = py::none(),
+		    py::arg("buffer_size") = DEFAULT_VIDEO_BUFFER_SIZE, py::kw_only(),
+		    py::arg("max_input_bytes") = DEFAULT_VIDEO_MAX_INPUT_BYTES,
+		    py::arg("max_frames") = DEFAULT_VIDEO_MAX_FRAMES, py::arg("max_pixels") = DEFAULT_VIDEO_MAX_PIXELS,
+		    py::arg("connection") = py::none());
 	}
 }
 

--- a/src/vane_py/native/file_reader.cpp
+++ b/src/vane_py/native/file_reader.cpp
@@ -73,9 +73,10 @@ void RunReaderContextOperation(ClientContext &context, DuckDBPyConnection &conne
 
 PythonFileReaderHandle::PythonFileReaderHandle(string url_p, idx_t buffer_size_p,
                                                shared_ptr<DuckDBPyConnection> connection_p,
-                                               shared_ptr<ClientContext> context_p, unique_ptr<ResolvedFile> resolved_p)
+                                               shared_ptr<ClientContext> context_p, unique_ptr<ResolvedFile> resolved_p,
+                                               uint64_t interrupt_generation_p)
     : url(std::move(url_p)), buffer_size(buffer_size_p), connection(std::move(connection_p)),
-      context(std::move(context_p)), resolved(std::move(resolved_p)) {
+      context(std::move(context_p)), resolved(std::move(resolved_p)), interrupt_generation(interrupt_generation_p) {
 }
 
 PythonFileReaderHandle::~PythonFileReaderHandle() = default;
@@ -84,11 +85,14 @@ void PythonFileReaderHandle::Initialize(py::module_ &m) {
 	py::class_<PythonFileReaderHandle, shared_ptr<PythonFileReaderHandle>>(m, "_VaneFileReaderHandle",
 	                                                                       py::module_local(), py::is_final())
 	    .def("_read", &PythonFileReaderHandle::Read, py::arg("size") = -1)
+	    .def("_read_and_check_interrupted", &PythonFileReaderHandle::ReadAndCheckInterrupted, py::arg("size") = -1)
 	    .def("_seek", &PythonFileReaderHandle::Seek, py::arg("offset"), py::arg("whence") = 0)
 	    .def("_tell", &PythonFileReaderHandle::Tell)
 	    .def("_size", &PythonFileReaderHandle::Size)
+	    .def("_check_interrupted", &PythonFileReaderHandle::CheckInterrupted)
 	    .def("_guess_mime_type", &PythonFileReaderHandle::GuessMimeType)
 	    .def("_close", &PythonFileReaderHandle::Close)
+	    .def("_close_and_check_interrupted", &PythonFileReaderHandle::CloseAndCheckInterrupted)
 	    .def_property_readonly("_closed", &PythonFileReaderHandle::Closed)
 	    .def("__str__", &PythonFileReaderHandle::ToString)
 	    .def("__repr__", &PythonFileReaderHandle::Repr);
@@ -116,8 +120,9 @@ shared_ptr<PythonFileReaderHandle> PythonFileReaderHandle::Open(const PythonFile
 		RunReaderContextOperation(*context, *connection, interrupt_generation,
 		                          [&](ReaderContextScope &) { resolved = ResolvedFile::Open(*context, reference); });
 	}
-	return shared_ptr<PythonFileReaderHandle>(new PythonFileReaderHandle(
-	    std::move(reference.url), buffer_size, std::move(connection), std::move(context), std::move(resolved)));
+	return shared_ptr<PythonFileReaderHandle>(new PythonFileReaderHandle(std::move(reference.url), buffer_size,
+	                                                                     std::move(connection), std::move(context),
+	                                                                     std::move(resolved), interrupt_generation));
 }
 
 void PythonFileReaderHandle::RequireOpen() const {
@@ -169,12 +174,23 @@ idx_t PythonFileReaderHandle::ReadLocked(data_ptr_t target, idx_t requested_size
 }
 
 py::bytes PythonFileReaderHandle::Read(int64_t size) {
+	return ReadInternal(size, false);
+}
+
+py::bytes PythonFileReaderHandle::ReadAndCheckInterrupted(int64_t size) {
+	return ReadInternal(size, true);
+}
+
+py::bytes PythonFileReaderHandle::ReadInternal(int64_t size, bool check_retained_interrupt) {
 	string result;
 	D_ASSERT(py::gil_check());
-	// Python connection.interrupt() also requires the GIL, and Close only resets
-	// the retained connection after reacquiring it. Snapshot before releasing the
-	// GIL so this call is cancellable while waiting on either mutex.
-	auto interrupt_generation = connection ? connection->InterruptGeneration() : 0;
+	// Generic reads establish an independent operation generation so a reader can
+	// be reused after an interrupted read. Video decoding instead retains the
+	// generation captured when the reader opened: checking it inside this native
+	// operation closes the gap between a Python callback's pre-read check and the
+	// connector read itself.
+	auto operation_generation =
+	    check_retained_interrupt ? interrupt_generation : (connection ? connection->InterruptGeneration() : 0);
 	{
 		py::gil_scoped_release release;
 		unique_lock<mutex> reader_guard(lock);
@@ -187,7 +203,7 @@ py::bytes PythonFileReaderHandle::Read(int64_t size) {
 			try {
 				unique_lock<mutex> connection_guard(connection->py_connection_lock);
 				RunReaderContextOperation(
-				    *context, *connection, interrupt_generation, [&](ReaderContextScope &context_scope) {
+				    *context, *connection, operation_generation, [&](ReaderContextScope &context_scope) {
 					    result.resize(NumericCast<idx_t>(requested_size));
 					    context_scope.CheckInterrupted();
 					    auto read_size =
@@ -273,6 +289,15 @@ int64_t PythonFileReaderHandle::Size() {
 	return NumericCast<int64_t>(result);
 }
 
+void PythonFileReaderHandle::CheckInterrupted() {
+	D_ASSERT(py::gil_check());
+	py::gil_scoped_release release;
+	unique_lock<mutex> reader_guard(lock);
+	RequireOpen();
+	unique_lock<mutex> connection_guard(connection->py_connection_lock);
+	ReaderContextScope(*context, *connection, interrupt_generation).CheckInterrupted();
+}
+
 py::object PythonFileReaderHandle::GuessMimeType() {
 	string result;
 	bool found;
@@ -292,7 +317,27 @@ py::object PythonFileReaderHandle::GuessMimeType() {
 }
 
 void PythonFileReaderHandle::Close() {
-	closed.store(true);
+	CloseInternal(false);
+}
+
+void PythonFileReaderHandle::CloseAndCheckInterrupted() {
+	CloseInternal(true);
+}
+
+void PythonFileReaderHandle::CloseInternal(bool check_interrupted) {
+	// Only one caller owns teardown. Other close calls wait without the GIL for
+	// that owner to finish, then observe the completed close. In particular, a
+	// later closer must not clear the context needed by a checked close.
+	unique_lock<mutex> close_guard(close_lock, std::defer_lock);
+	{
+		D_ASSERT(py::gil_check());
+		py::gil_scoped_release release;
+		close_guard.lock();
+	}
+	const auto first_close = !closed.exchange(true);
+	if (!first_close) {
+		return;
+	}
 	unique_lock<mutex> reader_guard(lock, std::defer_lock);
 	{
 		D_ASSERT(py::gil_check());
@@ -302,10 +347,24 @@ void PythonFileReaderHandle::Close() {
 		buffer.clear();
 	}
 	// Keep the reader lock across GIL reacquisition and release of the retained
-	// context/connection. Every concurrent close therefore returns only after the
-	// complete cleanup has finished.
+	// context/connection. On a checked close, compare against the reader's
+	// retained open generation after cleanup. This covers both the gap
+	// after the caller's final check and interrupts that race with native handle
+	// destruction. The GIL prevents another Python thread from advancing the
+	// generation between this check and releasing the retained connection.
+	std::exception_ptr close_error;
+	if (check_interrupted && context && connection) {
+		try {
+			ReaderContextScope(*context, *connection, interrupt_generation).CheckInterrupted();
+		} catch (...) {
+			close_error = std::current_exception();
+		}
+	}
 	context.reset();
 	connection.reset();
+	if (close_error) {
+		std::rethrow_exception(close_error);
+	}
 }
 
 bool PythonFileReaderHandle::Closed() const {

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -17,7 +17,7 @@ FILE_FIELDS = ("url", "content_type", "position", "size", "checksum")
 FILE_METHODS = ("exists", "mime_type", "open", "stat", "to_tempfile")
 IMAGE_FILE_METHODS = FILE_METHODS + ("decode", "metadata")
 AUDIO_FILE_METHODS = FILE_METHODS + ("metadata", "to_numpy")
-VIDEO_FILE_METHODS = FILE_METHODS + ("metadata",)
+VIDEO_FILE_METHODS = FILE_METHODS + ("frames", "keyframes", "metadata")
 MEDIA_FILE_CASES = (
     ("image", "IMAGEFILE", vane.ImageFile, vane.image_file),
     ("audio", "AUDIOFILE", vane.AudioFile, vane.audio_file),

--- a/tests/fast/test_file_reader.py
+++ b/tests/fast/test_file_reader.py
@@ -438,6 +438,10 @@ def test_file_reader_interrupt_cancels_only_the_active_operation():
         assert isinstance(errors[0], vane.InterruptException)
         assert reader.tell() == 0
         assert reader.read(4) == payload[1024 * 1024 : 1024 * 1024 + 4]
+        # A recovered generic reader must not report that historical interrupt
+        # again when its ordinary context-manager lifetime ends.
+        reader.__exit__(None, None, None)
+        assert reader.closed
     finally:
         handler.release_read.set()
         if read_thread is not None:
@@ -491,6 +495,80 @@ def test_concurrent_file_reader_close_waits_for_complete_cleanup():
         assert all(not thread.is_alive() for thread in close_threads)
         assert all(finished.is_set() for finished in close_finished)
         assert reader.closed
+    finally:
+        handler.release_read.set()
+        if read_thread is not None:
+            read_thread.join(timeout=5)
+        for thread in close_threads:
+            thread.join(timeout=5)
+        if reader is not None:
+            reader.close()
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=2)
+
+
+def test_file_reader_close_observes_interrupt_during_native_teardown():
+    payload = bytes(range(256)) * (2 * 1024 * 1024 // 256)
+    server, server_thread, handler = _start_object_server(payload)
+    connection = vane.connect()
+    reader = None
+    read_thread = None
+    close_threads = []
+    read_errors = []
+    close_errors = []
+    try:
+        connection.execute("SET http_proxy = ''")
+        url = f"http://127.0.0.1:{server.server_address[1]}/bucket/object.bin"
+        reader = vane.File(url).open(buffer_size=4096, connection=connection)
+        handler.block_reads = True
+
+        def read_file():
+            try:
+                reader.read()
+            except BaseException as error:
+                read_errors.append(error)
+
+        read_thread = threading.Thread(target=read_file)
+        read_thread.start()
+        assert handler.read_started.wait(timeout=5)
+
+        def close_reader():
+            try:
+                reader._close_and_check_interrupted()
+            except BaseException as error:
+                close_errors.append(error)
+
+        # Both checked closers must serialize behind one teardown owner. The
+        # non-owner may not clear the retained generation before it is checked.
+        close_threads.append(threading.Thread(target=close_reader))
+        close_threads[0].start()
+
+        # ``closed`` flips before native Close releases the GIL and waits for
+        # the in-flight read's mutex, so observing it proves native teardown
+        # started before this interrupt.
+        for _ in range(500):
+            if reader.closed:
+                break
+            threading.Event().wait(0.01)
+        assert reader.closed
+
+        close_threads.append(threading.Thread(target=close_reader))
+        close_threads[1].start()
+
+        connection.interrupt()
+        handler.release_read.set()
+        read_thread.join(timeout=5)
+        for thread in close_threads:
+            thread.join(timeout=5)
+
+        assert not read_thread.is_alive()
+        assert all(not thread.is_alive() for thread in close_threads)
+        assert len(read_errors) == 1
+        assert isinstance(read_errors[0], vane.InterruptException)
+        assert len(close_errors) == 1
+        assert isinstance(close_errors[0], vane.InterruptException)
     finally:
         handler.release_read.set()
         if read_thread is not None:

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -1,13 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
+import gc
 import importlib
 import io
 import struct
 import subprocess
 import sys
 import textwrap
+import threading
+import weakref
 import zlib
+from dataclasses import FrozenInstanceError
 from fractions import Fraction
 from types import SimpleNamespace
 
@@ -27,6 +31,8 @@ def _encoded_video(
     height: int = 12,
     frame_count: int = 4,
     frame_rate: int = 24,
+    gop_size: int | None = None,
+    max_b_frames: int = 0,
 ) -> bytes:
     buffer = io.BytesIO()
     with av.open(buffer, mode="w", format=container_format) as container:
@@ -35,8 +41,19 @@ def _encoded_video(
         stream.width = width
         stream.height = height
         stream.pix_fmt = "yuv420p"
+        stream.codec_context.max_b_frames = max_b_frames
+        if gop_size is not None:
+            stream.codec_context.gop_size = gop_size
         for index in range(frame_count):
-            pixels = np.full((height, width, 3), index * 20, dtype=np.uint8)
+            horizontal = np.broadcast_to(np.arange(width, dtype=np.uint8), (height, width))
+            pixels = np.stack(
+                (
+                    horizontal + index,
+                    np.full((height, width), index * 5, dtype=np.uint8),
+                    np.flip(horizontal, axis=1) + index,
+                ),
+                axis=2,
+            )
             frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
             for packet in stream.encode(frame):
                 container.mux(packet)
@@ -66,6 +83,74 @@ def _oversized_png() -> bytes:
     struct.pack_into(">II", payload, 16, 65_535, 32_768)
     struct.pack_into(">I", payload, 29, zlib.crc32(payload[12:29]) & 0xFFFFFFFF)
     return bytes(payload)
+
+
+class _FakeDecodedVideoFrame:
+    def __init__(
+        self,
+        *,
+        pts: object = 0,
+        width: int = 10,
+        height: int = 10,
+    ) -> None:
+        self.width = width
+        self.height = height
+        self.pts = pts
+        self.dts = None
+        self.duration = 1
+        self.time_base = Fraction(1, 10)
+        self.key_frame = False
+
+
+class _ColorRestoreFailureFrame:
+    def __init__(self, failures):
+        self._color_trc = 3
+        self._color_primaries = 3
+        self.failures = failures
+        self.restore_attempts = []
+
+    @property
+    def color_trc(self):
+        return self._color_trc
+
+    @color_trc.setter
+    def color_trc(self, value):
+        if value != 2:
+            self.restore_attempts.append("color_trc")
+            error = self.failures.get("color_trc")
+            if error is not None:
+                raise error
+        self._color_trc = value
+
+    @property
+    def color_primaries(self):
+        return self._color_primaries
+
+    @color_primaries.setter
+    def color_primaries(self, value):
+        if value != 2:
+            self.restore_attempts.append("color_primaries")
+            error = self.failures.get("color_primaries")
+            if error is not None:
+                raise error
+        self._color_primaries = value
+
+
+def _fake_decoder_video():
+    return SimpleNamespace(time_base=Fraction(1, 10))
+
+
+class _PacketSequenceContainer:
+    """Model a container cursor across Vane's one-packet demux iterators."""
+
+    def __init__(self, packets):
+        self.packets = list(packets)
+
+    def demux(self, video):
+        del video
+        if not self.packets:
+            return iter(())
+        return iter([self.packets.pop(0)])
 
 
 def test_video_metadata_sql_and_python_value(duckdb_cursor, tmp_path):
@@ -135,6 +220,2403 @@ def test_video_metadata_honors_logical_range(duckdb_cursor, tmp_path):
 
     assert (sql_metadata["width"], sql_metadata["height"]) == (18, 10)
     assert (value_metadata.width, value_metadata.height) == (18, 10)
+
+
+def test_video_frames_stream_detached_rgb_images_with_exact_provenance(duckdb_cursor, tmp_path):
+    path = tmp_path / "frames.mp4"
+    path.write_bytes(_encoded_video(frame_count=8, frame_rate=4, gop_size=3))
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    frames = list(value.frames(connection=duckdb_cursor))
+
+    assert len(frames) == 8
+    assert [frame.frame_index for frame in frames] == list(range(8))
+    assert all(isinstance(frame, vane.VideoFrameData) for frame in frames)
+    assert all(frame.data.mode == "RGB" and frame.data.size == (16, 12) for frame in frames)
+    assert all(isinstance(frame.frame_time_base, Fraction) for frame in frames)
+    assert all(
+        frame.frame_time == pytest.approx(float(frame.frame_pts * frame.frame_time_base))
+        for frame in frames
+        if frame.frame_pts is not None and frame.frame_time_base is not None
+    )
+    assert np.asarray(frames[-1].data).shape == (12, 16, 3)
+
+
+def test_video_frame_data_is_frozen_and_slotted():
+    image = Image.new("RGB", (1, 1))
+    frame = vane.VideoFrameData(0, 0.0, Fraction(1), 0, None, 1, True, image)
+
+    try:
+        assert not hasattr(frame, "__dict__")
+        with pytest.raises(FrozenInstanceError):
+            setattr(frame, "frame_pts", 1)
+    finally:
+        image.close()
+
+
+def test_video_frames_honor_logical_range_and_resize(duckdb_cursor, tmp_path):
+    payload = _encoded_video(width=18, height=10, frame_count=5, frame_rate=5)
+    prefix = b"not-a-video-prefix"
+    suffix = b"not-a-video-suffix"
+    path = tmp_path / "ranged-frames.bin"
+    path.write_bytes(prefix + payload + suffix)
+    value = vane.VideoFile(str(path), "video/mp4", len(prefix), len(payload))
+
+    frames = list(value.frames(width=9, height=6, buffer_size=64, connection=duckdb_cursor))
+
+    assert len(frames) == 5
+    assert all(frame.data.mode == "RGB" and frame.data.size == (9, 6) for frame in frames)
+
+
+def test_video_frames_filter_time_keyframes_and_sample_exactly(duckdb_cursor, tmp_path):
+    path = tmp_path / "selection.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4, gop_size=3, max_b_frames=2))
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    all_frames = list(value.frames(connection=duckdb_cursor))
+    selected = list(value.frames(0.75, 2.0, connection=duckdb_cursor))
+    key_frames = list(value.frames(is_key_frame=True, connection=duckdb_cursor))
+    non_key_frames = list(value.frames(is_key_frame=False, connection=duckdb_cursor))
+    sampled = list(value.frames(sample_interval_seconds=0.5, connection=duckdb_cursor))
+    combined = list(
+        value.frames(
+            0.75,
+            2.0,
+            is_key_frame=True,
+            sample_interval_seconds=0.5,
+            connection=duckdb_cursor,
+        )
+    )
+
+    def exact_time(frame):
+        assert frame.frame_pts is not None
+        assert frame.frame_time_base is not None
+        return frame.frame_pts * frame.frame_time_base
+
+    def expected_pts(*, start=Fraction(0), end=None, key_frame=None, interval=None):
+        result = []
+        next_sample = start if interval is not None else None
+        for frame in all_frames:
+            frame_time = exact_time(frame)
+            if frame_time < start:
+                continue
+            if end is not None and frame_time > end:
+                break
+            if key_frame is not None and frame.is_key_frame is not key_frame:
+                continue
+            if interval is not None:
+                assert next_sample is not None
+                if frame_time < next_sample:
+                    continue
+                next_sample += ((frame_time - next_sample) // interval + 1) * interval
+            result.append(frame.frame_pts)
+        return result
+
+    assert [frame.frame_pts for frame in selected] == expected_pts(start=Fraction(3, 4), end=Fraction(2))
+    assert all(frame.frame_index is None for frame in selected)
+    assert [frame.frame_pts for frame in key_frames] == expected_pts(key_frame=True)
+    assert [frame.frame_pts for frame in non_key_frames] == expected_pts(key_frame=False)
+    assert [frame.frame_pts for frame in sampled] == expected_pts(interval=Fraction(1, 2))
+    assert [frame.frame_pts for frame in combined] == expected_pts(
+        start=Fraction(3, 4),
+        end=Fraction(2),
+        key_frame=True,
+        interval=Fraction(1, 2),
+    )
+
+
+def test_video_frames_preserve_presentation_order_with_b_frames(duckdb_cursor, tmp_path):
+    path = tmp_path / "b-frames.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4, gop_size=6, max_b_frames=2))
+
+    frames = list(vane.VideoFile(str(path), "video/mp4").frames(connection=duckdb_cursor))
+
+    assert len(frames) == 12
+    assert [frame.frame_time for frame in frames] == pytest.approx([index / 4 for index in range(12)])
+    assert any(frame.frame_dts != frame.frame_pts for frame in frames)
+
+
+def test_video_visible_pixel_limit_is_independent_of_coded_alignment(duckdb_cursor, tmp_path):
+    path = tmp_path / "aligned.mp4"
+    path.write_bytes(_encoded_video(width=18, height=14, frame_count=1))
+
+    frames = list(vane.VideoFile(str(path), "video/mp4").frames(max_pixels=18 * 14, connection=duckdb_cursor))
+
+    assert len(frames) == 1
+    assert frames[0].data.size == (18, 14)
+
+
+def test_video_keyframes_reuse_streaming_selection(duckdb_cursor, tmp_path):
+    path = tmp_path / "keyframes.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4, gop_size=3))
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    all_frames = list(value.frames(connection=duckdb_cursor))
+    frame_records = list(value.frames(0.5, 2.25, is_key_frame=True, connection=duckdb_cursor))
+    images = list(value.keyframes(0.5, 2.25, connection=duckdb_cursor))
+    sampled_records = list(
+        value.frames(
+            width=8,
+            height=6,
+            is_key_frame=True,
+            sample_interval_seconds=1,
+            connection=duckdb_cursor,
+        )
+    )
+    sampled_images = list(
+        value.keyframes(
+            width=8,
+            height=6,
+            sample_interval_seconds=1,
+            connection=duckdb_cursor,
+        )
+    )
+    expected = [
+        frame
+        for frame in all_frames
+        if frame.is_key_frame
+        and frame.frame_time_base is not None
+        and frame.frame_pts is not None
+        and Fraction(1, 2) <= frame.frame_pts * frame.frame_time_base <= Fraction(9, 4)
+    ]
+
+    assert [frame.frame_pts for frame in frame_records] == [frame.frame_pts for frame in expected]
+    assert len(images) == len(expected)
+    assert expected
+    for image, record, baseline in zip(images, frame_records, expected, strict=True):
+        assert image.mode == "RGB"
+        np.testing.assert_array_equal(np.asarray(image), np.asarray(record.data))
+        np.testing.assert_array_equal(np.asarray(image), np.asarray(baseline.data))
+    assert len(sampled_images) == len(sampled_records)
+    assert sampled_images
+    for image, record in zip(sampled_images, sampled_records, strict=True):
+        assert image.size == (8, 6)
+        np.testing.assert_array_equal(np.asarray(image), np.asarray(record.data))
+
+
+def test_video_frames_start_after_duration_is_empty(duckdb_cursor, tmp_path):
+    path = tmp_path / "short.mp4"
+    path.write_bytes(_encoded_video(frame_count=4, frame_rate=4, gop_size=2))
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    assert list(value.frames(start_time=10, connection=duckdb_cursor)) == []
+    assert list(value.keyframes(start_time=10, connection=duckdb_cursor)) == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error_type", "message"),
+    [
+        ({"start_time": True}, TypeError, "start_time must be int or float"),
+        ({"start_time": -1}, ValueError, "start_time must be non-negative"),
+        ({"end_time": float("inf")}, ValueError, "end_time must be finite"),
+        ({"start_time": 2, "end_time": 1}, ValueError, "end_time must be greater"),
+        ({"width": 8}, ValueError, "width and height must be provided together"),
+        ({"width": True, "height": 8}, TypeError, "width must be int"),
+        ({"is_key_frame": 1}, TypeError, "is_key_frame must be bool or None"),
+        ({"sample_interval_seconds": 0}, ValueError, "must be greater than zero"),
+        ({"buffer_size": 0}, ValueError, "buffer_size must be greater than zero"),
+        ({"buffer_size": 1 << 31}, OverflowError, "C int accepted by PyAV"),
+        ({"max_input_bytes": 0}, ValueError, "max_input_bytes must be greater than zero"),
+        ({"max_frames": 0}, ValueError, "max_frames must be greater than zero"),
+        ({"max_pixels": 0}, ValueError, "max_pixels must be greater than zero"),
+        ({"max_pixels": 32 * 1024 * 1024 + 1}, ValueError, "max_pixels must be at most"),
+    ],
+)
+def test_video_frames_validate_arguments_without_opening_file(kwargs, error_type, message):
+    value = vane.VideoFile("memory://not-opened")
+
+    with pytest.raises(error_type, match=message):
+        value.frames(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"start_time": 2, "end_time": 1}, "end_time must be greater"),
+        ({"width": 8}, "width and height must be provided together"),
+        ({"sample_interval_seconds": 0}, "must be greater than zero"),
+    ],
+)
+def test_video_keyframes_validate_arguments_without_opening_file(kwargs, message):
+    value = vane.VideoFile("memory://not-opened")
+
+    with pytest.raises(ValueError, match=message):
+        value.keyframes(**kwargs)
+
+
+def test_video_frames_enforce_input_frame_and_pixel_limits(duckdb_cursor, tmp_path):
+    payload = _encoded_video(frame_count=4, frame_rate=4)
+    path = tmp_path / "bounded.mp4"
+    path.write_bytes(payload)
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    with pytest.raises(vane.VideoFileLimitError, match="max_input_bytes"):
+        list(value.frames(max_input_bytes=len(payload) - 1, connection=duckdb_cursor))
+    with pytest.raises(vane.VideoFileLimitError, match="max_frames=2"):
+        list(value.frames(max_frames=2, connection=duckdb_cursor))
+    with pytest.raises(vane.VideoFileLimitError, match="max_pixels=100"):
+        list(value.frames(max_pixels=100, connection=duckdb_cursor))
+
+
+def test_video_frames_apply_limits_to_actual_decoder_context(duckdb_cursor, tmp_path, monkeypatch):
+    path = tmp_path / "decoder-options.mp4"
+    path.write_bytes(_encoded_video(frame_count=1))
+    observed = []
+    configure_decoder = _video_file._configure_video_decoder
+
+    def record_decoder_options(video):
+        configure_decoder(video)
+        observed.append((video.codec_context.thread_count, dict(video.codec_context.options)))
+
+    monkeypatch.setattr(_video_file, "_configure_video_decoder", record_decoder_options)
+    frames = list(vane.VideoFile(str(path), "video/mp4").frames(max_pixels=1_000_000, connection=duckdb_cursor))
+
+    assert observed == [(1, {"max_pixels": str(64 * 1024 * 1024), "threads": "1"})]
+    for frame in frames:
+        frame.data.close()
+
+
+def test_video_frame_conversion_neutralizes_and_restores_color_metadata():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    observed = []
+    output_frame = SimpleNamespace(to_image=lambda: Image.new("RGB", (10, 10)))
+
+    def reformat(source, **kwargs):
+        del kwargs
+        assert source is frame
+        observed.append((frame.color_trc, frame.color_primaries))
+        return output_frame
+
+    frame = SimpleNamespace(
+        width=10,
+        height=10,
+        color_trc=3,
+        color_primaries=3,
+    )
+    info = SimpleNamespace(width=10, height=10)
+    reformatter = SimpleNamespace(reformat=reformat)
+    fake_av = SimpleNamespace(error=SimpleNamespace(FFmpegError=RuntimeError))
+
+    image = _video_file._frame_to_image(frame, info, options, fake_av, Image, reformatter, lambda: None)
+
+    assert observed == [(2, 2)]
+    assert (frame.color_trc, frame.color_primaries) == (3, 3)
+    image.close()
+
+
+def test_video_color_metadata_restore_preserves_control_flow_after_all_fields():
+    class RestoreControlFlow(BaseException):
+        pass
+
+    control_flow = RestoreControlFlow("stop restoration")
+    frame = _ColorRestoreFailureFrame(
+        {
+            "color_primaries": ValueError("invalid restored primaries"),
+            "color_trc": control_flow,
+        }
+    )
+
+    with pytest.raises(RestoreControlFlow, match="stop restoration") as raised:
+        with _video_file._neutralized_color_conversion_metadata(frame):
+            pass
+
+    assert raised.value is control_flow
+    assert frame.restore_attempts == ["color_primaries", "color_trc"]
+
+
+@pytest.mark.parametrize("restore_error", [MemoryError("out of memory"), OSError("restore I/O failed")])
+def test_video_color_metadata_restore_preserves_system_errors(restore_error):
+    frame = _ColorRestoreFailureFrame({"color_primaries": restore_error})
+
+    with pytest.raises(type(restore_error)) as raised:
+        with _video_file._neutralized_color_conversion_metadata(frame):
+            pass
+
+    assert raised.value is restore_error
+    assert frame.restore_attempts == ["color_primaries", "color_trc"]
+
+
+def test_video_color_metadata_restore_classifies_invalid_values():
+    restore_error = ValueError("invalid restored primaries")
+    frame = _ColorRestoreFailureFrame({"color_primaries": restore_error})
+
+    with pytest.raises(vane.VideoFileFormatError, match="color metadata could not be restored") as raised:
+        with _video_file._neutralized_color_conversion_metadata(frame):
+            pass
+
+    assert raised.value.__cause__ is restore_error
+    assert frame.restore_attempts == ["color_primaries", "color_trc"]
+
+
+def test_video_frame_conversion_checks_interrupt_after_atomic_reformat():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    interrupt_error = RuntimeError("query interrupted")
+    checks = 0
+
+    def check_interrupted():
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise interrupt_error
+
+    frame = SimpleNamespace(color_trc=3, color_primaries=3)
+    output_frame = SimpleNamespace(to_image=lambda: pytest.fail("Pillow conversion must not start"))
+    reformatter = SimpleNamespace(reformat=lambda source, **kwargs: output_frame)
+
+    class FakeFFmpegError(Exception):
+        pass
+
+    fake_av = SimpleNamespace(error=SimpleNamespace(FFmpegError=FakeFFmpegError))
+
+    with pytest.raises(RuntimeError, match="query interrupted") as raised:
+        _video_file._frame_to_image(
+            frame,
+            SimpleNamespace(width=10, height=10),
+            options,
+            fake_av,
+            Image,
+            reformatter,
+            check_interrupted,
+        )
+    assert raised.value is interrupt_error
+
+
+def test_video_frame_conversion_closes_image_when_interrupted_after_creation():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    interrupt_error = RuntimeError("query interrupted")
+    checks = 0
+    close_calls = 0
+    image_refs = []
+
+    class FakeImage:
+        mode = "RGB"
+        size = (10, 10)
+
+        def __init__(self):
+            image_refs.append(weakref.ref(self))
+
+        def load(self):
+            pytest.fail("image loading must not start")
+
+        def close(self):
+            nonlocal close_calls
+            close_calls += 1
+            raise RuntimeError("image close failed")
+
+    def check_interrupted():
+        nonlocal checks
+        checks += 1
+        if checks == 4:
+            raise interrupt_error
+
+    frame = SimpleNamespace(color_trc=3, color_primaries=3)
+    output_frame = SimpleNamespace(to_image=FakeImage)
+    reformatter = SimpleNamespace(reformat=lambda source, **kwargs: output_frame)
+
+    class FakeFFmpegError(Exception):
+        pass
+
+    fake_av = SimpleNamespace(error=SimpleNamespace(FFmpegError=FakeFFmpegError))
+
+    with pytest.raises(RuntimeError, match="query interrupted") as raised:
+        _video_file._frame_to_image(
+            frame,
+            SimpleNamespace(width=10, height=10),
+            options,
+            fake_av,
+            SimpleNamespace(Image=FakeImage),
+            reformatter,
+            check_interrupted,
+        )
+
+    gc.collect()
+    assert raised.value is interrupt_error
+    assert close_calls == 1
+    assert len(image_refs) == 1
+    assert image_refs[0]() is None
+
+
+@pytest.mark.parametrize(
+    ("stage", "error"),
+    [
+        ("reformat", av.error.BugError(1, "internal decoder bug")),
+        ("to_image", av.error.PyAVCallbackError(1, "callback failed")),
+        ("reformat", av.error.UnknownError(1, "unknown decoder failure")),
+        ("to_image", av.error.OverflowError(34, "decoder range failure")),
+    ],
+)
+def test_video_frame_conversion_preserves_pyav_internal_errors(stage, error):
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+
+    def fail():
+        raise error
+
+    frame = SimpleNamespace(color_trc=3, color_primaries=3)
+    output_frame = SimpleNamespace(to_image=fail)
+
+    def reformat(source, **kwargs):
+        del source, kwargs
+        if stage == "reformat":
+            fail()
+        return output_frame
+
+    with pytest.raises(type(error)) as raised:
+        _video_file._frame_to_image(
+            frame,
+            SimpleNamespace(width=10, height=10),
+            options,
+            av,
+            Image,
+            SimpleNamespace(reformat=reformat),
+            lambda: None,
+        )
+    assert raised.value is error
+
+
+def test_video_frame_conversion_classifies_explicit_media_errors():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    error = av.error.InvalidDataError(1, "invalid frame pixels")
+
+    def fail_reformat(source, **kwargs):
+        del source, kwargs
+        raise error
+
+    frame = SimpleNamespace(color_trc=3, color_primaries=3)
+    with pytest.raises(vane.VideoFileFormatError, match="RGB pixels") as raised:
+        _video_file._frame_to_image(
+            frame,
+            SimpleNamespace(width=10, height=10),
+            options,
+            av,
+            Image,
+            SimpleNamespace(reformat=fail_reformat),
+            lambda: None,
+        )
+    assert raised.value.__cause__ is error
+
+
+def test_video_frame_conversion_traceback_releases_native_frames():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+
+    class OutputFrame:
+        def to_image(self):
+            return Image.new("RGB", (1, 1))
+
+    class SourceFrame(_FakeDecodedVideoFrame):
+        color_trc = 3
+        color_primaries = 3
+
+        def __init__(self, output):
+            super().__init__()
+            self.output = output
+
+    output = OutputFrame()
+    source = SourceFrame(output)
+    source_ref = weakref.ref(source)
+    output_ref = weakref.ref(output)
+    info = SimpleNamespace(width=10, height=10)
+    reformatter = SimpleNamespace(reformat=lambda frame, **kwargs: frame.output)
+    fake_av = SimpleNamespace(error=SimpleNamespace(FFmpegError=RuntimeError))
+
+    with pytest.raises(RuntimeError, match="invalid RGB Pillow frame") as raised:
+        _video_file._frame_to_image(source, info, options, fake_av, Image, reformatter, lambda: None)
+    source.output = None
+    source = None
+    output = None
+    gc.collect()
+
+    assert raised.value is not None
+    assert source_ref() is None
+    assert output_ref() is None
+
+
+def test_video_frame_provenance_and_seek_rebase_nonzero_stream_origin():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    frame = _FakeDecodedVideoFrame(pts=105)
+    video = SimpleNamespace(start_time=100, time_base=Fraction(1, 10))
+    stream_start, stream_origin = _video_file._stream_time_origin(video, video.time_base)
+    info = _video_file._decoded_frame_info(
+        frame,
+        video,
+        options,
+        frame_index=0,
+        stream_time_origin=stream_origin,
+    )
+
+    assert info.frame_pts == 105
+    assert info.exact_time == Fraction(1, 2)
+    assert info.frame_time == 0.5
+    assert _video_file._seek_timestamp(Fraction(1, 2), video.time_base, stream_start) == 105
+
+
+def test_video_frame_preserves_zero_duration_provenance():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    frame = _FakeDecodedVideoFrame()
+    frame.duration = 0
+
+    info = _video_file._decoded_frame_info(
+        frame,
+        _fake_decoder_video(),
+        options,
+        frame_index=0,
+        stream_time_origin=Fraction(0),
+    )
+
+    assert info.frame_duration == 0
+
+
+def test_video_time_selection_rejects_dts_only_frame():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(1, 10),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    frame = _FakeDecodedVideoFrame(pts=None)
+    frame.dts = 105
+    video = SimpleNamespace(time_base=Fraction(1, 10))
+
+    info = _video_file._decoded_frame_info(
+        frame,
+        video,
+        options,
+        frame_index=0,
+        stream_time_origin=Fraction(10),
+    )
+
+    assert info.frame_pts is None
+    assert info.frame_dts == 105
+    assert info.frame_time is None
+    with pytest.raises(vane.VideoFileFormatError, match="presentation timestamp"):
+        _video_file._require_frame_time_for_selection(info, options)
+
+
+def test_video_packet_decode_checks_interrupt_after_dependency_failure():
+    decode_error = RuntimeError("decoder failed")
+    interrupt_error = RuntimeError("query interrupted")
+    checks = 0
+
+    def check_interrupted():
+        nonlocal checks
+        checks += 1
+        if checks == 2:
+            raise interrupt_error
+
+    def fail_decode():
+        raise decode_error
+
+    packet = SimpleNamespace(decode=fail_decode)
+    reader = SimpleNamespace(
+        check_interrupted=check_interrupted,
+        raise_if_error=lambda: None,
+    )
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(RuntimeError, match="query interrupted") as raised:
+        _video_file._decode_packet_frames(packet, reader, no_error)
+    assert raised.value is interrupt_error
+
+
+def test_video_packet_decode_preserves_direct_control_flow_exception():
+    class DecodeControlFlow(BaseException):
+        pass
+
+    control_flow = DecodeControlFlow("stop decode")
+    later_interrupt = RuntimeError("later query interrupt")
+    decode_failed = False
+    checks = 0
+
+    def fail_decode():
+        nonlocal decode_failed
+        decode_failed = True
+        raise control_flow
+
+    def check_interrupted():
+        nonlocal checks
+        checks += 1
+        if decode_failed:
+            raise later_interrupt
+
+    reader = SimpleNamespace(check_interrupted=check_interrupted, raise_if_error=lambda: None)
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(DecodeControlFlow, match="stop decode") as raised:
+        _video_file._decode_packet_frames(SimpleNamespace(decode=fail_decode), reader, no_error)
+
+    assert raised.value is control_flow
+    assert checks == 1
+
+
+@pytest.mark.parametrize(
+    ("callback", "arguments", "sentinel"),
+    [
+        ("read", (1,), b""),
+        ("readinto", (bytearray(1),), 0),
+        ("seek", (0,), -1),
+        ("tell", (), -1),
+        ("readable", (), False),
+        ("seekable", (), False),
+    ],
+)
+def test_video_reader_callbacks_stash_composite_operation_interrupt(callback, arguments, sentinel):
+    interrupt_error = RuntimeError("query interrupted between callbacks")
+    interrupted = False
+    callback_calls = []
+
+    class Reader:
+        def _check_interrupted(self):
+            if interrupted:
+                raise interrupt_error
+
+        def read(self, size=-1):
+            callback_calls.append(("read", size))
+            return b"x"
+
+        def _read_and_check_interrupted(self, size=-1):
+            return self.read(size)
+
+        def readinto(self, buffer):
+            callback_calls.append(("readinto", buffer))
+            return 1
+
+        def _readinto_and_check_interrupted(self, buffer):
+            return self.readinto(buffer)
+
+        def seek(self, offset, whence=io.SEEK_SET):
+            callback_calls.append(("seek", offset, whence))
+            return offset
+
+        def tell(self):
+            callback_calls.append(("tell",))
+            return 0
+
+        def readable(self):
+            callback_calls.append(("readable",))
+            return True
+
+        def seekable(self):
+            callback_calls.append(("seekable",))
+            return True
+
+    proxy = _video_file._VideoReaderProxy(Reader())
+    getattr(proxy, callback)(*arguments)
+    interrupted = True
+
+    assert getattr(proxy, callback)(*arguments) == sentinel
+    with pytest.raises(RuntimeError, match="interrupted between callbacks") as raised:
+        proxy.raise_if_error()
+
+    assert raised.value is interrupt_error
+    assert len(callback_calls) == 1
+
+
+def test_video_reader_read_atomically_observes_interrupt_after_callback_check(duckdb_cursor, tmp_path):
+    path = tmp_path / "interrupt-between-check-and-read.bin"
+    path.write_bytes(b"video bytes")
+    reader = vane.File(str(path)).open(buffer_size=4, connection=duckdb_cursor)
+    original_check = reader._check_interrupted
+    check_completed = threading.Event()
+    interrupt_completed = threading.Event()
+    check_calls = 0
+
+    def synchronized_check():
+        nonlocal check_calls
+        original_check()
+        check_calls += 1
+        if check_calls == 1:
+            check_completed.set()
+            if not interrupt_completed.wait(timeout=5):
+                raise AssertionError("interrupt did not complete")
+
+    reader._check_interrupted = synchronized_check
+
+    def interrupt_after_check():
+        if check_completed.wait(timeout=5):
+            duckdb_cursor.interrupt()
+        interrupt_completed.set()
+
+    interrupt_thread = threading.Thread(target=interrupt_after_check)
+    interrupt_thread.start()
+    try:
+        proxy = _video_file._VideoReaderProxy(reader)
+        assert proxy.read(4) == b""
+        with pytest.raises(vane.InterruptException):
+            proxy.raise_if_error()
+        # The retained operation generation is checked inside native Read,
+        # before the connector can advance the logical reader position.
+        assert reader.tell() == 0
+    finally:
+        interrupt_completed.set()
+        interrupt_thread.join(timeout=5)
+        reader.close()
+    assert not interrupt_thread.is_alive()
+
+
+@pytest.mark.parametrize("callback", ["readable", "seekable"])
+def test_video_reader_capability_callbacks_check_interrupt_after_call(callback):
+    interrupt_error = RuntimeError("query interrupted during capability callback")
+    interrupted = False
+    callback_calls = 0
+
+    class Reader:
+        def _check_interrupted(self):
+            if interrupted:
+                raise interrupt_error
+
+        def readable(self):
+            nonlocal interrupted, callback_calls
+            callback_calls += 1
+            interrupted = True
+            return True
+
+        def seekable(self):
+            nonlocal interrupted, callback_calls
+            callback_calls += 1
+            interrupted = True
+            return True
+
+    proxy = _video_file._VideoReaderProxy(Reader())
+
+    assert getattr(proxy, callback)() is False
+    with pytest.raises(RuntimeError, match="query interrupted during capability callback") as raised:
+        proxy.raise_if_error()
+
+    assert raised.value is interrupt_error
+    assert callback_calls == 1
+
+
+def test_video_reader_callback_stashes_control_flow_exception():
+    class CallbackControlFlow(BaseException):
+        pass
+
+    control_flow = CallbackControlFlow("stop callback")
+
+    class Reader:
+        def _check_interrupted(self):
+            raise control_flow
+
+    proxy = _video_file._VideoReaderProxy(Reader())
+
+    assert proxy.read(1) == b""
+    with pytest.raises(CallbackControlFlow, match="stop callback") as raised:
+        proxy.raise_if_error()
+    assert raised.value is control_flow
+
+
+def test_video_reader_stashed_control_flow_precedes_later_interrupt():
+    class CallbackControlFlow(BaseException):
+        pass
+
+    control_flow = CallbackControlFlow("stop callback")
+    later_interrupt = RuntimeError("later query interrupt")
+    checks = 0
+
+    class Reader:
+        def _check_interrupted(self):
+            nonlocal checks
+            checks += 1
+            if checks == 1:
+                raise control_flow
+            raise later_interrupt
+
+    proxy = _video_file._VideoReaderProxy(Reader())
+    no_nested_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    assert proxy.read(1) == b""
+    with pytest.raises(CallbackControlFlow, match="stop callback") as raised:
+        _video_file._check_video_io(proxy, no_nested_error)
+
+    assert raised.value is control_flow
+    assert raised.value.__context__ is later_interrupt
+    assert checks == 2
+
+
+@pytest.mark.parametrize("failure_at", ["demux", "next"])
+def test_video_demux_checks_interrupt_after_dependency_failure(failure_at):
+    dependency_error = RuntimeError(f"{failure_at} failed")
+    interrupt_error = RuntimeError("query interrupted")
+    dependency_failed = False
+
+    def fail_dependency():
+        nonlocal dependency_failed
+        dependency_failed = True
+        raise dependency_error
+
+    def check_interrupted():
+        if dependency_failed:
+            raise interrupt_error
+
+    if failure_at == "demux":
+
+        def demux(video):
+            del video
+            return fail_dependency()
+
+    else:
+
+        def failed_packets():
+            fail_dependency()
+            yield
+
+        def demux(video):
+            del video
+            return failed_packets()
+
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    reader = SimpleNamespace(
+        check_interrupted=check_interrupted,
+        raise_if_error=lambda: None,
+    )
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+    batches = _video_file._iter_decoded_packet_batches(
+        SimpleNamespace(demux=demux),
+        _fake_decoder_video(),
+        options,
+        reader,
+        no_error,
+    )
+
+    with pytest.raises(RuntimeError, match="query interrupted") as raised:
+        next(batches)
+    assert raised.value is interrupt_error
+
+
+@pytest.mark.parametrize("failure_at", ["demux", "next"])
+def test_video_demux_preserves_direct_control_flow_exception(failure_at):
+    class DemuxControlFlow(BaseException):
+        pass
+
+    control_flow = DemuxControlFlow(f"stop {failure_at}")
+    later_interrupt = RuntimeError("later query interrupt")
+    dependency_failed = False
+    checks = 0
+
+    def fail_dependency():
+        nonlocal dependency_failed
+        dependency_failed = True
+        raise control_flow
+
+    def check_interrupted():
+        nonlocal checks
+        checks += 1
+        if dependency_failed:
+            raise later_interrupt
+
+    if failure_at == "demux":
+
+        def demux(video):
+            del video
+            return fail_dependency()
+
+    else:
+
+        def failed_packets():
+            fail_dependency()
+            yield
+
+        def demux(video):
+            del video
+            return failed_packets()
+
+    reader = SimpleNamespace(check_interrupted=check_interrupted, raise_if_error=lambda: None)
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(DemuxControlFlow, match=f"stop {failure_at}") as raised:
+        _video_file._next_demuxed_packet(SimpleNamespace(demux=demux), object(), reader, no_error)
+
+    assert raised.value is control_flow
+    assert checks == (1 if failure_at == "demux" else 2)
+
+
+def test_video_post_demux_interrupt_traceback_releases_packet_and_native_owners():
+    packet_was_yielded = False
+
+    class CodecContext:
+        pass
+
+    class Container:
+        def __init__(self):
+            self.packet = None
+
+        def demux(self, selected_video):
+            nonlocal packet_was_yielded
+            del selected_video
+            current_packet = self.packet
+            self.packet = None
+
+            def packets():
+                nonlocal current_packet, packet_was_yielded
+                try:
+                    packet_was_yielded = True
+                    yield current_packet
+                finally:
+                    current_packet = None
+
+            return packets()
+
+    class Video:
+        def __init__(self, container, codec_context):
+            self.container = container
+            self.codec_context = codec_context
+
+    class Packet:
+        size = 1
+        buffer_ptr = 1
+
+        def __init__(self, stream):
+            self.stream = stream
+
+    container = Container()
+    codec_context = CodecContext()
+    video = Video(container, codec_context)
+    packet = Packet(video)
+    container.packet = packet
+    container_ref = weakref.ref(container)
+    codec_ref = weakref.ref(codec_context)
+    video_ref = weakref.ref(video)
+    packet_ref = weakref.ref(packet)
+    packet = None
+
+    def check_interrupted():
+        if packet_was_yielded:
+            raise RuntimeError("query interrupted after demux")
+
+    reader = SimpleNamespace(
+        check_interrupted=check_interrupted,
+        raise_if_error=lambda: None,
+    )
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(RuntimeError, match="interrupted after demux") as raised:
+        _video_file._next_demuxed_packet(container, video, reader, no_error)
+    container = None
+    codec_context = None
+    video = None
+    gc.collect()
+
+    assert raised.value is not None
+    assert packet_ref() is None
+    assert video_ref() is None
+    assert codec_ref() is None
+    assert container_ref() is None
+
+
+def test_video_flush_classification_traceback_releases_packet_and_native_owners():
+    class CodecContext:
+        pass
+
+    class Container:
+        def __init__(self):
+            self.packet = None
+
+        def demux(self, selected_video):
+            del selected_video
+            current_packet = self.packet
+            self.packet = None
+
+            def packets():
+                nonlocal current_packet
+                try:
+                    yield current_packet
+                finally:
+                    current_packet = None
+
+            return packets()
+
+    class Video:
+        def __init__(self, container, codec_context):
+            self.container = container
+            self.codec_context = codec_context
+
+    class Packet:
+        size = object()
+        buffer_ptr = 1
+
+        def __init__(self, stream):
+            self.stream = stream
+
+    container = Container()
+    codec_context = CodecContext()
+    video = Video(container, codec_context)
+    packet = Packet(video)
+    container.packet = packet
+    container_ref = weakref.ref(container)
+    codec_ref = weakref.ref(codec_context)
+    video_ref = weakref.ref(video)
+    packet_ref = weakref.ref(packet)
+    packet = None
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError, match="invalid packet buffer metadata") as raised:
+        _video_file._next_demuxed_packet(container, video, no_error, no_error)
+    container = None
+    codec_context = None
+    video = None
+    gc.collect()
+
+    assert raised.value is not None
+    assert packet_ref() is None
+    assert video_ref() is None
+    assert codec_ref() is None
+    assert container_ref() is None
+
+
+def test_video_demux_iterator_releases_its_packet_owner_before_batch_yield():
+    class Container:
+        def __init__(self):
+            self.packet = None
+            self.demux_closed = False
+
+        def demux(self, selected_video):
+            del selected_video
+            current_packet = self.packet
+            self.packet = None
+
+            def packets():
+                nonlocal current_packet
+                try:
+                    yield current_packet
+                finally:
+                    self.demux_closed = True
+                    current_packet = None
+
+            return packets()
+
+    class Video:
+        time_base = Fraction(1, 10)
+
+        def __init__(self, container):
+            self.container = container
+
+    class Packet:
+        size = 1
+        buffer_ptr = 1
+
+        def __init__(self, stream):
+            self.stream = stream
+
+        def decode(self):
+            assert self.stream.container.demux_closed
+            return [_FakeDecodedVideoFrame()]
+
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    container = Container()
+    video = Video(container)
+    packet = Packet(video)
+    packet_ref = weakref.ref(packet)
+    container.packet = packet
+    packet = None
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    batches = _video_file._iter_decoded_packet_batches(
+        container,
+        video,
+        options,
+        no_error,
+        no_error,
+    )
+
+    batch = next(batches)
+    gc.collect()
+
+    assert container.demux_closed
+    assert packet_ref() is None
+    batch.release()
+    batches.close()
+
+
+def test_video_demux_flush_packet_ends_one_packet_iterators():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+    regular = SimpleNamespace(
+        size=1,
+        buffer_ptr=1,
+        decode=lambda: [_FakeDecodedVideoFrame(pts=0)],
+    )
+    flush = SimpleNamespace(
+        size=0,
+        buffer_ptr=0,
+        has_sidedata=lambda _data_type: False,
+        decode=lambda: [_FakeDecodedVideoFrame(pts=1)],
+    )
+
+    class Container(_PacketSequenceContainer):
+        def demux(self, video):
+            if not self.packets:
+                pytest.fail("flush packet must end demux without another iterator")
+            return super().demux(video)
+
+    container = Container([regular, flush])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    batches = list(
+        _video_file._iter_decoded_packet_batches(
+            container,
+            _fake_decoder_video(),
+            options,
+            no_error,
+            no_error,
+        )
+    )
+
+    assert [info.frame_pts for batch in batches for info in batch.infos] == [0, 1]
+
+
+def test_video_demux_does_not_mistake_side_data_only_packet_for_flush():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+    decoded_packets = []
+    checked_side_data_types = []
+
+    def decode_side_data():
+        decoded_packets.append("side-data")
+        return []
+
+    def has_side_data(data_type):
+        checked_side_data_types.append(data_type)
+        return data_type == "display_matrix"
+
+    def copy_side_data():
+        pytest.fail("flush detection must not copy packet side data")
+
+    side_data_only = SimpleNamespace(
+        size=0,
+        buffer_ptr=0,
+        has_sidedata=has_side_data,
+        iter_sidedata=copy_side_data,
+        decode=decode_side_data,
+    )
+    regular = SimpleNamespace(
+        size=1,
+        buffer_ptr=1,
+        decode=lambda: [_FakeDecodedVideoFrame(pts=0)],
+    )
+    flush = SimpleNamespace(
+        size=0,
+        buffer_ptr=0,
+        has_sidedata=lambda _data_type: False,
+        iter_sidedata=copy_side_data,
+        decode=lambda: [_FakeDecodedVideoFrame(pts=1)],
+    )
+    container = _PacketSequenceContainer([side_data_only, regular, flush])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    batches = list(
+        _video_file._iter_decoded_packet_batches(
+            container,
+            _fake_decoder_video(),
+            options,
+            no_error,
+            no_error,
+        )
+    )
+
+    assert decoded_packets == ["side-data"]
+    assert checked_side_data_types[-1] == "display_matrix"
+    assert [info.frame_pts for batch in batches for info in batch.infos] == [0, 1]
+    assert container.packets == []
+
+
+def test_video_seek_checks_interrupt_after_dependency_failure():
+    seek_error = RuntimeError("seek failed")
+    interrupt_error = RuntimeError("query interrupted")
+    seek_failed = False
+
+    def fail_seek(timestamp, *, backward, any_frame, stream):
+        nonlocal seek_failed
+        del timestamp, backward, any_frame, stream
+        seek_failed = True
+        raise seek_error
+
+    def check_interrupted():
+        if seek_failed:
+            raise interrupt_error
+
+    video = SimpleNamespace(codec_context=SimpleNamespace(reorder_depth=2))
+    reader = SimpleNamespace(
+        check_interrupted=check_interrupted,
+        raise_if_error=lambda: None,
+    )
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(RuntimeError, match="query interrupted") as raised:
+        _video_file._seek_video_stream(SimpleNamespace(seek=fail_seek), video, 42, reader, no_error)
+    assert raised.value is interrupt_error
+
+
+def test_video_seek_preserves_direct_control_flow_exception():
+    class SeekControlFlow(BaseException):
+        pass
+
+    control_flow = SeekControlFlow("stop seek")
+    later_interrupt = RuntimeError("later query interrupt")
+    seek_failed = False
+    checks = 0
+
+    def fail_seek(timestamp, *, backward, any_frame, stream):
+        nonlocal seek_failed
+        del timestamp, backward, any_frame, stream
+        seek_failed = True
+        raise control_flow
+
+    def check_interrupted():
+        nonlocal checks
+        checks += 1
+        if seek_failed:
+            raise later_interrupt
+
+    video = SimpleNamespace(codec_context=SimpleNamespace(reorder_depth=2))
+    reader = SimpleNamespace(check_interrupted=check_interrupted, raise_if_error=lambda: None)
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(SeekControlFlow, match="stop seek") as raised:
+        _video_file._seek_video_stream(SimpleNamespace(seek=fail_seek), video, 42, reader, no_error)
+
+    assert raised.value is control_flow
+    assert checks == 1
+
+
+def test_video_seek_checks_interrupt_before_restoring_reorder_depth(monkeypatch):
+    events = []
+    video = SimpleNamespace(codec_context=SimpleNamespace(reorder_depth=2))
+
+    def seek(timestamp, *, backward, any_frame, stream):
+        assert (timestamp, backward, any_frame, stream) == (42, True, False, video)
+        events.append("seek")
+
+    def restore(selected_video, reorder_depth):
+        assert (selected_video, reorder_depth) == (video, 2)
+        events.append("restore")
+
+    reader = SimpleNamespace(
+        check_interrupted=lambda: events.append("check"),
+        raise_if_error=lambda: None,
+    )
+    no_error = SimpleNamespace(raise_if_error=lambda: None)
+    monkeypatch.setattr(_video_file, "_restore_video_reorder_depth", restore)
+
+    _video_file._seek_video_stream(SimpleNamespace(seek=seek), video, 42, reader, no_error)
+
+    assert events == ["check", "seek", "check", "restore", "check"]
+
+
+def test_video_seek_traceback_releases_container_and_codec_owners():
+    class CodecContext:
+        reorder_depth = 2
+
+    class Container:
+        def __init__(self, seek):
+            self.seek = seek
+
+    class Video:
+        def __init__(self, container, codec_context):
+            self.container = container
+            self.codec_context = codec_context
+
+    def fail_seek(timestamp, *, backward, any_frame, stream):
+        del timestamp, backward, any_frame, stream
+        raise RuntimeError("seek failed")
+
+    container = Container(fail_seek)
+    codec_context = CodecContext()
+    video = Video(container, codec_context)
+    container_ref = weakref.ref(container)
+    video_ref = weakref.ref(video)
+    codec_ref = weakref.ref(codec_context)
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="seek failed") as raised:
+        _video_file._seek_video_stream(container, video, 42, no_error, no_error)
+    container = None
+    video = None
+    codec_context = None
+    gc.collect()
+
+    assert raised.value is not None
+    assert container_ref() is None
+    assert video_ref() is None
+    assert codec_ref() is None
+
+
+def test_video_packet_decode_bounds_complete_returned_batch():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+    frames = [
+        _FakeDecodedVideoFrame(),
+        _FakeDecodedVideoFrame(),
+    ]
+    packet = SimpleNamespace(decode=lambda: frames)
+    container = _PacketSequenceContainer([packet])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    with pytest.raises(vane.VideoFileLimitError, match=r"max_frames=1"):
+        list(
+            _video_file._iter_decoded_packet_batches(
+                container,
+                _fake_decoder_video(),
+                options,
+                no_error,
+                no_error,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("frames", "error_type"),
+    [
+        (
+            [_FakeDecodedVideoFrame(), _FakeDecodedVideoFrame(pts=object())],
+            vane.VideoFileFormatError,
+        ),
+        (
+            [
+                _FakeDecodedVideoFrame(width=1, height=1),
+                _FakeDecodedVideoFrame(width=11, height=10),
+            ],
+            vane.VideoFileLimitError,
+        ),
+    ],
+    ids=["provenance", "visible-pixels"],
+)
+def test_video_packet_decode_prevalidates_complete_batch(frames, error_type):
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+    packet = SimpleNamespace(decode=lambda: frames)
+    container = _PacketSequenceContainer([packet])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    batches = _video_file._iter_decoded_packet_batches(
+        container,
+        _fake_decoder_video(),
+        options,
+        no_error,
+        no_error,
+    )
+
+    with pytest.raises(error_type):
+        next(batches)
+    assert frames == []
+
+
+def test_video_packet_decode_prevalidates_missing_pts_for_time_selection():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=Fraction(1),
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+    frames = [
+        _FakeDecodedVideoFrame(pts=0),
+        _FakeDecodedVideoFrame(pts=None),
+    ]
+    packet = SimpleNamespace(decode=lambda: frames)
+    container = _PacketSequenceContainer([packet])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    batches = _video_file._iter_decoded_packet_batches(
+        container,
+        _fake_decoder_video(),
+        options,
+        no_error,
+        no_error,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError, match="presentation timestamp"):
+        next(batches)
+    assert frames == []
+
+
+def test_video_packet_conversion_is_atomic(monkeypatch):
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+    frames = [_FakeDecodedVideoFrame(pts=0), _FakeDecodedVideoFrame(pts=1)]
+    video = _fake_decoder_video()
+    infos = tuple(
+        _video_file._decoded_frame_info(frame, video, options, frame_index=index, stream_time_origin=Fraction(0))
+        for index, frame in enumerate(frames)
+    )
+    batch = _video_file._DecodedPacketBatch(frames=frames, infos=infos)
+    conversion_calls = 0
+    close_calls = 0
+    first_image_ref = None
+
+    class TrackingImage:
+        def close(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    def convert_frame(*args, **kwargs):
+        nonlocal conversion_calls, first_image_ref
+        del args, kwargs
+        conversion_calls += 1
+        if conversion_calls == 2:
+            raise vane.VideoFileFormatError("second frame conversion failed")
+        image = TrackingImage()
+        first_image_ref = weakref.ref(image)
+        return image
+
+    monkeypatch.setattr(_video_file, "_frame_to_image", convert_frame)
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError, match="second frame conversion failed") as raised:
+        _video_file._prepare_video_packet_batch(
+            batch,
+            options,
+            SimpleNamespace(),
+            SimpleNamespace(),
+            object(),
+            no_error,
+            no_error,
+            did_seek=False,
+            next_sample_time=None,
+        )
+    gc.collect()
+
+    assert conversion_calls == 2
+    assert close_calls == 1
+    assert frames == []
+    assert first_image_ref is not None
+    assert first_image_ref() is None
+    assert raised.value is not None
+
+
+def test_video_packet_decode_traceback_releases_container_and_codec_owners():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+
+    class CodecContext:
+        height = 10
+        coded_height = 10
+
+    class Video:
+        time_base = Fraction(1, 10)
+
+        def __init__(self, codec_context):
+            self.codec_context = codec_context
+
+    decoded_frame = _FakeDecodedVideoFrame(pts=object())
+    returned_frames = [decoded_frame]
+    packet = SimpleNamespace(decode=lambda: returned_frames)
+    codec_context = CodecContext()
+    video = Video(codec_context)
+    container = _PacketSequenceContainer([packet])
+    codec_ref = weakref.ref(codec_context)
+    video_ref = weakref.ref(video)
+    container_ref = weakref.ref(container)
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    batches = _video_file._iter_decoded_packet_batches(
+        container,
+        video,
+        options,
+        no_error,
+        no_error,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError) as raised:
+        next(batches)
+    decoded_frame = None
+    returned_frames = None
+    packet = None
+    codec_context = None
+    video = None
+    container = None
+    batches = None
+    gc.collect()
+
+    assert raised.value is not None
+    assert codec_ref() is None
+    assert video_ref() is None
+    assert container_ref() is None
+
+
+def test_video_packet_batch_releases_each_taken_frame():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+    first = _FakeDecodedVideoFrame()
+    second = _FakeDecodedVideoFrame()
+    frames = [first, second]
+    packet = SimpleNamespace(decode=lambda: frames)
+    container = _PacketSequenceContainer([packet])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    decoded = _video_file._iter_decoded_packet_batches(
+        container,
+        _fake_decoder_video(),
+        options,
+        no_error,
+        no_error,
+    )
+
+    batch = next(decoded)
+    frame = batch.take_frame(0)
+
+    assert frame is first
+    assert frames == [None, second]
+    assert batch.infos[0].frame_index == 0
+    decoded.close()
+
+
+def test_video_packet_decode_releases_previous_batch_before_next_decode():
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=2,
+        max_pixels=100,
+    )
+
+    class OneShotPacket:
+        def __init__(self, frame):
+            self.frame = frame
+
+        def decode(self):
+            frame = self.frame
+            self.frame = None
+            return [frame]
+
+    first = _FakeDecodedVideoFrame()
+    first_ref = weakref.ref(first)
+    first_packet = OneShotPacket(first)
+    second = _FakeDecodedVideoFrame()
+
+    def decode_second():
+        assert first_ref() is None
+        return [second]
+
+    second_packet = SimpleNamespace(decode=decode_second)
+    container = _PacketSequenceContainer([first_packet, second_packet])
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    batches = _video_file._iter_decoded_packet_batches(
+        container,
+        _fake_decoder_video(),
+        options,
+        no_error,
+        no_error,
+    )
+
+    del first
+    first_batch = next(batches)
+    source_frame = first_batch.take_frame(0)
+    del source_frame
+    first_batch.release()
+    del first_batch
+    second_batch = next(batches)
+
+    assert second_batch.take_frame(0) is second
+    batches.close()
+
+
+def test_video_frames_classify_media_errors_but_propagate_file_io(duckdb_cursor, tmp_path):
+    corrupt = tmp_path / "corrupt-frames.mp4"
+    corrupt.write_bytes(b"not a video file")
+
+    with pytest.raises(vane.VideoFileFormatError, match="decodable video"):
+        list(vane.VideoFile(str(corrupt), "video/mp4").frames(connection=duckdb_cursor))
+    with pytest.raises(vane.IOException):
+        list(vane.VideoFile(str(tmp_path / "missing.mp4"), "video/mp4").frames(connection=duckdb_cursor))
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        av.error.MemoryError(12, "Cannot allocate memory", "decoder"),
+        av.error.PermissionError(13, "Permission denied", "decoder"),
+        av.error.BugError(1, "internal decoder bug", "decoder"),
+        av.error.PyAVCallbackError(1, "callback failed", "decoder"),
+        av.error.ExternalError(1, "external library failed", "decoder"),
+        av.error.HTTPClientError(400, "remote request failed", "decoder"),
+        av.error.FFmpegError(1, "unclassified decoder failure", "decoder"),
+        av.error.UndefinedError(1, "fallback decoder failure", "decoder"),
+        av.error.UnknownError(1, "unknown decoder failure", "decoder"),
+        av.error.ArgumentError(22, "invalid decoder argument", "decoder"),
+        av.error.BufferTooSmallError(1, "decoder buffer too small", "decoder"),
+        av.error.OverflowError(34, "decoder range failure", "decoder"),
+    ],
+    ids=[
+        "memory",
+        "permission",
+        "bug",
+        "callback",
+        "external",
+        "http",
+        "base",
+        "fallback",
+        "unknown",
+        "argument",
+        "buffer",
+        "range",
+    ],
+)
+def test_video_frames_preserve_pyav_system_and_internal_errors(error):
+    no_stored_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    with pytest.raises(type(error)) as raised:
+        _video_file._classify_video_decode_error(
+            error,
+            av_module=av,
+            reader=no_stored_error,
+            nested_io=no_stored_error,
+        )
+    assert raised.value is error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        av.error.DecoderNotFoundError(1, "decoder not found", "decoder"),
+        av.error.DemuxerNotFoundError(1, "demuxer not found", "decoder"),
+        av.error.EOFError(1, "unexpected end of file", "decoder"),
+        av.error.InvalidDataError(1, "invalid encoded data", "decoder"),
+    ],
+    ids=["decoder", "demuxer", "eof", "invalid-data"],
+)
+def test_video_frames_classify_explicit_pyav_media_errors(error):
+    no_stored_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError, match="decodable video") as raised:
+        _video_file._classify_video_decode_error(
+            error,
+            av_module=av,
+            reader=no_stored_error,
+            nested_io=no_stored_error,
+        )
+    assert raised.value.__cause__ is error
+
+
+def test_video_frames_give_pending_interrupt_precedence_during_classification():
+    interrupt_error = RuntimeError("query interrupted")
+
+    def raise_interrupt():
+        raise interrupt_error
+
+    reader = SimpleNamespace(
+        check_interrupted=raise_interrupt,
+        raise_if_error=lambda: None,
+    )
+    no_stored_error = SimpleNamespace(raise_if_error=lambda: None)
+
+    with pytest.raises(RuntimeError, match="query interrupted") as raised:
+        _video_file._classify_video_decode_error(
+            vane.VideoFileFormatError("media failed"),
+            av_module=av,
+            reader=reader,
+            nested_io=no_stored_error,
+        )
+    assert raised.value is interrupt_error
+
+
+def test_video_frames_propagate_reader_failures(duckdb_cursor, tmp_path, monkeypatch):
+    path = tmp_path / "reader-failure.mp4"
+    path.write_bytes(_encoded_video())
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    def fail_read(self, size=-1):
+        del self, size
+        raise OSError("connector frame read failed")
+
+    monkeypatch.setattr(vane.VaneFileReader, "_read_and_check_interrupted", fail_read)
+    with pytest.raises(OSError, match="connector frame read failed"):
+        list(value.frames(connection=duckdb_cursor))
+
+
+def test_video_frames_observe_connection_interrupt_between_buffered_frames(duckdb_cursor, tmp_path):
+    path = tmp_path / "interrupt.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4))
+    frames = vane.VideoFile(str(path), "video/mp4").frames(
+        sample_interval_seconds=100,
+        connection=duckdb_cursor,
+    )
+
+    first = next(frames)
+    duckdb_cursor.interrupt()
+
+    with pytest.raises(vane.InterruptException):
+        next(frames)
+    first.data.close()
+
+
+def test_video_frames_observe_connection_interrupt_before_successful_eof(duckdb_cursor, tmp_path):
+    path = tmp_path / "interrupt-at-eof.mp4"
+    path.write_bytes(_encoded_video(frame_count=1))
+    frames = vane.VideoFile(str(path), "video/mp4").frames(connection=duckdb_cursor)
+
+    first = next(frames)
+    duckdb_cursor.interrupt()
+
+    with pytest.raises(vane.InterruptException):
+        next(frames)
+    first.data.close()
+
+
+def test_video_frames_observe_interrupt_during_container_close(monkeypatch):
+    interrupt_error = RuntimeError("query interrupted during container close")
+
+    class Reader:
+        interrupted = False
+
+        def close(self):
+            pass
+
+        def size(self):
+            return 1
+
+        def _check_interrupted(self):
+            if self.interrupted:
+                raise interrupt_error
+
+    reader = Reader()
+
+    class Value:
+        content_type = None
+
+        def open(self, **kwargs):
+            del kwargs
+            return reader
+
+    class Container:
+        def close(self):
+            reader.interrupted = True
+
+    class FakeFFmpegError(Exception):
+        pass
+
+    class FakeExitError(FakeFFmpegError):
+        pass
+
+    fake_av = SimpleNamespace(
+        open=lambda *args, **kwargs: Container(),
+        error=SimpleNamespace(ExitError=FakeExitError, FFmpegError=FakeFFmpegError),
+        video=SimpleNamespace(reformatter=SimpleNamespace(VideoReformatter=object)),
+    )
+    monkeypatch.setattr(
+        _video_file,
+        "_metadata_from_container",
+        lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
+    )
+    monkeypatch.setattr(_video_file, "_select_video_stream", lambda *args: object())
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: (0, Fraction(0)))
+    monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
+    monkeypatch.setattr(_video_file, "_iter_decoded_packet_batches", lambda *args, **kwargs: (x for x in ()))
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+
+    with pytest.raises(RuntimeError, match="interrupted during container close") as raised:
+        list(_video_file._iter_video_frames(Value(), options, fake_av, SimpleNamespace(), None))
+    assert raised.value is interrupt_error
+
+
+def test_video_reader_close_failure_traceback_releases_native_owners(monkeypatch):
+    close_error = RuntimeError("reader close failed")
+    owner_refs = {}
+
+    class Reader:
+        def close(self):
+            pass
+
+        def _close_and_check_interrupted(self):
+            raise close_error
+
+        def size(self):
+            return 1
+
+        def _check_interrupted(self):
+            pass
+
+    class Value:
+        content_type = None
+
+        def open(self, **kwargs):
+            del kwargs
+            return Reader()
+
+    class Container:
+        def close(self):
+            pass
+
+    class Video:
+        pass
+
+    class Reformatter:
+        def __init__(self):
+            owner_refs["reformatter"] = weakref.ref(self)
+
+    def open_container(*args, **kwargs):
+        del args, kwargs
+        container = Container()
+        owner_refs["container"] = weakref.ref(container)
+        return container
+
+    def select_video(*args):
+        del args
+        video = Video()
+        owner_refs["video"] = weakref.ref(video)
+        return video
+
+    class FakeFFmpegError(Exception):
+        pass
+
+    class FakeExitError(FakeFFmpegError):
+        pass
+
+    fake_av = SimpleNamespace(
+        open=open_container,
+        error=SimpleNamespace(ExitError=FakeExitError, FFmpegError=FakeFFmpegError),
+        video=SimpleNamespace(reformatter=SimpleNamespace(VideoReformatter=Reformatter)),
+    )
+    monkeypatch.setattr(
+        _video_file,
+        "_metadata_from_container",
+        lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
+    )
+    monkeypatch.setattr(_video_file, "_select_video_stream", select_video)
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: (0, Fraction(0)))
+    monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
+    monkeypatch.setattr(_video_file, "_iter_decoded_packet_batches", lambda *args, **kwargs: (x for x in ()))
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+
+    with pytest.raises(RuntimeError, match="reader close failed") as raised:
+        list(_video_file._iter_video_frames(Value(), options, fake_av, SimpleNamespace(), None))
+    gc.collect()
+
+    assert raised.value is close_error
+    assert set(owner_refs) == {"container", "video", "reformatter"}
+    assert all(owner_ref() is None for owner_ref in owner_refs.values())
+
+
+def test_video_reader_close_failure_does_not_replace_active_decode_error(monkeypatch):
+    primary_error = vane.VideoFileFormatError("primary decode failure")
+    close_error = RuntimeError("competing reader close failure")
+
+    class NativeReader:
+        _closed = False
+
+        def _size(self):
+            return 1
+
+        def _check_interrupted(self):
+            pass
+
+        def _close(self):
+            self._closed = True
+            raise close_error
+
+    reader = vane.VaneFileReader(NativeReader())
+
+    class Value:
+        content_type = None
+
+        def open(self, **kwargs):
+            del kwargs
+            return reader
+
+    class Container:
+        def close(self):
+            pass
+
+    class FakeFFmpegError(Exception):
+        pass
+
+    class FakeExitError(FakeFFmpegError):
+        pass
+
+    fake_av = SimpleNamespace(
+        open=lambda *args, **kwargs: Container(),
+        error=SimpleNamespace(ExitError=FakeExitError, FFmpegError=FakeFFmpegError),
+        video=SimpleNamespace(reformatter=SimpleNamespace(VideoReformatter=object)),
+    )
+
+    def fail_decode(*args, **kwargs):
+        del args, kwargs
+        if False:
+            yield None
+        raise primary_error
+
+    monkeypatch.setattr(
+        _video_file,
+        "_metadata_from_container",
+        lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
+    )
+    monkeypatch.setattr(_video_file, "_select_video_stream", lambda *args: object())
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: (0, Fraction(0)))
+    monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
+    monkeypatch.setattr(_video_file, "_iter_decoded_packet_batches", fail_decode)
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError, match="primary decode failure") as raised:
+        list(_video_file._iter_video_frames(Value(), options, fake_av, SimpleNamespace(), None))
+
+    assert raised.value is primary_error
+    assert reader.closed
+
+
+def test_video_frames_give_interrupt_precedence_after_input_size_check(duckdb_cursor, tmp_path, monkeypatch):
+    path = tmp_path / "interrupt-after-size.mp4"
+    path.write_bytes(_encoded_video(frame_count=1))
+    original_size = vane.VaneFileReader.size
+
+    def interrupt_after_size(reader):
+        size = original_size(reader)
+        duckdb_cursor.interrupt()
+        return size
+
+    monkeypatch.setattr(vane.VaneFileReader, "size", interrupt_after_size)
+
+    with pytest.raises(vane.InterruptException):
+        list(vane.VideoFile(str(path), "video/mp4").frames(max_input_bytes=1, connection=duckdb_cursor))
+
+
+def test_video_frames_close_undelivered_image_when_interrupted_before_yield(
+    duckdb_cursor,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "interrupt-before-yield.mp4"
+    path.write_bytes(_encoded_video(frame_count=1))
+    converted = False
+    close_calls = 0
+    image_refs = []
+
+    class TrackingImage:
+        def __init__(self):
+            image_refs.append(weakref.ref(self))
+
+        def close(self):
+            nonlocal close_calls
+            close_calls += 1
+            raise RuntimeError("image close failed")
+
+    original_check = _video_file._check_video_io
+
+    def convert_frame(*args, **kwargs):
+        nonlocal converted
+        del args, kwargs
+        converted = True
+        return TrackingImage()
+
+    def interrupt_after_conversion(reader, nested_io):
+        if converted:
+            raise RuntimeError("query interrupted before yield")
+        original_check(reader, nested_io)
+
+    monkeypatch.setattr(_video_file, "_frame_to_image", convert_frame)
+    monkeypatch.setattr(_video_file, "_check_video_io", interrupt_after_conversion)
+
+    frames = vane.VideoFile(str(path), "video/mp4").frames(connection=duckdb_cursor)
+    with pytest.raises(RuntimeError, match="interrupted before yield") as raised:
+        next(frames)
+    gc.collect()
+
+    assert raised.value is not None
+    assert close_calls == 1
+    assert len(image_refs) == 1
+    assert image_refs[0]() is None
+
+
+def test_video_frames_release_internal_image_ownership_before_next_decode(
+    duckdb_cursor,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "released-output.mp4"
+    path.write_bytes(_encoded_video(frame_count=2))
+
+    class TrackingImage:
+        def close(self):
+            pass
+
+    image_refs: list[weakref.ReferenceType[TrackingImage]] = []
+
+    def convert_frame(*args, **kwargs):
+        del args, kwargs
+        if image_refs:
+            gc.collect()
+            assert image_refs[-1]() is None
+        image = TrackingImage()
+        image_refs.append(weakref.ref(image))
+        return image
+
+    monkeypatch.setattr(_video_file, "_frame_to_image", convert_frame)
+    frames = vane.VideoFile(str(path), "video/mp4").frames(connection=duckdb_cursor)
+    first = next(frames)
+    del first
+
+    second = next(frames)
+
+    assert len(image_refs) == 2
+    del second
+    frames.close()
+
+
+def test_video_frames_throw_preserves_consumer_error_and_releases_handed_off_image(
+    duckdb_cursor,
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / "throw-output.mp4"
+    path.write_bytes(_encoded_video(frame_count=2))
+    image_refs = []
+    close_error = RuntimeError("competing reader close failure")
+
+    original_close = vane.VaneFileReader.close
+
+    def fail_reader_close(reader):
+        original_close(reader)
+        raise close_error
+
+    monkeypatch.setattr(vane.VaneFileReader, "close", fail_reader_close)
+
+    class TrackingImage:
+        def close(self):
+            pass
+
+    def convert_frame(*args, **kwargs):
+        del args, kwargs
+        image = TrackingImage()
+        image_refs.append(weakref.ref(image))
+        return image
+
+    monkeypatch.setattr(_video_file, "_frame_to_image", convert_frame)
+    frames = vane.VideoFile(str(path), "video/mp4").frames(connection=duckdb_cursor)
+    first = next(frames)
+    del first
+    consumer_error = av.error.InvalidDataError(1094995529, "consumer stopped", "consumer")
+
+    with pytest.raises(av.error.InvalidDataError) as raised:
+        frames.throw(consumer_error)
+    gc.collect()
+
+    assert raised.value is consumer_error
+    assert len(image_refs) == 1
+    assert image_refs[0]() is None
+
+
+def test_video_keyframes_release_wrapper_image_before_requesting_next():
+    first_image: Image.Image | None = Image.new("RGB", (1, 1))
+    first_image_ref = weakref.ref(first_image)
+
+    def frame_records():
+        nonlocal first_image
+        assert first_image is not None
+        first_record = vane.VideoFrameData(None, None, None, None, None, None, True, first_image)
+        first_image = None
+        yield first_record
+        first_record = None
+        gc.collect()
+        assert first_image_ref() is None
+        yield vane.VideoFrameData(None, None, None, None, None, None, True, Image.new("RGB", (1, 1)))
+
+    images = _video_file._iter_keyframe_images(frame_records())
+    first = next(images)
+    del first
+
+    second = next(images)
+
+    second.close()
+    images.close()
+
+
+@pytest.mark.parametrize("method_name", ["frames", "keyframes"])
+def test_video_iterators_close_reader_when_closed_early(duckdb_cursor, tmp_path, monkeypatch, method_name):
+    path = tmp_path / "early-close.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4))
+    closed_readers = []
+    original_close = vane.VaneFileReader.close
+
+    def track_close(self):
+        closed_readers.append(self)
+        return original_close(self)
+
+    monkeypatch.setattr(vane.VaneFileReader, "close", track_close)
+    frames = getattr(vane.VideoFile(str(path), "video/mp4"), method_name)(connection=duckdb_cursor)
+
+    first = next(frames)
+    frames.close()
+
+    assert len({id(reader) for reader in closed_readers}) == 1
+    assert all(reader.closed for reader in closed_readers)
+    image = first.data if isinstance(first, vane.VideoFrameData) else first
+    image.close()
+
+
+def test_video_frames_optional_dependencies_are_lazy(monkeypatch):
+    original_import = importlib.import_module
+
+    def fail_pillow(name, package=None):
+        if name == "PIL.Image":
+            raise ImportError("missing Pillow")
+        return original_import(name, package)
+
+    monkeypatch.setattr(_video_file.importlib, "import_module", fail_pillow)
+
+    with pytest.raises(ImportError, match=r"Pillow.*vane-ai\[video\]"):
+        vane.VideoFile("memory://not-opened").frames()
 
 
 def test_video_metadata_preserves_unknown_frame_count(duckdb_cursor, tmp_path):
@@ -239,6 +2721,24 @@ def test_video_metadata_skips_attached_picture_streams():
         _video_file._metadata_from_container(container, None, av)
 
 
+def test_video_metadata_does_not_infer_visible_limit_from_missing_dimensions():
+    video = SimpleNamespace(
+        type="video",
+        disposition=av.stream.Disposition(0),
+        codec_context=object(),
+        width=0,
+        height=0,
+    )
+    container = SimpleNamespace(
+        streams=[video],
+        format=SimpleNamespace(name="mov,mp4,m4a,3gp,3g2,mj2"),
+        duration=None,
+    )
+
+    with pytest.raises(vane.VideoFileFormatError, match="dimensions must be positive"):
+        _video_file._metadata_from_container(container, "video/mp4", av, max_pixels=100)
+
+
 def test_video_metadata_configures_bounded_probe(monkeypatch):
     class FakeFFmpegError(Exception):
         pass
@@ -275,7 +2775,7 @@ def test_video_metadata_configures_bounded_probe(monkeypatch):
     assert open_options["metadata_errors"] == "replace"
     assert open_options["timeout"] == (5.0, 5.0)
     assert open_options["options"] == {
-        "max_pixels": str(32 * 1024 * 1024),
+        "max_pixels": str(64 * 1024 * 1024),
         "max_samples": str(1024 * 1024),
         "skip_frame": "all",
         "threads": "1",
@@ -363,10 +2863,12 @@ def test_video_metadata_budget_is_enforced(duckdb_cursor, tmp_path):
     "failure",
     [
         MemoryError("allocation failed"),
+        av.error.MemoryError(12, "Cannot allocate memory", "parser"),
+        av.error.PermissionError(13, "Permission denied", "parser"),
         RuntimeError("parser invariant failed"),
         _video_file.VideoFileFormatError("classified media failure"),
     ],
-    ids=["memory", "internal", "classified-media"],
+    ids=["memory", "pyav-memory", "pyav-permission", "internal", "classified-media"],
 )
 def test_video_metadata_probe_preserves_non_parser_errors_after_budget_exhaustion(monkeypatch, failure):
     class FakeFFmpegError(Exception):

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -28,6 +28,7 @@ def _encoded_video(
     container_format: str = "mp4",
     *,
     codec_name: str | None = None,
+    muxer_options: dict[str, str] | None = None,
     width: int = 16,
     height: int = 12,
     frame_count: int = 4,
@@ -36,7 +37,7 @@ def _encoded_video(
     max_b_frames: int = 0,
 ) -> bytes:
     buffer = io.BytesIO()
-    with av.open(buffer, mode="w", format=container_format) as container:
+    with av.open(buffer, mode="w", format=container_format, options=muxer_options) as container:
         codec = codec_name or ("libvpx" if container_format == "ogg" else "mpeg4")
         stream = container.add_stream(codec, rate=frame_rate)
         stream.width = width
@@ -396,6 +397,38 @@ def test_video_frames_time_window_with_distinct_pts_dts_origins_matches_full_dec
 
     assert [frame.frame_pts for frame in selected] == [frame.frame_pts for frame in expected]
     assert [frame.frame_time for frame in selected] == pytest.approx([0.125, 0.25, 0.375])
+
+
+def test_video_frames_time_window_scans_across_timestamp_discontinuities(duckdb_cursor, tmp_path):
+    segment = _encoded_video(
+        "mpegts",
+        codec_name="mpeg2video",
+        muxer_options={"mpegts_flags": "resend_headers+initial_discontinuity"},
+        frame_count=8,
+        frame_rate=8,
+        gop_size=3,
+        max_b_frames=1,
+    )
+    path = tmp_path / "timestamp-discontinuity.ts"
+    path.write_bytes(segment + segment)
+    value = vane.VideoFile(str(path), "video/mp2t")
+
+    all_frames = list(value.frames(connection=duckdb_cursor))
+    selected = list(value.frames(start_time=0.125, end_time=0.25, connection=duckdb_cursor))
+    sampled = list(
+        value.frames(
+            start_time=0.125,
+            end_time=0.25,
+            sample_interval_seconds=0.125,
+            connection=duckdb_cursor,
+        )
+    )
+    expected = [frame for frame in all_frames if frame.frame_time is not None and 0.125 <= frame.frame_time <= 0.25]
+
+    assert len(all_frames) == 16
+    assert [frame.frame_index for frame in expected] == [1, 2, 9, 10]
+    assert [frame.frame_index for frame in selected] == [frame.frame_index for frame in expected]
+    assert [frame.frame_index for frame in sampled] == [frame.frame_index for frame in expected]
 
 
 def test_video_visible_pixel_limit_is_independent_of_coded_alignment(duckdb_cursor, tmp_path):
@@ -1801,6 +1834,7 @@ def test_video_packet_conversion_is_atomic(monkeypatch):
             no_error,
             no_error,
             next_sample_time=None,
+            last_frame_time=None,
         )
     gc.collect()
 

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -27,6 +27,7 @@ from vane import _video_file
 def _encoded_video(
     container_format: str = "mp4",
     *,
+    codec_name: str | None = None,
     width: int = 16,
     height: int = 12,
     frame_count: int = 4,
@@ -36,7 +37,7 @@ def _encoded_video(
 ) -> bytes:
     buffer = io.BytesIO()
     with av.open(buffer, mode="w", format=container_format) as container:
-        codec = "libvpx" if container_format == "ogg" else "mpeg4"
+        codec = codec_name or ("libvpx" if container_format == "ogg" else "mpeg4")
         stream = container.add_stream(codec, rate=frame_rate)
         stream.width = width
         stream.height = height
@@ -313,7 +314,12 @@ def test_video_frames_filter_time_keyframes_and_sample_exactly(duckdb_cursor, tm
         return result
 
     assert [frame.frame_pts for frame in selected] == expected_pts(start=Fraction(3, 4), end=Fraction(2))
-    assert all(frame.frame_index is None for frame in selected)
+    expected_indices = {
+        frame.frame_pts: frame.frame_index
+        for frame in all_frames
+        if frame.frame_pts in expected_pts(start=Fraction(3, 4), end=Fraction(2))
+    }
+    assert [frame.frame_index for frame in selected] == [expected_indices[frame.frame_pts] for frame in selected]
     assert [frame.frame_pts for frame in key_frames] == expected_pts(key_frame=True)
     assert [frame.frame_pts for frame in non_key_frames] == expected_pts(key_frame=False)
     assert [frame.frame_pts for frame in sampled] == expected_pts(interval=Fraction(1, 2))
@@ -353,6 +359,43 @@ def test_video_frames_time_window_with_b_frames_matches_full_decode(duckdb_curso
 
     assert [frame.frame_pts for frame in selected] == [frame.frame_pts for frame in expected]
     assert [frame.frame_time for frame in selected] == pytest.approx([0.25, 0.5])
+
+
+def test_video_frames_time_window_with_distinct_pts_dts_origins_matches_full_decode(duckdb_cursor, tmp_path):
+    payload = _encoded_video(
+        "mpegts",
+        codec_name="mpeg2video",
+        frame_count=12,
+        frame_rate=8,
+        gop_size=3,
+        max_b_frames=1,
+    )
+    with av.open(io.BytesIO(payload), mode="r") as container:
+        video = container.streams.video[0]
+        first_packet = next(packet for packet in container.demux(video) if packet.size)
+        assert first_packet.pts is not None
+        assert first_packet.dts is not None
+        assert first_packet.pts != first_packet.dts
+
+    path = tmp_path / "distinct-pts-dts-origins.ts"
+    path.write_bytes(payload)
+    value = vane.VideoFile(str(path), "video/mp2t")
+
+    all_frames = list(value.frames(connection=duckdb_cursor))
+    selected = list(value.frames(start_time=0.125, end_time=0.375, connection=duckdb_cursor))
+    assert all_frames[0].frame_pts is not None
+    assert all_frames[0].frame_time_base is not None
+    stream_origin = all_frames[0].frame_pts * all_frames[0].frame_time_base
+    expected = [
+        frame
+        for frame in all_frames
+        if frame.frame_pts is not None
+        and frame.frame_time_base is not None
+        and Fraction(1, 8) <= frame.frame_pts * frame.frame_time_base - stream_origin <= Fraction(3, 8)
+    ]
+
+    assert [frame.frame_pts for frame in selected] == [frame.frame_pts for frame in expected]
+    assert [frame.frame_time for frame in selected] == pytest.approx([0.125, 0.25, 0.375])
 
 
 def test_video_visible_pixel_limit_is_independent_of_coded_alignment(duckdb_cursor, tmp_path):
@@ -815,7 +858,7 @@ def test_video_frame_conversion_traceback_releases_native_frames():
     assert output_ref() is None
 
 
-def test_video_frame_provenance_and_seek_rebase_nonzero_stream_origin():
+def test_video_frame_provenance_rebases_nonzero_stream_origin():
     options = _video_file._VideoFrameOptions(
         start_time=Fraction(0),
         end_time=None,
@@ -830,7 +873,7 @@ def test_video_frame_provenance_and_seek_rebase_nonzero_stream_origin():
     )
     frame = _FakeDecodedVideoFrame(pts=105)
     video = SimpleNamespace(start_time=100, time_base=Fraction(1, 10))
-    stream_start, stream_origin = _video_file._stream_time_origin(video, video.time_base)
+    stream_origin = _video_file._stream_time_origin(video, video.time_base)
     info = _video_file._decoded_frame_info(
         frame,
         video,
@@ -842,7 +885,6 @@ def test_video_frame_provenance_and_seek_rebase_nonzero_stream_origin():
     assert info.frame_pts == 105
     assert info.exact_time == Fraction(1, 2)
     assert info.frame_time == 0.5
-    assert _video_file._seek_timestamp(Fraction(1, 2), video.time_base, stream_start) == 105
 
 
 def test_video_frame_preserves_zero_duration_provenance():
@@ -1583,130 +1625,6 @@ def test_video_demux_does_not_mistake_side_data_only_packet_for_flush():
     assert container.packets == []
 
 
-def test_video_seek_checks_interrupt_after_dependency_failure():
-    seek_error = RuntimeError("seek failed")
-    interrupt_error = RuntimeError("query interrupted")
-    seek_failed = False
-
-    def fail_seek(timestamp, *, backward, any_frame, stream):
-        nonlocal seek_failed
-        del timestamp, backward, any_frame, stream
-        seek_failed = True
-        raise seek_error
-
-    def check_interrupted():
-        if seek_failed:
-            raise interrupt_error
-
-    video = SimpleNamespace(codec_context=SimpleNamespace(reorder_depth=2))
-    reader = SimpleNamespace(
-        check_interrupted=check_interrupted,
-        raise_if_error=lambda: None,
-    )
-    no_error = SimpleNamespace(raise_if_error=lambda: None)
-
-    with pytest.raises(RuntimeError, match="query interrupted") as raised:
-        _video_file._seek_video_stream(SimpleNamespace(seek=fail_seek), video, 42, reader, no_error)
-    assert raised.value is interrupt_error
-
-
-def test_video_seek_preserves_direct_control_flow_exception():
-    class SeekControlFlow(BaseException):
-        pass
-
-    control_flow = SeekControlFlow("stop seek")
-    later_interrupt = RuntimeError("later query interrupt")
-    seek_failed = False
-    checks = 0
-
-    def fail_seek(timestamp, *, backward, any_frame, stream):
-        nonlocal seek_failed
-        del timestamp, backward, any_frame, stream
-        seek_failed = True
-        raise control_flow
-
-    def check_interrupted():
-        nonlocal checks
-        checks += 1
-        if seek_failed:
-            raise later_interrupt
-
-    video = SimpleNamespace(codec_context=SimpleNamespace(reorder_depth=2))
-    reader = SimpleNamespace(check_interrupted=check_interrupted, raise_if_error=lambda: None)
-    no_error = SimpleNamespace(raise_if_error=lambda: None)
-
-    with pytest.raises(SeekControlFlow, match="stop seek") as raised:
-        _video_file._seek_video_stream(SimpleNamespace(seek=fail_seek), video, 42, reader, no_error)
-
-    assert raised.value is control_flow
-    assert checks == 1
-
-
-def test_video_seek_checks_interrupt_before_restoring_reorder_depth(monkeypatch):
-    events = []
-    video = SimpleNamespace(codec_context=SimpleNamespace(reorder_depth=2))
-
-    def seek(timestamp, *, backward, any_frame, stream):
-        assert (timestamp, backward, any_frame, stream) == (42, True, False, video)
-        events.append("seek")
-
-    def restore(selected_video, reorder_depth):
-        assert (selected_video, reorder_depth) == (video, 2)
-        events.append("restore")
-
-    reader = SimpleNamespace(
-        check_interrupted=lambda: events.append("check"),
-        raise_if_error=lambda: None,
-    )
-    no_error = SimpleNamespace(raise_if_error=lambda: None)
-    monkeypatch.setattr(_video_file, "_restore_video_reorder_depth", restore)
-
-    _video_file._seek_video_stream(SimpleNamespace(seek=seek), video, 42, reader, no_error)
-
-    assert events == ["check", "seek", "check", "restore", "check"]
-
-
-def test_video_seek_traceback_releases_container_and_codec_owners():
-    class CodecContext:
-        reorder_depth = 2
-
-    class Container:
-        def __init__(self, seek):
-            self.seek = seek
-
-    class Video:
-        def __init__(self, container, codec_context):
-            self.container = container
-            self.codec_context = codec_context
-
-    def fail_seek(timestamp, *, backward, any_frame, stream):
-        del timestamp, backward, any_frame, stream
-        raise RuntimeError("seek failed")
-
-    container = Container(fail_seek)
-    codec_context = CodecContext()
-    video = Video(container, codec_context)
-    container_ref = weakref.ref(container)
-    video_ref = weakref.ref(video)
-    codec_ref = weakref.ref(codec_context)
-    no_error = SimpleNamespace(
-        check_interrupted=lambda: None,
-        raise_if_error=lambda: None,
-    )
-
-    with pytest.raises(RuntimeError, match="seek failed") as raised:
-        _video_file._seek_video_stream(container, video, 42, no_error, no_error)
-    container = None
-    video = None
-    codec_context = None
-    gc.collect()
-
-    assert raised.value is not None
-    assert container_ref() is None
-    assert video_ref() is None
-    assert codec_ref() is None
-
-
 def test_video_packet_decode_bounds_complete_returned_batch():
     options = _video_file._VideoFrameOptions(
         start_time=Fraction(0),
@@ -1882,7 +1800,6 @@ def test_video_packet_conversion_is_atomic(monkeypatch):
             object(),
             no_error,
             no_error,
-            did_seek=False,
             next_sample_time=None,
         )
     gc.collect()
@@ -2248,7 +2165,7 @@ def test_video_frames_observe_interrupt_during_container_close(monkeypatch):
         lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
     )
     monkeypatch.setattr(_video_file, "_select_video_stream", lambda *args: object())
-    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: (0, Fraction(0)))
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: Fraction(0))
     monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
     monkeypatch.setattr(_video_file, "_iter_decoded_packet_batches", lambda *args, **kwargs: (x for x in ()))
     options = _video_file._VideoFrameOptions(
@@ -2333,7 +2250,7 @@ def test_video_reader_close_failure_traceback_releases_native_owners(monkeypatch
         lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
     )
     monkeypatch.setattr(_video_file, "_select_video_stream", select_video)
-    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: (0, Fraction(0)))
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: Fraction(0))
     monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
     monkeypatch.setattr(_video_file, "_iter_decoded_packet_batches", lambda *args, **kwargs: (x for x in ()))
     options = _video_file._VideoFrameOptions(
@@ -2412,7 +2329,7 @@ def test_video_reader_close_failure_does_not_replace_active_decode_error(monkeyp
         lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
     )
     monkeypatch.setattr(_video_file, "_select_video_stream", lambda *args: object())
-    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: (0, Fraction(0)))
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: Fraction(0))
     monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
     monkeypatch.setattr(_video_file, "_iter_decoded_packet_batches", fail_decode)
     options = _video_file._VideoFrameOptions(

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -336,6 +336,25 @@ def test_video_frames_preserve_presentation_order_with_b_frames(duckdb_cursor, t
     assert any(frame.frame_dts != frame.frame_pts for frame in frames)
 
 
+def test_video_frames_time_window_with_b_frames_matches_full_decode(duckdb_cursor, tmp_path):
+    path = tmp_path / "b-frame-window.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4, gop_size=6, max_b_frames=2))
+    value = vane.VideoFile(str(path), "video/mp4")
+
+    all_frames = list(value.frames(connection=duckdb_cursor))
+    selected = list(value.frames(start_time=0.25, end_time=0.5, connection=duckdb_cursor))
+    expected = [
+        frame
+        for frame in all_frames
+        if frame.frame_pts is not None
+        and frame.frame_time_base is not None
+        and Fraction(1, 4) <= frame.frame_pts * frame.frame_time_base <= Fraction(1, 2)
+    ]
+
+    assert [frame.frame_pts for frame in selected] == [frame.frame_pts for frame in expected]
+    assert [frame.frame_time for frame in selected] == pytest.approx([0.25, 0.5])
+
+
 def test_video_visible_pixel_limit_is_independent_of_coded_alignment(duckdb_cursor, tmp_path):
     path = tmp_path / "aligned.mp4"
     path.write_bytes(_encoded_video(width=18, height=14, frame_count=1))

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -67,6 +67,7 @@ from vane._video_file import (
     VideoFileError,
     VideoFileFormatError,
     VideoFileLimitError,
+    VideoFrameData,
     VideoMetadata,
     video_metadata,
 )
@@ -500,6 +501,7 @@ __all__: list[str] = [
     "VideoFileError",
     "VideoFileFormatError",
     "VideoFileLimitError",
+    "VideoFrameData",
     "VideoMetadata",
     "VaneFileReader",
     "Warning",

--- a/vane/_file.py
+++ b/vane/_file.py
@@ -33,6 +33,16 @@ class VaneFileReader(io.RawIOBase):
         return self._inner._read(size)
 
     def readinto(self, buffer: Any, /) -> int:
+        return self._readinto_from(buffer, self._inner._read)
+
+    def _read_and_check_interrupted(self, size: int = -1, /) -> bytes:
+        return self._inner._read_and_check_interrupted(size)
+
+    def _readinto_and_check_interrupted(self, buffer: Any, /) -> int:
+        return self._readinto_from(buffer, self._inner._read_and_check_interrupted)
+
+    @staticmethod
+    def _readinto_from(buffer: Any, read: Any) -> int:
         try:
             view = memoryview(buffer)
         except TypeError as error:
@@ -45,7 +55,7 @@ class VaneFileReader(io.RawIOBase):
                 byte_view = view.cast("B")
             except TypeError as error:
                 raise TypeError("readinto() argument must be a contiguous writable bytes-like object") from error
-            data = self._inner._read(byte_view.nbytes)
+            data = read(byte_view.nbytes)
             byte_view[: len(data)] = data
             return len(data)
         finally:
@@ -67,6 +77,9 @@ class VaneFileReader(io.RawIOBase):
         """Return the size of this FILE's logical byte view."""
         return self._inner._size()
 
+    def _check_interrupted(self) -> None:
+        self._inner._check_interrupted()
+
     def guess_mime_type(self) -> str | None:
         """Inspect bounded bytes without changing the current stream position."""
         return self._inner._guess_mime_type()
@@ -74,6 +87,12 @@ class VaneFileReader(io.RawIOBase):
     def close(self) -> None:
         try:
             self._inner._close()
+        finally:
+            super().close()
+
+    def _close_and_check_interrupted(self) -> None:
+        try:
+            self._inner._close_and_check_interrupted()
         finally:
             super().close()
 
@@ -105,8 +124,16 @@ class VaneFileReader(io.RawIOBase):
         self._require_open()
         return self
 
-    def __exit__(self, _exc_type: object, _exc_value: object, _traceback: object) -> None:
-        self.close()
+    def __exit__(self, exc_type: object, _exc_value: object, _traceback: object) -> None:
+        if exc_type is None:
+            self.close()
+            return
+        try:
+            self.close()
+        except BaseException:
+            # Cleanup must not replace an exception already escaping the reader
+            # body, including control-flow exceptions injected into a generator.
+            pass
 
     def __str__(self) -> str:
         return str(self._inner)

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -30,7 +30,7 @@ if typing.TYPE_CHECKING:
     from vane._audio_file import AudioMetadata
     from vane._file import VaneFileReader
     from vane._image_file import ImageMetadata
-    from vane._video_file import VideoMetadata
+    from vane._video_file import VideoFrameData, VideoMetadata
     from vane.ai.options import EmbedOptions, PromptOptions
     from vane.ai.provider import Provider
     from vane.ai.typing import JSONSchema
@@ -1047,6 +1047,35 @@ class AudioFile(File):
 
 @typing.final
 class VideoFile(File):
+    def frames(
+        self,
+        start_time: int | float = 0,
+        end_time: int | float | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        is_key_frame: bool | None = None,
+        sample_interval_seconds: int | float | None = None,
+        buffer_size: int = 1048576,
+        *,
+        max_input_bytes: int = 8589934592,
+        max_frames: int = 1000000,
+        max_pixels: int = 33554432,
+        connection: DuckDBPyConnection | None = None,
+    ) -> typing.Generator[VideoFrameData, None, None]: ...
+    def keyframes(
+        self,
+        start_time: int | float = 0,
+        end_time: int | float | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        sample_interval_seconds: int | float | None = None,
+        buffer_size: int = 1048576,
+        *,
+        max_input_bytes: int = 8589934592,
+        max_frames: int = 1000000,
+        max_pixels: int = 33554432,
+        connection: DuckDBPyConnection | None = None,
+    ) -> typing.Generator[PIL.Image.Image, None, None]: ...
     def metadata(
         self,
         *,
@@ -1059,8 +1088,11 @@ class _VaneFileReaderHandle:
     def __repr__(self) -> str: ...
     def __str__(self) -> str: ...
     def _close(self) -> None: ...
+    def _close_and_check_interrupted(self) -> None: ...
+    def _check_interrupted(self) -> None: ...
     def _guess_mime_type(self) -> str | None: ...
     def _read(self, size: int = -1) -> bytes: ...
+    def _read_and_check_interrupted(self, size: int = -1) -> bytes: ...
     def _seek(self, offset: int, whence: int = 0) -> int: ...
     def _size(self) -> int: ...
     def _tell(self) -> int: ...

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -1344,6 +1344,58 @@ def _seek_video_stream(
         video = None
 
 
+def _seek_video_stream_for_time_window(
+    container: Any,
+    video: Any,
+    requested_timestamp: int,
+    stream_start: int,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+) -> None:
+    """Seek only when the selected random-access point can cover the window.
+
+    FFmpeg's seek index can be ordered by decode timestamps. For streams with
+    reordered frames, seeking to a presentation timestamp may therefore land on
+    a keyframe whose PTS is *after* the requested boundary. Probe the first
+    selected packet without decoding it and keep the optimized seek only when
+    that keyframe is early enough. Otherwise restart at the stream origin, which
+    is the correctness fallback when the container cannot prove safe preroll.
+    """
+
+    packet_and_flush: tuple[Any, bool] | None = None
+    packet: Any = None
+    try:
+        if requested_timestamp <= stream_start:
+            _seek_video_stream(container, video, stream_start, reader, nested_io)
+            return
+
+        _seek_video_stream(container, video, requested_timestamp, reader, nested_io)
+        packet_and_flush = _next_demuxed_packet(container, video, reader, nested_io)
+        seek_is_safe = False
+        if packet_and_flush is not None:
+            packet, is_flush = packet_and_flush
+            packet_and_flush = None
+            if not is_flush:
+                packet_pts = _optional_frame_integer(packet.pts, name="seek packet PTS")
+                try:
+                    is_keyframe = packet.is_keyframe
+                except AttributeError as error:
+                    raise VideoFileFormatError("video demuxer did not report seek packet keyframe state") from error
+                if not isinstance(is_keyframe, bool):
+                    raise VideoFileFormatError("video demuxer reported invalid seek packet keyframe state")
+                seek_is_safe = is_keyframe and packet_pts is not None and packet_pts <= requested_timestamp
+            packet = None
+
+        safe_timestamp = requested_timestamp if seek_is_safe else stream_start
+        _seek_video_stream(container, video, safe_timestamp, reader, nested_io)
+    finally:
+        # Probe failures must not retain native packet/container/codec owners.
+        packet = None
+        packet_and_flush = None
+        container = None
+        video = None
+
+
 def _decode_packet_frames(
     packet: Any,
     reader: _VideoReaderProxy,
@@ -1763,7 +1815,14 @@ def _iter_video_frames(
                 did_seek = options.start_time > 0
                 if did_seek:
                     seek_timestamp = _seek_timestamp(options.start_time, metadata.time_base, stream_start)
-                    _seek_video_stream(container, video, int(seek_timestamp), reader, nested_io)
+                    _seek_video_stream_for_time_window(
+                        container,
+                        video,
+                        int(seek_timestamp),
+                        stream_start,
+                        reader,
+                        nested_io,
+                    )
 
                 next_sample_time = options.start_time if options.sample_interval_seconds is not None else None
                 decoded_batches = _iter_decoded_packet_batches(

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -154,9 +154,8 @@ class VideoFrameData:
 
     ``frame_time`` is elapsed presentation time from the stream's declared
     timestamp origin. ``frame_time_base`` is the exact unit for the raw PTS,
-    DTS, and duration fields. The zero-based ``frame_index`` is present only
-    when decoding starts at the beginning; after keyframe seek it remains
-    ``None`` rather than being estimated from an average frame rate.
+    DTS, and duration fields. The zero-based ``frame_index`` records the frame's
+    position in the sequential decode stream when the decoder can establish it.
     """
 
     frame_index: int | None
@@ -1008,12 +1007,12 @@ def _frame_time_base(frame: Any, video: Any) -> Fraction | None:
         video = None
 
 
-def _stream_time_origin(video: Any, time_base: Fraction) -> tuple[int, Fraction]:
+def _stream_time_origin(video: Any, time_base: Fraction) -> Fraction:
     try:
         stream_start = _optional_frame_integer(getattr(video, "start_time", None), name="stream start time")
         if stream_start is None:
-            return 0, Fraction(0)
-        return stream_start, stream_start * time_base
+            return Fraction(0)
+        return stream_start * time_base
     finally:
         video = None
 
@@ -1030,13 +1029,6 @@ def _frame_time(
     if not math.isfinite(result):
         raise VideoFileFormatError("video decoder reported a non-finite frame time")
     return exact_time, result
-
-
-def _seek_timestamp(start_time: Fraction, time_base: Fraction, stream_start: int) -> int:
-    timestamp = stream_start + start_time // time_base
-    if timestamp < _MIN_BIGINT or timestamp > _MAX_BIGINT:
-        raise ValueError("start_time is outside the supported video timestamp range")
-    return int(timestamp)
 
 
 def _decoded_frame_dimensions(frame: Any, options: _VideoFrameOptions) -> tuple[int, int]:
@@ -1219,39 +1211,6 @@ def _configure_video_decoder(video: Any) -> None:
         video = None
 
 
-def _video_reorder_depth(video: Any) -> int:
-    codec_context: Any = None
-    try:
-        codec_context = getattr(video, "codec_context", None)
-        if codec_context is None:
-            raise VideoFileFormatError("video stream does not have an available decoder")
-        try:
-            reorder_depth = operator.index(codec_context.reorder_depth)
-        except (AttributeError, TypeError, ValueError, OverflowError) as error:
-            raise VideoFileFormatError("video decoder reported an invalid reorder depth") from error
-        if reorder_depth < 0 or reorder_depth > _MAX_PYAV_BUFFER_SIZE:
-            raise VideoFileFormatError("video decoder reported an out-of-range reorder depth")
-        return reorder_depth
-    finally:
-        codec_context = None
-        video = None
-
-
-def _restore_video_reorder_depth(video: Any, reorder_depth: int) -> None:
-    codec_context: Any = None
-    try:
-        codec_context = getattr(video, "codec_context", None)
-        if codec_context is None:
-            raise VideoFileFormatError("video stream does not have an available decoder")
-        try:
-            codec_context.reorder_depth = reorder_depth
-        except (AttributeError, TypeError, ValueError, OverflowError) as error:
-            raise VideoFileFormatError("video decoder reorder depth could not be restored after seek") from error
-    finally:
-        codec_context = None
-        video = None
-
-
 def _advance_sample_target(current: Fraction, interval: Fraction, frame_time: Fraction) -> Fraction:
     skipped_intervals = (frame_time - current) // interval
     return current + (skipped_intervals + 1) * interval
@@ -1307,93 +1266,6 @@ def _check_video_io(reader: _VideoReaderProxy, nested_io: _NestedIOBlocker) -> N
     reader.check_interrupted()
     reader.raise_if_error()
     nested_io.raise_if_error()
-
-
-def _seek_video_stream(
-    container: Any,
-    video: Any,
-    seek_timestamp: int,
-    reader: _VideoReaderProxy,
-    nested_io: _NestedIOBlocker,
-) -> None:
-    """Seek at a checked native boundary and restore PyAV's reorder state."""
-
-    try:
-        reorder_depth = _video_reorder_depth(video)
-        _check_video_io(reader, nested_io)
-        try:
-            container.seek(seek_timestamp, backward=True, any_frame=False, stream=video)
-        except BaseException as error:
-            if not isinstance(error, Exception):
-                raise
-            _check_video_io(reader, nested_io)
-            raise
-        _check_video_io(reader, nested_io)
-        try:
-            _restore_video_reorder_depth(video, reorder_depth)
-        except BaseException as error:
-            if not isinstance(error, Exception):
-                raise
-            _check_video_io(reader, nested_io)
-            raise
-        _check_video_io(reader, nested_io)
-    finally:
-        # A retained seek traceback must not own the PyAV container, stream,
-        # or native codec context after the outer operation has closed them.
-        container = None
-        video = None
-
-
-def _seek_video_stream_for_time_window(
-    container: Any,
-    video: Any,
-    requested_timestamp: int,
-    stream_start: int,
-    reader: _VideoReaderProxy,
-    nested_io: _NestedIOBlocker,
-) -> None:
-    """Seek only when the selected random-access point can cover the window.
-
-    FFmpeg's seek index can be ordered by decode timestamps. For streams with
-    reordered frames, seeking to a presentation timestamp may therefore land on
-    a keyframe whose PTS is *after* the requested boundary. Probe the first
-    selected packet without decoding it and keep the optimized seek only when
-    that keyframe is early enough. Otherwise restart at the stream origin, which
-    is the correctness fallback when the container cannot prove safe preroll.
-    """
-
-    packet_and_flush: tuple[Any, bool] | None = None
-    packet: Any = None
-    try:
-        if requested_timestamp <= stream_start:
-            _seek_video_stream(container, video, stream_start, reader, nested_io)
-            return
-
-        _seek_video_stream(container, video, requested_timestamp, reader, nested_io)
-        packet_and_flush = _next_demuxed_packet(container, video, reader, nested_io)
-        seek_is_safe = False
-        if packet_and_flush is not None:
-            packet, is_flush = packet_and_flush
-            packet_and_flush = None
-            if not is_flush:
-                packet_pts = _optional_frame_integer(packet.pts, name="seek packet PTS")
-                try:
-                    is_keyframe = packet.is_keyframe
-                except AttributeError as error:
-                    raise VideoFileFormatError("video demuxer did not report seek packet keyframe state") from error
-                if not isinstance(is_keyframe, bool):
-                    raise VideoFileFormatError("video demuxer reported invalid seek packet keyframe state")
-                seek_is_safe = is_keyframe and packet_pts is not None and packet_pts <= requested_timestamp
-            packet = None
-
-        safe_timestamp = requested_timestamp if seek_is_safe else stream_start
-        _seek_video_stream(container, video, safe_timestamp, reader, nested_io)
-    finally:
-        # Probe failures must not retain native packet/container/codec owners.
-        packet = None
-        packet_and_flush = None
-        container = None
-        video = None
 
 
 def _decode_packet_frames(
@@ -1621,7 +1493,6 @@ def _prepare_video_packet_batch(
     reader: _VideoReaderProxy,
     nested_io: _NestedIOBlocker,
     *,
-    did_seek: bool,
     next_sample_time: Fraction | None,
 ) -> _PreparedFrameBatch:
     """Detach every selected image before exposing any result from a packet."""
@@ -1669,7 +1540,7 @@ def _prepare_video_packet_batch(
                 try:
                     _check_video_io(reader, nested_io)
                     result = VideoFrameData(
-                        frame_index=None if did_seek else info.frame_index,
+                        frame_index=info.frame_index,
                         frame_time=info.frame_time,
                         frame_time_base=info.time_base,
                         frame_pts=info.frame_pts,
@@ -1809,20 +1680,9 @@ def _iter_video_frames(
                     max_pixels=options.max_pixels,
                 )
                 video = _select_video_stream(container, av_module)
-                stream_start, stream_time_origin = _stream_time_origin(video, metadata.time_base)
+                stream_time_origin = _stream_time_origin(video, metadata.time_base)
                 _configure_video_decoder(video)
                 reformatter = av_module.video.reformatter.VideoReformatter()
-                did_seek = options.start_time > 0
-                if did_seek:
-                    seek_timestamp = _seek_timestamp(options.start_time, metadata.time_base, stream_start)
-                    _seek_video_stream_for_time_window(
-                        container,
-                        video,
-                        int(seek_timestamp),
-                        stream_start,
-                        reader,
-                        nested_io,
-                    )
 
                 next_sample_time = options.start_time if options.sample_interval_seconds is not None else None
                 decoded_batches = _iter_decoded_packet_batches(
@@ -1848,7 +1708,6 @@ def _iter_video_frames(
                             reformatter,
                             reader,
                             nested_io,
-                            did_seek=did_seek,
                             next_sample_time=next_sample_time,
                         )
                         del batch

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -1,43 +1,113 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Encoded VIDEOFILE metadata helpers."""
+"""Encoded VIDEOFILE metadata and streaming frame helpers."""
 
 from __future__ import annotations
 
 import importlib
 import io
 import math
+import operator
 from bisect import bisect_left, bisect_right
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import vane
 from vane._expressions import as_expression
+from vane._file import _positive_buffer_size
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage  # type: ignore[import-not-found]
+else:
+    PILImage = Any
 
 DEFAULT_VIDEO_METADATA_BYTES = 8 * 1024 * 1024
+DEFAULT_VIDEO_BUFFER_SIZE = 1024 * 1024
+DEFAULT_VIDEO_MAX_INPUT_BYTES = 8 * 1024 * 1024 * 1024
+DEFAULT_VIDEO_MAX_FRAMES = 1_000_000
+DEFAULT_VIDEO_MAX_PIXELS = 32 * 1024 * 1024
 MAX_VIDEO_METADATA_BYTES = 64 * 1024 * 1024
 _MAX_VIDEO_METADATA_FETCH_BYTES = 64 * 1024
 _VIDEO_METADATA_FETCHES_PER_BUDGET = 8
 _MAX_VIDEO_METADATA_FETCHES = 1024
 _VIDEO_METADATA_TIMEOUT_SECONDS = 5.0
-# Permit 8K UHD metadata while bounding decoder allocation before dimensions
-# become available to Vane's post-probe validation.
+# Permit 8K UHD metadata and visible decoded frames by default.
 _MAX_VIDEO_FRAME_PIXELS = 32 * 1024 * 1024
+# FFmpeg applies AVCodecContext.max_pixels to coded/aligned dimensions. Leave
+# bounded headroom above the public visible-frame ceiling so ordinary alignment
+# and cropping cannot make a valid visible frame fail the wrong contract.
+_MAX_VIDEO_CODED_FRAME_PIXELS = 64 * 1024 * 1024
 _MAX_VIDEO_AUDIO_SAMPLES = 1024 * 1024
 _MAX_VIDEO_STREAMS = 64
 _MAX_VIDEO_PROBE_PACKETS = 256
 _MAX_VIDEO_INDEX_BYTES = 256 * 1024
 _MAX_VIDEO_ANALYZE_DURATION_US = 5 * 1_000_000
 _MAX_VIDEO_FPS_PROBE_FRAMES = 32
+_MAX_PYAV_BUFFER_SIZE = (1 << 31) - 1
+_MIN_BIGINT = -(1 << 63)
 _MAX_BIGINT = (1 << 63) - 1
 _MAX_UINTEGER = (1 << 32) - 1
+_MAX_UBIGINT = (1 << 64) - 1
 
 _PYAV_UNSAFE_STREAM_OPTIONS_ERROR = (
     "stream_options were provided, but this format does not expose its streams before avformat_find_stream_info"
+)
+
+_PYAV_MEDIA_ERROR_NAMES = (
+    "DecoderNotFoundError",
+    "DemuxerNotFoundError",
+    "EOFError",
+    "InvalidDataError",
+)
+
+# PyAV 17.1 exposes a non-copying presence check only for a named packet side-
+# data kind. Keep this synchronized with its public ``PktSideDataT`` literals;
+# ``iter_sidedata()`` copies each payload merely to discover whether one exists.
+_PYAV_PACKET_SIDE_DATA_TYPES = (
+    "palette",
+    "new_extradata",
+    "param_change",
+    "h263_mb_info",
+    "replay_gain",
+    "display_matrix",
+    "stereo_3d",
+    "audio_service_type",
+    "quality_stats",
+    "fallback_track",
+    "cpb_properties",
+    "skip_samples",
+    "jp_dual_mono",
+    "strings_metadata",
+    "subtitle_position",
+    "matroska_block_additional",
+    "webvtt_identifier",
+    "webvtt_settings",
+    "metadata_update",
+    "mpegts_stream_id",
+    "mastering_display_metadata",
+    "spherical",
+    "content_light_level",
+    "a53_cc",
+    "encryption_init_info",
+    "encryption_info",
+    "afd",
+    "prft",
+    "icc_profile",
+    "dovi_conf",
+    "s12m_timecode",
+    "dynamic_hdr10_plus",
+    "iamf_mix_gain_param",
+    "iamf_info_param",
+    "iamf_recon_gain_info_param",
+    "ambient_viewing_environment",
+    "frame_cropping",
+    "lcevc",
+    "3d_reference_displays",
+    "rtcp_sr",
 )
 
 _MIME_ALIASES = {
@@ -78,6 +148,27 @@ class VideoMetadata:
     time_base: Fraction
 
 
+@dataclass(frozen=True, slots=True)
+class VideoFrameData:
+    """One detached RGB frame and its decoder-reported temporal provenance.
+
+    ``frame_time`` is elapsed presentation time from the stream's declared
+    timestamp origin. ``frame_time_base`` is the exact unit for the raw PTS,
+    DTS, and duration fields. The zero-based ``frame_index`` is present only
+    when decoding starts at the beginning; after keyframe seek it remains
+    ``None`` rather than being estimated from an average frame rate.
+    """
+
+    frame_index: int | None
+    frame_time: float | None
+    frame_time_base: Fraction | None
+    frame_pts: int | None
+    frame_dts: int | None
+    frame_duration: int | None
+    is_key_frame: bool
+    data: PILImage
+
+
 class VideoFileError(RuntimeError):
     """Base class for failures caused by encoded video content."""
 
@@ -90,19 +181,109 @@ class VideoFileLimitError(VideoFileError):
     """A VideoFile operation exceeded an explicit resource limit."""
 
 
+@dataclass(frozen=True, slots=True)
+class _VideoFrameOptions:
+    start_time: Fraction
+    end_time: Fraction | None
+    width: int | None
+    height: int | None
+    is_key_frame: bool | None
+    sample_interval_seconds: Fraction | None
+    buffer_size: int
+    max_input_bytes: int
+    max_frames: int
+    max_pixels: int
+
+
+@dataclass(frozen=True, slots=True)
+class _DecodedFrameInfo:
+    width: int
+    height: int
+    frame_index: int
+    frame_pts: int | None
+    frame_dts: int | None
+    frame_duration: int | None
+    time_base: Fraction | None
+    exact_time: Fraction | None
+    frame_time: float | None
+    is_key_frame: bool
+
+
+@dataclass(slots=True)
+class _DecodedPacketBatch:
+    frames: list[Any | None]
+    infos: tuple[_DecodedFrameInfo, ...]
+
+    def take_frame(self, index: int) -> Any:
+        frame = self.frames[index]
+        if frame is None:
+            raise RuntimeError("decoded video frame was already released")
+        self.frames[index] = None
+        return frame
+
+    def release(self) -> None:
+        self.frames.clear()
+
+
+@dataclass(slots=True)
+class _PreparedFrameBatch:
+    results: list[VideoFrameData | None]
+    next_sample_time: Fraction | None
+    reached_end: bool
+
+    def take_result(self, index: int) -> VideoFrameData:
+        result = self.results[index]
+        if result is None:
+            raise RuntimeError("prepared video frame was already released")
+        self.results[index] = None
+        return result
+
+    def release(self) -> None:
+        for result in self.results:
+            if result is not None:
+                _close_image(result.data)
+        self.results.clear()
+
+
 @contextmanager
 def _close_container(container: Any) -> Iterator[Any]:
     """Close a PyAV container without replacing its operation's exception."""
     try:
-        yield container
-    except BaseException:
         try:
-            container.close()
+            yield container
         except BaseException:
-            pass
-        raise
-    else:
-        container.close()
+            try:
+                container.close()
+            except BaseException:
+                pass
+            raise
+        else:
+            container.close()
+    finally:
+        # A retained exception traceback must not keep the container's stream
+        # objects and their native codec contexts alive.
+        container = None
+
+
+@contextmanager
+def _close_video_reader(reader: vane.VaneFileReader | None) -> Iterator[vane.VaneFileReader]:
+    """Check the retained open generation only after a successful video run."""
+
+    if reader is None:
+        raise TypeError("video reader must not be None")
+    try:
+        try:
+            yield reader
+        except BaseException:
+            try:
+                reader.close()
+            except BaseException:
+                pass
+            raise
+        else:
+            reader._close_and_check_interrupted()
+    finally:
+        reader = None
 
 
 class _VideoMetadataView:
@@ -275,12 +456,122 @@ class _NestedIOBlocker:
         # Do not echo a nested URL because manifests can contain signed query
         # parameters or embedded credentials.
         del url, flags, options
-        self.error = VideoFileFormatError("video metadata does not permit nested external resources")
+        self.error = VideoFileFormatError("VideoFile does not permit nested external resources")
         raise self.error
 
     def raise_if_error(self) -> None:
         if self.error is not None:
             raise self.error.with_traceback(self.error.__traceback__)
+
+
+class _VideoReaderProxy:
+    """Keep FILE resolver failures distinct from FFmpeg media failures."""
+
+    def __init__(self, reader: vane.VaneFileReader) -> None:
+        self._reader = reader
+        self._error: BaseException | None = None
+
+    def _remember(self, error: BaseException) -> None:
+        if self._error is None:
+            self._error = error
+
+    def read(self, size: int = -1, /) -> bytes:
+        if self._error is not None:
+            return b""
+        try:
+            self._reader._check_interrupted()
+            result = self._reader._read_and_check_interrupted(size)
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            return b""
+        return result
+
+    def check_interrupted(self) -> None:
+        control_flow_error = self._error if self._error is not None and not isinstance(self._error, Exception) else None
+        try:
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            if control_flow_error is not None:
+                # Once a callback has captured caller control flow (for example
+                # KeyboardInterrupt or SystemExit), a later query interrupt must
+                # not replace it at another checked FFmpeg boundary.
+                raise control_flow_error.with_traceback(control_flow_error.__traceback__)
+            raise
+        if control_flow_error is not None:
+            raise control_flow_error.with_traceback(control_flow_error.__traceback__)
+
+    def readinto(self, buffer: Any, /) -> int:
+        if self._error is not None:
+            return 0
+        try:
+            self._reader._check_interrupted()
+            result = self._reader._readinto_and_check_interrupted(buffer)
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            return 0
+        return result
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET, /) -> int:
+        if self._error is not None:
+            return -1
+        try:
+            self._reader._check_interrupted()
+            result = self._reader.seek(offset, whence)
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            return -1
+        return result
+
+    def tell(self) -> int:
+        if self._error is not None:
+            return -1
+        try:
+            self._reader._check_interrupted()
+            result = self._reader.tell()
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            return -1
+        return result
+
+    def readable(self) -> bool:
+        if self._error is not None:
+            return False
+        try:
+            self._reader._check_interrupted()
+            result = self._reader.readable()
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            return False
+        return result
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        if self._error is not None:
+            return False
+        try:
+            self._reader._check_interrupted()
+            result = self._reader.seekable()
+            self._reader._check_interrupted()
+        except BaseException as error:
+            self._remember(error)
+            return False
+        return result
+
+    @property
+    def closed(self) -> bool:
+        return self._reader.closed
+
+    def raise_if_error(self) -> None:
+        if self._error is not None:
+            raise self._error.with_traceback(self._error.__traceback__)
 
 
 def _load_av() -> Any:
@@ -291,12 +582,24 @@ def _load_av() -> Any:
         av_module.error.FFmpegError
         av_module.stream.Disposition.attached_pic
         av_module.time_base
+        av_module.video.reformatter.VideoReformatter
     except (AttributeError, ImportError, OSError) as error:
         raise ImportError(
-            "VideoFile metadata requires the 'av' package and its bundled FFmpeg libraries. "
+            "VideoFile operations require the 'av' package and its bundled FFmpeg libraries. "
             "Please `pip install 'vane-ai[video]'`."
         ) from error
     return av_module
+
+
+def _load_pillow() -> Any:
+    try:
+        image_module = importlib.import_module("PIL.Image")
+        image_module.Image
+    except (AttributeError, ImportError, OSError) as error:
+        raise ImportError(
+            "VideoFile frame decoding requires the 'Pillow' package. Please `pip install 'vane-ai[video]'`."
+        ) from error
+    return image_module
 
 
 def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> int:
@@ -307,6 +610,100 @@ def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> 
     if maximum is not None and value > maximum:
         raise ValueError(f"{name} must be at most {maximum}")
     return value
+
+
+def _nonnegative_time(value: object, *, name: str, optional: bool = False) -> Fraction | None:
+    if value is None:
+        if optional:
+            return None
+        raise TypeError(f"{name} must be int or float, not 'NoneType'")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        expected = "int, float, or None" if optional else "int or float"
+        raise TypeError(f"{name} must be {expected}, not {type(value).__name__!r}")
+    if isinstance(value, int):
+        result = Fraction(value)
+    else:
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+        result = Fraction(str(value))
+    if result < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _optional_keyframe_filter(value: object) -> bool | None:
+    if value is None or isinstance(value, bool):
+        return value
+    raise TypeError(f"is_key_frame must be bool or None, not {type(value).__name__!r}")
+
+
+def _optional_dimensions(width: object, height: object, *, max_pixels: int) -> tuple[int | None, int | None]:
+    if (width is None) != (height is None):
+        raise ValueError("width and height must be provided together")
+    if width is None:
+        return None, None
+    normalized_width = _positive_limit(width, name="width", maximum=_MAX_UINTEGER)
+    normalized_height = _positive_limit(height, name="height", maximum=_MAX_UINTEGER)
+    output_pixels = normalized_width * normalized_height
+    if output_pixels > max_pixels:
+        raise VideoFileLimitError(
+            f"requested video frames contain {output_pixels} pixels, exceeding max_pixels={max_pixels}"
+        )
+    return normalized_width, normalized_height
+
+
+def _normalize_frame_options(
+    *,
+    start_time: object,
+    end_time: object,
+    width: object,
+    height: object,
+    is_key_frame: object,
+    sample_interval_seconds: object,
+    buffer_size: object,
+    max_input_bytes: object,
+    max_frames: object,
+    max_pixels: object,
+) -> _VideoFrameOptions:
+    normalized_start = _nonnegative_time(start_time, name="start_time")
+    assert normalized_start is not None
+    normalized_end = _nonnegative_time(end_time, name="end_time", optional=True)
+    if normalized_end is not None and normalized_end < normalized_start:
+        raise ValueError("end_time must be greater than or equal to start_time")
+    normalized_interval = _nonnegative_time(
+        sample_interval_seconds,
+        name="sample_interval_seconds",
+        optional=True,
+    )
+    if normalized_interval == 0:
+        raise ValueError("sample_interval_seconds must be greater than zero")
+    normalized_buffer = _positive_buffer_size(buffer_size, none_default=None, name="buffer_size")
+    if normalized_buffer > _MAX_PYAV_BUFFER_SIZE:
+        raise OverflowError("buffer_size must fit in the C int accepted by PyAV")
+    normalized_max_input = _positive_limit(max_input_bytes, name="max_input_bytes", maximum=_MAX_UBIGINT)
+    normalized_max_frames = _positive_limit(max_frames, name="max_frames", maximum=_MAX_BIGINT)
+    normalized_max_pixels = _positive_limit(
+        max_pixels,
+        name="max_pixels",
+        maximum=_MAX_VIDEO_FRAME_PIXELS,
+    )
+    normalized_width, normalized_height = _optional_dimensions(
+        width,
+        height,
+        max_pixels=normalized_max_pixels,
+    )
+    return _VideoFrameOptions(
+        start_time=normalized_start,
+        end_time=normalized_end,
+        width=normalized_width,
+        height=normalized_height,
+        is_key_frame=_optional_keyframe_filter(is_key_frame),
+        sample_interval_seconds=normalized_interval,
+        buffer_size=normalized_buffer,
+        max_input_bytes=normalized_max_input,
+        max_frames=normalized_max_frames,
+        max_pixels=normalized_max_pixels,
+    )
 
 
 def _limit_expression(value: int | vane.Expression, *, name: str, maximum: int) -> vane.Expression:
@@ -321,14 +718,17 @@ def _canonical_mime_type(value: str) -> str:
 
 
 def _container_format_names(container: Any) -> frozenset[str]:
-    container_format = container.format
-    format_name = None if container_format is None else container_format.name
-    if not isinstance(format_name, str) or not format_name:
-        raise VideoFileFormatError("video parser did not report a container format")
-    names = frozenset(part.strip().lower() for part in format_name.split(",") if part.strip())
-    if not names:
-        raise VideoFileFormatError("video parser reported an invalid container format")
-    return names
+    try:
+        container_format = container.format
+        format_name = None if container_format is None else container_format.name
+        if not isinstance(format_name, str) or not format_name:
+            raise VideoFileFormatError("video parser did not report a container format")
+        names = frozenset(part.strip().lower() for part in format_name.split(",") if part.strip())
+        if not names:
+            raise VideoFileFormatError("video parser reported an invalid container format")
+        return names
+    finally:
+        container = None
 
 
 def _validate_content_type(content_type: str | None, format_names: frozenset[str]) -> None:
@@ -363,98 +763,137 @@ def _positive_fraction(value: Any, *, name: str) -> Fraction:
 
 
 def _optional_rate(video: Any) -> float | None:
-    for attribute in ("average_rate", "guessed_rate"):
-        rate = getattr(video, attribute)
-        if rate is None:
-            continue
-        try:
-            exact_rate = Fraction(rate)
-        except (TypeError, ValueError, ZeroDivisionError) as error:
-            raise VideoFileFormatError("video parser reported an invalid frame rate") from error
-        # FFmpeg uses a zero rational when this rate is unavailable. Let the
-        # guessed rate fill an unavailable average rate, then preserve NULL if
-        # neither source provides a positive value.
-        if exact_rate == 0:
-            continue
-        if exact_rate < 0 or exact_rate.numerator > _MAX_BIGINT or exact_rate.denominator > _MAX_BIGINT:
-            raise VideoFileFormatError("video parser reported an out-of-range frame rate")
-        result = float(exact_rate)
-        if not math.isfinite(result):
-            raise VideoFileFormatError("video parser reported a non-finite frame rate")
-        return result
-    return None
+    try:
+        for attribute in ("average_rate", "guessed_rate"):
+            rate = getattr(video, attribute)
+            if rate is None:
+                continue
+            try:
+                exact_rate = Fraction(rate)
+            except (TypeError, ValueError, ZeroDivisionError) as error:
+                raise VideoFileFormatError("video parser reported an invalid frame rate") from error
+            # FFmpeg uses a zero rational when this rate is unavailable. Let the
+            # guessed rate fill an unavailable average rate, then preserve NULL if
+            # neither source provides a positive value.
+            if exact_rate == 0:
+                continue
+            if exact_rate < 0 or exact_rate.numerator > _MAX_BIGINT or exact_rate.denominator > _MAX_BIGINT:
+                raise VideoFileFormatError("video parser reported an out-of-range frame rate")
+            result = float(exact_rate)
+            if not math.isfinite(result):
+                raise VideoFileFormatError("video parser reported a non-finite frame rate")
+            return result
+        return None
+    finally:
+        video = None
 
 
 def _optional_duration(container: Any, video: Any, time_base: Fraction, av_module: Any) -> float | None:
-    stream_duration = video.duration
-    if stream_duration is not None:
-        stream_duration = int(stream_duration)
-        if stream_duration < 0:
-            raise VideoFileFormatError("video parser reported a negative stream duration")
-        if stream_duration > 0:
-            exact_duration = stream_duration * time_base
-            result = float(exact_duration)
-            if not math.isfinite(result):
-                raise VideoFileFormatError("video parser reported a non-finite duration")
-            return result
+    try:
+        stream_duration = video.duration
+        if stream_duration is not None:
+            stream_duration = int(stream_duration)
+            if stream_duration < 0:
+                raise VideoFileFormatError("video parser reported a negative stream duration")
+            if stream_duration > 0:
+                exact_duration = stream_duration * time_base
+                result = float(exact_duration)
+                if not math.isfinite(result):
+                    raise VideoFileFormatError("video parser reported a non-finite duration")
+                return result
 
-    if container.duration is not None:
-        container_duration = int(container.duration)
-        if container_duration < 0:
-            raise VideoFileFormatError("video parser reported a negative container duration")
-        if container_duration > 0:
-            exact_duration = Fraction(container_duration, int(av_module.time_base))
-            result = float(exact_duration)
-            if not math.isfinite(result):
-                raise VideoFileFormatError("video parser reported a non-finite duration")
-            return result
+        if container.duration is not None:
+            container_duration = int(container.duration)
+            if container_duration < 0:
+                raise VideoFileFormatError("video parser reported a negative container duration")
+            if container_duration > 0:
+                exact_duration = Fraction(container_duration, int(av_module.time_base))
+                result = float(exact_duration)
+                if not math.isfinite(result):
+                    raise VideoFileFormatError("video parser reported a non-finite duration")
+                return result
 
-    # Zero is also FFmpeg's unknown-duration sentinel. Returning NULL avoids
-    # claiming that an unindexed stream is an exact zero-length video.
-    return None
+        # Zero is also FFmpeg's unknown-duration sentinel. Returning NULL avoids
+        # claiming that an unindexed stream is an exact zero-length video.
+        return None
+    finally:
+        container = None
+        video = None
 
 
 def _optional_frame_count(video: Any) -> int | None:
-    if video.frames is None:
-        return None
-    frame_count = int(video.frames)
-    if frame_count < 0 or frame_count > _MAX_BIGINT:
-        raise VideoFileFormatError("video parser reported an out-of-range frame count")
-    # FFmpeg uses zero when the container does not carry an exact frame count.
-    return frame_count or None
+    try:
+        if video.frames is None:
+            return None
+        frame_count = int(video.frames)
+        if frame_count < 0 or frame_count > _MAX_BIGINT:
+            raise VideoFileFormatError("video parser reported an out-of-range frame count")
+        # FFmpeg uses zero when the container does not carry an exact frame count.
+        return frame_count or None
+    finally:
+        video = None
 
 
-def _metadata_from_container(container: Any, content_type: str | None, av_module: Any) -> VideoMetadata:
-    attached_pic = av_module.stream.Disposition.attached_pic
-    video = next(
-        (stream for stream in container.streams if stream.type == "video" and not (stream.disposition & attached_pic)),
-        None,
-    )
-    if video is None:
-        raise VideoFileFormatError("logical FILE view does not contain a video stream")
-
-    format_names = _container_format_names(container)
-    _validate_content_type(content_type, format_names)
-    if getattr(video, "codec_context", None) is None:
-        raise VideoFileFormatError("video stream does not have an available decoder")
-
-    width = int(video.width)
-    height = int(video.height)
-    if width <= 0 or width > _MAX_UINTEGER or height <= 0 or height > _MAX_UINTEGER:
-        raise VideoFileFormatError(f"video dimensions must fit positive UINTEGER values, found {width}x{height}")
-    if width * height > _MAX_VIDEO_FRAME_PIXELS:
-        raise VideoFileLimitError(
-            f"video dimensions {width}x{height} exceed the metadata pixel limit of {_MAX_VIDEO_FRAME_PIXELS}"
+def _select_video_stream(container: Any, av_module: Any) -> Any:
+    video: Any = None
+    try:
+        attached_pic = av_module.stream.Disposition.attached_pic
+        video = next(
+            (
+                stream
+                for stream in container.streams
+                if stream.type == "video" and not (stream.disposition & attached_pic)
+            ),
+            None,
         )
-    time_base = _positive_fraction(video.time_base, name="time base")
-    return VideoMetadata(
-        width=width,
-        height=height,
-        fps=_optional_rate(video),
-        duration=_optional_duration(container, video, time_base, av_module),
-        frame_count=_optional_frame_count(video),
-        time_base=time_base,
-    )
+        if video is None:
+            raise VideoFileFormatError("logical FILE view does not contain a video stream")
+        return video
+    finally:
+        container = None
+        video = None
+
+
+def _metadata_from_container(
+    container: Any,
+    content_type: str | None,
+    av_module: Any,
+    *,
+    max_pixels: int = _MAX_VIDEO_FRAME_PIXELS,
+) -> VideoMetadata:
+    video: Any = None
+    try:
+        video = _select_video_stream(container, av_module)
+
+        format_names = _container_format_names(container)
+        _validate_content_type(content_type, format_names)
+        if getattr(video, "codec_context", None) is None:
+            raise VideoFileFormatError("video stream does not have an available decoder")
+
+        width = int(video.width)
+        height = int(video.height)
+        if width <= 0 or height <= 0:
+            raise VideoFileFormatError(f"video dimensions must be positive, found {width}x{height}")
+        if width > _MAX_UINTEGER or height > _MAX_UINTEGER:
+            raise VideoFileFormatError(f"video dimensions must fit positive UINTEGER values, found {width}x{height}")
+        if width * height > max_pixels:
+            if max_pixels == _MAX_VIDEO_FRAME_PIXELS:
+                limit_description = f"the metadata pixel limit of {max_pixels}"
+            else:
+                limit_description = f"max_pixels={max_pixels}"
+            raise VideoFileLimitError(f"video dimensions {width}x{height} exceed {limit_description}")
+        time_base = _positive_fraction(video.time_base, name="time base")
+        return VideoMetadata(
+            width=width,
+            height=height,
+            fps=_optional_rate(video),
+            duration=_optional_duration(container, video, time_base, av_module),
+            frame_count=_optional_frame_count(video),
+            time_base=time_base,
+        )
+    finally:
+        video = None
+        container = None
 
 
 def _probe_video_metadata(
@@ -468,7 +907,7 @@ def _probe_video_metadata(
     stream = _VideoMetadataView(read_at, logical_size=logical_size, max_bytes=max_bytes)
     nested_io = _NestedIOBlocker()
     decoder_options = {
-        "max_pixels": str(_MAX_VIDEO_FRAME_PIXELS),
+        "max_pixels": str(_MAX_VIDEO_CODED_FRAME_PIXELS),
         "max_samples": str(_MAX_VIDEO_AUDIO_SAMPLES),
         "skip_frame": "all",
         "threads": "1",
@@ -516,19 +955,21 @@ def _probe_video_metadata(
             raise VideoFileLimitError(
                 f"a video metadata probe phase exceeded its {_VIDEO_METADATA_TIMEOUT_SECONDS:g}-second timeout"
             ) from error
+        if isinstance(error, (MemoryError, OSError)):
+            raise
         if isinstance(error, ValueError) and str(error).startswith(_PYAV_UNSAFE_STREAM_OPTIONS_ERROR):
             raise VideoFileFormatError(
                 "video container cannot be inspected safely within metadata resource limits"
             ) from error
-        if not isinstance(error, av_module.error.FFmpegError):
-            raise
-        if stream.budget_exhausted:
-            raise VideoFileLimitError(f"video metadata requires more than max_bytes={max_bytes}") from error
-        if stream.fetch_limit_exhausted:
-            raise VideoFileLimitError(
-                f"video metadata requires more than {_MAX_VIDEO_METADATA_FETCHES} source ranges"
-            ) from error
-        raise VideoFileFormatError("logical FILE view is not a supported encoded video") from error
+        if _is_pyav_media_or_codec_error(error, av_module):
+            if stream.budget_exhausted:
+                raise VideoFileLimitError(f"video metadata requires more than max_bytes={max_bytes}") from error
+            if stream.fetch_limit_exhausted:
+                raise VideoFileLimitError(
+                    f"video metadata requires more than {_MAX_VIDEO_METADATA_FETCHES} source ranges"
+                ) from error
+            raise VideoFileFormatError("logical FILE view is not a supported encoded video") from error
+        raise
     if stream.budget_exhausted:
         raise VideoFileLimitError(f"video metadata requires more than max_bytes={max_bytes}")
     if stream.fetch_limit_exhausted:
@@ -542,6 +983,953 @@ def _probe_video_metadata(
         metadata.time_base.numerator,
         metadata.time_base.denominator,
     )
+
+
+def _optional_frame_integer(value: Any, *, name: str, nonnegative: bool = False) -> int | None:
+    if value is None:
+        return None
+    try:
+        result = operator.index(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise VideoFileFormatError(f"video decoder reported an invalid {name}") from error
+    if result < _MIN_BIGINT or result > _MAX_BIGINT or (nonnegative and result < 0):
+        raise VideoFileFormatError(f"video decoder reported an out-of-range {name}")
+    return result
+
+
+def _frame_time_base(frame: Any, video: Any) -> Fraction | None:
+    try:
+        value = frame.time_base if frame.time_base is not None else video.time_base
+        if value is None:
+            return None
+        return _positive_fraction(value, name="frame time base")
+    finally:
+        frame = None
+        video = None
+
+
+def _stream_time_origin(video: Any, time_base: Fraction) -> tuple[int, Fraction]:
+    try:
+        stream_start = _optional_frame_integer(getattr(video, "start_time", None), name="stream start time")
+        if stream_start is None:
+            return 0, Fraction(0)
+        return stream_start, stream_start * time_base
+    finally:
+        video = None
+
+
+def _frame_time(
+    frame_pts: int | None,
+    time_base: Fraction | None,
+    stream_time_origin: Fraction,
+) -> tuple[Fraction | None, float | None]:
+    if frame_pts is None or time_base is None:
+        return None, None
+    exact_time = frame_pts * time_base - stream_time_origin
+    result = float(exact_time)
+    if not math.isfinite(result):
+        raise VideoFileFormatError("video decoder reported a non-finite frame time")
+    return exact_time, result
+
+
+def _seek_timestamp(start_time: Fraction, time_base: Fraction, stream_start: int) -> int:
+    timestamp = stream_start + start_time // time_base
+    if timestamp < _MIN_BIGINT or timestamp > _MAX_BIGINT:
+        raise ValueError("start_time is outside the supported video timestamp range")
+    return int(timestamp)
+
+
+def _decoded_frame_dimensions(frame: Any, options: _VideoFrameOptions) -> tuple[int, int]:
+    try:
+        try:
+            width = int(frame.width)
+            height = int(frame.height)
+        except (AttributeError, TypeError, ValueError, OverflowError) as error:
+            raise VideoFileFormatError("video decoder reported invalid frame dimensions") from error
+        if width <= 0 or height <= 0:
+            raise VideoFileFormatError(f"video frame dimensions must be positive, found {width}x{height}")
+        pixels = width * height
+        if pixels > options.max_pixels:
+            raise VideoFileLimitError(
+                f"decoded video frame contains {pixels} pixels, exceeding max_pixels={options.max_pixels}"
+            )
+        return width, height
+    finally:
+        frame = None
+
+
+def _close_image(image: Any) -> None:
+    try:
+        image.close()
+    except BaseException:
+        pass
+
+
+@contextmanager
+def _neutralized_color_conversion_metadata(frame: Any) -> Iterator[None]:
+    """Apply PyAV 18's safe default behavior while Python 3.10 uses PyAV 17."""
+    saved: list[tuple[str, Any]] = []
+    body_failed = True
+    try:
+        for attribute in ("color_trc", "color_primaries"):
+            try:
+                value = getattr(frame, attribute)
+            except AttributeError:
+                continue
+            saved.append((attribute, value))
+            try:
+                setattr(frame, attribute, 2)  # FFmpeg's UNSPECIFIED value for both fields.
+            except (TypeError, ValueError, OverflowError) as error:
+                raise VideoFileFormatError("video decoder reported invalid color metadata") from error
+        yield
+        body_failed = False
+    finally:
+        restore_error: BaseException | None = None
+        restore_system_error: BaseException | None = None
+        restore_control_flow: BaseException | None = None
+        for attribute, value in reversed(saved):
+            try:
+                setattr(frame, attribute, value)
+            except BaseException as error:
+                if restore_error is None:
+                    restore_error = error
+                if not isinstance(error, Exception):
+                    if restore_control_flow is None:
+                        restore_control_flow = error
+                elif not isinstance(error, (TypeError, ValueError, OverflowError)):
+                    if restore_system_error is None:
+                        restore_system_error = error
+        saved.clear()
+        frame = None
+        if not body_failed:
+            if restore_control_flow is not None:
+                raise restore_control_flow
+            if restore_system_error is not None:
+                raise restore_system_error
+            if restore_error is not None:
+                raise VideoFileFormatError("video decoder color metadata could not be restored") from restore_error
+
+
+def _is_pyav_media_or_codec_error(error: BaseException, av_module: Any) -> bool:
+    """Return whether PyAV explicitly classified a content/decoder failure."""
+
+    # Keep this allowlist deliberately narrow. In particular, PyAV's fallback,
+    # unknown, argument, buffer, range, callback, and internal errors must not
+    # become suppressible media failures merely because they inherit
+    # ``FFmpegError``.
+    for name in _PYAV_MEDIA_ERROR_NAMES:
+        error_type = getattr(av_module.error, name, None)
+        if isinstance(error_type, type) and isinstance(error, error_type):
+            return True
+    return False
+
+
+def _frame_to_image(
+    frame: Any,
+    info: _DecodedFrameInfo,
+    options: _VideoFrameOptions,
+    av_module: Any,
+    image_module: Any,
+    reformatter: Any,
+    check_interrupted: Callable[[], None],
+) -> PILImage:
+    output_frame: Any = None
+    image: Any = None
+    try:
+        output_width = options.width if options.width is not None else info.width
+        output_height = options.height if options.height is not None else info.height
+        try:
+            # PyAV 18 neutralizes transfer/primary tags unless conversion was
+            # explicitly requested. Mirror that upstream fix for Python 3.10, where
+            # PyAV 17 remains the latest supported release, and restore the source
+            # frame metadata before returning.
+            check_interrupted()
+            with _neutralized_color_conversion_metadata(frame):
+                output_frame = reformatter.reformat(
+                    frame,
+                    width=output_width,
+                    height=output_height,
+                    format="rgb24",
+                    threads=1,
+                )
+            check_interrupted()
+        except av_module.error.FFmpegError as error:
+            check_interrupted()
+            if _is_pyav_media_or_codec_error(error, av_module):
+                raise VideoFileFormatError("video frame could not be converted to RGB pixels") from error
+            raise
+        try:
+            check_interrupted()
+            image = output_frame.to_image()
+            check_interrupted()
+        except av_module.error.FFmpegError as error:
+            check_interrupted()
+            if _is_pyav_media_or_codec_error(error, av_module):
+                raise VideoFileFormatError("video frame could not be converted to RGB pixels") from error
+            raise
+        check_interrupted()
+        image.load()
+        check_interrupted()
+        if (
+            not isinstance(image, image_module.Image)
+            or image.mode != "RGB"
+            or image.size != (output_width, output_height)
+        ):
+            raise RuntimeError("PyAV returned an invalid RGB Pillow frame")
+        result = image
+        image = None
+        return result
+    finally:
+        if image is not None:
+            _close_image(image)
+            image = None
+        # Propagated exception tracebacks must not keep native decoder frames
+        # or an undelivered Pillow image alive after cleanup.
+        output_frame = None
+        frame = None
+        del reformatter
+        del check_interrupted
+
+
+def _configure_video_decoder(video: Any) -> None:
+    codec_context: Any = None
+    try:
+        codec_context = getattr(video, "codec_context", None)
+        if codec_context is None:
+            raise VideoFileFormatError("video stream does not have an available decoder")
+        if codec_context.is_open:
+            raise VideoFileLimitError("video decoder opened before resource limits could be applied")
+
+        decoder_options = dict(codec_context.options or {})
+        decoder_options.pop("skip_frame", None)
+        decoder_options.update(
+            {
+                # ``AVCodecContext.max_pixels`` applies to coded/aligned buffer
+                # dimensions rather than the visible frame. Keep this internal
+                # safety ceiling separate from the public visible-pixel limit,
+                # which Vane enforces from metadata and every decoded frame.
+                "max_pixels": str(_MAX_VIDEO_CODED_FRAME_PIXELS),
+                "threads": "1",
+            }
+        )
+        codec_context.options = decoder_options
+        codec_context.thread_count = 1
+    finally:
+        codec_context = None
+        video = None
+
+
+def _video_reorder_depth(video: Any) -> int:
+    codec_context: Any = None
+    try:
+        codec_context = getattr(video, "codec_context", None)
+        if codec_context is None:
+            raise VideoFileFormatError("video stream does not have an available decoder")
+        try:
+            reorder_depth = operator.index(codec_context.reorder_depth)
+        except (AttributeError, TypeError, ValueError, OverflowError) as error:
+            raise VideoFileFormatError("video decoder reported an invalid reorder depth") from error
+        if reorder_depth < 0 or reorder_depth > _MAX_PYAV_BUFFER_SIZE:
+            raise VideoFileFormatError("video decoder reported an out-of-range reorder depth")
+        return reorder_depth
+    finally:
+        codec_context = None
+        video = None
+
+
+def _restore_video_reorder_depth(video: Any, reorder_depth: int) -> None:
+    codec_context: Any = None
+    try:
+        codec_context = getattr(video, "codec_context", None)
+        if codec_context is None:
+            raise VideoFileFormatError("video stream does not have an available decoder")
+        try:
+            codec_context.reorder_depth = reorder_depth
+        except (AttributeError, TypeError, ValueError, OverflowError) as error:
+            raise VideoFileFormatError("video decoder reorder depth could not be restored after seek") from error
+    finally:
+        codec_context = None
+        video = None
+
+
+def _advance_sample_target(current: Fraction, interval: Fraction, frame_time: Fraction) -> Fraction:
+    skipped_intervals = (frame_time - current) // interval
+    return current + (skipped_intervals + 1) * interval
+
+
+def _require_frame_time_for_selection(info: _DecodedFrameInfo, options: _VideoFrameOptions) -> None:
+    requires_time = (
+        options.start_time > 0 or options.end_time is not None or options.sample_interval_seconds is not None
+    )
+    if requires_time and info.exact_time is None:
+        raise VideoFileFormatError("video time selection requires a presentation timestamp for every decoded frame")
+
+
+def _decoded_frame_info(
+    frame: Any,
+    video: Any,
+    options: _VideoFrameOptions,
+    *,
+    frame_index: int,
+    stream_time_origin: Fraction,
+) -> _DecodedFrameInfo:
+    try:
+        width, height = _decoded_frame_dimensions(frame, options)
+        frame_pts = _optional_frame_integer(frame.pts, name="frame PTS")
+        frame_dts = _optional_frame_integer(frame.dts, name="frame DTS")
+        frame_duration = _optional_frame_integer(
+            frame.duration,
+            name="frame duration",
+            nonnegative=True,
+        )
+        time_base = _frame_time_base(frame, video)
+        exact_time, frame_time = _frame_time(frame_pts, time_base, stream_time_origin)
+        return _DecodedFrameInfo(
+            width=width,
+            height=height,
+            frame_index=frame_index,
+            frame_pts=frame_pts,
+            frame_dts=frame_dts,
+            frame_duration=frame_duration,
+            time_base=time_base,
+            exact_time=exact_time,
+            frame_time=frame_time,
+            is_key_frame=bool(frame.key_frame),
+        )
+    finally:
+        frame = None
+        video = None
+
+
+def _check_video_io(reader: _VideoReaderProxy, nested_io: _NestedIOBlocker) -> None:
+    """Give query cancellation precedence over stored I/O and media errors."""
+
+    reader.check_interrupted()
+    reader.raise_if_error()
+    nested_io.raise_if_error()
+
+
+def _seek_video_stream(
+    container: Any,
+    video: Any,
+    seek_timestamp: int,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+) -> None:
+    """Seek at a checked native boundary and restore PyAV's reorder state."""
+
+    try:
+        reorder_depth = _video_reorder_depth(video)
+        _check_video_io(reader, nested_io)
+        try:
+            container.seek(seek_timestamp, backward=True, any_frame=False, stream=video)
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            _check_video_io(reader, nested_io)
+            raise
+        _check_video_io(reader, nested_io)
+        try:
+            _restore_video_reorder_depth(video, reorder_depth)
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            _check_video_io(reader, nested_io)
+            raise
+        _check_video_io(reader, nested_io)
+    finally:
+        # A retained seek traceback must not own the PyAV container, stream,
+        # or native codec context after the outer operation has closed them.
+        container = None
+        video = None
+
+
+def _decode_packet_frames(
+    packet: Any,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+) -> list[Any]:
+    """Decode one atomic PyAV packet with checks on every return path."""
+    frames: list[Any] | None = None
+    try:
+        _check_video_io(reader, nested_io)
+        try:
+            decoded = packet.decode()
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            # An interrupt that raced with a dependency failure takes
+            # precedence, matching DuckDB's query-cancellation semantics.
+            _check_video_io(reader, nested_io)
+            raise
+        if not isinstance(decoded, list):
+            raise RuntimeError("PyAV packet.decode() returned a non-list frame batch")
+        frames = decoded
+        _check_video_io(reader, nested_io)
+        return frames
+    except BaseException:
+        if frames is not None:
+            frames.clear()
+        raise
+    finally:
+        packet = None
+
+
+@contextmanager
+def _close_demux_iterator(packets: Any) -> Iterator[Any]:
+    """Close one PyAV demux iterator without replacing its body exception."""
+
+    close: Any = None
+    try:
+        try:
+            yield packets
+        except BaseException:
+            try:
+                close = getattr(packets, "close", None)
+                if close is not None:
+                    close()
+            except BaseException:
+                pass
+            raise
+        else:
+            close = getattr(packets, "close", None)
+            if close is not None:
+                close()
+    finally:
+        # A retained close traceback must not keep the demux generator and its
+        # current native packet alive.
+        close = None
+        packets = None
+
+
+def _is_flush_packet(packet: Any) -> bool:
+    """Recognize PyAV's synthetic decoder-drain packet."""
+
+    has_sidedata: Any = None
+    try:
+        try:
+            size = operator.index(packet.size)
+            buffer_ptr = operator.index(packet.buffer_ptr)
+        except AttributeError:
+            # Small test doubles need not reproduce PyAV's native buffer facade.
+            return False
+        except (TypeError, ValueError, OverflowError) as error:
+            raise VideoFileFormatError("video demuxer reported invalid packet buffer metadata") from error
+        if size < 0 or buffer_ptr < 0:
+            raise VideoFileFormatError("video demuxer reported invalid packet buffer metadata")
+        if size != 0 or buffer_ptr != 0:
+            return False
+
+        # FFmpeg treats a zero-payload packet with side data as real decoder
+        # input. PyAV's synthetic EOF packet has neither payload nor side data,
+        # so both properties are required before ending demux and draining once.
+        has_sidedata = packet.has_sidedata
+        return not any(has_sidedata(data_type) for data_type in _PYAV_PACKET_SIDE_DATA_TYPES)
+    finally:
+        # An exceptional classification traceback must not retain the packet's
+        # native stream, container, codec context, or FILE reader.
+        has_sidedata = None
+        packet = None
+
+
+def _next_demuxed_packet(
+    container: Any,
+    video: Any,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+) -> tuple[Any, bool] | None:
+    """Read one packet and close PyAV's owning demux generator before returning."""
+
+    packets: Any = None
+    packet: Any = None
+    received_packet = False
+    try:
+        _check_video_io(reader, nested_io)
+        try:
+            packets = container.demux(video)
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            _check_video_io(reader, nested_io)
+            raise
+
+        try:
+            with _close_demux_iterator(packets):
+                _check_video_io(reader, nested_io)
+                packet = next(packets)
+                received_packet = True
+        except StopIteration:
+            _check_video_io(reader, nested_io)
+            if received_packet:
+                # A dependency close unexpectedly raised StopIteration after a
+                # packet had already been read; this is not successful EOF.
+                raise
+            return None
+        except BaseException as error:
+            if not isinstance(error, Exception):
+                raise
+            _check_video_io(reader, nested_io)
+            raise
+
+        # PyAV 17.1 retains its local Packet at the demux generator's yield.
+        # The iterator has been closed above, so this check and the caller can no
+        # longer leave that second native-buffer owner suspended indefinitely.
+        _check_video_io(reader, nested_io)
+        is_flush = _is_flush_packet(packet)
+        result = (packet, is_flush)
+        packet = None
+        return result
+    finally:
+        packet = None
+        packets = None
+        video = None
+        container = None
+
+
+def _iter_decoded_packet_batches(
+    container: Any,
+    video: Any,
+    options: _VideoFrameOptions,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+    *,
+    stream_time_origin: Fraction = Fraction(0),
+) -> Generator[_DecodedPacketBatch, None, None]:
+    """Validate each PyAV packet batch before exposing any frame from it.
+
+    PyAV exposes one packet decode as an atomic dependency call, so cooperative
+    interruption happens immediately before and after that call. The complete
+    returned batch is then subject to frame-count, provenance, and visible
+    frame-dimension validation. ``max_frames`` is a packet-boundary count
+    guard, not a native-memory limit.
+    """
+    decoded_frames = 0
+    packet_and_flush: tuple[Any, bool] | None = None
+    packet: Any = None
+    frames: list[Any] | None = None
+    try:
+        while True:
+            packet_and_flush = _next_demuxed_packet(container, video, reader, nested_io)
+            if packet_and_flush is None:
+                break
+            packet, is_flush = packet_and_flush
+            packet_and_flush = None
+            try:
+                frames = _decode_packet_frames(packet, reader, nested_io)
+            finally:
+                packet = None
+            try:
+                batch_size = len(frames)
+                if batch_size > options.max_frames - decoded_frames:
+                    raise VideoFileLimitError(f"video decode exceeded max_frames={options.max_frames} decoded frames")
+
+                infos: list[_DecodedFrameInfo] = []
+                for index in range(batch_size):
+                    infos.append(
+                        _decoded_frame_info(
+                            frames[index],
+                            video,
+                            options,
+                            frame_index=decoded_frames + index,
+                            stream_time_origin=stream_time_origin,
+                        )
+                    )
+                for info in infos:
+                    _require_frame_time_for_selection(info, options)
+                decoded_frames += batch_size
+
+                if batch_size:
+                    batch = _DecodedPacketBatch(frames=frames, infos=tuple(infos))
+                    yield batch
+            finally:
+                # This guard starts immediately after the atomic decode returns,
+                # so rejected batches cannot remain pinned by an error traceback.
+                frames.clear()
+                frames = None
+            if is_flush:
+                break
+    finally:
+        # Exception tracebacks from this generator must not own PyAV's stream,
+        # packet, container, or native codec context.
+        if frames is not None:
+            frames.clear()
+        frames = None
+        packet = None
+        packet_and_flush = None
+        video = None
+        container = None
+
+
+def _prepare_video_packet_batch(
+    batch: _DecodedPacketBatch,
+    options: _VideoFrameOptions,
+    av_module: Any,
+    image_module: Any,
+    reformatter: Any,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+    *,
+    did_seek: bool,
+    next_sample_time: Fraction | None,
+) -> _PreparedFrameBatch:
+    """Detach every selected image before exposing any result from a packet."""
+
+    results: list[VideoFrameData | None] = []
+    frame: Any = None
+    image: Any = None
+    result: VideoFrameData | None = None
+    reached_end = False
+    try:
+        for index, info in enumerate(batch.infos):
+            _check_video_io(reader, nested_io)
+            frame = batch.take_frame(index)
+            try:
+                if info.exact_time is not None:
+                    if info.exact_time < options.start_time:
+                        continue
+                    if options.end_time is not None and info.exact_time > options.end_time:
+                        reached_end = True
+                        break
+
+                if options.is_key_frame is not None and info.is_key_frame is not options.is_key_frame:
+                    continue
+
+                if options.sample_interval_seconds is not None:
+                    assert info.exact_time is not None
+                    assert next_sample_time is not None
+                    if info.exact_time < next_sample_time:
+                        continue
+                    next_sample_time = _advance_sample_target(
+                        next_sample_time,
+                        options.sample_interval_seconds,
+                        info.exact_time,
+                    )
+
+                image = _frame_to_image(
+                    frame,
+                    info,
+                    options,
+                    av_module,
+                    image_module,
+                    reformatter,
+                    lambda: _check_video_io(reader, nested_io),
+                )
+                try:
+                    _check_video_io(reader, nested_io)
+                    result = VideoFrameData(
+                        frame_index=None if did_seek else info.frame_index,
+                        frame_time=info.frame_time,
+                        frame_time_base=info.time_base,
+                        frame_pts=info.frame_pts,
+                        frame_dts=info.frame_dts,
+                        frame_duration=info.frame_duration,
+                        is_key_frame=info.is_key_frame,
+                        data=image,
+                    )
+                    results.append(result)
+                except BaseException:
+                    _close_image(image)
+                    image = None
+                    result = None
+                    raise
+                else:
+                    # The prepared batch now owns the detached image.
+                    image = None
+                    result = None
+            finally:
+                # Filtering and conversion must release each source frame before
+                # the detached packet batch can be returned to the caller.
+                frame = None
+
+        _check_video_io(reader, nested_io)
+        prepared = _PreparedFrameBatch(
+            results=results,
+            next_sample_time=next_sample_time,
+            reached_end=reached_end,
+        )
+        results = []
+        return prepared
+    except BaseException:
+        for pending in results:
+            if pending is not None:
+                _close_image(pending.data)
+        results.clear()
+        # The re-raised exception retains this frame. Do not let the loop target
+        # keep the final undelivered image alive through its traceback.
+        pending = None
+        raise
+    finally:
+        if image is not None:
+            _close_image(image)
+        result = None
+        frame = None
+        batch.release()
+        del batch
+        reformatter = None
+        av_module = None
+        image_module = None
+
+
+def _classify_video_decode_error(
+    error: Exception,
+    *,
+    av_module: Any,
+    reader: _VideoReaderProxy,
+    nested_io: _NestedIOBlocker,
+) -> None:
+    _check_video_io(reader, nested_io)
+    if isinstance(error, VideoFileError):
+        raise error
+    if isinstance(error, av_module.error.ExitError):
+        raise VideoFileLimitError(
+            f"a video frame decode phase exceeded its {_VIDEO_METADATA_TIMEOUT_SECONDS:g}-second I/O timeout"
+        ) from error
+    if isinstance(error, ValueError) and str(error).startswith(_PYAV_UNSAFE_STREAM_OPTIONS_ERROR):
+        raise VideoFileFormatError("video container cannot be decoded safely within resource limits") from error
+    if _is_pyav_media_or_codec_error(error, av_module):
+        raise VideoFileFormatError("logical FILE view is not a supported decodable video") from error
+    raise error
+
+
+def _iter_video_frames(
+    value: vane.VideoFile,
+    options: _VideoFrameOptions,
+    av_module: Any,
+    image_module: Any,
+    connection: vane.DuckDBPyConnection | None,
+) -> Generator[VideoFrameData, None, None]:
+    file_reader = value.open(buffer_size=options.buffer_size, connection=connection)
+    with _close_video_reader(file_reader):
+        input_size = file_reader.size()
+        file_reader._check_interrupted()
+        if input_size > options.max_input_bytes:
+            raise VideoFileLimitError(
+                f"encoded video contains {input_size} bytes, exceeding max_input_bytes={options.max_input_bytes}"
+            )
+
+        reader = _VideoReaderProxy(file_reader)
+        nested_io = _NestedIOBlocker()
+        probe_decoder_options = {
+            # FFmpeg checks coded/aligned allocation dimensions here. The
+            # caller-facing visible-frame contract is checked separately.
+            "max_pixels": str(_MAX_VIDEO_CODED_FRAME_PIXELS),
+            "max_samples": str(_MAX_VIDEO_AUDIO_SAMPLES),
+            "skip_frame": "all",
+            "threads": "1",
+        }
+        probe_bytes = min(input_size, DEFAULT_VIDEO_METADATA_BYTES)
+        probe_options = {
+            "analyzeduration": str(_MAX_VIDEO_ANALYZE_DURATION_US),
+            "formatprobesize": str(max(2048, probe_bytes)),
+            "fpsprobesize": str(_MAX_VIDEO_FPS_PROBE_FRAMES),
+            "indexmem": str(_MAX_VIDEO_INDEX_BYTES),
+            "max_probe_packets": str(_MAX_VIDEO_PROBE_PACKETS),
+            "max_streams": str(_MAX_VIDEO_STREAMS),
+            "probesize": str(max(32, probe_bytes)),
+            "skip_estimate_duration_from_pts": "1",
+        }
+        container: Any = None
+        video: Any = None
+        reformatter: Any = None
+        decoded_batches: Generator[_DecodedPacketBatch, None, None] | None = None
+        prepared_batch: _PreparedFrameBatch | None = None
+        error_from_consumer = False
+        try:
+            _check_video_io(reader, nested_io)
+            container = av_module.open(
+                reader,
+                mode="r",
+                options=probe_decoder_options,
+                container_options=probe_options,
+                stream_options=[probe_decoder_options.copy()],
+                metadata_encoding="utf-8",
+                metadata_errors="replace",
+                buffer_size=options.buffer_size,
+                timeout=(_VIDEO_METADATA_TIMEOUT_SECONDS, _VIDEO_METADATA_TIMEOUT_SECONDS),
+                io_open=nested_io,
+            )
+            with _close_container(container):
+                _check_video_io(reader, nested_io)
+                metadata = _metadata_from_container(
+                    container,
+                    value.content_type,
+                    av_module,
+                    max_pixels=options.max_pixels,
+                )
+                video = _select_video_stream(container, av_module)
+                stream_start, stream_time_origin = _stream_time_origin(video, metadata.time_base)
+                _configure_video_decoder(video)
+                reformatter = av_module.video.reformatter.VideoReformatter()
+                did_seek = options.start_time > 0
+                if did_seek:
+                    seek_timestamp = _seek_timestamp(options.start_time, metadata.time_base, stream_start)
+                    _seek_video_stream(container, video, int(seek_timestamp), reader, nested_io)
+
+                next_sample_time = options.start_time if options.sample_interval_seconds is not None else None
+                decoded_batches = _iter_decoded_packet_batches(
+                    container,
+                    video,
+                    options,
+                    reader,
+                    nested_io,
+                    stream_time_origin=stream_time_origin,
+                )
+                reached_end = False
+                try:
+                    while not reached_end:
+                        try:
+                            batch = next(decoded_batches)
+                        except StopIteration:
+                            break
+                        prepared_batch = _prepare_video_packet_batch(
+                            batch,
+                            options,
+                            av_module,
+                            image_module,
+                            reformatter,
+                            reader,
+                            nested_io,
+                            did_seek=did_seek,
+                            next_sample_time=next_sample_time,
+                        )
+                        del batch
+                        next_sample_time = prepared_batch.next_sample_time
+                        reached_end = prepared_batch.reached_end
+                        try:
+                            for index in range(len(prepared_batch.results)):
+                                _check_video_io(reader, nested_io)
+                                result = prepared_batch.take_result(index)
+                                try:
+                                    yield result
+                                except BaseException:
+                                    # ``Generator.throw()`` injects a caller-owned
+                                    # exception at this boundary. It must survive
+                                    # operation cleanup without being classified as
+                                    # a PyAV/FFmpeg dependency failure below.
+                                    error_from_consumer = True
+                                    raise
+                                finally:
+                                    # ``throw()`` and ``close()`` resume at the
+                                    # yield itself. The caller owns this result;
+                                    # only later undelivered batch entries are closed.
+                                    del result
+                                _check_video_io(reader, nested_io)
+                        finally:
+                            prepared_batch.release()
+                            prepared_batch = None
+                finally:
+                    decoded_batches.close()
+                _check_video_io(reader, nested_io)
+            # ``container.close()`` releases the GIL, so cancellation may race
+            # with an otherwise successful context-manager exit.
+            _check_video_io(reader, nested_io)
+        except BaseException as error:
+            if error_from_consumer or not isinstance(error, Exception):
+                raise
+            _classify_video_decode_error(
+                error,
+                av_module=av_module,
+                reader=reader,
+                nested_io=nested_io,
+            )
+        finally:
+            if prepared_batch is not None:
+                prepared_batch.release()
+            # Clear every PyAV owner before the outer reader context closes. A
+            # reader-close failure traceback must not retain native codec state.
+            prepared_batch = None
+            decoded_batches = None
+            reformatter = None
+            video = None
+            container = None
+
+
+def _video_file_frames_value(
+    value: vane.VideoFile,
+    start_time: int | float = 0,
+    end_time: int | float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    is_key_frame: bool | None = None,
+    sample_interval_seconds: int | float | None = None,
+    buffer_size: int = DEFAULT_VIDEO_BUFFER_SIZE,
+    *,
+    max_input_bytes: int = DEFAULT_VIDEO_MAX_INPUT_BYTES,
+    max_frames: int = DEFAULT_VIDEO_MAX_FRAMES,
+    max_pixels: int = DEFAULT_VIDEO_MAX_PIXELS,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> Generator[VideoFrameData, None, None]:
+    options = _normalize_frame_options(
+        start_time=start_time,
+        end_time=end_time,
+        width=width,
+        height=height,
+        is_key_frame=is_key_frame,
+        sample_interval_seconds=sample_interval_seconds,
+        buffer_size=buffer_size,
+        max_input_bytes=max_input_bytes,
+        max_frames=max_frames,
+        max_pixels=max_pixels,
+    )
+    av_module = _load_av()
+    image_module = _load_pillow()
+    return _iter_video_frames(value, options, av_module, image_module, connection)
+
+
+def _iter_keyframe_images(frames: Generator[VideoFrameData, None, None]) -> Generator[PILImage, None, None]:
+    try:
+        for frame in frames:
+            image = frame.data
+            del frame
+            try:
+                yield image
+            finally:
+                # Do not retain the previously returned image while asking the
+                # source iterator to decode the next keyframe.
+                del image
+    except BaseException:
+        close = getattr(frames, "close", None)
+        if close is not None:
+            try:
+                close()
+            except BaseException:
+                pass
+        raise
+    else:
+        close = getattr(frames, "close", None)
+        if close is not None:
+            close()
+
+
+def _video_file_keyframes_value(
+    value: vane.VideoFile,
+    start_time: int | float = 0,
+    end_time: int | float | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    sample_interval_seconds: int | float | None = None,
+    buffer_size: int = DEFAULT_VIDEO_BUFFER_SIZE,
+    *,
+    max_input_bytes: int = DEFAULT_VIDEO_MAX_INPUT_BYTES,
+    max_frames: int = DEFAULT_VIDEO_MAX_FRAMES,
+    max_pixels: int = DEFAULT_VIDEO_MAX_PIXELS,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> Generator[PILImage, None, None]:
+    frames = _video_file_frames_value(
+        value,
+        start_time,
+        end_time,
+        width,
+        height,
+        True,
+        sample_interval_seconds,
+        buffer_size,
+        max_input_bytes=max_input_bytes,
+        max_frames=max_frames,
+        max_pixels=max_pixels,
+        connection=connection,
+    )
+    return _iter_keyframe_images(frames)
 
 
 def _video_file_metadata_value(
@@ -586,6 +1974,7 @@ def video_metadata(
 __all__ = [
     "VideoFileError",
     "VideoFileFormatError",
+    "VideoFrameData",
     "VideoFileLimitError",
     "VideoMetadata",
     "video_metadata",

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -228,7 +228,7 @@ class _DecodedPacketBatch:
 class _PreparedFrameBatch:
     results: list[VideoFrameData | None]
     next_sample_time: Fraction | None
-    reached_end: bool
+    last_frame_time: Fraction | None
 
     def take_result(self, index: int) -> VideoFrameData:
         result = self.results[index]
@@ -1494,6 +1494,7 @@ def _prepare_video_packet_batch(
     nested_io: _NestedIOBlocker,
     *,
     next_sample_time: Fraction | None,
+    last_frame_time: Fraction | None,
 ) -> _PreparedFrameBatch:
     """Detach every selected image before exposing any result from a packet."""
 
@@ -1501,18 +1502,25 @@ def _prepare_video_packet_batch(
     frame: Any = None
     image: Any = None
     result: VideoFrameData | None = None
-    reached_end = False
     try:
         for index, info in enumerate(batch.infos):
             _check_video_io(reader, nested_io)
             frame = batch.take_frame(index)
             try:
                 if info.exact_time is not None:
+                    if last_frame_time is not None and info.exact_time < last_frame_time:
+                        # MPEG-TS and other streaming containers can reset their
+                        # presentation timeline at a discontinuity. Sampling
+                        # targets belong to each monotonic segment rather than a
+                        # previous segment's now-unreachable timestamp range.
+                        next_sample_time = options.start_time if options.sample_interval_seconds is not None else None
+                    last_frame_time = info.exact_time
                     if info.exact_time < options.start_time:
                         continue
                     if options.end_time is not None and info.exact_time > options.end_time:
-                        reached_end = True
-                        break
+                        # Do not stop globally: a later discontinuity can move
+                        # presentation timestamps back into the requested window.
+                        continue
 
                 if options.is_key_frame is not None and info.is_key_frame is not options.is_key_frame:
                     continue
@@ -1568,7 +1576,7 @@ def _prepare_video_packet_batch(
         prepared = _PreparedFrameBatch(
             results=results,
             next_sample_time=next_sample_time,
-            reached_end=reached_end,
+            last_frame_time=last_frame_time,
         )
         results = []
         return prepared
@@ -1693,9 +1701,9 @@ def _iter_video_frames(
                     nested_io,
                     stream_time_origin=stream_time_origin,
                 )
-                reached_end = False
+                last_frame_time: Fraction | None = None
                 try:
-                    while not reached_end:
+                    while True:
                         try:
                             batch = next(decoded_batches)
                         except StopIteration:
@@ -1709,10 +1717,11 @@ def _iter_video_frames(
                             reader,
                             nested_io,
                             next_sample_time=next_sample_time,
+                            last_frame_time=last_frame_time,
                         )
                         del batch
                         next_sample_time = prepared_batch.next_sample_time
-                        reached_end = prepared_batch.reached_end
+                        last_frame_time = prepared_batch.last_frame_time
                         try:
                             for index in range(len(prepared_batch.results)):
                                 _check_video_io(reader, nested_io)


### PR DESCRIPTION
## Summary

- Add the frozen, slotted `VideoFrameData` value with exact PTS/DTS, rational time-base, duration, keyframe, and detached RGB image provenance.
- Add bounded, streaming `VideoFile.frames()` and `VideoFile.keyframes()` APIs backed by PyAV and the existing range-aware FILE reader.
- Use one unseeked sequential demux as the correctness baseline for exact time-window, keyframe, interval, and resize selection across reordered frames, distinct presentation/decode timestamp origins, and timestamp discontinuities.

## Related issue

Refs #714

This PR implements the streaming Python value API slice. Efficient indexed/keyframe seeking, exact frame-index access, FILE-aware `VideoFrameSource` distributed execution, SQL collection APIs, and a decoded IMAGE logical type remain follow-up work.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The additive public contract is recorded in docstrings, native stubs, and tests. README changes are intentionally out of scope.

## Validation

- `scripts/format root --changed`
- `/home/kaka/.local/bin/pre-commit run --files vane/_video_file.py tests/fast/test_video_file.py`
- Incremental non-editable Release install with `CMAKE_BUILD_PARALLEL_LEVEL=24`
- `scripts/run_installed_pytest.sh -q` for the MPEG-TS timestamp-discontinuity, distinct PTS/DTS-origin, MP4 B-frame, and combined-selection regressions — 4 passed
- `scripts/run_installed_pytest.sh -q tests/fast/test_video_file.py` — 168 passed
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
