### PR TITLE
[feat](cli) Add declarative pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/da
 
 Follow the [Quickstart guide](https://vane.astrovela.ai/docs/data/quickstart/quickstart) to build and run your first Vane pipeline.
 
+Vane also supports declarative YAML pipelines for common file-to-file workflows:
+
+```bash
+vane run examples/pipeline.yaml \
+  --param input=/data/quality-results.parquet \
+  --param output=/data/review-queue.parquet
+```
+
+Use `--check` to render parameters and validate a pipeline without executing it. The initial YAML schema supports local or Ray runners, Parquet/CSV/JSON/SQL sources, filter/select/SQL/limit/order transformations, and Parquet/CSV/JSON sinks.
+
 ### More Resources
 
 - [Examples](https://vane.astrovela.ai/docs/data/examples)

--- a/examples/pipeline.yaml
+++ b/examples/pipeline.yaml
@@ -1,0 +1,25 @@
+version: 1
+name: manufacturing-quality-filter
+
+runner:
+  type: local
+
+source:
+  type: parquet
+  path: "{{ input }}"
+
+steps:
+  - type: filter
+    expression: "quality_score < 0.95"
+  - type: select
+    expressions:
+      - serial_no
+      - product_model
+      - quality_score
+      - "CASE WHEN quality_score < 0.70 THEN 'BLOCK' ELSE 'MANUAL_REVIEW' END AS disposition"
+  - type: order
+    expression: "quality_score ASC"
+
+sink:
+  type: parquet
+  path: "{{ output }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "numpy",
     "pyarrow>=14.0.0",
     "pyelftools>=0.33,<1",
+    "pyyaml>=6.0,<7",
     "ray>=2.53.0,<3",
     "typing-extensions",
 ]
@@ -63,6 +64,9 @@ Documentation = "https://github.com/AstroVela/vane#readme"
 Source = "https://github.com/AstroVela/vane"
 Issues = "https://github.com/AstroVela/vane/issues"
 Changelog = "https://github.com/AstroVela/vane/releases"
+
+[project.scripts]
+vane = "vane.cli:main"
 
 [project.optional-dependencies]
 milvus = ["pymilvus>=3.0.1,<4"]

--- a/tests/fast/test_pipeline_cli.py
+++ b/tests/fast/test_pipeline_cli.py
@@ -7,6 +7,7 @@ import json
 
 import pytest
 
+import vane
 from vane import cli
 from vane.pipeline import PipelineConfigError, execute_pipeline, load_pipeline, validate_pipeline
 
@@ -54,6 +55,37 @@ def test_load_pipeline_rejects_missing_parameter(tmp_path):
 
     with pytest.raises(PipelineConfigError, match="missing pipeline parameter: input"):
         load_pipeline(path)
+
+
+def test_load_pipeline_reads_only_up_to_size_limit(tmp_path):
+    path = tmp_path / "pipeline.yaml"
+    path.write_bytes(b" " * (1024 * 1024 + 100))
+
+    with pytest.raises(PipelineConfigError, match="pipeline file exceeds"):
+        load_pipeline(path)
+
+
+def test_load_pipeline_rejects_yaml_aliases(tmp_path):
+    path = tmp_path / "pipeline.yaml"
+    path.write_text("version: 1\nsteps: &steps [*steps]\n", encoding="utf-8")
+
+    with pytest.raises(PipelineConfigError, match="YAML aliases are not supported"):
+        load_pipeline(path)
+
+
+@pytest.mark.parametrize(
+    ("runner", "message"),
+    [
+        ({"type": "ray", "typo": 1}, "unknown keys: typo"),
+        ({"type": "ray", "ray_max_task_backlog": "many"}, "ray_max_task_backlog must be int"),
+    ],
+)
+def test_validate_pipeline_rejects_invalid_runner_options(runner, message):
+    config = _pipeline()
+    config["runner"] = runner
+
+    with pytest.raises(PipelineConfigError, match=message):
+        validate_pipeline(config)
 
 
 @pytest.mark.parametrize(
@@ -140,3 +172,19 @@ def test_cli_check_prints_rendered_configuration(tmp_path, capsys):
 
     assert result == 0
     assert json.loads(capsys.readouterr().out)["source"]["query"] == "select 42 as value"
+
+
+def test_cli_handles_engine_errors(tmp_path, monkeypatch, capsys):
+    path = tmp_path / "pipeline.yaml"
+    path.write_text(
+        "version: 1\nsource: {type: sql, query: 'select 1'}\nsink: {type: csv, path: out.csv}\n",
+        encoding="utf-8",
+    )
+
+    def fail(_config):
+        raise vane.IOException("input is unavailable")
+
+    monkeypatch.setattr(cli, "execute_pipeline", fail)
+
+    assert cli.main(["run", str(path)]) == 2
+    assert "input is unavailable" in capsys.readouterr().err

--- a/tests/fast/test_pipeline_cli.py
+++ b/tests/fast/test_pipeline_cli.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vane import cli
+from vane.pipeline import PipelineConfigError, execute_pipeline, load_pipeline, validate_pipeline
+
+
+def _pipeline() -> dict:
+    return {
+        "version": 1,
+        "name": "test",
+        "runner": {"type": "local"},
+        "source": {"type": "parquet", "path": "input.parquet"},
+        "steps": [
+            {"type": "filter", "expression": "score < 0.9"},
+            {"type": "select", "expressions": ["id", "score"]},
+            {"type": "limit", "count": 10},
+        ],
+        "sink": {"type": "json", "path": "output.json"},
+    }
+
+
+def test_load_pipeline_renders_parameters(tmp_path):
+    path = tmp_path / "pipeline.yaml"
+    path.write_text(
+        """\
+version: 1
+source: {type: parquet, path: '{{ input }}'}
+steps: []
+sink: {type: parquet, path: '{{ output }}'}
+""",
+        encoding="utf-8",
+    )
+
+    config = load_pipeline(path, {"input": "in.parquet", "output": "out.parquet"})
+
+    assert config["source"]["path"] == "in.parquet"
+    assert config["sink"]["path"] == "out.parquet"
+    assert config["runner"] == {"type": "ray"}
+
+
+def test_load_pipeline_rejects_missing_parameter(tmp_path):
+    path = tmp_path / "pipeline.yaml"
+    path.write_text(
+        "version: 1\nsource: {type: parquet, path: '{{ input }}'}\nsink: {type: csv, path: out.csv}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PipelineConfigError, match="missing pipeline parameter: input"):
+        load_pipeline(path)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda config: config.update(version=2),
+        lambda config: config.update(unknown=True),
+        lambda config: config["steps"].append({"type": "python", "code": "do_anything()"}),
+        lambda config: config["sink"].update(type="shell"),
+    ],
+)
+def test_validate_pipeline_rejects_unsupported_configuration(mutation):
+    config = _pipeline()
+    mutation(config)
+
+    with pytest.raises(PipelineConfigError):
+        validate_pipeline(config)
+
+
+def test_execute_pipeline_builds_expected_relation_chain():
+    events = []
+
+    class Relation:
+        def filter(self, expression):
+            events.append(("filter", expression))
+            return self
+
+        def project(self, expression):
+            events.append(("project", expression))
+            return self
+
+        def limit(self, count):
+            events.append(("limit", count))
+            return self
+
+        def write_file(self, path, *, format):
+            events.append(("write", path, format))
+
+    class Connection:
+        def read_parquet(self, path):
+            events.append(("read_parquet", path))
+            return Relation()
+
+        def close(self):
+            events.append(("close",))
+
+    class Engine:
+        @staticmethod
+        def configure(**options):
+            events.append(("configure", options))
+
+        @staticmethod
+        def connect():
+            events.append(("connect",))
+            return Connection()
+
+        @staticmethod
+        def teardown_runner():
+            events.append(("teardown",))
+
+    execute_pipeline(_pipeline(), engine=Engine())
+
+    assert events == [
+        ("configure", {"runner": "local"}),
+        ("connect",),
+        ("read_parquet", "input.parquet"),
+        ("filter", "score < 0.9"),
+        ("project", "id, score"),
+        ("limit", 10),
+        ("write", "output.json", "json"),
+        ("close",),
+        ("teardown",),
+    ]
+
+
+def test_cli_check_prints_rendered_configuration(tmp_path, capsys):
+    path = tmp_path / "pipeline.yaml"
+    path.write_text(
+        "version: 1\nsource: {type: sql, query: 'select {{ value }} as value'}\nsink: {type: csv, path: out.csv}\n",
+        encoding="utf-8",
+    )
+
+    result = cli.main(["run", str(path), "--param", "value=42", "--check"])
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out)["source"]["query"] == "select 42 as value"

--- a/vane/cli.py
+++ b/vane/cli.py
@@ -10,6 +10,7 @@ import json
 import sys
 from collections.abc import Sequence
 
+from vane import Error as VaneError
 from vane.pipeline import PipelineConfigError, execute_pipeline, load_pipeline
 
 
@@ -42,7 +43,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(json.dumps(config, indent=2, sort_keys=True))
             return 0
         execute_pipeline(config)
-    except (OSError, PipelineConfigError) as error:
+    except (OSError, PipelineConfigError, VaneError) as error:
         print(f"vane: {error}", file=sys.stderr)
         return 2
     return 0

--- a/vane/cli.py
+++ b/vane/cli.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line interface for declarative Vane pipelines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+
+from vane.pipeline import PipelineConfigError, execute_pipeline, load_pipeline
+
+
+def _parameter(value: str) -> tuple[str, str]:
+    name, separator, parameter_value = value.partition("=")
+    if not separator or not name.strip():
+        raise argparse.ArgumentTypeError("parameters must use NAME=VALUE")
+    return name.strip(), parameter_value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vane", description="Run declarative Vane pipelines.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run", help="validate and run a YAML pipeline")
+    run.add_argument("pipeline", help="path to pipeline.yaml")
+    run.add_argument("--param", action="append", default=[], type=_parameter, metavar="NAME=VALUE")
+    run.add_argument("--check", action="store_true", help="validate and render configuration without executing")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Vane command-line interface."""
+    args = _parser().parse_args(argv)
+    try:
+        parameters = dict(args.param)
+        if len(parameters) != len(args.param):
+            raise PipelineConfigError("pipeline parameters must not be repeated")
+        config = load_pipeline(args.pipeline, parameters)
+        if args.check:
+            print(json.dumps(config, indent=2, sort_keys=True))
+            return 0
+        execute_pipeline(config)
+    except (OSError, PipelineConfigError) as error:
+        print(f"vane: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/vane/pipeline.py
+++ b/vane/pipeline.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Declarative YAML pipelines for the Vane data engine."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_MAX_PIPELINE_BYTES = 1024 * 1024
+_PARAMETER_PATTERN = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_.-]*)\s*}}")
+_TOP_LEVEL_KEYS = frozenset({"version", "name", "runner", "source", "steps", "sink"})
+_SOURCE_KEYS = frozenset({"type", "path", "query"})
+_SINK_KEYS = frozenset({"type", "path"})
+_STEP_KEYS = {
+    "filter": frozenset({"type", "expression"}),
+    "select": frozenset({"type", "expressions"}),
+    "sql": frozenset({"type", "query", "alias"}),
+    "limit": frozenset({"type", "count"}),
+    "order": frozenset({"type", "expression"}),
+}
+
+
+class PipelineConfigError(ValueError):
+    """Raised when a declarative pipeline is invalid."""
+
+
+def _mapping(value: Any, location: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise PipelineConfigError(f"{location} must be a mapping")
+    if any(not isinstance(key, str) for key in value):
+        raise PipelineConfigError(f"{location} keys must be strings")
+    return dict(value)
+
+
+def _reject_unknown_keys(value: Mapping[str, Any], allowed: frozenset[str], location: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise PipelineConfigError(f"{location} contains unknown keys: {', '.join(unknown)}")
+
+
+def _required_string(value: Mapping[str, Any], key: str, location: str) -> str:
+    result = value.get(key)
+    if not isinstance(result, str) or not result.strip():
+        raise PipelineConfigError(f"{location}.{key} must be a non-empty string")
+    return result
+
+
+def _render_parameters(value: Any, parameters: Mapping[str, str]) -> Any:
+    if isinstance(value, str):
+
+        def replace(match: re.Match[str]) -> str:
+            name = match.group(1)
+            try:
+                return parameters[name]
+            except KeyError:
+                raise PipelineConfigError(f"missing pipeline parameter: {name}") from None
+
+        return _PARAMETER_PATTERN.sub(replace, value)
+    if isinstance(value, list):
+        return [_render_parameters(item, parameters) for item in value]
+    if isinstance(value, Mapping):
+        return {key: _render_parameters(item, parameters) for key, item in value.items()}
+    return value
+
+
+def validate_pipeline(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and normalize one parsed pipeline document."""
+    normalized = _mapping(config, "pipeline")
+    _reject_unknown_keys(normalized, _TOP_LEVEL_KEYS, "pipeline")
+    if normalized.get("version") != 1:
+        raise PipelineConfigError("pipeline.version must be 1")
+    if "name" in normalized:
+        _required_string(normalized, "name", "pipeline")
+
+    runner = normalized.get("runner", {"type": "ray"})
+    if isinstance(runner, str):
+        runner = {"type": runner}
+    runner = _mapping(runner, "pipeline.runner")
+    runner_type = _required_string(runner, "type", "pipeline.runner").lower()
+    if runner_type not in {"local", "ray"}:
+        raise PipelineConfigError("pipeline.runner.type must be 'local' or 'ray'")
+    runner["type"] = runner_type
+    normalized["runner"] = runner
+
+    source = _mapping(normalized.get("source"), "pipeline.source")
+    _reject_unknown_keys(source, _SOURCE_KEYS, "pipeline.source")
+    source_type = _required_string(source, "type", "pipeline.source").lower()
+    if source_type in {"parquet", "csv", "json"}:
+        _required_string(source, "path", "pipeline.source")
+    elif source_type == "sql":
+        _required_string(source, "query", "pipeline.source")
+    else:
+        raise PipelineConfigError("pipeline.source.type must be parquet, csv, json, or sql")
+    source["type"] = source_type
+    normalized["source"] = source
+
+    raw_steps = normalized.get("steps", [])
+    if not isinstance(raw_steps, Sequence) or isinstance(raw_steps, (str, bytes)):
+        raise PipelineConfigError("pipeline.steps must be a list")
+    steps: list[dict[str, Any]] = []
+    for index, raw_step in enumerate(raw_steps):
+        location = f"pipeline.steps[{index}]"
+        step = _mapping(raw_step, location)
+        step_type = _required_string(step, "type", location).lower()
+        allowed = _STEP_KEYS.get(step_type)
+        if allowed is None:
+            raise PipelineConfigError(f"{location}.type is unsupported: {step_type}")
+        _reject_unknown_keys(step, allowed, location)
+        if step_type in {"filter", "order"}:
+            _required_string(step, "expression", location)
+        elif step_type == "sql":
+            _required_string(step, "query", location)
+            if "alias" in step:
+                _required_string(step, "alias", location)
+        elif step_type == "select":
+            expressions = step.get("expressions")
+            if (
+                not isinstance(expressions, Sequence)
+                or isinstance(expressions, (str, bytes))
+                or not expressions
+                or any(not isinstance(item, str) or not item.strip() for item in expressions)
+            ):
+                raise PipelineConfigError(f"{location}.expressions must be a non-empty list of strings")
+            step["expressions"] = list(expressions)
+        elif step_type == "limit":
+            count = step.get("count")
+            if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+                raise PipelineConfigError(f"{location}.count must be a non-negative integer")
+        step["type"] = step_type
+        steps.append(step)
+    normalized["steps"] = steps
+
+    sink = _mapping(normalized.get("sink"), "pipeline.sink")
+    _reject_unknown_keys(sink, _SINK_KEYS, "pipeline.sink")
+    sink_type = _required_string(sink, "type", "pipeline.sink").lower()
+    if sink_type not in {"parquet", "csv", "json"}:
+        raise PipelineConfigError("pipeline.sink.type must be parquet, csv, or json")
+    _required_string(sink, "path", "pipeline.sink")
+    sink["type"] = sink_type
+    normalized["sink"] = sink
+    return normalized
+
+
+def load_pipeline(path: str | Path, parameters: Mapping[str, str] | None = None) -> dict[str, Any]:
+    """Load, parameterize, and validate a YAML pipeline file."""
+    pipeline_path = Path(path)
+    raw = pipeline_path.read_bytes()
+    if len(raw) > _MAX_PIPELINE_BYTES:
+        raise PipelineConfigError(f"pipeline file exceeds {_MAX_PIPELINE_BYTES} bytes")
+    try:
+        document = yaml.safe_load(raw.decode("utf-8"))
+    except (UnicodeDecodeError, yaml.YAMLError) as error:
+        raise PipelineConfigError(f"could not parse pipeline YAML: {error}") from error
+    rendered = _render_parameters(document, parameters or {})
+    return validate_pipeline(_mapping(rendered, "pipeline"))
+
+
+def execute_pipeline(config: Mapping[str, Any], *, engine: Any = None) -> None:
+    """Build and execute a previously loaded declarative pipeline."""
+    normalized = validate_pipeline(config)
+    if engine is None:
+        import vane as engine
+
+    runner = normalized["runner"]
+    runner_options = {key: value for key, value in runner.items() if key != "type"}
+    engine.configure(runner=runner["type"], **runner_options)
+    connection = engine.connect()
+    try:
+        source = normalized["source"]
+        source_type = source["type"]
+        if source_type == "sql":
+            relation = connection.sql(source["query"])
+        elif source_type == "parquet":
+            relation = connection.read_parquet(source["path"])
+        elif source_type == "csv":
+            relation = connection.read_csv(source["path"])
+        else:
+            relation = connection.read_json(source["path"])
+
+        for step in normalized["steps"]:
+            step_type = step["type"]
+            if step_type == "filter":
+                relation = relation.filter(step["expression"])
+            elif step_type == "select":
+                relation = relation.project(", ".join(step["expressions"]))
+            elif step_type == "sql":
+                relation = relation.query(step.get("alias", "input"), step["query"])
+            elif step_type == "limit":
+                relation = relation.limit(step["count"])
+            else:
+                relation = relation.order(step["expression"])
+
+        sink = normalized["sink"]
+        relation.write_file(sink["path"], format=sink["type"])
+    finally:
+        connection.close()
+        teardown = getattr(engine, "teardown_runner", None)
+        if callable(teardown):
+            teardown()

--- a/vane/pipeline.py
+++ b/vane/pipeline.py
@@ -12,6 +12,8 @@ from typing import Any
 
 import yaml
 
+from vane.config import VaneConfig
+
 _MAX_PIPELINE_BYTES = 1024 * 1024
 _PARAMETER_PATTERN = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_.-]*)\s*}}")
 _TOP_LEVEL_KEYS = frozenset({"version", "name", "runner", "source", "steps", "sink"})
@@ -24,6 +26,7 @@ _STEP_KEYS = {
     "limit": frozenset({"type", "count"}),
     "order": frozenset({"type", "expression"}),
 }
+_RUNNER_OPTION_TYPES = {name: field.type for name, field in VaneConfig.__dataclass_fields__.items() if name != "runner"}
 
 
 class PipelineConfigError(ValueError):
@@ -49,6 +52,16 @@ def _required_string(value: Mapping[str, Any], key: str, location: str) -> str:
     if not isinstance(result, str) or not result.strip():
         raise PipelineConfigError(f"{location}.{key} must be a non-empty string")
     return result
+
+
+def _validate_runner_option(name: str, value: Any) -> None:
+    expected = _RUNNER_OPTION_TYPES[name]
+    if expected is int:
+        valid = isinstance(value, int) and not isinstance(value, bool)
+    else:
+        valid = isinstance(value, expected)
+    if not valid:
+        raise PipelineConfigError(f"pipeline.runner.{name} must be {expected.__name__}")
 
 
 def _render_parameters(value: Any, parameters: Mapping[str, str]) -> Any:
@@ -82,10 +95,14 @@ def validate_pipeline(config: Mapping[str, Any]) -> dict[str, Any]:
     if isinstance(runner, str):
         runner = {"type": runner}
     runner = _mapping(runner, "pipeline.runner")
+    _reject_unknown_keys(runner, frozenset({"type", *_RUNNER_OPTION_TYPES}), "pipeline.runner")
     runner_type = _required_string(runner, "type", "pipeline.runner").lower()
     if runner_type not in {"local", "ray"}:
         raise PipelineConfigError("pipeline.runner.type must be 'local' or 'ray'")
     runner["type"] = runner_type
+    for option, value in runner.items():
+        if option != "type":
+            _validate_runner_option(option, value)
     normalized["runner"] = runner
 
     source = _mapping(normalized.get("source"), "pipeline.source")
@@ -150,11 +167,15 @@ def validate_pipeline(config: Mapping[str, Any]) -> dict[str, Any]:
 def load_pipeline(path: str | Path, parameters: Mapping[str, str] | None = None) -> dict[str, Any]:
     """Load, parameterize, and validate a YAML pipeline file."""
     pipeline_path = Path(path)
-    raw = pipeline_path.read_bytes()
+    with pipeline_path.open("rb") as pipeline_file:
+        raw = pipeline_file.read(_MAX_PIPELINE_BYTES + 1)
     if len(raw) > _MAX_PIPELINE_BYTES:
         raise PipelineConfigError(f"pipeline file exceeds {_MAX_PIPELINE_BYTES} bytes")
     try:
-        document = yaml.safe_load(raw.decode("utf-8"))
+        text = raw.decode("utf-8")
+        if any(isinstance(token, yaml.tokens.AliasToken) for token in yaml.scan(text)):
+            raise PipelineConfigError("pipeline YAML aliases are not supported")
+        document = yaml.safe_load(text)
     except (UnicodeDecodeError, yaml.YAMLError) as error:
         raise PipelineConfigError(f"could not parse pipeline YAML: {error}") from error
     rendered = _render_parameters(document, parameters or {})


### PR DESCRIPTION
## Summary

- Add a `vane run` CLI for declarative YAML pipelines.
- Support parameter rendering, local/Ray runners, common file and SQL sources, relation transformations, and file sinks.
- Bound YAML reads, reject aliases, validate runner options, and handle public Vane engine errors at the CLI boundary.
- Add a manufacturing quality-filter example and focused tests.

## Related issue

N/A — this is a self-contained feature proposal.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] A follow-up issue is required in `AstroVela/vane-website`.

The repository README includes the new CLI usage and `--check` behavior.

## Validation

- `scripts/run_installed_pytest.sh tests/fast/test_pipeline_cli.py` — 13 passed on macOS arm64, Python 3.12.
- Ruff format and lint checks passed for all changed Python files.
- `git diff --check` passed.
- `scripts/run_release_tests.sh` — 763 passed, 46 failed, 5 skipped; failures reproduce the existing unsupported macOS/sandbox constraints, primarily Linux-specific DataSink resource discovery and denied local socket binding. No failures involve the new pipeline CLI tests.
- Manual local-runner Parquet smoke test successfully filtered manufacturing quality records and wrote the expected output.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.
