### PR TITLE
[feat](file) Get exact VideoFile frame by index

### DIFF
--- a/src/vane_py/native/file.cpp
+++ b/src/vane_py/native/file.cpp
@@ -249,6 +249,22 @@ static void BindMediaFileClass(py::handle &m, const char *class_name) {
 		    py::arg("max_input_bytes") = DEFAULT_VIDEO_MAX_INPUT_BYTES,
 		    py::arg("max_frames") = DEFAULT_VIDEO_MAX_FRAMES, py::arg("max_pixels") = DEFAULT_VIDEO_MAX_PIXELS,
 		    py::arg("connection") = py::none());
+		file.def(
+		    "get_frame_by_idx",
+		    [](const FILE_TYPE &value, const py::object &idx, const py::object &buffer_size,
+		       const py::object &max_input_bytes, const py::object &max_frames, const py::object &max_pixels,
+		       shared_ptr<DuckDBPyConnection> connection) {
+			    return py::module_::import("vane._video_file")
+			        .attr("_video_file_frame_by_idx_value")(
+			            py::cast(value, py::return_value_policy::copy), idx, buffer_size,
+			            py::arg("max_input_bytes") = max_input_bytes, py::arg("max_frames") = max_frames,
+			            py::arg("max_pixels") = max_pixels, py::arg("connection") = std::move(connection));
+		    },
+		    "Sequentially decode the exact zero-based presentation-order frame into a detached RGB Pillow image",
+		    py::arg("idx"), py::arg("buffer_size") = DEFAULT_VIDEO_BUFFER_SIZE, py::kw_only(),
+		    py::arg("max_input_bytes") = DEFAULT_VIDEO_MAX_INPUT_BYTES,
+		    py::arg("max_frames") = DEFAULT_VIDEO_MAX_FRAMES, py::arg("max_pixels") = DEFAULT_VIDEO_MAX_PIXELS,
+		    py::arg("connection") = py::none());
 	}
 }
 

--- a/tests/fast/test_file.py
+++ b/tests/fast/test_file.py
@@ -17,7 +17,7 @@ FILE_FIELDS = ("url", "content_type", "position", "size", "checksum")
 FILE_METHODS = ("exists", "mime_type", "open", "stat", "to_tempfile")
 IMAGE_FILE_METHODS = FILE_METHODS + ("decode", "metadata")
 AUDIO_FILE_METHODS = FILE_METHODS + ("metadata", "to_numpy")
-VIDEO_FILE_METHODS = FILE_METHODS + ("frames", "keyframes", "metadata")
+VIDEO_FILE_METHODS = FILE_METHODS + ("frames", "get_frame_by_idx", "keyframes", "metadata")
 MEDIA_FILE_CASES = (
     ("image", "IMAGEFILE", vane.ImageFile, vane.image_file),
     ("audio", "AUDIOFILE", vane.AudioFile, vane.audio_file),

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -364,6 +364,109 @@ def test_video_get_frame_by_idx_enforces_decode_budget_without_opening_file():
         vane.VideoFile("memory://not-opened").get_frame_by_idx(5, max_frames=5)
 
 
+@pytest.mark.parametrize("teardown", ["success", "container_error", "interrupt"])
+def test_video_get_frame_by_idx_finishes_teardown_before_transferring_image(monkeypatch, teardown):
+    teardown_error = RuntimeError(f"{teardown} during video teardown")
+    image_close_calls = 0
+    container_close_calls = 0
+
+    class TrackingImage:
+        def close(self):
+            nonlocal image_close_calls
+            image_close_calls += 1
+
+    image = TrackingImage()
+
+    class Reader:
+        interrupted = False
+        close_calls = 0
+        checked_close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+        def _close_and_check_interrupted(self):
+            self.checked_close_calls += 1
+            self._check_interrupted()
+
+        def size(self):
+            return 1
+
+        def _check_interrupted(self):
+            if self.interrupted:
+                raise teardown_error
+
+    reader = Reader()
+
+    class Value:
+        content_type = None
+
+        def open(self, **kwargs):
+            del kwargs
+            return reader
+
+    class Container:
+        def close(self):
+            nonlocal container_close_calls
+            container_close_calls += 1
+            if teardown == "container_error":
+                raise teardown_error
+            if teardown == "interrupt":
+                reader.interrupted = True
+
+    class FakeFFmpegError(Exception):
+        pass
+
+    class FakeExitError(FakeFFmpegError):
+        pass
+
+    fake_av = SimpleNamespace(
+        open=lambda *args, **kwargs: Container(),
+        error=SimpleNamespace(ExitError=FakeExitError, FFmpegError=FakeFFmpegError),
+        video=SimpleNamespace(reformatter=SimpleNamespace(VideoReformatter=object)),
+    )
+    prepared_batch = _video_file._PreparedFrameBatch(
+        results=[vane.VideoFrameData(0, 0.0, Fraction(1), 0, 0, 1, True, image)],
+        next_sample_time=None,
+        last_frame_time=None,
+    )
+
+    monkeypatch.setattr(_video_file, "_load_av", lambda: fake_av)
+    monkeypatch.setattr(_video_file, "_load_pillow", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        _video_file,
+        "_metadata_from_container",
+        lambda *args, **kwargs: SimpleNamespace(time_base=Fraction(1)),
+    )
+    monkeypatch.setattr(_video_file, "_select_video_stream", lambda *args: object())
+    monkeypatch.setattr(_video_file, "_stream_time_origin", lambda *args: Fraction(0))
+    monkeypatch.setattr(_video_file, "_configure_video_decoder", lambda *args: None)
+    monkeypatch.setattr(
+        _video_file,
+        "_iter_decoded_packet_batches",
+        lambda *args, **kwargs: (batch for batch in (object(),)),
+    )
+    monkeypatch.setattr(_video_file, "_prepare_video_packet_batch", lambda *args, **kwargs: prepared_batch)
+
+    if teardown == "success":
+        selected = _video_file._video_file_frame_by_idx_value(Value(), 0)
+        assert selected is image
+        assert image_close_calls == 0
+        assert reader.checked_close_calls == 1
+        assert reader.close_calls == 0
+        selected.close()
+        assert image_close_calls == 1
+    else:
+        with pytest.raises(RuntimeError, match=f"{teardown} during video teardown") as raised:
+            _video_file._video_file_frame_by_idx_value(Value(), 0)
+        assert raised.value is teardown_error
+        assert image_close_calls == 1
+        assert reader.checked_close_calls == 0
+        assert reader.close_calls == 1
+
+    assert container_close_calls == 1
+
+
 def test_video_frames_honor_logical_range_and_resize(duckdb_cursor, tmp_path):
     payload = _encoded_video(width=18, height=10, frame_count=5, frame_rate=5)
     prefix = b"not-a-video-prefix"

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -2057,6 +2057,66 @@ def test_video_packet_conversion_is_atomic(monkeypatch):
     assert raised.value is not None
 
 
+def test_video_index_selection_keeps_preroll_frame_before_stream_origin(monkeypatch):
+    options = _video_file._VideoFrameOptions(
+        start_time=Fraction(0),
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=1024,
+        max_input_bytes=1024,
+        max_frames=1,
+        max_pixels=100,
+        target_frame_index=0,
+    )
+    frame = _FakeDecodedVideoFrame(pts=5)
+    video = _fake_decoder_video()
+    info = _video_file._decoded_frame_info(
+        frame,
+        video,
+        options,
+        frame_index=0,
+        stream_time_origin=Fraction(1),
+    )
+    batch = _video_file._DecodedPacketBatch(frames=[frame], infos=(info,))
+    converted_images = []
+
+    def convert_frame(*args, **kwargs):
+        del args, kwargs
+        image = Image.new("RGB", (10, 10))
+        converted_images.append(image)
+        return image
+
+    monkeypatch.setattr(_video_file, "_frame_to_image", convert_frame)
+    no_error = SimpleNamespace(
+        check_interrupted=lambda: None,
+        raise_if_error=lambda: None,
+    )
+    prepared = _video_file._prepare_video_packet_batch(
+        batch,
+        options,
+        SimpleNamespace(),
+        SimpleNamespace(),
+        object(),
+        no_error,
+        no_error,
+        next_sample_time=None,
+        last_frame_time=None,
+    )
+
+    try:
+        result = prepared.take_result(0)
+        assert result.frame_index == 0
+        assert result.frame_time == pytest.approx(-0.5)
+        assert result.data is converted_images[0]
+    finally:
+        prepared.release()
+        for image in converted_images:
+            image.close()
+
+
 def test_video_packet_decode_traceback_releases_container_and_codec_owners():
     options = _video_file._VideoFrameOptions(
         start_time=Fraction(0),

--- a/tests/fast/test_video_file.py
+++ b/tests/fast/test_video_file.py
@@ -256,6 +256,114 @@ def test_video_frame_data_is_frozen_and_slotted():
         image.close()
 
 
+def test_video_get_frame_by_idx_matches_sequential_b_frame_decode(duckdb_cursor, tmp_path):
+    path = tmp_path / "indexed-b-frames.mp4"
+    path.write_bytes(_encoded_video(frame_count=12, frame_rate=4, gop_size=6, max_b_frames=2))
+    value = vane.VideoFile(str(path), "video/mp4")
+    frames = list(value.frames(connection=duckdb_cursor))
+    selected_images = []
+    try:
+        for idx in (0, 5, 11):
+            image = value.get_frame_by_idx(idx, connection=duckdb_cursor)
+            selected_images.append(image)
+            assert image.mode == "RGB"
+            np.testing.assert_array_equal(np.asarray(image), np.asarray(frames[idx].data))
+    finally:
+        for image in selected_images:
+            image.close()
+        for frame in frames:
+            frame.data.close()
+
+
+def test_video_get_frame_by_idx_honors_logical_range_vfr_and_timestamp_discontinuity(duckdb_cursor, tmp_path):
+    first_segment = _encoded_video(
+        "mpegts",
+        codec_name="mpeg2video",
+        muxer_options={"mpegts_flags": "resend_headers+initial_discontinuity"},
+        frame_count=8,
+        frame_rate=8,
+        gop_size=3,
+        max_b_frames=1,
+    )
+    second_segment = _encoded_video(
+        "mpegts",
+        codec_name="mpeg2video",
+        muxer_options={"mpegts_flags": "resend_headers+initial_discontinuity"},
+        frame_count=8,
+        frame_rate=4,
+        gop_size=3,
+        max_b_frames=1,
+    )
+    payload = first_segment + second_segment
+    prefix = b"not-a-video-prefix"
+    suffix = b"not-a-video-suffix"
+    path = tmp_path / "ranged-timestamp-discontinuity.bin"
+    path.write_bytes(prefix + payload + suffix)
+    value = vane.VideoFile(str(path), "video/mp2t", len(prefix), len(payload))
+    frames = list(value.frames(connection=duckdb_cursor))
+    image = None
+    try:
+        image = value.get_frame_by_idx(9, buffer_size=64, connection=duckdb_cursor)
+        assert len(frames) == 16
+        assert all(frames[index].frame_time is not None for index in (1, 2, 7, 8, 9))
+        assert frames[2].frame_time - frames[1].frame_time == pytest.approx(0.125)
+        assert frames[9].frame_time - frames[8].frame_time == pytest.approx(0.25)
+        assert frames[8].frame_time < frames[7].frame_time
+        np.testing.assert_array_equal(np.asarray(image), np.asarray(frames[9].data))
+    finally:
+        if image is not None:
+            image.close()
+        for frame in frames:
+            frame.data.close()
+
+
+def test_video_get_frame_by_idx_converts_only_the_target_frame(duckdb_cursor, tmp_path, monkeypatch):
+    path = tmp_path / "single-conversion.mp4"
+    path.write_bytes(_encoded_video(frame_count=8, frame_rate=4, gop_size=3, max_b_frames=2))
+    converted_indices = []
+    convert_frame = _video_file._frame_to_image
+
+    def record_conversion(frame, info, *args, **kwargs):
+        converted_indices.append(info.frame_index)
+        return convert_frame(frame, info, *args, **kwargs)
+
+    monkeypatch.setattr(_video_file, "_frame_to_image", record_conversion)
+    image = vane.VideoFile(str(path), "video/mp4").get_frame_by_idx(5, connection=duckdb_cursor)
+    try:
+        assert converted_indices == [5]
+        assert image.mode == "RGB"
+        assert image.size == (16, 12)
+    finally:
+        image.close()
+
+
+def test_video_get_frame_by_idx_reports_out_of_range(duckdb_cursor, tmp_path):
+    path = tmp_path / "four-frames.mp4"
+    path.write_bytes(_encoded_video(frame_count=4))
+
+    with pytest.raises(IndexError, match="video frame index 4 is out of range"):
+        vane.VideoFile(str(path), "video/mp4").get_frame_by_idx(4, connection=duckdb_cursor)
+
+
+@pytest.mark.parametrize(
+    ("idx", "error_type", "message"),
+    [
+        (True, TypeError, "idx must be int"),
+        (1.0, TypeError, "idx must be int"),
+        (-1, ValueError, "idx must be non-negative"),
+        (1 << 63, ValueError, "idx must be at most"),
+    ],
+)
+def test_video_get_frame_by_idx_validates_index_without_opening_file(idx, error_type, message):
+    with pytest.raises(error_type, match=message):
+        vane.VideoFile("memory://not-opened").get_frame_by_idx(idx)
+
+
+def test_video_get_frame_by_idx_enforces_decode_budget_without_opening_file():
+    with pytest.raises(vane.VideoFileLimitError, match="exceeding max_frames=5"):
+        vane.VideoFile("memory://not-opened").get_frame_by_idx(5, max_frames=5)
+
+
 def test_video_frames_honor_logical_range_and_resize(duckdb_cursor, tmp_path):
     payload = _encoded_video(width=18, height=10, frame_count=5, frame_rate=5)
     prefix = b"not-a-video-prefix"

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -1076,6 +1076,16 @@ class VideoFile(File):
         max_pixels: int = 33554432,
         connection: DuckDBPyConnection | None = None,
     ) -> typing.Generator[PIL.Image.Image, None, None]: ...
+    def get_frame_by_idx(
+        self,
+        idx: int,
+        buffer_size: int = 1048576,
+        *,
+        max_input_bytes: int = 8589934592,
+        max_frames: int = 1000000,
+        max_pixels: int = 33554432,
+        connection: DuckDBPyConnection | None = None,
+    ) -> PIL.Image.Image: ...
     def metadata(
         self,
         *,

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -192,6 +192,7 @@ class _VideoFrameOptions:
     max_input_bytes: int
     max_frames: int
     max_pixels: int
+    target_frame_index: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -611,6 +612,16 @@ def _positive_limit(value: object, *, name: str, maximum: int | None = None) -> 
     return value
 
 
+def _nonnegative_frame_index(value: object, *, name: str = "idx") -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be int, not {type(value).__name__!r}")
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    if value > _MAX_BIGINT:
+        raise ValueError(f"{name} must be at most {_MAX_BIGINT}")
+    return value
+
+
 def _nonnegative_time(value: object, *, name: str, optional: bool = False) -> Fraction | None:
     if value is None:
         if optional:
@@ -663,6 +674,7 @@ def _normalize_frame_options(
     max_input_bytes: object,
     max_frames: object,
     max_pixels: object,
+    target_frame_index: object | None = None,
 ) -> _VideoFrameOptions:
     normalized_start = _nonnegative_time(start_time, name="start_time")
     assert normalized_start is not None
@@ -702,6 +714,7 @@ def _normalize_frame_options(
         max_input_bytes=normalized_max_input,
         max_frames=normalized_max_frames,
         max_pixels=normalized_max_pixels,
+        target_frame_index=(None if target_frame_index is None else _nonnegative_frame_index(target_frame_index)),
     )
 
 
@@ -1507,6 +1520,8 @@ def _prepare_video_packet_batch(
             _check_video_io(reader, nested_io)
             frame = batch.take_frame(index)
             try:
+                if options.target_frame_index is not None and info.frame_index != options.target_frame_index:
+                    continue
                 if info.exact_time is not None:
                     if last_frame_time is not None and info.exact_time < last_frame_time:
                         # MPEG-TS and other streaming containers can reset their
@@ -1801,6 +1816,71 @@ def _video_file_frames_value(
     av_module = _load_av()
     image_module = _load_pillow()
     return _iter_video_frames(value, options, av_module, image_module, connection)
+
+
+def _video_file_frame_by_idx_value(
+    value: vane.VideoFile,
+    idx: int,
+    buffer_size: int = DEFAULT_VIDEO_BUFFER_SIZE,
+    *,
+    max_input_bytes: int = DEFAULT_VIDEO_MAX_INPUT_BYTES,
+    max_frames: int = DEFAULT_VIDEO_MAX_FRAMES,
+    max_pixels: int = DEFAULT_VIDEO_MAX_PIXELS,
+    connection: vane.DuckDBPyConnection | None = None,
+) -> PILImage:
+    target_index = _nonnegative_frame_index(idx)
+    options = _normalize_frame_options(
+        start_time=0,
+        end_time=None,
+        width=None,
+        height=None,
+        is_key_frame=None,
+        sample_interval_seconds=None,
+        buffer_size=buffer_size,
+        max_input_bytes=max_input_bytes,
+        max_frames=max_frames,
+        max_pixels=max_pixels,
+        target_frame_index=target_index,
+    )
+    if target_index >= options.max_frames:
+        raise VideoFileLimitError(
+            f"video frame index {target_index} requires decoding at least {target_index + 1} frames, "
+            f"exceeding max_frames={options.max_frames}"
+        )
+
+    av_module = _load_av()
+    image_module = _load_pillow()
+    frames = _iter_video_frames(value, options, av_module, image_module, connection)
+    frame: VideoFrameData | None = None
+    image: PILImage | None = None
+    try:
+        try:
+            frame = next(frames)
+        except StopIteration:
+            raise IndexError(f"video frame index {target_index} is out of range") from None
+        if frame.frame_index != target_index:
+            raise RuntimeError(
+                f"video decoder returned frame index {frame.frame_index!r} while selecting {target_index}"
+            )
+        image = frame.data
+        frame = None
+    except BaseException:
+        if frame is not None:
+            _close_image(frame.data)
+            frame = None
+        try:
+            frames.close()
+        except BaseException:
+            pass
+        raise
+    try:
+        frames.close()
+    except BaseException:
+        assert image is not None
+        _close_image(image)
+        raise
+    assert image is not None
+    return image
 
 
 def _iter_keyframe_images(frames: Generator[VideoFrameData, None, None]) -> Generator[PILImage, None, None]:

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -1520,36 +1520,40 @@ def _prepare_video_packet_batch(
             _check_video_io(reader, nested_io)
             frame = batch.take_frame(index)
             try:
-                if options.target_frame_index is not None and info.frame_index != options.target_frame_index:
-                    continue
-                if info.exact_time is not None:
-                    if last_frame_time is not None and info.exact_time < last_frame_time:
-                        # MPEG-TS and other streaming containers can reset their
-                        # presentation timeline at a discontinuity. Sampling
-                        # targets belong to each monotonic segment rather than a
-                        # previous segment's now-unreachable timestamp range.
-                        next_sample_time = options.start_time if options.sample_interval_seconds is not None else None
-                    last_frame_time = info.exact_time
-                    if info.exact_time < options.start_time:
+                if options.target_frame_index is not None:
+                    if info.frame_index != options.target_frame_index:
                         continue
-                    if options.end_time is not None and info.exact_time > options.end_time:
-                        # Do not stop globally: a later discontinuity can move
-                        # presentation timestamps back into the requested window.
+                else:
+                    if info.exact_time is not None:
+                        if last_frame_time is not None and info.exact_time < last_frame_time:
+                            # MPEG-TS and other streaming containers can reset their
+                            # presentation timeline at a discontinuity. Sampling
+                            # targets belong to each monotonic segment rather than a
+                            # previous segment's now-unreachable timestamp range.
+                            next_sample_time = (
+                                options.start_time if options.sample_interval_seconds is not None else None
+                            )
+                        last_frame_time = info.exact_time
+                        if info.exact_time < options.start_time:
+                            continue
+                        if options.end_time is not None and info.exact_time > options.end_time:
+                            # Do not stop globally: a later discontinuity can move
+                            # presentation timestamps back into the requested window.
+                            continue
+
+                    if options.is_key_frame is not None and info.is_key_frame is not options.is_key_frame:
                         continue
 
-                if options.is_key_frame is not None and info.is_key_frame is not options.is_key_frame:
-                    continue
-
-                if options.sample_interval_seconds is not None:
-                    assert info.exact_time is not None
-                    assert next_sample_time is not None
-                    if info.exact_time < next_sample_time:
-                        continue
-                    next_sample_time = _advance_sample_target(
-                        next_sample_time,
-                        options.sample_interval_seconds,
-                        info.exact_time,
-                    )
+                    if options.sample_interval_seconds is not None:
+                        assert info.exact_time is not None
+                        assert next_sample_time is not None
+                        if info.exact_time < next_sample_time:
+                            continue
+                        next_sample_time = _advance_sample_target(
+                            next_sample_time,
+                            options.sample_interval_seconds,
+                            info.exact_time,
+                        )
 
                 image = _frame_to_image(
                     frame,

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -1680,6 +1680,7 @@ def _iter_video_frames(
         decoded_batches: Generator[_DecodedPacketBatch, None, None] | None = None
         prepared_batch: _PreparedFrameBatch | None = None
         error_from_consumer = False
+        target_delivered = False
         try:
             _check_video_io(reader, nested_io)
             container = av_module.open(
@@ -1756,9 +1757,14 @@ def _iter_video_frames(
                                     # only later undelivered batch entries are closed.
                                     del result
                                 _check_video_io(reader, nested_io)
+                                if options.target_frame_index is not None:
+                                    target_delivered = True
+                                    break
                         finally:
                             prepared_batch.release()
                             prepared_batch = None
+                        if target_delivered:
+                            break
                 finally:
                     decoded_batches.close()
                 _check_video_io(reader, nested_io)
@@ -1873,14 +1879,30 @@ def _video_file_frame_by_idx_value(
         except BaseException:
             pass
         raise
+    assert image is not None
+    try:
+        unexpected_frame = next(frames)
+    except StopIteration:
+        # Advancing the dedicated single-frame generator to normal exhaustion
+        # runs container and reader teardown on their success paths. In
+        # particular, close-time connector failures and cancellation remain
+        # observable instead of being suppressed as effects of GeneratorExit.
+        return image
+    except BaseException:
+        _close_image(image)
+        try:
+            frames.close()
+        except BaseException:
+            pass
+        raise
+
+    _close_image(unexpected_frame.data)
+    _close_image(image)
     try:
         frames.close()
     except BaseException:
-        assert image is not None
-        _close_image(image)
-        raise
-    assert image is not None
-    return image
+        pass
+    raise RuntimeError("single-frame video selection yielded more than one frame")
 
 
 def _iter_keyframe_images(frames: Generator[VideoFrameData, None, None]) -> Generator[PILImage, None, None]:


### PR DESCRIPTION
## Summary

- Add `VideoFile.get_frame_by_idx()` for exact zero-based presentation-order frame access.
- Reuse the range-aware FILE reader and PyAV sequential decoder as the correctness baseline, without PTS/FPS estimation or speculative seeking.
- Convert only the selected frame to a detached RGB Pillow image while preserving input, decoded-frame, and pixel resource limits.
- Cover reordered B-frames, piecewise variable frame rates, timestamp discontinuities, logical byte ranges, invalid indices, out-of-range access, and decode budgets.

## Related issue

Refs #714

This PR closes the exact Python value-access slice. FILE-aware distributed `VideoFrameSource` execution remains in #714.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

The additive public contract is recorded in the native docstring, type stub, and tests. Expression/SQL access remains gated on a decoded IMAGE logical type.

## Validation

- `scripts/format root --changed`
- `pre-commit run --files src/vane_py/native/file.cpp tests/fast/test_video_file.py vane/_native/__init__.pyi vane/_video_file.py`
- Incremental non-editable Python 3.12 Release install with `CMAKE_BUILD_PARALLEL_LEVEL=24`
- `scripts/run_installed_pytest.sh -q tests/fast/test_video_file.py -k get_frame_by_idx` — 9 passed
- `scripts/run_installed_pytest.sh -q tests/fast/test_video_file.py` — 177 passed
- `scripts/run_release_tests.sh` — 806 passed, 5 skipped; 3 unrelated Ray diagnostic-message assertions failed in the fresh local Python 3.12.3/pybind11 3.1 build and passed 3/3 against the previously validated #742 native environment
- `git diff --check`

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
