### PR TITLE
[feat](extensions) Add remote provider catalog discovery

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -331,11 +331,13 @@ Known provider distributions are maintained independently in
 `AstroVela/vane-extensions`. Vane contains only the generic client for its
 versioned HTTPS index, so adding a provider does not require a Vane change or
 release. The runtime parser is strict and the fetch is bounded: redirects,
-duplicate names, aliases, unknown fields, non-HTTPS URLs, and unsupported
-catalog format versions are rejected. There is no cache or fallback. Catalog
-metadata is for discovery only; do not add artifact versions, digests, platform
-selection, or trust policy to it. Those values belong to each immutable dynamic
-descriptor and are checked only after explicit provider initialization.
+duplicate or ambiguously normalized names, aliases, invalid Unicode scalar
+values, unknown fields, non-HTTPS URLs, and unsupported catalog format versions
+are rejected. The complete request has a 10-second wall-clock deadline. There
+is no cache or fallback. Catalog metadata is for discovery only; do not add
+artifact versions, digests, platform selection, or trust policy to it. Those
+values belong to each immutable dynamic descriptor and are checked only after
+explicit provider initialization.
 
 Every Ray node must install the same platform extension wheels before queries
 start. Each wheel supplies one provider entry point under

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -327,6 +327,16 @@ the verified cache snapshot, Vane records the artifact's canonical
 that ordered descriptor manifest, including each SHA-256 digest and dependency
 identity, but never a local artifact path or binary payload.
 
+Known provider distributions are maintained independently in
+`AstroVela/vane-extensions`. Vane contains only the generic client for its
+versioned HTTPS index, so adding a provider does not require a Vane change or
+release. The runtime parser is strict and the fetch is bounded: redirects,
+duplicate names, aliases, unknown fields, non-HTTPS URLs, and unsupported
+catalog format versions are rejected. There is no cache or fallback. Catalog
+metadata is for discovery only; do not add artifact versions, digests, platform
+selection, or trust policy to it. Those values belong to each immutable dynamic
+descriptor and are checked only after explicit provider initialization.
+
 Every Ray node must install the same platform extension wheels before queries
 start. Each wheel supplies one provider entry point under
 `vane.dynamic_extension_providers`; its name is the canonical DuckDB extension

--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -172,9 +172,11 @@ vane.load_installed_extension("iceberg", connection=connection)
 ```
 
 `extension_catalog()` makes one bounded HTTPS request to the default versioned
-registry index. It rejects redirects and malformed metadata and has no cache or
-fallback. A caller may explicitly supply another HTTPS catalog URL, or pass a
-previously fetched tuple to `vane_extensions(catalog=...)`.
+registry index under a 10-second wall-clock deadline. It rejects redirects,
+malformed metadata, and extension names with ambiguous Python distribution
+normalization, and it has no cache or fallback. A caller may explicitly supply
+another HTTPS catalog URL, or pass a previously fetched tuple to
+`vane_extensions(catalog=...)`.
 
 `vane_extensions()` returns a DuckDB relation modeled after
 `duckdb_extensions()`. It combines the fetched catalog, installed

--- a/DISTRIBUTED_EXTENSIONS.md
+++ b/DISTRIBUTED_EXTENSIONS.md
@@ -140,6 +140,61 @@ other's installed files. Each extension wheel is tagged for the active
 supported CPython minor, matching the native base wheel selected for that
 runtime instead of claiming cross-interpreter availability. The base Vane wheel
 contains no optional extension artifact.
+
+### Provider catalog and package management
+
+The independent
+[`AstroVela/vane-extensions`](https://github.com/AstroVela/vane-extensions)
+repository publishes a strict, versioned catalog of known provider
+distributions. Adding a provider updates that registry without changing or
+releasing Vane. The catalog is discovery metadata, not another artifact
+transport or a trust allowlist. Standard Python package tooling installs and
+removes providers; Vane does not invoke pip, contact a provider repository, or
+choose another package when a provider is missing.
+
+```bash
+python -m pip install vane-extension-iceberg
+```
+
+The catalog and the current connection state are available through the Python
+API:
+
+```python
+import vane
+
+connection = vane.connect()
+
+for entry in vane.extension_catalog():
+    print(entry.extension_name, entry.distribution_name)
+
+vane.vane_extensions(connection=connection).show()
+vane.load_installed_extension("iceberg", connection=connection)
+```
+
+`extension_catalog()` makes one bounded HTTPS request to the default versioned
+registry index. It rejects redirects and malformed metadata and has no cache or
+fallback. A caller may explicitly supply another HTTPS catalog URL, or pass a
+previously fetched tuple to `vane_extensions(catalog=...)`.
+
+`vane_extensions()` returns a DuckDB relation modeled after
+`duckdb_extensions()`. It combines the fetched catalog, installed
+`vane.dynamic_extension_providers` entry-point metadata, and the exact dynamic
+descriptor manifest recorded on the supplied connection. `installed` means at
+least one named provider entry point exists, while `loadable` requires exactly
+one. `loaded` means Vane has verified and recorded the descriptor on that
+connection. The relation also exposes the installed distribution version and,
+after loading, the artifact SHA-256 and trust identity. If duplicate provider
+entry points make a name ambiguous, `provider_distributions` identifies every
+conflicting package while `loadable` remains false.
+
+Catalog and status enumeration never import or initialize third-party provider
+code. Workers never query the registry. An uncataloged provider remains visible
+because the installed package is the local trust boundary; `cataloged`
+describes discoverability only. Provider initialization and native artifact
+verification occur only on the explicit `load_installed_extension()` path.
+Install the same exact provider dependency closure in every Ray runtime
+environment before submitting distributed work.
+
 Release tooling binds the wheel tag to inspected ELF or Mach-O requirements,
 records the exact musl build baseline when applicable, and requires publishers
 to explicitly allowlist every unique dependency signer rather than deriving

--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ Install the `vane-ai` package from PyPI:
 ```bash
 pip install vane-ai
 ```
+
+Optional DuckDB extensions are separate platform packages. Install a provider
+with pip from the package index configured for your deployment, then load it by
+name on the connection that will plan the query:
+
+```bash
+python -m pip install vane-extension-iceberg
+```
+
+```python
+import vane
+
+connection = vane.connect()
+vane.load_installed_extension("iceberg", connection=connection)
+vane.vane_extensions(connection=connection).show()
+```
+
+`vane.extension_catalog()` reads the live, independent
+[`vane-extensions`](https://github.com/AstroVela/vane-extensions) registry, so
+new provider packages do not require a Vane release. See the
+[distributed extension architecture](DISTRIBUTED_EXTENSIONS.md) for discovery,
+installation, verification, and Ray worker requirements.
+
 For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/data/quickstart/installation).
 
 ### Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ include = [
     "/tests/ray_test_profile.py",
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",
+    "/tests/fast/test_extension_catalog.py",
     "/tests/fast/test_milvus_datasink.py",
     "/tests/fast/test_qdrant_datasink.py",
     "/tests/fast/test_package_metadata.py",

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -23,6 +23,7 @@ export VANE_FAST_TEST_ARTIFACT_MODE=1
 release_tests=(
   "$project_root/tests/fast/test_ai_release_contracts.py"
   "$project_root/tests/fast/test_datasink.py"
+  "$project_root/tests/fast/test_extension_catalog.py"
   "$project_root/tests/fast/test_milvus_datasink.py"
   "$project_root/tests/fast/test_qdrant_datasink.py"
   "$project_root/tests/fast/test_package_metadata.py"

--- a/tests/fast/test_extension_catalog.py
+++ b/tests/fast/test_extension_catalog.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from http.client import HTTPException
+from itertools import repeat
+from urllib.error import URLError
+
+import pytest
+
+import vane
+import vane.extensions as extension_module
+from vane.extensions import DynamicExtensionDescriptor, ExtensionCatalogEntry
+
+_CATALOG_URL = "https://catalog.example/v1/index.json"
+
+
+class _Distribution:
+    def __init__(self, name, version):
+        self.metadata = {"Name": name}
+        self.version = version
+
+
+class _EntryPoint:
+    def __init__(self, name, distribution_name, distribution_version):
+        self.name = name
+        self.dist = _Distribution(distribution_name, distribution_version)
+        self.load_calls = 0
+
+    def load(self):
+        self.load_calls += 1
+        pytest.fail("extension status discovery must not initialize providers")
+
+
+class _SnapshotConnection:
+    def __init__(self, descriptors=()):
+        self._entries = [descriptor.to_json() for descriptor in descriptors]
+
+    def _export_dynamic_extension_snapshot_entries(self):
+        return list(self._entries)
+
+
+class _CatalogResponse:
+    def __init__(self, contents, *, url=_CATALOG_URL, status=200):
+        self.contents = contents
+        self.url = url
+        self.status = status
+        self.read_limit = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception, traceback):
+        return False
+
+    def geturl(self):
+        return self.url
+
+    def read(self, limit):
+        self.read_limit = limit
+        return self.contents
+
+
+class _CatalogOpener:
+    def __init__(self, result):
+        self.result = result
+        self.request = None
+        self.timeout = None
+
+    def open(self, request, *, timeout):
+        self.request = request
+        self.timeout = timeout
+        if isinstance(self.result, BaseException):
+            raise self.result
+        return self.result
+
+
+def _catalog_document():
+    return {
+        "format_version": 1,
+        "extensions": [
+            {
+                "extension_name": "iceberg",
+                "distribution_name": "vane-extension-iceberg",
+                "description": "Read and write Apache Iceberg tables from Vane.",
+                "repository": "https://github.com/AstroVela/duckdb-iceberg",
+                "publisher": "AstroVela",
+                "license": "MIT",
+            },
+            {
+                "extension_name": "lance",
+                "distribution_name": "vane-extension-lance",
+                "description": "Read and write Lance tables from Vane.",
+                "repository": "https://github.com/AstroVela/lance-duckdb",
+                "publisher": "AstroVela",
+                "license": "Apache-2.0",
+            },
+            {
+                "extension_name": "paimon",
+                "distribution_name": "vane-extension-paimon",
+                "description": "Read and write Apache Paimon tables from Vane.",
+                "repository": "https://github.com/AstroVela/duckdb-paimon",
+                "publisher": "AstroVela",
+                "license": "Apache-2.0",
+            },
+        ],
+    }
+
+
+def _catalog_entries():
+    return extension_module._parse_extension_catalog(_catalog_document())
+
+
+def _loaded_descriptor(name="iceberg"):
+    return DynamicExtensionDescriptor(
+        name=name,
+        extension_version="extension-version",
+        abi_type="CPP",
+        duckdb_source_id="a" * 40,
+        vane_version="0.2.0",
+        platform="linux_amd64",
+        sha256="b" * 64,
+        trust_identity="astrovela/vane",
+    )
+
+
+def test_extension_catalog_fetches_one_bounded_remote_index(monkeypatch):
+    response = _CatalogResponse(json.dumps(_catalog_document()).encode())
+    opener = _CatalogOpener(response)
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", opener)
+
+    entries = vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+    assert [entry.extension_name for entry in entries] == ["iceberg", "lance", "paimon"]
+    assert opener.request.full_url == _CATALOG_URL
+    assert opener.request.get_header("Accept") == "application/json"
+    assert opener.timeout == extension_module._EXTENSION_CATALOG_TIMEOUT_SECONDS
+    assert response.read_limit == extension_module._EXTENSION_CATALOG_MAX_BYTES + 1
+
+
+@pytest.mark.parametrize(
+    "catalog_url",
+    [
+        "http://catalog.example/v1/index.json",
+        "https://catalog.example:443/v1/index.json",
+        "https://user@catalog.example/v1/index.json",
+        "https://catalog.example/v1/index.json?channel=dev",
+        "https://catalog.example/v1/index.json#latest",
+    ],
+)
+def test_extension_catalog_rejects_noncanonical_url_before_request(catalog_url, monkeypatch):
+    opener = _CatalogOpener(AssertionError("network request was not expected"))
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", opener)
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        vane.extension_catalog(catalog_url=catalog_url)
+
+    assert opener.request is None
+
+
+def test_extension_catalog_does_not_fallback_when_endpoint_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        extension_module,
+        "_EXTENSION_CATALOG_OPENER",
+        _CatalogOpener(URLError("unavailable")),
+    )
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_UNAVAILABLE"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_wraps_an_interrupted_http_response(monkeypatch):
+    monkeypatch.setattr(
+        extension_module,
+        "_EXTENSION_CATALOG_OPENER",
+        _CatalogOpener(HTTPException("response interrupted")),
+    )
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_UNAVAILABLE"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_rejects_a_redirected_response(monkeypatch):
+    response = _CatalogResponse(b'{"format_version": 1, "extensions": []}', url="https://other.example/index.json")
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", _CatalogOpener(response))
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_UNAVAILABLE"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_rejects_an_unsuccessful_response(monkeypatch):
+    response = _CatalogResponse(b'{"format_version": 1, "extensions": []}', status=204)
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", _CatalogOpener(response))
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_UNAVAILABLE"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_rejects_oversized_response(monkeypatch):
+    response = _CatalogResponse(b"x" * (extension_module._EXTENSION_CATALOG_MAX_BYTES + 1))
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", _CatalogOpener(response))
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_rejects_duplicate_json_keys(monkeypatch):
+    response = _CatalogResponse(b'{"format_version": 1, "format_version": 1, "extensions": []}')
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", _CatalogOpener(response))
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"format_version": 2, "extensions": []},
+        {"format_version": 1, "extensions": [], "unexpected": True},
+        {
+            "format_version": 1,
+            "extensions": [
+                {
+                    "extension_name": "iceberg",
+                    "distribution_name": "vane_extension_iceberg",
+                    "description": "Iceberg",
+                    "repository": "https://example.com/iceberg",
+                    "publisher": "Example",
+                    "license": "MIT",
+                }
+            ],
+        },
+        {
+            "format_version": 1,
+            "extensions": [
+                {
+                    "extension_name": "iceberg",
+                    "distribution_name": "vane-extension-iceberg",
+                    "description": "Iceberg",
+                    "repository": "https://example.com:not-a-port/iceberg",
+                    "publisher": "Example",
+                    "license": "MIT",
+                }
+            ],
+        },
+        {
+            "format_version": 1,
+            "extensions": [
+                {
+                    "extension_name": "iceberg",
+                    "distribution_name": "vane-extension-iceberg",
+                    "description": "Iceberg",
+                    "repository": "https:///iceberg",
+                    "publisher": "Example",
+                    "license": "MIT",
+                }
+            ],
+        },
+    ],
+)
+def test_extension_catalog_rejects_noncanonical_documents(document):
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        extension_module._parse_extension_catalog(document)
+
+
+def test_extension_statuses_combine_catalog_provider_and_loaded_state_without_importing(monkeypatch):
+    descriptor = _loaded_descriptor()
+    iceberg = _EntryPoint("iceberg", "vane_extension_iceberg", "0.2.0.1")
+    community = _EntryPoint("community", "community-provider", "3.4.5")
+    entry_points = (community, iceberg)
+    monkeypatch.setattr(
+        extension_module,
+        "entry_points",
+        lambda *, group: entry_points if group == "vane.dynamic_extension_providers" else (),
+    )
+
+    statuses = {
+        status.extension_name: status
+        for status in vane.extension_statuses(
+            connection=_SnapshotConnection((descriptor,)),
+            catalog=_catalog_entries(),
+        )
+    }
+
+    assert list(statuses) == ["community", "iceberg", "lance", "paimon"]
+    assert statuses["iceberg"] == extension_module.ExtensionStatus(
+        extension_name="iceberg",
+        cataloged=True,
+        installed=True,
+        loadable=True,
+        loaded=True,
+        description="Read and write Apache Iceberg tables from Vane.",
+        distribution_name="vane-extension-iceberg",
+        installed_distribution_name="vane-extension-iceberg",
+        distribution_version="0.2.0.1",
+        repository="https://github.com/AstroVela/duckdb-iceberg",
+        publisher="AstroVela",
+        license="MIT",
+        provider_distributions=("vane-extension-iceberg==0.2.0.1",),
+        provider_count=1,
+        extension_version="extension-version",
+        trust_identity="astrovela/vane",
+        artifact_sha256="b" * 64,
+    )
+    assert statuses["community"].cataloged is False
+    assert statuses["community"].installed_distribution_name == "community-provider"
+    assert statuses["community"].loadable is True
+    assert statuses["lance"].installed is False
+    assert statuses["lance"].loadable is False
+    assert [entry_point.load_calls for entry_point in entry_points] == [0, 0]
+
+
+def test_extension_statuses_report_ambiguous_providers_without_selecting_one(monkeypatch):
+    entry_points = (
+        _EntryPoint("iceberg", "vane-extension-iceberg", "1"),
+        _EntryPoint("iceberg", "another-iceberg-provider", "2"),
+    )
+    monkeypatch.setattr(extension_module, "entry_points", lambda *, group: entry_points)
+
+    status = next(
+        status
+        for status in vane.extension_statuses(
+            connection=_SnapshotConnection(),
+            catalog=_catalog_entries(),
+        )
+        if status.extension_name == "iceberg"
+    )
+
+    assert status.installed is True
+    assert status.loadable is False
+    assert status.provider_count == 2
+    assert status.provider_distributions == (
+        "another-iceberg-provider==2",
+        "vane-extension-iceberg==1",
+    )
+    assert status.installed_distribution_name is None
+    assert status.distribution_version is None
+    assert [entry_point.load_calls for entry_point in entry_points] == [0, 0]
+
+
+def test_extension_statuses_accept_an_explicit_empty_catalog_without_network(monkeypatch):
+    monkeypatch.setattr(
+        extension_module,
+        "_EXTENSION_CATALOG_OPENER",
+        _CatalogOpener(AssertionError("network request was not expected")),
+    )
+    monkeypatch.setattr(extension_module, "entry_points", lambda *, group: ())
+
+    assert vane.extension_statuses(connection=_SnapshotConnection(), catalog=()) == ()
+
+
+def test_extension_statuses_validate_explicit_catalog_entries(monkeypatch):
+    monkeypatch.setattr(extension_module, "entry_points", lambda *, group: ())
+    invalid_entry = ExtensionCatalogEntry(
+        extension_name="iceberg",
+        distribution_name="another-package",
+        description="Iceberg",
+        repository="https://example.com/iceberg",
+        publisher="Example",
+        license="MIT",
+    )
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        vane.extension_statuses(connection=_SnapshotConnection(), catalog=(invalid_entry,))
+
+
+def test_extension_statuses_bound_an_explicit_catalog_iterable():
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        vane.extension_statuses(
+            connection=_SnapshotConnection(),
+            catalog=repeat(_catalog_entries()[0]),
+        )
+
+
+def test_vane_extensions_returns_a_queryable_relation(duckdb_cursor, monkeypatch):
+    monkeypatch.setattr(extension_module, "entry_points", lambda *, group: ())
+
+    relation = vane.vane_extensions(connection=duckdb_cursor, catalog=_catalog_entries())
+
+    assert relation.columns == [
+        "extension_name",
+        "loaded",
+        "installed",
+        "loadable",
+        "cataloged",
+        "description",
+        "extension_version",
+        "distribution_name",
+        "installed_distribution_name",
+        "distribution_version",
+        "repository",
+        "publisher",
+        "license",
+        "provider_distributions",
+        "provider_count",
+        "trust_identity",
+        "artifact_sha256",
+    ]
+    assert relation.project("extension_name, installed, loaded").order("extension_name").fetchall() == [
+        ("iceberg", False, False),
+        ("lance", False, False),
+        ("paimon", False, False),
+    ]

--- a/tests/fast/test_extension_catalog.py
+++ b/tests/fast/test_extension_catalog.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import threading
+import time
 from http.client import HTTPException
 from itertools import repeat
 from urllib.error import URLError
@@ -45,7 +47,8 @@ class _CatalogResponse:
         self.contents = contents
         self.url = url
         self.status = status
-        self.read_limit = None
+        self.read_limits = []
+        self.read_offset = 0
 
     def __enter__(self):
         return self
@@ -56,9 +59,28 @@ class _CatalogResponse:
     def geturl(self):
         return self.url
 
-    def read(self, limit):
-        self.read_limit = limit
-        return self.contents
+    def read1(self, limit):
+        self.read_limits.append(limit)
+        chunk = self.contents[self.read_offset : self.read_offset + limit]
+        self.read_offset += len(chunk)
+        return chunk
+
+
+class _BlockingCatalogResponse(_CatalogResponse):
+    def __init__(self):
+        super().__init__(b"")
+        self.entered_read = threading.Event()
+        self.release_read = threading.Event()
+        self.finished = threading.Event()
+
+    def __exit__(self, exception_type, exception, traceback):
+        self.finished.set()
+        return False
+
+    def read1(self, limit):
+        self.entered_read.set()
+        self.release_read.wait(timeout=2)
+        return b""
 
 
 class _CatalogOpener:
@@ -134,8 +156,26 @@ def test_extension_catalog_fetches_one_bounded_remote_index(monkeypatch):
     assert [entry.extension_name for entry in entries] == ["iceberg", "lance", "paimon"]
     assert opener.request.full_url == _CATALOG_URL
     assert opener.request.get_header("Accept") == "application/json"
-    assert opener.timeout == extension_module._EXTENSION_CATALOG_TIMEOUT_SECONDS
-    assert response.read_limit == extension_module._EXTENSION_CATALOG_MAX_BYTES + 1
+    assert 0 < opener.timeout <= extension_module._EXTENSION_CATALOG_TIMEOUT_SECONDS
+    assert response.read_limits
+    assert max(response.read_limits) <= extension_module._EXTENSION_CATALOG_READ_CHUNK_BYTES
+
+
+def test_extension_catalog_enforces_a_total_wall_clock_deadline(monkeypatch):
+    response = _BlockingCatalogResponse()
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", _CatalogOpener(response))
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_TIMEOUT_SECONDS", 0.5)
+
+    started = time.monotonic()
+    try:
+        with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_UNAVAILABLE"):
+            vane.extension_catalog(catalog_url=_CATALOG_URL)
+    finally:
+        response.release_read.set()
+
+    assert time.monotonic() - started < 2
+    assert response.entered_read.is_set()
+    assert response.finished.wait(timeout=1)
 
 
 @pytest.mark.parametrize(
@@ -210,6 +250,25 @@ def test_extension_catalog_rejects_duplicate_json_keys(monkeypatch):
 
     with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
         vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_rejects_a_lone_unicode_surrogate(monkeypatch):
+    document = _catalog_document()
+    document["extensions"][0]["description"] = "\ud800"
+    response = _CatalogResponse(json.dumps(document).encode())
+    monkeypatch.setattr(extension_module, "_EXTENSION_CATALOG_OPENER", _CatalogOpener(response))
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        vane.extension_catalog(catalog_url=_CATALOG_URL)
+
+
+def test_extension_catalog_rejects_names_with_ambiguous_distribution_normalization():
+    document = _catalog_document()
+    document["extensions"][0]["extension_name"] = "ice__berg"
+    document["extensions"][0]["distribution_name"] = "vane-extension-ice-berg"
+
+    with pytest.raises(extension_module.DynamicExtensionError, match="VANE_DYNAMIC_EXTENSION_CATALOG_INVALID"):
+        extension_module._parse_extension_catalog(document)
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -26,6 +26,7 @@ def test_vane_public_exports_are_unique_and_resolvable():
 
     expected_vane_exports = {
         "Connection",
+        "DEFAULT_EXTENSION_CATALOG_URL",
         "EnvRegistry",
         "File",
         "Relation",
@@ -39,12 +40,15 @@ def test_vane_public_exports_are_unique_and_resolvable():
         "current_config",
         "detach_function",
         "env",
+        "extension_catalog",
+        "extension_statuses",
         "file",
         "file_type",
         "func",
         "lit",
         "load_installed_extension",
         "sql_expr",
+        "vane_extensions",
     }
     assert expected_vane_exports <= set(vane.__all__)
     assert all(hasattr(vane, name) for name in vane.__all__)

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -261,15 +261,21 @@ from vane.datasink import (
 from vane.datasink.milvus import MilvusSink
 from vane.datasink.qdrant import QdrantSink
 from vane.extensions import (
+    DEFAULT_EXTENSION_CATALOG_URL,
     DynamicExtensionDependency,
     DynamicExtensionDescriptor,
     DynamicExtensionError,
     DynamicExtensionResolver,
+    ExtensionCatalogEntry,
+    ExtensionStatus,
     LocalExtensionArtifact,
     LocalExtensionProvider,
     ResolvedDynamicExtension,
     create_dynamic_extension_descriptor,
+    extension_catalog,
+    extension_statuses,
     load_installed_extension,
+    vane_extensions,
 )
 from vane.value.constant import (
     BinaryValue,
@@ -376,6 +382,7 @@ def __dir__() -> list[str]:
 
 
 __all__: list[str] = [
+    "DEFAULT_EXTENSION_CATALOG_URL",
     "AudioFile",
     "AudioFileError",
     "AudioFileFormatError",
@@ -421,6 +428,8 @@ __all__: list[str] = [
     "EnvRegistry",
     "EnvironmentSecret",
     "Error",
+    "ExtensionCatalogEntry",
+    "ExtensionStatus",
     "ExpectedResultType",
     "ExplainType",
     "Expression",
@@ -545,6 +554,8 @@ __all__: list[str] = [
     "enum_type",
     "execute",
     "executemany",
+    "extension_catalog",
+    "extension_statuses",
     "extract_statements",
     "fetch_arrow_table",
     "fetch_df",
@@ -636,6 +647,7 @@ __all__: list[str] = [
     "union_type",
     "unregister",
     "unregister_filesystem",
+    "vane_extensions",
     "values",
     "view",
     "version",

--- a/vane/extensions.py
+++ b/vane/extensions.py
@@ -432,11 +432,11 @@ def _fetch_extension_catalog_contents(request: Request, validated_url: str) -> b
         _fail("CATALOG_UNAVAILABLE", "extension catalog request exceeded its wall-clock deadline")
     try:
         worker.start()
-    except RuntimeError as exception:
+    except RuntimeError as start_exception:
         _EXTENSION_CATALOG_FETCH_SLOTS.release()
         raise DynamicExtensionError(
             "CATALOG_UNAVAILABLE", "could not start the extension catalog request"
-        ) from exception
+        ) from start_exception
     except BaseException:
         _EXTENSION_CATALOG_FETCH_SLOTS.release()
         raise
@@ -446,13 +446,13 @@ def _fetch_extension_catalog_contents(request: Request, validated_url: str) -> b
         cancelled.set()
         _fail("CATALOG_UNAVAILABLE", "extension catalog request exceeded its wall-clock deadline")
     try:
-        contents, exception = results.get_nowait()
+        contents, fetch_exception = results.get_nowait()
     except queue.Empty as queue_exception:
         raise DynamicExtensionError(
             "CATALOG_UNAVAILABLE", "extension catalog request did not return a result"
         ) from queue_exception
-    if exception is not None:
-        raise exception
+    if fetch_exception is not None:
+        raise fetch_exception
     if contents is None:
         _fail("CATALOG_UNAVAILABLE", "extension catalog request did not return a response body")
     return contents

--- a/vane/extensions.py
+++ b/vane/extensions.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import queue
 import re
 import shutil
 import stat
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
 _DESCRIPTOR_FORMAT_VERSION = 1
 _VALID_ABI_TYPES = frozenset({"CPP", "C_STRUCT", "C_STRUCT_UNSTABLE"})
 _EXTENSION_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_CATALOG_EXTENSION_NAME_RE = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
 _HEX_RE = re.compile(r"^[0-9a-f]{7,64}$")
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _PLATFORM_RE = re.compile(r"^[a-z0-9_]+$")
@@ -51,6 +53,8 @@ _EXTENSION_CATALOG_FORMAT_VERSION = 1
 _EXTENSION_CATALOG_MAX_BYTES = 64 * 1024
 _EXTENSION_CATALOG_MAX_ENTRIES = 1024
 _EXTENSION_CATALOG_TIMEOUT_SECONDS = 10.0
+_EXTENSION_CATALOG_READ_CHUNK_BYTES = 16 * 1024
+_EXTENSION_CATALOG_MAX_CONCURRENT_FETCHES = 4
 _DISTRIBUTION_NAME_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
 DEFAULT_EXTENSION_CATALOG_URL = "https://astrovela.github.io/vane-extensions/v1/index.json"
 
@@ -69,6 +73,7 @@ class _RejectCatalogRedirects(HTTPRedirectHandler):
 
 
 _EXTENSION_CATALOG_OPENER = build_opener(_RejectCatalogRedirects())
+_EXTENSION_CATALOG_FETCH_SLOTS = threading.BoundedSemaphore(_EXTENSION_CATALOG_MAX_CONCURRENT_FETCHES)
 
 
 def _snapshot_mode_is_read_only(mode: int) -> bool:
@@ -114,8 +119,11 @@ def _make_snapshot_read_only(path: Path, *, description: str) -> None:
 def _require_string(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not value:
         _fail("DESCRIPTOR_INVALID", f"{field_name} must be a non-empty string")
-    if any(character.isspace() or ord(character) < 32 for character in value):
-        _fail("DESCRIPTOR_INVALID", f"{field_name} must not contain whitespace or control characters")
+    if any(character.isspace() or ord(character) < 32 or 0xD800 <= ord(character) <= 0xDFFF for character in value):
+        _fail(
+            "DESCRIPTOR_INVALID",
+            f"{field_name} must not contain whitespace, control characters, or lone Unicode surrogates",
+        )
     return value
 
 
@@ -153,6 +161,8 @@ def _catalog_string(value: object, field_name: str, *, max_length: int) -> str:
         _fail("CATALOG_INVALID", f"{field_name} exceeds its {max_length}-character limit")
     if any(ord(character) < 32 or ord(character) == 127 for character in value):
         _fail("CATALOG_INVALID", f"{field_name} must not contain control characters")
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+        _fail("CATALOG_INVALID", f"{field_name} must not contain lone Unicode surrogates")
     return value
 
 
@@ -224,7 +234,7 @@ def _parse_extension_catalog(value: object) -> tuple[ExtensionCatalogEntry, ...]
             f"extensions[{index}].extension_name",
             max_length=128,
         )
-        if not _EXTENSION_NAME_RE.fullmatch(extension_name):
+        if not _CATALOG_EXTENSION_NAME_RE.fullmatch(extension_name):
             _fail(
                 "CATALOG_INVALID",
                 f"extensions[{index}].extension_name must use lowercase ASCII extension-name syntax",
@@ -347,6 +357,107 @@ def _reject_duplicate_catalog_keys(pairs: list[tuple[str, object]]) -> dict[str,
     return result
 
 
+def _extension_catalog_deadline_remaining(deadline: float) -> float:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        _fail("CATALOG_UNAVAILABLE", "extension catalog request exceeded its wall-clock deadline")
+    return remaining
+
+
+def _read_extension_catalog_response(
+    response: object,
+    *,
+    deadline: float,
+    cancelled: threading.Event,
+) -> bytes:
+    read_one = getattr(response, "read1", None)
+    if not callable(read_one):
+        _fail("CATALOG_UNAVAILABLE", "extension catalog response does not support bounded reads")
+
+    contents = bytearray()
+    maximum_read = _EXTENSION_CATALOG_MAX_BYTES + 1
+    while len(contents) < maximum_read:
+        if cancelled.is_set():
+            _fail("CATALOG_UNAVAILABLE", "extension catalog request was cancelled")
+        _extension_catalog_deadline_remaining(deadline)
+        read_size = min(_EXTENSION_CATALOG_READ_CHUNK_BYTES, maximum_read - len(contents))
+        chunk = read_one(read_size)
+        _extension_catalog_deadline_remaining(deadline)
+        if not isinstance(chunk, bytes) or len(chunk) > read_size:
+            _fail("CATALOG_UNAVAILABLE", "extension catalog endpoint returned an invalid response body")
+        if not chunk:
+            break
+        contents.extend(chunk)
+    return bytes(contents)
+
+
+def _extension_catalog_fetch_worker(
+    request: Request,
+    validated_url: str,
+    deadline: float,
+    cancelled: threading.Event,
+    results: queue.Queue[tuple[bytes | None, Exception | None]],
+) -> None:
+    try:
+        with _EXTENSION_CATALOG_OPENER.open(
+            request,
+            timeout=_extension_catalog_deadline_remaining(deadline),
+        ) as response:
+            get_url = getattr(response, "geturl", None)
+            if getattr(response, "status", None) != 200 or not callable(get_url) or get_url() != validated_url:
+                _fail("CATALOG_UNAVAILABLE", "extension catalog endpoint did not return the requested resource")
+            contents = _read_extension_catalog_response(
+                response,
+                deadline=deadline,
+                cancelled=cancelled,
+            )
+        results.put((contents, None))
+    except Exception as exception:
+        results.put((None, exception))
+    finally:
+        _EXTENSION_CATALOG_FETCH_SLOTS.release()
+
+
+def _fetch_extension_catalog_contents(request: Request, validated_url: str) -> bytes:
+    deadline = time.monotonic() + _EXTENSION_CATALOG_TIMEOUT_SECONDS
+    cancelled = threading.Event()
+    results: queue.Queue[tuple[bytes | None, Exception | None]] = queue.Queue(maxsize=1)
+    worker = threading.Thread(
+        target=_extension_catalog_fetch_worker,
+        args=(request, validated_url, deadline, cancelled, results),
+        name="vane-extension-catalog-fetch",
+        daemon=True,
+    )
+    if not _EXTENSION_CATALOG_FETCH_SLOTS.acquire(timeout=_extension_catalog_deadline_remaining(deadline)):
+        _fail("CATALOG_UNAVAILABLE", "extension catalog request exceeded its wall-clock deadline")
+    try:
+        worker.start()
+    except RuntimeError as exception:
+        _EXTENSION_CATALOG_FETCH_SLOTS.release()
+        raise DynamicExtensionError(
+            "CATALOG_UNAVAILABLE", "could not start the extension catalog request"
+        ) from exception
+    except BaseException:
+        _EXTENSION_CATALOG_FETCH_SLOTS.release()
+        raise
+
+    worker.join(max(0.0, deadline - time.monotonic()))
+    if worker.is_alive() or time.monotonic() >= deadline:
+        cancelled.set()
+        _fail("CATALOG_UNAVAILABLE", "extension catalog request exceeded its wall-clock deadline")
+    try:
+        contents, exception = results.get_nowait()
+    except queue.Empty as queue_exception:
+        raise DynamicExtensionError(
+            "CATALOG_UNAVAILABLE", "extension catalog request did not return a result"
+        ) from queue_exception
+    if exception is not None:
+        raise exception
+    if contents is None:
+        _fail("CATALOG_UNAVAILABLE", "extension catalog request did not return a response body")
+    return contents
+
+
 def extension_catalog(
     *,
     catalog_url: str = DEFAULT_EXTENSION_CATALOG_URL,
@@ -365,10 +476,7 @@ def extension_catalog(
         },
     )
     try:
-        with _EXTENSION_CATALOG_OPENER.open(request, timeout=_EXTENSION_CATALOG_TIMEOUT_SECONDS) as response:
-            if response.status != 200 or response.geturl() != validated_url:
-                _fail("CATALOG_UNAVAILABLE", "extension catalog endpoint did not return the requested resource")
-            contents = response.read(_EXTENSION_CATALOG_MAX_BYTES + 1)
+        contents = _fetch_extension_catalog_contents(request, validated_url)
     except DynamicExtensionError:
         raise
     except (HTTPError, URLError, HTTPException, OSError, TimeoutError) as exception:
@@ -907,8 +1015,14 @@ class _InstalledExtensionProviderMetadata:
 def _provider_metadata_string(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not value or value != value.strip():
         _fail("PROVIDER_INVALID", f"installed provider {field_name} must be a non-empty trimmed string")
-    if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
-        _fail("PROVIDER_INVALID", f"installed provider {field_name} must not contain whitespace or control characters")
+    if any(
+        character.isspace() or ord(character) < 32 or ord(character) == 127 or 0xD800 <= ord(character) <= 0xDFFF
+        for character in value
+    ):
+        _fail(
+            "PROVIDER_INVALID",
+            f"installed provider {field_name} must not contain whitespace, control characters, or lone Unicode surrogates",
+        )
     return value
 
 

--- a/vane/extensions.py
+++ b/vane/extensions.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: Apache-2.0
-"""Trusted local resolution for loadable DuckDB extensions.
+"""Discovery and trusted local resolution for loadable DuckDB extensions.
 
-This module deliberately has no repository, download, or implicit-directory
-lookup. A caller supplies an explicit artifact or an installed local provider,
-and a descriptor pins the exact bytes that may be loaded into a connection.
+The remote catalog supplies discovery metadata only. Resolution never obtains
+an artifact from that catalog: a caller supplies an explicit artifact or an
+installed local provider, and a descriptor pins the exact bytes that may be
+loaded into a connection.
 """
 
 from __future__ import annotations
@@ -20,12 +21,17 @@ import threading
 import time
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from http.client import HTTPException, HTTPMessage
 from importlib.metadata import entry_points
+from itertools import islice
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
+from typing import IO, TYPE_CHECKING, NoReturn
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 if TYPE_CHECKING:
-    from vane import DuckDBPyConnection
+    from vane import DuckDBPyConnection, DuckDBPyRelation
 
 _DESCRIPTOR_FORMAT_VERSION = 1
 _VALID_ABI_TYPES = frozenset({"CPP", "C_STRUCT", "C_STRUCT_UNSTABLE"})
@@ -41,6 +47,28 @@ _SHARED_DIRECTORY_WRITE_BITS = stat.S_IWGRP | stat.S_IWOTH
 _CACHE_DIRECTORY_NORMALIZATION_TIMEOUT_SECONDS = 5.0
 _CACHE_DIRECTORY_NORMALIZATION_RETRY_SECONDS = 0.01
 _DYNAMIC_EXTENSION_PROVIDER_ENTRY_POINT_GROUP = "vane.dynamic_extension_providers"
+_EXTENSION_CATALOG_FORMAT_VERSION = 1
+_EXTENSION_CATALOG_MAX_BYTES = 64 * 1024
+_EXTENSION_CATALOG_MAX_ENTRIES = 1024
+_EXTENSION_CATALOG_TIMEOUT_SECONDS = 10.0
+_DISTRIBUTION_NAME_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
+DEFAULT_EXTENSION_CATALOG_URL = "https://astrovela.github.io/vane-extensions/v1/index.json"
+
+
+class _RejectCatalogRedirects(HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+_EXTENSION_CATALOG_OPENER = build_opener(_RejectCatalogRedirects())
 
 
 def _snapshot_mode_is_read_only(mode: int) -> bool:
@@ -116,6 +144,275 @@ def _validate_extension_name(name: object, field_name: str = "name") -> str:
             f"{field_name} must use canonical DuckDB extension name {canonical_name!r}, not alias {value!r}",
         )
     return value
+
+
+def _catalog_string(value: object, field_name: str, *, max_length: int) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("CATALOG_INVALID", f"{field_name} must be a non-empty trimmed string")
+    if len(value) > max_length:
+        _fail("CATALOG_INVALID", f"{field_name} exceeds its {max_length}-character limit")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        _fail("CATALOG_INVALID", f"{field_name} must not contain control characters")
+    return value
+
+
+def _canonical_distribution_name(value: str) -> str:
+    return re.sub(r"[-_.]+", "-", value).lower()
+
+
+@dataclass(frozen=True)
+class ExtensionCatalogEntry:
+    """One discoverable Vane extension provider package."""
+
+    extension_name: str
+    distribution_name: str
+    description: str
+    repository: str
+    publisher: str
+    license: str
+
+
+@dataclass(frozen=True)
+class ExtensionStatus:
+    """Installed-provider and connection state for one extension name."""
+
+    extension_name: str
+    cataloged: bool
+    installed: bool
+    loadable: bool
+    loaded: bool
+    description: str | None
+    distribution_name: str | None
+    installed_distribution_name: str | None
+    distribution_version: str | None
+    repository: str | None
+    publisher: str | None
+    license: str | None
+    provider_distributions: tuple[str, ...]
+    provider_count: int
+    extension_version: str | None
+    trust_identity: str | None
+    artifact_sha256: str | None
+
+
+def _parse_extension_catalog(value: object) -> tuple[ExtensionCatalogEntry, ...]:
+    if not isinstance(value, Mapping) or set(value) != {"format_version", "extensions"}:
+        _fail("CATALOG_INVALID", "catalog must contain only format_version and extensions")
+    if type(value["format_version"]) is not int or value["format_version"] != _EXTENSION_CATALOG_FORMAT_VERSION:
+        _fail("CATALOG_INVALID", f"catalog format_version must be {_EXTENSION_CATALOG_FORMAT_VERSION}")
+    raw_extensions = value["extensions"]
+    if not isinstance(raw_extensions, list):
+        _fail("CATALOG_INVALID", "catalog extensions must be a list")
+    if len(raw_extensions) > _EXTENSION_CATALOG_MAX_ENTRIES:
+        _fail("CATALOG_INVALID", f"catalog exceeds its {_EXTENSION_CATALOG_MAX_ENTRIES}-entry limit")
+
+    expected_entry_keys = {
+        "extension_name",
+        "distribution_name",
+        "description",
+        "repository",
+        "publisher",
+        "license",
+    }
+    entries: list[ExtensionCatalogEntry] = []
+    seen_names: set[str] = set()
+    for index, raw_entry in enumerate(raw_extensions):
+        if not isinstance(raw_entry, Mapping) or set(raw_entry) != expected_entry_keys:
+            _fail("CATALOG_INVALID", f"extensions[{index}] does not contain the exact catalog entry fields")
+        extension_name = _catalog_string(
+            raw_entry["extension_name"],
+            f"extensions[{index}].extension_name",
+            max_length=128,
+        )
+        if not _EXTENSION_NAME_RE.fullmatch(extension_name):
+            _fail(
+                "CATALOG_INVALID",
+                f"extensions[{index}].extension_name must use lowercase ASCII extension-name syntax",
+            )
+        try:
+            canonical_name = _native_canonical_extension_name(extension_name)
+        except DynamicExtensionError as exception:
+            raise DynamicExtensionError(
+                "CATALOG_INVALID",
+                f"could not canonicalize extensions[{index}].extension_name",
+            ) from exception
+        if canonical_name != extension_name:
+            _fail(
+                "CATALOG_INVALID",
+                f"extensions[{index}].extension_name must use canonical DuckDB name {canonical_name!r}",
+            )
+        if extension_name in seen_names:
+            _fail("CATALOG_INVALID", f"catalog repeats extension name {extension_name!r}")
+
+        distribution_name = _catalog_string(
+            raw_entry["distribution_name"],
+            f"extensions[{index}].distribution_name",
+            max_length=256,
+        )
+        if not _DISTRIBUTION_NAME_RE.fullmatch(distribution_name):
+            _fail("CATALOG_INVALID", f"extensions[{index}].distribution_name is not a Python distribution name")
+        expected_distribution_name = _canonical_distribution_name(f"vane-extension-{extension_name}")
+        if distribution_name != expected_distribution_name:
+            _fail(
+                "CATALOG_INVALID",
+                f"extensions[{index}].distribution_name must be canonical name {expected_distribution_name!r}",
+            )
+
+        repository = _catalog_string(
+            raw_entry["repository"],
+            f"extensions[{index}].repository",
+            max_length=2048,
+        )
+        try:
+            repository_url = urlsplit(repository)
+            repository_hostname = repository_url.hostname
+            repository_port = repository_url.port
+        except ValueError as exception:
+            raise DynamicExtensionError(
+                "CATALOG_INVALID",
+                f"extensions[{index}].repository is not a valid URL",
+            ) from exception
+        if (
+            repository_url.scheme != "https"
+            or not repository_hostname
+            or repository_port is not None
+            or repository_url.username is not None
+            or repository_url.password is not None
+            or not repository_url.path.strip("/")
+            or repository_url.query
+            or repository_url.fragment
+            or not repository.isascii()
+            or any(character.isspace() for character in repository)
+        ):
+            _fail("CATALOG_INVALID", f"extensions[{index}].repository must be a canonical HTTPS repository URL")
+        entries.append(
+            ExtensionCatalogEntry(
+                extension_name=extension_name,
+                distribution_name=distribution_name,
+                description=_catalog_string(
+                    raw_entry["description"],
+                    f"extensions[{index}].description",
+                    max_length=500,
+                ),
+                repository=repository,
+                publisher=_catalog_string(
+                    raw_entry["publisher"],
+                    f"extensions[{index}].publisher",
+                    max_length=100,
+                ),
+                license=_catalog_string(
+                    raw_entry["license"],
+                    f"extensions[{index}].license",
+                    max_length=200,
+                ),
+            )
+        )
+        seen_names.add(extension_name)
+
+    names = [entry.extension_name for entry in entries]
+    if names != sorted(names):
+        _fail("CATALOG_INVALID", "catalog extensions must be sorted by extension_name")
+    return tuple(entries)
+
+
+def _validate_extension_catalog_url(value: object) -> str:
+    catalog_url = _catalog_string(value, "catalog_url", max_length=2048)
+    try:
+        parsed = urlsplit(catalog_url)
+        port = parsed.port
+    except ValueError as exception:
+        raise DynamicExtensionError("CATALOG_INVALID", "catalog_url is not a valid URL") from exception
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or not parsed.path.strip("/")
+        or parsed.query
+        or parsed.fragment
+        or not catalog_url.isascii()
+        or any(character.isspace() for character in catalog_url)
+    ):
+        _fail("CATALOG_INVALID", "catalog_url must be a canonical HTTPS URL")
+    return catalog_url
+
+
+def _reject_duplicate_catalog_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail("CATALOG_INVALID", f"catalog JSON object repeats key {key!r}")
+        result[key] = value
+    return result
+
+
+def extension_catalog(
+    *,
+    catalog_url: str = DEFAULT_EXTENSION_CATALOG_URL,
+) -> tuple[ExtensionCatalogEntry, ...]:
+    """Fetch and validate one Vane provider discovery catalog.
+
+    The request is bounded, rejects redirects, and has no cache or fallback.
+    Catalog entries are discovery metadata only and never initialize providers.
+    """
+    validated_url = _validate_extension_catalog_url(catalog_url)
+    request = Request(
+        validated_url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "vane-extension-catalog/1",
+        },
+    )
+    try:
+        with _EXTENSION_CATALOG_OPENER.open(request, timeout=_EXTENSION_CATALOG_TIMEOUT_SECONDS) as response:
+            if response.status != 200 or response.geturl() != validated_url:
+                _fail("CATALOG_UNAVAILABLE", "extension catalog endpoint did not return the requested resource")
+            contents = response.read(_EXTENSION_CATALOG_MAX_BYTES + 1)
+    except DynamicExtensionError:
+        raise
+    except (HTTPError, URLError, HTTPException, OSError, TimeoutError) as exception:
+        raise DynamicExtensionError("CATALOG_UNAVAILABLE", "could not fetch the extension catalog") from exception
+    if len(contents) > _EXTENSION_CATALOG_MAX_BYTES:
+        _fail("CATALOG_INVALID", "extension catalog exceeds its size limit")
+    try:
+        document = json.loads(contents.decode("utf-8"), object_pairs_hook=_reject_duplicate_catalog_keys)
+    except DynamicExtensionError:
+        raise
+    except (UnicodeError, ValueError, RecursionError) as exception:
+        raise DynamicExtensionError("CATALOG_INVALID", "extension catalog is not valid UTF-8 JSON") from exception
+    return _parse_extension_catalog(document)
+
+
+def _validate_extension_catalog_entries(
+    entries: Iterable[ExtensionCatalogEntry],
+) -> tuple[ExtensionCatalogEntry, ...]:
+    try:
+        supplied_entries = tuple(islice(iter(entries), _EXTENSION_CATALOG_MAX_ENTRIES + 1))
+    except TypeError as exception:
+        raise DynamicExtensionError("CATALOG_INVALID", "catalog entries must be iterable") from exception
+    if len(supplied_entries) > _EXTENSION_CATALOG_MAX_ENTRIES:
+        _fail("CATALOG_INVALID", f"catalog exceeds its {_EXTENSION_CATALOG_MAX_ENTRIES}-entry limit")
+    raw_entries: list[dict[str, object]] = []
+    for index, entry in enumerate(supplied_entries):
+        if not isinstance(entry, ExtensionCatalogEntry):
+            _fail("CATALOG_INVALID", f"catalog entry {index} must be ExtensionCatalogEntry")
+        raw_entries.append(
+            {
+                "extension_name": entry.extension_name,
+                "distribution_name": entry.distribution_name,
+                "description": entry.description,
+                "repository": entry.repository,
+                "publisher": entry.publisher,
+                "license": entry.license,
+            }
+        )
+    return _parse_extension_catalog(
+        {
+            "format_version": _EXTENSION_CATALOG_FORMAT_VERSION,
+            "extensions": raw_entries,
+        }
+    )
 
 
 def _validate_sha256(value: object, field_name: str = "sha256") -> str:
@@ -598,6 +895,189 @@ def _installed_dynamic_extension_provider_entry_points() -> tuple[object, ...]:
         raise DynamicExtensionError(
             "PROVIDER_DISCOVERY_FAILED", "could not enumerate installed dynamic extension providers"
         ) from exception
+
+
+@dataclass(frozen=True)
+class _InstalledExtensionProviderMetadata:
+    extension_name: str
+    distribution_name: str
+    distribution_version: str
+
+
+def _provider_metadata_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail("PROVIDER_INVALID", f"installed provider {field_name} must be a non-empty trimmed string")
+    if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in value):
+        _fail("PROVIDER_INVALID", f"installed provider {field_name} must not contain whitespace or control characters")
+    return value
+
+
+def _installed_dynamic_extension_provider_metadata(
+    installed_entry_points: tuple[object, ...],
+) -> tuple[_InstalledExtensionProviderMetadata, ...]:
+    """Inspect provider package metadata without importing provider code."""
+    providers: list[_InstalledExtensionProviderMetadata] = []
+    for index, installed in enumerate(installed_entry_points):
+        try:
+            raw_name = getattr(installed, "name", None)
+            name = _provider_metadata_string(raw_name, f"entry point {index} name")
+            if not _EXTENSION_NAME_RE.fullmatch(name) or _native_canonical_extension_name(name) != name:
+                _fail("PROVIDER_INVALID", f"installed provider entry point {index} has non-canonical name {name!r}")
+
+            distribution = getattr(installed, "dist", None)
+            metadata = getattr(distribution, "metadata", None)
+            metadata_get = getattr(metadata, "get", None)
+            if not callable(metadata_get):
+                _fail("PROVIDER_INVALID", f"installed provider entry point {name!r} has no distribution metadata")
+            distribution_name = _provider_metadata_string(
+                metadata_get("Name"),
+                f"entry point {name!r} distribution name",
+            )
+            if not _DISTRIBUTION_NAME_RE.fullmatch(distribution_name):
+                _fail(
+                    "PROVIDER_INVALID",
+                    f"installed provider entry point {name!r} has an invalid distribution name",
+                )
+            distribution_version = _provider_metadata_string(
+                getattr(distribution, "version", None),
+                f"entry point {name!r} distribution version",
+            )
+        except DynamicExtensionError:
+            raise
+        except Exception as exception:
+            raise DynamicExtensionError(
+                "PROVIDER_INVALID",
+                f"could not inspect installed provider entry point {index}",
+            ) from exception
+        providers.append(
+            _InstalledExtensionProviderMetadata(
+                extension_name=name,
+                distribution_name=_canonical_distribution_name(distribution_name),
+                distribution_version=distribution_version,
+            )
+        )
+    return tuple(
+        sorted(
+            providers,
+            key=lambda provider: (
+                provider.extension_name,
+                provider.distribution_name,
+                provider.distribution_version,
+            ),
+        )
+    )
+
+
+def extension_statuses(
+    *,
+    connection: DuckDBPyConnection,
+    catalog: Iterable[ExtensionCatalogEntry] | None = None,
+) -> tuple[ExtensionStatus, ...]:
+    """Return catalog, installation, and verified-load state for a connection.
+
+    Enumerating installed providers reads only Python distribution metadata. It
+    never imports or initializes an extension provider; provider code runs only
+    after an explicit :func:`load_installed_extension` call.
+    """
+    catalog_entries = extension_catalog() if catalog is None else _validate_extension_catalog_entries(catalog)
+    catalog_by_name = {entry.extension_name: entry for entry in catalog_entries}
+    provider_metadata = _installed_dynamic_extension_provider_metadata(
+        _installed_dynamic_extension_provider_entry_points()
+    )
+    providers_by_name: dict[str, list[_InstalledExtensionProviderMetadata]] = {}
+    for provider in provider_metadata:
+        providers_by_name.setdefault(provider.extension_name, []).append(provider)
+
+    loaded_descriptors = _parse_dynamic_extension_snapshot(_capture_dynamic_extension_snapshot(connection))
+    loaded_by_name = {descriptor.name: descriptor for descriptor in loaded_descriptors}
+    extension_names = sorted(set(catalog_by_name) | set(providers_by_name) | set(loaded_by_name))
+    statuses: list[ExtensionStatus] = []
+    for extension_name in extension_names:
+        catalog_entry = catalog_by_name.get(extension_name)
+        installed_providers = providers_by_name.get(extension_name, [])
+        installed_provider = installed_providers[0] if len(installed_providers) == 1 else None
+        loaded_descriptor = loaded_by_name.get(extension_name)
+        statuses.append(
+            ExtensionStatus(
+                extension_name=extension_name,
+                cataloged=catalog_entry is not None,
+                installed=bool(installed_providers),
+                loadable=len(installed_providers) == 1,
+                loaded=loaded_descriptor is not None,
+                description=None if catalog_entry is None else catalog_entry.description,
+                distribution_name=None if catalog_entry is None else catalog_entry.distribution_name,
+                installed_distribution_name=(
+                    None if installed_provider is None else installed_provider.distribution_name
+                ),
+                distribution_version=None if installed_provider is None else installed_provider.distribution_version,
+                repository=None if catalog_entry is None else catalog_entry.repository,
+                publisher=None if catalog_entry is None else catalog_entry.publisher,
+                license=None if catalog_entry is None else catalog_entry.license,
+                provider_distributions=tuple(
+                    f"{provider.distribution_name}=={provider.distribution_version}" for provider in installed_providers
+                ),
+                provider_count=len(installed_providers),
+                extension_version=None if loaded_descriptor is None else loaded_descriptor.extension_version,
+                trust_identity=None if loaded_descriptor is None else loaded_descriptor.trust_identity,
+                artifact_sha256=None if loaded_descriptor is None else loaded_descriptor.sha256,
+            )
+        )
+    return tuple(statuses)
+
+
+def vane_extensions(
+    *,
+    connection: DuckDBPyConnection,
+    catalog: Iterable[ExtensionCatalogEntry] | None = None,
+) -> DuckDBPyRelation:
+    """Return a DuckDB relation describing Vane extension provider state."""
+    import pyarrow as pa
+
+    statuses = extension_statuses(connection=connection, catalog=catalog)
+    schema = pa.schema(
+        (
+            pa.field("extension_name", pa.string(), nullable=False),
+            pa.field("loaded", pa.bool_(), nullable=False),
+            pa.field("installed", pa.bool_(), nullable=False),
+            pa.field("loadable", pa.bool_(), nullable=False),
+            pa.field("cataloged", pa.bool_(), nullable=False),
+            pa.field("description", pa.string()),
+            pa.field("extension_version", pa.string()),
+            pa.field("distribution_name", pa.string()),
+            pa.field("installed_distribution_name", pa.string()),
+            pa.field("distribution_version", pa.string()),
+            pa.field("repository", pa.string()),
+            pa.field("publisher", pa.string()),
+            pa.field("license", pa.string()),
+            pa.field("provider_distributions", pa.list_(pa.string()), nullable=False),
+            pa.field("provider_count", pa.uint64(), nullable=False),
+            pa.field("trust_identity", pa.string()),
+            pa.field("artifact_sha256", pa.string()),
+        )
+    )
+    rows = [
+        {
+            "extension_name": status.extension_name,
+            "loaded": status.loaded,
+            "installed": status.installed,
+            "loadable": status.loadable,
+            "cataloged": status.cataloged,
+            "description": status.description,
+            "extension_version": status.extension_version,
+            "distribution_name": status.distribution_name,
+            "installed_distribution_name": status.installed_distribution_name,
+            "distribution_version": status.distribution_version,
+            "repository": status.repository,
+            "publisher": status.publisher,
+            "license": status.license,
+            "provider_distributions": list(status.provider_distributions),
+            "provider_count": status.provider_count,
+            "trust_identity": status.trust_identity,
+            "artifact_sha256": status.artifact_sha256,
+        }
+        for status in statuses
+    ]
+    return connection.from_arrow(pa.Table.from_pylist(rows, schema=schema)).set_alias("vane_extensions")
 
 
 def _load_installed_dynamic_extension_provider(
@@ -1579,13 +2059,19 @@ def _copy_and_hash_artifact(source: Path, destination: Path) -> str:
 
 
 __all__ = [
+    "DEFAULT_EXTENSION_CATALOG_URL",
     "DynamicExtensionDependency",
     "DynamicExtensionDescriptor",
     "DynamicExtensionError",
     "DynamicExtensionResolver",
+    "ExtensionCatalogEntry",
+    "ExtensionStatus",
     "LocalExtensionArtifact",
     "LocalExtensionProvider",
     "ResolvedDynamicExtension",
     "create_dynamic_extension_descriptor",
+    "extension_catalog",
+    "extension_statuses",
     "load_installed_extension",
+    "vane_extensions",
 ]


### PR DESCRIPTION
## Summary

- Add a generic HTTPS extension catalog client with strict parsing, bounded concurrency, one wall-clock deadline, and no compatibility fallback.
- Expose catalog entries and local extension status through Python APIs and an Arrow-backed `vane_extensions()` relation.
- Combine discovery metadata with installed provider entry points and the current connection's loaded state without importing provider packages.
- Keep loading and Ray worker preparation independent of the catalog; adding a provider only requires a manifest in the companion registry.

Companion registry: AstroVela/vane-extensions#1

## Related issue

Related: #614

This PR adds discovery only. #614 remains open for its signed artifact publication, local installation, retention, and cache-validation scope.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`README.md`, `DEVELOPMENT.md`, and `DISTRIBUTED_EXTENSIONS.md` document the catalog boundary and APIs.

## Validation

- Release wheel built and installed non-editably with `uv pip install --python .venv/bin/python . --no-build-isolation` using the Release incremental build directory and 36 build jobs.
- `scripts/run_installed_pytest.sh tests/fast/test_extension_catalog.py tests/fast/test_package_metadata.py::test_vane_public_exports_are_unique_and_resolvable` (27 passed)
- `ruff check vane/extensions.py vane/__init__.py tests/fast/test_extension_catalog.py tests/fast/test_package_metadata.py`
- Targeted Mypy check passed for the two changed production modules. A broader transitive probe also reported existing errors outside the changed files.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
