### PR TITLE
[feat](datasink) Add Apache Doris Arrow Stream Load sink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,6 +645,89 @@ jobs:
         continue-on-error: true
         run: docker rm --force vane-qdrant
 
+  doris-tests:
+    name: Doris integration test
+    needs:
+      - changes
+      - native-fast-tests
+    if: needs.changes.outputs.run_full == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      VANE_TEST_DORIS_ENDPOINT: http://127.0.0.1:8030
+      VANE_TEST_DORIS_MYSQL_HOST: 127.0.0.1
+      VANE_TEST_DORIS_MYSQL_PORT: "9030"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Download the built wheel
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ci-python-artifacts-3.12
+          path: dist
+
+      - name: Install the wheel and Doris test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          wheel_path="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          test -n "$wheel_path"
+          python -m pip install --force-reinstall "${wheel_path}[doris]" pymysql pytest
+          python -m pip check
+          python -c 'import aiohttp, pymysql'
+
+      - name: Start Doris all-in-one
+        run: |
+          docker run --detach \
+            --name vane-doris \
+            --publish 127.0.0.1:8030:8030 \
+            --publish 127.0.0.1:8040:8040 \
+            --publish 127.0.0.1:9030:9030 \
+            apache/doris:all-in-one-4.1.3@sha256:4f8ae854f4d282710013f11705c8c867c2086d22df3ea3e4c6160ef0a3363813
+
+      - name: Wait for Doris to become healthy
+        run: |
+          for attempt in {1..120}; do
+            health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}missing{{end}}' vane-doris)"
+            if [[ "$health" == "healthy" ]] && curl --fail --silent http://127.0.0.1:8030/api/health > /dev/null; then
+              exit 0
+            fi
+            if [[ "$(docker inspect --format '{{.State.Status}}' vane-doris)" != "running" ]]; then
+              echo "Doris stopped before becoming healthy" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Doris did not become healthy within 240 seconds" >&2
+          exit 1
+
+      - name: Run the live Doris sink test
+        run: |
+          timeout --signal=INT --kill-after=30s 300s \
+            scripts/run_installed_pytest.sh \
+              -o addopts= \
+              -m external_service \
+              tests/fast/test_doris_datasink.py
+
+      - name: Print Doris logs on failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        run: docker logs vane-doris
+
+      - name: Stop Doris
+        if: ${{ always() }}
+        continue-on-error: true
+        run: docker rm --force vane-doris
+
   ai-tests:
     name: AI tests
     needs:
@@ -727,6 +810,7 @@ jobs:
       - source-package
       - native-fast-tests
       - fast-tests
+      - doris-tests
       - milvus-tests
       - qdrant-tests
       - ai-tests
@@ -737,6 +821,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           AI_TESTS_RESULT: ${{ needs.ai-tests.result }}
           FAST_TESTS_RESULT: ${{ needs.fast-tests.result }}
+          DORIS_TESTS_RESULT: ${{ needs.doris-tests.result }}
           MILVUS_TESTS_RESULT: ${{ needs.milvus-tests.result }}
           QDRANT_TESTS_RESULT: ${{ needs.qdrant-tests.result }}
           RUN_FULL: ${{ needs.changes.outputs.run_full }}
@@ -764,10 +849,11 @@ jobs:
           if [[ "$SOURCE_PACKAGE_RESULT" != "$expected_result" ||
                 "$NATIVE_TESTS_RESULT" != "$expected_result" ||
                 "$FAST_TESTS_RESULT" != "$expected_result" ||
+                "$DORIS_TESTS_RESULT" != "$expected_result" ||
                 "$MILVUS_TESTS_RESULT" != "$expected_result" ||
                 "$QDRANT_TESTS_RESULT" != "$expected_result" ||
                 "$AI_TESTS_RESULT" != "$expected_result" ]]; then
-            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT, milvus-tests=$MILVUS_TESTS_RESULT, qdrant-tests=$QDRANT_TESTS_RESULT, ai-tests=$AI_TESTS_RESULT" >&2
+            echo "Unexpected CI results: source-package=$SOURCE_PACKAGE_RESULT, native-fast-tests=$NATIVE_TESTS_RESULT, fast-tests=$FAST_TESTS_RESULT, doris-tests=$DORIS_TESTS_RESULT, milvus-tests=$MILVUS_TESTS_RESULT, qdrant-tests=$QDRANT_TESTS_RESULT, ai-tests=$AI_TESTS_RESULT" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ synchronous request at a time; increase `worker_count` for concurrent Stream
 Loads and tune `send_batch_parallelism` for Doris-side fan-out. When an FE
 endpoint redirects to a different BE host, list that host in
 `trusted_redirect_hosts` before Vane will send the configured Basic Auth
-credentials. Passwords must be supplied through `EnvironmentSecret`. Vane does
+credentials. Entries contain only a hostname or IP address, without a port;
+IPv6 literals can be bare (`2001:db8::42`) or bracketed (`[2001:db8::42]`).
+Passwords must be supplied through `EnvironmentSecret`. Vane does
 not retry an Arrow Stream Load request: if a connection fails after upload, the
 batch outcome is unknown and its reported Doris label must be inspected before
 submitting new data. `timeout` sets the Doris import deadline; the HTTP

--- a/README.md
+++ b/README.md
@@ -106,17 +106,14 @@ pip install 'vane-ai[doris]'
 import pyarrow as pa
 import vane
 
-relation = vane.from_arrow(
-    pa.table(
-        {
-            "id": [1, 2],
-            "embedding": pa.array(
-                [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
-                type=pa.list_(pa.float32(), 3),
-            ),
-            "title": ["one", "two"],
-        }
-    )
+relation = vane.sql(
+    """
+    SELECT
+        i AS id,
+        (CASE WHEN i = 1 THEN [0.1, 0.2, 0.3] ELSE [0.4, 0.5, 0.6] END)::FLOAT[] AS embedding,
+        CASE WHEN i = 1 THEN 'one' ELSE 'two' END AS title
+    FROM range(1, 3) AS t(i)
+    """
 )
 summary = relation.write_datasink(
     vane.DorisStreamLoadSink(
@@ -135,6 +132,9 @@ summary = relation.write_datasink(
     )
 )
 ```
+
+For the `local` and `ray` runners, supply a distributable SQL or file relation;
+in-memory `from_arrow()` relations are not supported for distributed sink writes.
 
 The required `destination_schema` lists the selected Doris columns in upload
 order and declares their exact Arrow physical types: for example, Doris `INT`

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ Arrow) cannot be misread as Doris `INT`; overflow, incompatible nested values,
 and nulls for non-nullable fields fail locally. Floating-point narrowing rejects
 finite values that become infinity while allowing normal rounding. The currently
 supported destination types are booleans, signed integers, float32/float64, UTF-8
-strings, and recursive regular lists of those types. Temporal Arrow types are
+strings, and recursive regular lists of those types. Execution workers may use
+64-bit Arrow offsets (`large_string`, `large_list`); the sink accepts equivalent
+input representations and safely normalizes them to the destination schema,
+including nested lists. Temporal Arrow types are
 rejected, including nested values, because Doris 4.1.3 does not preserve their
 timezone semantics; explicitly convert them to a supported non-temporal type
 before writing.

--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ is `pa.int32()`, `FLOAT` is `pa.float32()`, and `ARRAY<FLOAT>` is
 `pa.list_(pa.float32())`. The sink safely casts every input column to this
 schema before opening an HTTP request, so inferred Python integers (`int64` in
 Arrow) cannot be misread as Doris `INT`; overflow, incompatible nested values,
-and nulls for non-nullable fields fail locally. The currently supported
-destination types are booleans, signed integers, float32/float64, UTF-8
+and nulls for non-nullable fields fail locally. Floating-point narrowing rejects
+finite values that become infinity while allowing normal rounding. The currently
+supported destination types are booleans, signed integers, float32/float64, UTF-8
 strings, and recursive regular lists of those types. Temporal Arrow types are
 rejected, including nested values, because Doris 4.1.3 does not preserve their
 timezone semantics; explicitly convert them to a supported non-temporal type

--- a/README.md
+++ b/README.md
@@ -123,18 +123,38 @@ summary = relation.write_datasink(
         "analytics",
         "items",
         endpoint="http://doris-fe.example:8030",
+        destination_schema=pa.schema(
+            [
+                pa.field("id", pa.int32(), nullable=False),
+                pa.field("embedding", pa.list_(pa.float32()), nullable=False),
+                pa.field("title", pa.string(), nullable=False),
+            ]
+        ),
         vector_dimensions={"embedding": 3},
         worker_count=4,
     )
 )
 ```
 
+The required `destination_schema` lists the selected Doris columns in upload
+order and declares their exact Arrow physical types: for example, Doris `INT`
+is `pa.int32()`, `FLOAT` is `pa.float32()`, and `ARRAY<FLOAT>` is
+`pa.list_(pa.float32())`. The sink safely casts every input column to this
+schema before opening an HTTP request, so inferred Python integers (`int64` in
+Arrow) cannot be misread as Doris `INT`; overflow, incompatible nested values,
+and nulls for non-nullable fields fail locally. The currently supported
+destination types are booleans, signed integers, float32/float64, UTF-8
+strings, and recursive regular lists of those types. Temporal Arrow types are
+rejected, including nested values, because Doris 4.1.3 does not preserve their
+timezone semantics; explicitly convert them to a supported non-temporal type
+before writing.
+
 The sink uses Arrow IPC throughout and does not materialize Python rows.
 `max_batch_bytes` limits input Arrow batches to 128 MiB by default, while
 `max_request_bytes` independently caps encoded HTTP bodies at 160 MiB. Peak
-worker memory includes at least the input and encoded buffers plus vector
-offsets; the HTTP transport drains each request through bounded 256 KiB views
-instead of enqueueing the complete body again. Each worker performs one
+worker memory includes at least the input and encoded buffers plus any safe-cast
+buffers and vector offsets; the HTTP transport drains each request through
+bounded 256 KiB views instead of enqueueing the complete body again. Each worker performs one
 synchronous request at a time; increase `worker_count` for concurrent Stream
 Loads and tune `send_batch_parallelism` for Doris-side fan-out. When an FE
 endpoint redirects to a different BE host, list that host in

--- a/README.md
+++ b/README.md
@@ -93,6 +93,61 @@ installation, verification, and Ray worker requirements.
 
 For more details, see the [Installation Guide](https://vane.astrovela.ai/docs/data/quickstart/installation).
 
+### Apache Doris Arrow Stream Load
+
+Install the HTTP transport and write Arrow batches directly to a Doris FE or
+BE Stream Load endpoint:
+
+```bash
+pip install 'vane-ai[doris]'
+```
+
+```python
+import pyarrow as pa
+import vane
+
+relation = vane.from_arrow(
+    pa.table(
+        {
+            "id": [1, 2],
+            "embedding": pa.array(
+                [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+                type=pa.list_(pa.float32(), 3),
+            ),
+            "title": ["one", "two"],
+        }
+    )
+)
+summary = relation.write_datasink(
+    vane.DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://doris-fe.example:8030",
+        vector_dimensions={"embedding": 3},
+        worker_count=4,
+    )
+)
+```
+
+The sink uses Arrow IPC throughout and does not materialize Python rows.
+`max_batch_bytes` limits input Arrow batches to 128 MiB by default, while
+`max_request_bytes` independently caps encoded HTTP bodies at 160 MiB. Peak
+worker memory includes at least the input and encoded buffers plus vector
+offsets; the HTTP transport drains each request through bounded 256 KiB views
+instead of enqueueing the complete body again. Each worker performs one
+synchronous request at a time; increase `worker_count` for concurrent Stream
+Loads and tune `send_batch_parallelism` for Doris-side fan-out. When an FE
+endpoint redirects to a different BE host, list that host in
+`trusted_redirect_hosts` before Vane will send the configured Basic Auth
+credentials. Passwords must be supplied through `EnvironmentSecret`. Vane does
+not retry an Arrow Stream Load request: if a connection fails after upload, the
+batch outcome is unknown and its reported Doris label must be inspected before
+submitting new data. `timeout` sets the Doris import deadline; the HTTP
+transport adds 30 seconds to receive the terminal response without racing that
+server-side deadline. For a large initial vector load, create and build the
+Doris ANN index after ingestion so index construction does not slow every
+incoming batch.
+
 ### Quick Start
 
 Follow the [Quickstart guide](https://vane.astrovela.ai/docs/data/quickstart/quickstart) to build and run your first Vane pipeline.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ summary = relation.write_datasink(
 
 For the `local` and `ray` runners, supply a distributable SQL or file relation;
 in-memory `from_arrow()` relations are not supported for distributed sink writes.
+`write_datasink()` is synchronous. In an async caller, offload the complete
+connection/relation/write operation with `asyncio.to_thread()`; the Ray runner
+explicitly rejects blocking execution on the caller's event-loop thread.
 
 The required `destination_schema` lists the selected Doris columns in upload
 order and declares their exact Arrow physical types: for example, Doris `INT`
@@ -148,14 +151,23 @@ supported destination types are booleans, signed integers, float32/float64, UTF-
 strings, and recursive regular lists of those types. Execution workers may use
 64-bit Arrow offsets (`large_string`, `large_list`); the sink accepts equivalent
 input representations and safely normalizes them to the destination schema,
-including nested lists. Temporal Arrow types are
+including nested lists. Only visible list children are converted; hidden
+payloads beneath null list slots cannot cause false overflow errors. Supported
+inputs are null, boolean, integer, floating-point, string, binary, and standard
+list arrays recursively composed from them. Dictionary, run-end encoded, view,
+and other unsupported representations must be converted and rebatched before
+writing. String destinations require string or binary input; explicitly
+stringify other types in the input relation. Temporal Arrow types are
 rejected, including nested values, because Doris 4.1.3 does not preserve their
 timezone semantics; explicitly convert them to a supported non-temporal type
 before writing.
 
 The sink uses Arrow IPC throughout and does not materialize Python rows.
 `max_batch_bytes` limits input Arrow batches to 128 MiB by default, while
-`max_request_bytes` independently caps encoded HTTP bodies at 160 MiB. Peak
+`max_request_bytes` independently caps encoded HTTP bodies at 160 MiB.
+Destination buffer sizes are conservatively checked against the request budget
+before casting. The full IPC stream, including schema and chunk metadata, is
+sized before allocating one fixed-size request buffer. Peak
 worker memory includes at least the input and encoded buffers plus any safe-cast
 buffers and vector offsets; the HTTP transport drains each request through
 bounded 256 KiB views instead of enqueueing the complete body again. Each worker performs one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ Issues = "https://github.com/AstroVela/vane/issues"
 Changelog = "https://github.com/AstroVela/vane/releases"
 
 [project.optional-dependencies]
+doris = ["aiohttp>=3.14.3,<4"]
 milvus = ["pymilvus>=3.0.1,<4"]
 qdrant = ["qdrant-client>=1.19.0,<2"]
 openai = ["openai>=1.66.0", "tiktoken"] # floor adds the Responses API used by the default Prompt path
@@ -104,6 +105,7 @@ all = [ # Cloud providers and dataframe/filesystem integrations; local model run
     "adbc-driver-manager", # for the adbc driver
     "av>=17.1,<18", # VideoFile metadata through PyAV/FFmpeg
     "pillow>=10", # used for image inputs and video frames
+    "aiohttp>=3.14.3,<4", # Apache Doris Arrow Stream Load DataSink
     "pymilvus>=3.0.1,<4", # Milvus DataSink
     "qdrant-client>=1.19.0,<2", # Qdrant DataSink
     "soundfile>=0.14", # AudioFile metadata and waveform decoding
@@ -241,6 +243,7 @@ include = [
     "/tests/ray_test_profile.py",
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",
+    "/tests/fast/test_doris_datasink.py",
     "/tests/fast/test_extension_catalog.py",
     "/tests/fast/test_milvus_datasink.py",
     "/tests/fast/test_qdrant_datasink.py",

--- a/scripts/run_release_tests.sh
+++ b/scripts/run_release_tests.sh
@@ -23,6 +23,7 @@ export VANE_FAST_TEST_ARTIFACT_MODE=1
 release_tests=(
   "$project_root/tests/fast/test_ai_release_contracts.py"
   "$project_root/tests/fast/test_datasink.py"
+  "$project_root/tests/fast/test_doris_datasink.py"
   "$project_root/tests/fast/test_extension_catalog.py"
   "$project_root/tests/fast/test_milvus_datasink.py"
   "$project_root/tests/fast/test_qdrant_datasink.py"

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import builtins
 import json
 import os
+import threading
 import uuid
-from collections.abc import AsyncIterable, Callable, Mapping
+from collections.abc import AsyncIterable, Callable, Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, cast
 
 import cloudpickle
@@ -19,9 +21,10 @@ import pytest
 import vane
 import vane.datasink.doris as doris
 from vane import DorisStreamLoadSink, EnvironmentSecret
-from vane.datasink import BoundDataSink, WriteContext
+from vane.datasink import BoundDataSink, WriteContext, WriteOutcome
 
 _REAL_LOAD_AIOHTTP = doris._load_aiohttp
+_REAL_OPEN_HTTP_TRANSPORT = doris._open_http_transport
 
 
 class _TransportError(Exception):
@@ -252,6 +255,126 @@ def _success(call: _Call, *, status: str = "Success", **overrides: object) -> _R
     }
     payload.update(overrides)
     return _Response(200, json.dumps(payload).encode())
+
+
+@pytest.fixture
+def _stream_load_server(monkeypatch: pytest.MonkeyPatch) -> Iterator[tuple[str, list[_Call]]]:
+    pytest.importorskip("aiohttp")
+    monkeypatch.setattr(doris, "_open_http_transport", _REAL_OPEN_HTTP_TRANSPORT)
+    calls: list[_Call] = []
+    calls_lock = threading.Lock()
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_PUT(self) -> None:
+            self.connection.settimeout(10)
+            body = self.rfile.read(int(self.headers["Content-Length"]))
+            call = _Call("PUT", self.path, dict(self.headers), body)
+            response = _success(call)
+            with calls_lock:
+                calls.append(call)
+            self.send_response(response.status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response.body)))
+            self.end_headers()
+            self.wfile.write(response.body)
+
+        def log_message(self, *_args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", calls
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.fixture(params=["local-fast", "local", pytest.param("ray", marks=pytest.mark.real_ray)])
+def _doris_runner(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    from vane import runners
+
+    runner_type = request.param
+    runner = None
+    if runner_type == "ray":
+        request.getfixturevalue("ray_local")
+        from vane.runners.ray.runner import RayRunner
+
+        runner = RayRunner(address=None, max_task_backlog=None)
+    elif runner_type == "local":
+        from vane.runners.local.runner import LocalRunner
+
+        # LocalRunner writes these settings too; retain pytest's environment cleanup.
+        monkeypatch.setenv("VANE_LOCAL_FTE_WORKERS", "2")
+        monkeypatch.setenv("VANE_LOCAL_FTE_EXECUTION_MODE", "in_process")
+        runner = LocalRunner(num_workers=2)
+    monkeypatch.setattr(runners, "get_or_infer_runner_type", lambda: runner_type)
+    if runner is not None:
+        monkeypatch.setattr(runners, "get_or_create_runner", lambda: runner)
+    try:
+        yield runner_type
+    finally:
+        if runner_type == "ray":
+            assert runner is not None
+            runner.close()
+
+
+@pytest.mark.parametrize("column_name", ["title", "embedding"])
+def test_doris_sink_runner_normalizes_worker_arrow_types(
+    _stream_load_server: tuple[str, list[_Call]], _doris_runner: str, column_name: str
+) -> None:
+    endpoint, calls = _stream_load_server
+    row_count = 513
+    if column_name == "title":
+        projection = "'item_' || i AS title"
+        column_type = pa.string()
+        values = [f"item_{i}" for i in range(row_count)]
+        vectors = {}
+    else:
+        projection = "[i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT] AS embedding"
+        column_type = pa.list_(pa.float32())
+        values = [[float(i), float(i + 1), float(i + 2)] for i in range(row_count)]
+        vectors = {"embedding": 3}
+    destination_schema = pa.schema(
+        [pa.field("id", pa.int32(), nullable=False), pa.field(column_name, column_type, nullable=False)]
+    )
+    with vane.connect() as connection:
+        relation = connection.sql(f"SELECT i::BIGINT AS id, {projection} FROM range({row_count}) AS t(i)")
+        summary = relation.write_datasink(
+            DorisStreamLoadSink(
+                "analytics",
+                "items",
+                endpoint=endpoint,
+                destination_schema=destination_schema,
+                vector_dimensions=vectors,
+                worker_count=2,
+                max_batch_rows=64,
+                timeout=10,
+            ),
+            operation_id=f"doris-{_doris_runner}-{column_name}",
+        )
+
+    assert summary.outcome is WriteOutcome.APPLIED
+    assert summary.rows_received == summary.rows_affected == row_count
+    assert len(calls) >= 9
+    assert len({call.headers["label"] for call in calls}) == len(calls)
+    batches = []
+    for call in calls:
+        assert call.url == "/api/analytics/items/_stream_load"
+        assert call.headers["format"] == "arrow"
+        assert call.headers["Expect"] == "100-continue"
+        assert int(call.headers["Content-Length"]) == len(call.body)
+        batch = pa.ipc.open_stream(call.body).read_all()
+        assert batch.schema == destination_schema
+        assert 0 < batch.num_rows <= 64
+        batches.append(batch)
+    received = pa.concat_tables(batches).sort_by("id")
+    expected = pa.table({"id": list(range(row_count)), column_name: values}, schema=destination_schema)
+    assert received.equals(expected)
 
 
 def test_doris_sink_is_public_without_importing_aiohttp() -> None:
@@ -518,6 +641,124 @@ def test_doris_sink_safely_casts_nested_destination_values() -> None:
 
 
 @pytest.mark.parametrize(
+    ("bound_type", "batch_type", "target_type", "values"),
+    [
+        (pa.string(), pa.large_string(), pa.string(), ["one", "二"]),
+        (pa.large_string(), pa.string(), pa.string(), ["one", "二"]),
+        (pa.binary(), pa.large_binary(), pa.string(), ["one", "two"]),
+        (pa.large_binary(), pa.binary(), pa.string(), ["one", "two"]),
+        (pa.list_(pa.int64()), pa.large_list(pa.int64()), pa.list_(pa.int32()), [[1, 2], [3]]),
+        (pa.large_list(pa.int64()), pa.list_(pa.int64()), pa.list_(pa.int32()), [[1, 2], [3]]),
+        (
+            pa.list_(pa.list_(pa.string())),
+            pa.large_list(pa.large_list(pa.large_string())),
+            pa.list_(pa.list_(pa.string())),
+            [[["one"], None], [[], ["二"]]],
+        ),
+        (
+            pa.large_list(pa.list_(pa.large_string())),
+            pa.list_(pa.large_list(pa.string())),
+            pa.list_(pa.list_(pa.string())),
+            [[["one"], None], [[], ["二"]]],
+        ),
+        (
+            pa.list_(pa.string(), 2),
+            pa.list_(pa.large_string(), 2),
+            pa.list_(pa.string()),
+            [["one", "two"], ["三", None]],
+        ),
+        (
+            pa.list_(pa.list_(pa.string(), 2)),
+            pa.large_list(pa.list_(pa.large_string(), 2)),
+            pa.list_(pa.list_(pa.string())),
+            [[["one", "two"]], [["三", None]]],
+        ),
+    ],
+)
+def test_doris_sink_normalizes_equivalent_worker_types(
+    bound_type: pa.DataType,
+    batch_type: pa.DataType,
+    target_type: pa.DataType,
+    values: list[Any],
+) -> None:
+    destination_schema = pa.schema([("value", target_type)])
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=destination_schema
+    )
+    column = pa.chunked_array([values, values], type=batch_type).slice(1, 2)
+    table = pa.table({"value": column})
+    worker = sink.bind(pa.schema([("value", bound_type)])).open_worker(WriteContext("worker-offsets"))
+    _Transport.responses = [_success]
+    try:
+        result = worker.write(table)
+    finally:
+        worker.close()
+
+    assert result.rows_received == result.rows_affected == 2
+    assert result.bytes_received == table.nbytes
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    expected = pa.table({"value": [values[1], values[0]]}, schema=destination_schema)
+    assert decoded.equals(expected)
+
+
+@pytest.mark.parametrize(
+    ("bound_type", "batch_type"),
+    [
+        (pa.int64(), pa.int32()),
+        (pa.int64(), pa.uint64()),
+        (pa.float32(), pa.float64()),
+        (pa.string(), pa.large_binary()),
+        (pa.binary(), pa.large_string()),
+        (pa.int64(), pa.timestamp("us")),
+        (pa.list_(pa.float32()), pa.large_list(pa.float64())),
+        (pa.list_(pa.int64()), pa.large_list(pa.int32())),
+        (pa.list_(pa.list_(pa.int64())), pa.large_list(pa.large_list(pa.float64()))),
+        (pa.list_(pa.float32(), 3), pa.list_(pa.float32(), 2)),
+        (pa.list_(pa.float32(), 3), pa.large_list(pa.float32())),
+        (pa.list_(pa.float32()), pa.list_(pa.float32(), 3)),
+        (pa.list_(pa.field("item", pa.int64(), nullable=False)), pa.large_list(pa.int64())),
+    ],
+)
+def test_doris_sink_rejects_worker_logical_type_changes_before_http(
+    bound_type: pa.DataType, batch_type: pa.DataType
+) -> None:
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=pa.schema([("value", pa.int32())])
+    )
+    worker = sink.bind(pa.schema([("value", bound_type)])).open_worker(WriteContext("worker-type-drift"))
+    try:
+        with pytest.raises(ValueError, match="bound input schema"):
+            worker.write(pa.table({"value": pa.array([], type=batch_type)}))
+    finally:
+        worker.close()
+    assert not _Transport.instances[0].calls
+
+
+@pytest.mark.parametrize(
+    ("source_type", "target_type", "values", "message"),
+    [
+        (pa.int64(), pa.int32(), [[1 << 40]], "cannot be safely cast"),
+        (pa.float64(), pa.float32(), [[1e40]], "floating-point overflow"),
+        (pa.int64(), pa.int32(), [[None]], "non-nullable"),
+    ],
+)
+def test_doris_sink_checks_destination_values_after_worker_offset_normalization(
+    source_type: pa.DataType, target_type: pa.DataType, values: list[Any], message: str
+) -> None:
+    destination_schema = pa.schema([("value", pa.list_(pa.field("item", target_type, nullable=False)))])
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=destination_schema
+    )
+    worker = sink.bind(pa.schema([("value", pa.list_(source_type))])).open_worker(WriteContext("worker-safe-cast"))
+    try:
+        with pytest.raises(ValueError, match=message):
+            worker.write(pa.table({"value": pa.array(values, type=pa.large_list(source_type))}))
+    finally:
+        worker.close()
+    assert not _Transport.instances[0].calls
+
+
+@pytest.mark.parametrize(
     ("column", "target_type", "path"),
     [
         (
@@ -728,6 +969,7 @@ def test_doris_sink_rejects_secret_endpoint_delimiters_before_opening_transport(
     assert not _Transport.instances
 
 
+@pytest.mark.parametrize("batch_vector_type", [pa.list_(pa.float32()), pa.large_list(pa.float32())])
 @pytest.mark.parametrize(
     ("vectors", "message"),
     [
@@ -738,17 +980,29 @@ def test_doris_sink_rejects_secret_endpoint_delimiters_before_opening_transport(
         ([[0.1, float("inf"), 0.3], [0.4, 0.5, 0.6]], "finite float32"),
     ],
 )
-def test_doris_sink_validates_vector_values_before_http(vectors: list[list[float] | None], message: str) -> None:
+def test_doris_sink_validates_vector_values_before_http(
+    vectors: list[list[float] | None], message: str, batch_vector_type: pa.DataType
+) -> None:
     schema = _schema(vector_type=pa.list_(pa.float32()))
     worker = _worker(schema=schema)
     with pytest.raises(ValueError, match=message):
-        worker.write(_table(vectors=vectors, schema=schema))
+        worker.write(_table(vectors=vectors, schema=_schema(vector_type=batch_vector_type)))
     assert not _Transport.instances[0].calls
 
 
-def test_doris_sink_accepts_large_list_vectors_and_encodes_plain_list() -> None:
-    schema = _schema(vector_type=pa.large_list(pa.float32()))
-    table = _table(schema=schema)
+@pytest.mark.parametrize(
+    ("bound_vector_type", "batch_vector_type"),
+    [
+        (pa.large_list(pa.float32()), pa.large_list(pa.float32())),
+        (pa.list_(pa.float32()), pa.large_list(pa.float32())),
+        (pa.large_list(pa.float32()), pa.list_(pa.float32())),
+    ],
+)
+def test_doris_sink_accepts_equivalent_list_vectors_and_encodes_plain_list(
+    bound_vector_type: pa.DataType, batch_vector_type: pa.DataType
+) -> None:
+    schema = _schema(vector_type=bound_vector_type)
+    table = _table(schema=_schema(vector_type=batch_vector_type))
     _Transport.responses = [_success]
 
     _worker(schema=schema).write(table)
@@ -976,7 +1230,7 @@ def test_doris_sink_retains_transport_ownership_when_close_fails() -> None:
 
 
 @pytest.mark.external_service
-def test_doris_sink_live_arrow_stream_load() -> None:
+def test_doris_sink_live_arrow_stream_load(_doris_runner: str) -> None:
     endpoint = os.environ.get("VANE_TEST_DORIS_ENDPOINT")
     if not endpoint:
         pytest.skip("VANE_TEST_DORIS_ENDPOINT is required for the external Doris test")
@@ -1017,7 +1271,7 @@ def test_doris_sink_live_arrow_stream_load() -> None:
                 """
             )
 
-        input_table = _table()
+        input_table = _table(schema=_schema(vector_type=pa.list_(pa.float32())))
         assert input_table.schema.field("source_id").type == pa.int64()
         relation = vane.from_arrow(input_table)
         summary = relation.write_datasink(
@@ -1032,6 +1286,8 @@ def test_doris_sink_live_arrow_stream_load() -> None:
                 ),
                 field_mapping={"source_id": "id", "source_title": "title"},
                 vector_dimensions={"embedding": 3},
+                worker_count=2,
+                max_batch_rows=1,
                 trusted_redirect_hosts=(() if redirect_host is None else (redirect_host,)),
                 timeout=60,
             ),

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -501,6 +501,127 @@ def test_doris_sink_safely_casts_nested_destination_values() -> None:
     assert decoded.column("score").to_pylist() == pytest.approx([1.25, 2.5])
 
 
+@pytest.mark.parametrize(
+    ("column", "target_type", "path"),
+    [
+        (
+            pa.chunked_array([[0.1], [None, float("inf"), 1e40]], type=pa.float64()),
+            pa.float32(),
+            "score",
+        ),
+        (
+            pa.chunked_array([[float("-inf"), -1e40]], type=pa.float64()),
+            pa.float32(),
+            "score",
+        ),
+        (
+            pa.chunked_array([[[0.1, None]], [None, [1e40]]], type=pa.list_(pa.float64())),
+            pa.list_(pa.float32()),
+            r"score\[\]",
+        ),
+        (
+            pa.chunked_array([[[0.1, -1e40]]], type=pa.large_list(pa.float64())),
+            pa.list_(pa.float32()),
+            r"score\[\]",
+        ),
+        (
+            pa.chunked_array([[[0.1, 1e40]]], type=pa.list_(pa.float64(), 2)),
+            pa.list_(pa.float32()),
+            r"score\[\]",
+        ),
+        (
+            pa.chunked_array([[[[0.1], None, [-1e40]]]], type=pa.list_(pa.list_(pa.float64()))),
+            pa.list_(pa.list_(pa.float32())),
+            r"score\[\]\[\]",
+        ),
+        (
+            pa.chunked_array([pa.array([0.1, None, 1e40]).dictionary_encode()]),
+            pa.float32(),
+            "score",
+        ),
+    ],
+    ids=[
+        "scalar-positive",
+        "scalar-negative",
+        "list",
+        "large-list",
+        "fixed-list",
+        "nested-list",
+        "dictionary",
+    ],
+)
+def test_doris_sink_rejects_float_narrowing_overflow_before_http(
+    column: pa.ChunkedArray, target_type: pa.DataType, path: str
+) -> None:
+    table = pa.table({"score": column})
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=pa.schema([("score", target_type)]),
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("float-overflow"))
+    _Transport.responses = [_success]
+
+    with pytest.raises(ValueError, match=f"destination field '{path}'.*floating-point overflow"):
+        worker.write(table)
+
+    assert not _Transport.instances[0].calls
+    worker.close()
+
+
+def test_doris_sink_float_narrowing_preserves_rounding_and_existing_nonfinite_values() -> None:
+    max_float32 = float.fromhex("0x1.fffffep+127")
+    source = pa.array(
+        [1e40, 0.1, None, float("nan"), float("inf"), float("-inf"), max_float32 + 1e30, -max_float32 - 1e30, -1e40],
+        type=pa.float64(),
+    ).slice(1, 7)
+    table = pa.table({"score": pa.chunked_array([source.slice(0, 3), source.slice(3)])})
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=pa.schema([("score", pa.float32())]),
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("float-rounding"))
+    _Transport.responses = [_success]
+
+    result = worker.write(table)
+
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    assert result.rows_affected == 7
+    assert decoded.column("score").to_pylist() == pytest.approx(
+        [0.1, None, float("nan"), float("inf"), float("-inf"), max_float32, -max_float32], nan_ok=True
+    )
+    worker.close()
+
+
+def test_doris_sink_float_narrowing_ignores_hidden_list_values() -> None:
+    source = pa.ListArray.from_arrays(
+        pa.array([0, 1, 2, 4, 6, 7], type=pa.int32()),
+        pa.array([1e40, -1e40, 0.1, None, float("inf"), float("-inf"), 1e40], type=pa.float64()),
+        mask=pa.array([False, True, False, False, False]),
+    ).slice(1, 3)
+    table = pa.table({"score": source})
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=pa.schema([("score", pa.list_(pa.float32()))]),
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("float-list-slice"))
+    _Transport.responses = [_success]
+
+    worker.write(table)
+
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    rows = decoded.column("score").to_pylist()
+    assert rows[0] is None
+    assert rows[1] == pytest.approx([0.1, None])
+    assert rows[2] == [float("inf"), float("-inf")]
+    worker.close()
+
+
 def test_doris_sink_rejects_unsafe_casts_and_destination_nulls_before_http() -> None:
     worker = _worker()
     overflow = _table().set_column(
@@ -537,6 +658,23 @@ def test_doris_sink_rejects_unsafe_casts_and_destination_nulls_before_http() -> 
     with pytest.raises(ValueError, match=r"destination field 'values\[\]'.*non-nullable"):
         worker.write(pa.table({"values": [[1, None]]}, schema=source_schema))
     assert not _Transport.instances[2].calls
+
+    dictionary_list = pa.DictionaryArray.from_arrays(
+        pa.array([1, None, 0], type=pa.int8()),
+        pa.array([[1e40], [0.1, None]], type=pa.list_(pa.float64())),
+    )
+    table = pa.table({"values": dictionary_list})
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=pa.schema([("values", pa.list_(pa.float32()))]),
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("unsupported-dictionary-list"))
+    with pytest.raises(ValueError, match=r"values.*cannot be safely cast.*Unsupported cast"):
+        worker.write(table)
+    assert not _Transport.instances[3].calls
+    worker.close()
 
 
 def test_doris_sink_defers_endpoint_and_password_resolution_to_worker(

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import json
 import os
@@ -18,9 +19,10 @@ import pyarrow as pa
 import pytest
 
 import vane
+import vane.datasink as datasink
 import vane.datasink.doris as doris
 from vane import DorisStreamLoadSink, EnvironmentSecret
-from vane.datasink import BoundDataSink, WriteContext, WriteOutcome
+from vane.datasink import BoundDataSink, DataSinkExecutionOptions, DataSinkWriteError, WriteContext, WriteOutcome
 
 _REAL_LOAD_AIOHTTP = doris._load_aiohttp
 _REAL_OPEN_HTTP_TRANSPORT = doris._open_http_transport
@@ -1202,6 +1204,159 @@ def test_doris_sink_never_retries_an_unknown_batch(response: _Response | BaseExc
         _worker().write(_table())
 
     assert len(_Transport.instances[0].calls) == 1
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, asyncio.CancelledError, SystemExit, GeneratorExit])
+@pytest.mark.parametrize("stage", ["upload", "redirected-upload", "response-validation"])
+def test_doris_sink_interruption_preserves_the_current_batch_label(
+    monkeypatch: pytest.MonkeyPatch, error_type: type[BaseException], stage: str
+) -> None:
+    interruption = error_type("planned write interruption")
+    _Transport.responses = [_success]
+    worker = _worker()
+    try:
+        completed = worker.write(_table())
+        if stage == "redirected-upload":
+            _Transport.responses.append(
+                _Response(307, headers={"Location": "http://be.example:8040/api/analytics/items/_stream_load"})
+            )
+        if stage == "response-validation":
+            _Transport.responses.append(_success)
+
+            def interrupt_result(**_kwargs: object) -> None:
+                raise interruption
+
+            monkeypatch.setattr(worker, "_applied_result", interrupt_result)
+        else:
+            _Transport.responses.append(interruption)
+        _Transport.responses.append(_success)
+
+        with pytest.raises(error_type) as exc_info:
+            worker.write(_table())
+
+        assert exc_info.value is interruption
+        assert datasink._is_execution_interruption(exc_info.value)
+        calls = _Transport.instances[0].calls
+        label = calls[-1].headers["label"]
+        assert len(calls) == (3 if stage == "redirected-upload" else 2)
+        assert len(_Transport.responses) == 1
+        assert label != completed.metadata["label"]
+        assert all(call.headers["label"] == label for call in calls[1:])
+        assert f"label {label!r}" in exc_info.value.args[0]
+        assert completed.metadata["label"] not in exc_info.value.args[0]
+        assert "planned write interruption" in exc_info.value.args[0]
+        assert "inspect that label" in exc_info.value.args[0]
+        if isinstance(interruption, SystemExit):
+            assert interruption.code == "planned write interruption"
+        worker.abort(interruption)
+    finally:
+        worker.close()
+    assert _Transport.instances[0].close_calls == 1
+
+
+@pytest.mark.parametrize(
+    "args",
+    [(), (object(),), ("interrupted " + "\u53d6\u6d88\ud800" * 10_000,)],
+    ids=["no-message", "non-string-message", "oversized-unicode-message"],
+)
+def test_doris_sink_interruption_diagnostics_are_bounded_without_formatting_the_exception(
+    args: tuple[object, ...],
+) -> None:
+    class UnprintableCancellation(asyncio.CancelledError):
+        def __str__(self) -> str:
+            raise AssertionError("must not format the interruption")
+
+    interruption = UnprintableCancellation(*args)
+    _Transport.responses = [interruption]
+    worker = _worker()
+    try:
+        with pytest.raises(UnprintableCancellation) as exc_info:
+            worker.write(_table())
+
+        assert exc_info.value is interruption
+        label = _Transport.instances[0].calls[0].headers["label"]
+        message = exc_info.value.args[0]
+        assert f"label {label!r}" in message
+        assert "inspect that label" in message
+        assert len(message.encode("utf-8")) < 1024
+    finally:
+        worker.close()
+
+
+def test_doris_sink_cancellation_after_async_body_upload_keeps_the_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    aiohttp = _AioHttpModule()
+    interruption = asyncio.CancelledError("cancelled after upload")
+    original_enter = _AsyncResponseContext.__aenter__
+
+    async def cancel_after_upload(context: _AsyncResponseContext) -> _AsyncResponse:
+        await original_enter(context)
+        raise interruption
+
+    monkeypatch.setattr(_AsyncResponseContext, "__aenter__", cancel_after_upload)
+    monkeypatch.setattr(doris, "_load_aiohttp", lambda: aiohttp)
+    monkeypatch.setattr(doris, "_open_http_transport", _REAL_OPEN_HTTP_TRANSPORT)
+    worker = _worker()
+    transport = worker._transport
+    try:
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            worker.write(_table())
+
+        assert exc_info.value is interruption
+        assert len(aiohttp.session.put_options) == len(aiohttp.session.written_chunks) == 1
+        headers = cast(Mapping[str, str], aiohttp.session.put_options[0]["headers"])
+        assert f"label {headers['label']!r}" in exc_info.value.args[0]
+        assert pa.ipc.open_stream(b"".join(aiohttp.session.written_chunks[0])).read_all().num_rows == 2
+        worker.abort(interruption)
+    finally:
+        worker.close()
+    assert aiohttp.session.closed
+    assert transport._loop.is_closed()
+
+
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, asyncio.CancelledError])
+def test_doris_sink_interruption_keeps_the_label_in_the_public_error(
+    monkeypatch: pytest.MonkeyPatch, error_type: type[BaseException]
+) -> None:
+    from vane import runners
+
+    interruption = error_type("planned write interruption")
+    _Transport.responses = [interruption, _success]
+    operation_id = "doris-interruption-no-retry"
+
+    class FakeRunner:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def run_datasink(self, _relation: object) -> None:
+            self.calls += 1
+            runtime = datasink._SinkBatchRuntime(_bound(), WriteContext(operation_id), None)
+            try:
+                runtime(_table())
+            finally:
+                runtime.close()
+
+    runner = FakeRunner()
+    monkeypatch.setattr(runners, "get_or_infer_runner_type", lambda: "ray")
+    monkeypatch.setattr(runners, "get_or_create_runner", lambda: runner)
+    # Fault-inject a retry budget: cancellation must stay terminal even when
+    # the framework would otherwise replay an UNKNOWN outcome.
+    monkeypatch.setattr(
+        doris._BoundDorisStreamLoadSink,
+        "execution_options",
+        property(lambda _self: DataSinkExecutionOptions(max_retries=3)),
+    )
+    with vane.connect() as connection, pytest.raises(DataSinkWriteError) as exc_info:
+        _live_input_relation(connection).write_datasink(_sink(), operation_id=operation_id)
+
+    assert runner.calls == 1
+    assert exc_info.value.outcome is WriteOutcome.UNKNOWN
+    assert exc_info.value.__cause__ is interruption
+    assert exc_info.value.summary.results == ()
+    assert not any("framework retry" in warning for warning in exc_info.value.summary.warnings)
+    transport = _Transport.instances[0]
+    assert len(transport.calls) == len(_Transport.responses) == transport.close_calls == 1
+    assert f"label {transport.calls[0].headers['label']!r}" in exc_info.value.detail
+    assert "inspect that label" in exc_info.value.detail
 
 
 def test_doris_sink_treats_publish_timeout_as_applied_with_warning() -> None:

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -323,6 +323,10 @@ def test_doris_transport_streams_replayable_chunks_with_real_expect_continue(
         ({"endpoint": "http://doris.example/path"}, ValueError, "path"),
         ({"endpoint": "http://user:secret@doris.example"}, ValueError, "credentials"),
         ({"endpoint": "http://doris.example?token=secret"}, ValueError, "query parameters"),
+        ({"endpoint": "http://doris.example?"}, ValueError, "query parameters"),
+        ({"endpoint": "http://doris.example#"}, ValueError, "fragments"),
+        ({"endpoint": "http://doris.example/?"}, ValueError, "query parameters"),
+        ({"endpoint": "http://doris.example/#"}, ValueError, "fragments"),
         ({"user": ""}, ValueError, "user"),
         ({"user": "domain:alice"}, ValueError, "colon"),
         ({"password": "plain-text"}, TypeError, "EnvironmentSecret"),
@@ -346,7 +350,19 @@ def test_doris_transport_streams_replayable_chunks_with_real_expect_continue(
         ({"trusted_redirect_hosts": "be.example"}, TypeError, "sequence"),
         ({"trusted_redirect_hosts": ("http://be.example",)}, ValueError, "bare host"),
         ({"trusted_redirect_hosts": ("be.example:8040",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("be.example:",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("be.example?",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("be.example#",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("be.\texample",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("[2001:db8::42]:8040",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("[2001:db8::42]:",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("2001:db8::invalid",)}, ValueError, "bare host"),
         ({"trusted_redirect_hosts": ("be.example", "BE.EXAMPLE")}, ValueError, "duplicates"),
+        (
+            {"trusted_redirect_hosts": ("2001:db8::42", "[2001:0DB8:0:0:0:0:0:0042]")},
+            ValueError,
+            "duplicates",
+        ),
         ({"worker_count": True}, TypeError, "worker_count"),
         ({"worker_count": 0}, ValueError, "worker_count"),
         ({"max_batch_rows": -1}, ValueError, "max_batch_rows"),
@@ -699,6 +715,19 @@ def test_doris_sink_defers_endpoint_and_password_resolution_to_worker(
     worker.close()
 
 
+@pytest.mark.parametrize("suffix", ["?", "#"])
+def test_doris_sink_rejects_secret_endpoint_delimiters_before_opening_transport(
+    monkeypatch: pytest.MonkeyPatch, suffix: str
+) -> None:
+    monkeypatch.setenv("VANE_TEST_DORIS_ENDPOINT", f"http://fe.example:8030{suffix}")
+    bound = _sink(endpoint=EnvironmentSecret("VANE_TEST_DORIS_ENDPOINT")).bind(_schema())
+
+    with pytest.raises(ValueError, match="query parameters, or fragments"):
+        bound.open_worker(WriteContext("invalid-secret-endpoint"))
+
+    assert not _Transport.instances
+
+
 @pytest.mark.parametrize(
     ("vectors", "message"),
     [
@@ -792,6 +821,67 @@ def test_doris_sink_follows_one_trusted_redirect_and_replays_identical_body() ->
     ]
     assert calls[0].body == calls[1].body
     assert calls[0].headers["label"] == calls[1].headers["label"]
+
+
+@pytest.mark.parametrize("trusted_host", ["2001:db8::42", "[2001:db8::42]", "2001:0DB8:0:0:0:0:0:0042"])
+def test_doris_sink_trusts_ipv6_redirect_hosts(trusted_host: str) -> None:
+    _Transport.responses = [
+        _Response(307, headers={"Location": "http://root:@[2001:db8::42]:8040/api/analytics/items/_stream_load"}),
+        _success,
+    ]
+    worker = _worker(trusted_redirect_hosts=(trusted_host,))
+
+    result = worker.write(_table())
+
+    calls = _Transport.instances[0].calls
+    assert result.rows_affected == 2
+    assert [call.url for call in calls] == [
+        "http://fe.example:8030/api/analytics/items/_stream_load",
+        "http://[2001:db8::42]:8040/api/analytics/items/_stream_load",
+    ]
+    assert calls[0].body == calls[1].body
+    worker.close()
+
+
+def test_doris_sink_matches_equivalent_ipv6_endpoint_and_redirect_addresses() -> None:
+    _Transport.responses = [
+        _Response(307, headers={"Location": "http://[2001:db8::42]:8040/api/analytics/items/_stream_load"}),
+        _success,
+    ]
+    worker = _worker(endpoint="http://[2001:0DB8:0:0:0:0:0:0042]:8030", trusted_redirect_hosts=())
+
+    worker.write(_table())
+
+    calls = _Transport.instances[0].calls
+    assert len(calls) == 2
+    assert calls[1].url == "http://[2001:db8::42]:8040/api/analytics/items/_stream_load"
+    worker.close()
+
+
+def test_doris_sink_rejects_an_untrusted_ipv6_redirect() -> None:
+    _Transport.responses = [
+        _Response(307, headers={"Location": "http://[2001:db8::99]:8040/api/analytics/items/_stream_load"}),
+    ]
+    worker = _worker(trusted_redirect_hosts=("2001:db8::42",))
+
+    with pytest.raises(RuntimeError, match="untrusted host"):
+        worker.write(_table())
+
+    assert len(_Transport.instances[0].calls) == 1
+    worker.close()
+
+
+def test_doris_sink_does_not_trust_a_distinct_casefolded_hostname() -> None:
+    _Transport.responses = [
+        _Response(307, headers={"Location": "http://strasse.example:8040/api/analytics/items/_stream_load"}),
+    ]
+    worker = _worker(trusted_redirect_hosts=("straße.example",))
+
+    with pytest.raises(RuntimeError, match="untrusted host"):
+        worker.write(_table())
+
+    assert len(_Transport.instances[0].calls) == 1
+    worker.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -1,0 +1,679 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+import uuid
+from collections.abc import AsyncIterable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, cast
+
+import cloudpickle
+import pyarrow as pa
+import pytest
+
+import vane
+import vane.datasink.doris as doris
+from vane import DorisStreamLoadSink, EnvironmentSecret
+from vane.datasink import BoundDataSink, WriteContext
+
+_REAL_LOAD_AIOHTTP = doris._load_aiohttp
+
+
+class _TransportError(Exception):
+    pass
+
+
+@dataclass
+class _Response:
+    status_code: int
+    body: bytes = b""
+    headers: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.headers is None:
+            self.headers = {}
+
+
+@dataclass(frozen=True)
+class _Call:
+    method: str
+    url: str
+    headers: dict[str, str]
+    body: bytes
+
+
+_ResponseFactory = Callable[[_Call], _Response]
+
+
+class _Transport:
+    responses: list[_Response | _ResponseFactory | BaseException] = []
+    instances: list[_Transport] = []
+    close_error: BaseException | None = None
+
+    def __init__(self, user: str, password: str, timeout: int) -> None:
+        self.options = {"user": user, "password": password, "timeout": timeout}
+        self.calls: list[_Call] = []
+        self.close_calls = 0
+        type(self).instances.append(self)
+
+    def put(self, url: str, headers: Mapping[str, str], body: pa.Buffer) -> _Response:
+        call = _Call("PUT", url, dict(headers), body.to_pybytes())
+        self.calls.append(call)
+        if not type(self).responses:
+            raise AssertionError("fake HTTP response queue is empty")
+        response = type(self).responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response(call) if callable(response) else response
+
+    def close(self) -> None:
+        self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
+
+
+class _AsyncChunks:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = iter(chunks)
+
+    def iter_any(self) -> _AsyncChunks:
+        return self
+
+    def __aiter__(self) -> _AsyncChunks:
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            return next(self._chunks)
+        except StopIteration as error:
+            raise StopAsyncIteration from error
+
+
+class _AsyncResponse:
+    def __init__(self) -> None:
+        self.status = 200
+        self.headers = {"content-type": "application/json"}
+        self.content = _AsyncChunks([b'{"Status":', b'"Success"}'])
+
+
+class _AsyncResponseContext:
+    def __init__(self, session: _AsyncSession, options: Mapping[str, object]) -> None:
+        self._session = session
+        self._options = options
+
+    async def __aenter__(self) -> _AsyncResponse:
+        chunks: list[bytes] = []
+        body = cast(AsyncIterable[bytes | bytearray | memoryview], self._options["data"])
+        async for chunk in body:
+            chunks.append(bytes(chunk))
+        self._session.written_chunks.append(chunks)
+        return _AsyncResponse()
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class _AsyncSession:
+    def __init__(self) -> None:
+        self.put_options: list[dict[str, object]] = []
+        self.written_chunks: list[list[bytes]] = []
+        self.closed = False
+
+    def put(self, url: str, **options: object) -> _AsyncResponseContext:
+        request_options = {"url": url, **options}
+        self.put_options.append(request_options)
+        return _AsyncResponseContext(self, request_options)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _AioHttpModule:
+    def __init__(self) -> None:
+        self.session = _AsyncSession()
+        self.session_options: dict[str, object] | None = None
+
+    @staticmethod
+    def BasicAuth(user: str, password: str, *, encoding: str) -> tuple[str, str, str]:
+        return user, password, encoding
+
+    @staticmethod
+    def ClientTimeout(*, total: float, sock_connect: float) -> tuple[float, float]:
+        return total, sock_connect
+
+    def ClientSession(self, **options: object) -> _AsyncSession:
+        self.session_options = options
+        return self.session
+
+
+@pytest.fixture(autouse=True)
+def _fake_http_transport(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    if request.node.get_closest_marker("external_service") is not None:
+        return
+    _Transport.responses = []
+    _Transport.instances = []
+    _Transport.close_error = None
+    monkeypatch.setattr(doris, "_open_http_transport", _Transport)
+
+
+def _schema(*, vector_type: pa.DataType | None = None) -> pa.Schema:
+    return pa.schema(
+        [
+            ("source_id", pa.int64()),
+            ("embedding", pa.list_(pa.float32(), 3) if vector_type is None else vector_type),
+            ("source_title", pa.string()),
+        ]
+    )
+
+
+def _table(
+    *,
+    vectors: list[list[float] | None] | None = None,
+    schema: pa.Schema | None = None,
+) -> pa.Table:
+    return pa.table(
+        {
+            "source_id": [1, 2],
+            "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] if vectors is None else vectors,
+            "source_title": ["one", "two"],
+        },
+        schema=_schema() if schema is None else schema,
+    )
+
+
+def _sink(**overrides: object) -> DorisStreamLoadSink:
+    options: dict[str, object] = {
+        "endpoint": "http://fe.example:8030",
+        "field_mapping": {"source_id": "id", "source_title": "title"},
+        "vector_dimensions": {"embedding": 3},
+        "trusted_redirect_hosts": ("be.example",),
+        "timeout": 5,
+    }
+    options.update(overrides)
+    return DorisStreamLoadSink("analytics", "items", **options)  # type: ignore[arg-type]
+
+
+def _bound(*, schema: pa.Schema | None = None, **overrides: object) -> BoundDataSink:
+    return _sink(**overrides).bind(_schema() if schema is None else schema)
+
+
+def _worker(*, schema: pa.Schema | None = None, **overrides: object) -> Any:
+    return _bound(schema=schema, **overrides).open_worker(WriteContext("doris-test-operation"))
+
+
+def _success(call: _Call, *, status: str = "Success", **overrides: object) -> _Response:
+    table = pa.ipc.open_stream(call.body).read_all()
+    payload: dict[str, object] = {
+        "TxnId": 17,
+        "Label": call.headers["label"],
+        "Status": status,
+        "Message": "OK",
+        "NumberTotalRows": table.num_rows,
+        "NumberLoadedRows": table.num_rows,
+        "NumberFilteredRows": 0,
+        "NumberUnselectedRows": 0,
+        "LoadBytes": len(call.body),
+        "LoadTimeMs": 12,
+    }
+    payload.update(overrides)
+    return _Response(200, json.dumps(payload).encode())
+
+
+def test_doris_sink_is_public_without_importing_aiohttp() -> None:
+    assert vane.DorisStreamLoadSink is DorisStreamLoadSink
+    assert doris.__all__ == ["DorisStreamLoadSink"]
+
+
+def test_doris_sink_reports_the_missing_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def missing_aiohttp(name: str, *args: object, **kwargs: object) -> Any:
+        if name == "aiohttp":
+            raise ModuleNotFoundError("No module named 'aiohttp'", name="aiohttp")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_aiohttp)
+    with pytest.raises(ImportError, match=r"vane-ai\[doris\]"):
+        _REAL_LOAD_AIOHTTP()
+
+
+def test_doris_transport_streams_replayable_chunks_with_real_expect_continue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    aiohttp = _AioHttpModule()
+    monkeypatch.setattr(doris, "_load_aiohttp", lambda: aiohttp)
+    transport = doris._AioHttpTransport("alice", "secret", 17)
+    body = b"a" * (2 * doris._HTTP_BODY_CHUNK_BYTES + 7)
+
+    first_response = transport.put(
+        "http://fe.example:8030/api/db/table/_stream_load",
+        {"Content-Length": str(len(body))},
+        pa.py_buffer(body),
+    )
+    second_response = transport.put(
+        "http://be.example:8040/api/db/table/_stream_load",
+        {"Content-Length": str(len(body))},
+        pa.py_buffer(body),
+    )
+    transport.close()
+
+    assert aiohttp.session_options == {
+        "auth": ("alice", "secret", "utf-8"),
+        "auto_decompress": False,
+        "skip_auto_headers": {"Accept-Encoding"},
+        "timeout": (47.0, 30.0),
+        "trust_env": False,
+    }
+    assert len(aiohttp.session.put_options) == 2
+    assert all(options["allow_redirects"] is False for options in aiohttp.session.put_options)
+    assert all(options["expect100"] is True for options in aiohttp.session.put_options)
+    assert [b"".join(chunks) for chunks in aiohttp.session.written_chunks] == [body, body]
+    assert [[len(chunk) for chunk in chunks] for chunks in aiohttp.session.written_chunks] == [
+        [doris._HTTP_BODY_CHUNK_BYTES, doris._HTTP_BODY_CHUNK_BYTES, 7],
+        [doris._HTTP_BODY_CHUNK_BYTES, doris._HTTP_BODY_CHUNK_BYTES, 7],
+    ]
+    assert first_response.status_code == second_response.status_code == 200
+    assert first_response.body == second_response.body == b'{"Status":"Success"}'
+    assert aiohttp.session.closed is True
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error", "message"),
+    [
+        ({"database": ""}, ValueError, "database"),
+        ({"table": "bad`table"}, ValueError, "ASCII Doris identifier"),
+        ({"database": ".."}, ValueError, "beginning with a letter"),
+        ({"endpoint": "doris.example:8030"}, ValueError, "HTTP or HTTPS"),
+        ({"endpoint": "http://doris.example/path"}, ValueError, "path"),
+        ({"endpoint": "http://user:secret@doris.example"}, ValueError, "credentials"),
+        ({"endpoint": "http://doris.example?token=secret"}, ValueError, "query parameters"),
+        ({"user": ""}, ValueError, "user"),
+        ({"user": "domain:alice"}, ValueError, "colon"),
+        ({"password": "plain-text"}, TypeError, "EnvironmentSecret"),
+        ({"field_mapping": []}, TypeError, "field_mapping"),
+        ({"vector_dimensions": []}, TypeError, "vector_dimensions"),
+        ({"vector_dimensions": {"embedding": 1 << 31}}, ValueError, "signed 32-bit"),
+        ({"trusted_redirect_hosts": "be.example"}, TypeError, "sequence"),
+        ({"trusted_redirect_hosts": ("http://be.example",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("be.example:8040",)}, ValueError, "bare host"),
+        ({"trusted_redirect_hosts": ("be.example", "BE.EXAMPLE")}, ValueError, "duplicates"),
+        ({"worker_count": True}, TypeError, "worker_count"),
+        ({"worker_count": 0}, ValueError, "worker_count"),
+        ({"max_batch_rows": -1}, ValueError, "max_batch_rows"),
+        ({"max_batch_bytes": 1.5}, TypeError, "max_batch_bytes"),
+        ({"max_request_bytes": 1.5}, TypeError, "max_request_bytes"),
+        ({"send_batch_parallelism": 0}, ValueError, "send_batch_parallelism"),
+        ({"timeout": 0}, ValueError, "timeout"),
+        ({"timeout": 259_201}, ValueError, "259200"),
+    ],
+)
+def test_doris_sink_validates_constructor(
+    overrides: dict[str, object], error: type[Exception], message: str
+) -> None:
+    options: dict[str, object] = {
+        "database": "analytics",
+        "table": "items",
+        "endpoint": "http://doris.example:8030",
+    }
+    options.update(overrides)
+    with pytest.raises(error, match=message):
+        DorisStreamLoadSink(**options)  # type: ignore[arg-type]
+
+
+def test_doris_sink_binds_mapping_vectors_and_execution_options() -> None:
+    bound = _bound(worker_count=3, max_batch_rows=17, max_batch_bytes=2_048, send_batch_parallelism=4)
+
+    assert isinstance(bound, BoundDataSink)
+    assert bound.execution_options.worker_count == 3
+    assert bound.execution_options.batch_size == 17
+    assert bound.execution_options.target_max_batch_bytes == 2_048
+    assert bound.execution_options.max_retries == 0
+
+
+def test_doris_sink_rejects_invalid_bound_schema_and_mappings() -> None:
+    with pytest.raises(TypeError, match="pyarrow.Schema"):
+        _sink().bind(object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="at least one"):
+        _sink().bind(pa.schema([]))
+    with pytest.raises(ValueError, match="unique input"):
+        _sink(field_mapping=None, vector_dimensions=None).bind(pa.schema([("id", pa.int64()), ("id", pa.int64())]))
+    with pytest.raises(ValueError, match="unknown input"):
+        _sink(field_mapping={"missing": "id"}).bind(_schema())
+    with pytest.raises(ValueError, match="unknown input"):
+        _sink(vector_dimensions={"missing": 3}).bind(_schema())
+    with pytest.raises(ValueError, match="case-insensitively unique"):
+        _sink(field_mapping={"source_id": "VALUE", "source_title": "value"}).bind(_schema())
+    with pytest.raises(ValueError, match="ASCII"):
+        _sink(field_mapping={"source_title": "标题"}).bind(_schema())
+    with pytest.raises(ValueError, match="ASCII"):
+        _sink(field_mapping={"source_title": "title=value"}).bind(_schema())
+    with pytest.raises(ValueError, match="float32"):
+        _sink().bind(_schema(vector_type=pa.list_(pa.float64())))
+    with pytest.raises(ValueError, match="fixed dimension"):
+        _sink().bind(_schema(vector_type=pa.list_(pa.float32(), 2)))
+
+
+def test_doris_sink_writes_arrow_stream_without_row_materialization() -> None:
+    _Transport.responses = [_success, _success]
+    worker = _worker()
+    table = _table()
+
+    first = worker.write(table)
+    second = worker.write(table)
+
+    transport = _Transport.instances[0]
+    assert transport.options == {"user": "root", "password": "", "timeout": 5}
+    assert len(transport.calls) == 2
+    call = transport.calls[0]
+    assert call.method == "PUT"
+    assert call.url == "http://fe.example:8030/api/analytics/items/_stream_load"
+    assert call.headers["Expect"] == "100-continue"
+    assert call.headers["Content-Type"] == "application/vnd.apache.arrow.stream"
+    assert call.headers["Content-Length"] == str(len(call.body))
+    assert call.headers["format"] == "arrow"
+    assert call.headers["columns"] == "`id`,`embedding`,`title`"
+    assert call.headers["strict_mode"] == "true"
+    assert call.headers["max_filter_ratio"] == "0"
+    assert call.headers["send_batch_parallelism"] == "1"
+    assert call.headers["timeout"] == "5"
+    assert call.headers["label"].startswith("vane_")
+    assert transport.calls[1].headers["label"] != call.headers["label"]
+
+    decoded = pa.ipc.open_stream(call.body).read_all()
+    assert decoded.schema.names == ["id", "embedding", "title"]
+    assert decoded.schema.field("embedding").type == pa.list_(pa.float32())
+    assert decoded.column("id").to_pylist() == [1, 2]
+    vectors = decoded.column("embedding").to_pylist()
+    assert vectors[0] == pytest.approx([0.1, 0.2, 0.3])
+    assert vectors[1] == pytest.approx([0.4, 0.5, 0.6])
+    assert decoded.column("title").to_pylist() == ["one", "two"]
+
+    assert first.rows_received == first.rows_affected == 2
+    assert first.bytes_received == table.nbytes
+    assert first.metadata["provider"] == "doris"
+    assert first.metadata["database"] == "analytics"
+    assert first.metadata["table"] == "items"
+    assert first.metadata["format"] == "arrow"
+    assert first.metadata["status"] == "Success"
+    assert first.metadata["txn_id"] == 17
+    assert first.metadata["wire_bytes"] == len(call.body)
+    assert len(first.warnings) == 1
+    assert second.warnings == ()
+
+
+def test_doris_sink_defers_endpoint_and_password_resolution_to_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VANE_TEST_DORIS_ENDPOINT", "https://private-doris.example:8030")
+    monkeypatch.setenv("VANE_TEST_DORIS_PASSWORD", "worker-only-password")
+    sink = _sink(
+        endpoint=EnvironmentSecret("VANE_TEST_DORIS_ENDPOINT"),
+        password=EnvironmentSecret("VANE_TEST_DORIS_PASSWORD"),
+    )
+    serialized = cloudpickle.dumps(sink)
+    assert b"private-doris.example" not in serialized
+    assert b"worker-only-password" not in serialized
+
+    bound = sink.bind(_schema())
+    assert b"private-doris.example" not in cloudpickle.dumps(bound)
+    assert b"worker-only-password" not in cloudpickle.dumps(bound)
+    worker = bound.open_worker(WriteContext("secret-test"))
+
+    assert _Transport.instances[0].options["password"] == "worker-only-password"
+    worker.close()
+
+
+@pytest.mark.parametrize(
+    ("vectors", "message"),
+    [
+        ([[0.1, 0.2, 0.3], None], "null vectors"),
+        ([[0.1, 0.2], [0.3, 0.4, 0.5]], "invalid dimension"),
+        ([[0.1, None, 0.3], [0.4, 0.5, 0.6]], "null elements"),
+        ([[0.1, float("nan"), 0.3], [0.4, 0.5, 0.6]], "finite float32"),
+        ([[0.1, float("inf"), 0.3], [0.4, 0.5, 0.6]], "finite float32"),
+    ],
+)
+def test_doris_sink_validates_vector_values_before_http(vectors: list[list[float] | None], message: str) -> None:
+    schema = _schema(vector_type=pa.list_(pa.float32()))
+    worker = _worker(schema=schema)
+    with pytest.raises(ValueError, match=message):
+        worker.write(_table(vectors=vectors, schema=schema))
+    assert not _Transport.instances[0].calls
+
+
+def test_doris_sink_accepts_large_list_vectors_and_encodes_plain_list() -> None:
+    schema = _schema(vector_type=pa.large_list(pa.float32()))
+    table = _table(schema=schema)
+    _Transport.responses = [_success]
+
+    _worker(schema=schema).write(table)
+
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    assert decoded.schema.field("embedding").type == pa.list_(pa.float32())
+
+
+def test_doris_sink_normalizes_sliced_vector_offsets() -> None:
+    table = _table().slice(1, 1)
+    _Transport.responses = [_success]
+
+    result = _worker().write(table)
+
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    assert result.rows_affected == 1
+    assert decoded.column("embedding").to_pylist()[0] == pytest.approx([0.4, 0.5, 0.6])
+
+
+def test_doris_sink_enforces_schema_and_batch_limits_before_http() -> None:
+    worker = _worker(max_batch_rows=1)
+    with pytest.raises(ValueError, match="max_batch_rows"):
+        worker.write(_table())
+    assert not _Transport.instances[0].calls
+
+    worker = _worker(max_batch_bytes=1)
+    with pytest.raises(ValueError, match="max_batch_bytes"):
+        worker.write(_table())
+    assert not _Transport.instances[1].calls
+
+    worker = _worker()
+    bad_schema = pa.schema([("source_id", pa.int64()), ("embedding", pa.list_(pa.float32(), 3)), ("other", pa.string())])
+    bad_table = pa.table(
+        {"source_id": [1], "embedding": [[0.1, 0.2, 0.3]], "other": ["bad"]},
+        schema=bad_schema,
+    )
+    with pytest.raises(ValueError, match="bound input schema"):
+        worker.write(bad_table)
+    assert not _Transport.instances[2].calls
+
+    table = _table()
+    worker = _worker(max_request_bytes=table.nbytes)
+    with pytest.raises(ValueError, match="max_request_bytes"):
+        worker.write(table)
+    assert not _Transport.instances[3].calls
+
+
+def test_doris_sink_skips_http_for_an_empty_batch() -> None:
+    worker = _worker()
+    result = worker.write(_table().slice(0, 0))
+    assert result.rows_received == result.rows_affected == 0
+    assert not _Transport.instances[0].calls
+
+
+def test_doris_sink_follows_one_trusted_redirect_and_replays_identical_body() -> None:
+    _Transport.responses = [
+        _Response(307, headers={"Location": "http://root:@be.example:8040/api/analytics/items/_stream_load"}),
+        _success,
+    ]
+
+    result = _worker().write(_table())
+
+    calls = _Transport.instances[0].calls
+    assert result.rows_affected == 2
+    assert [call.url for call in calls] == [
+        "http://fe.example:8030/api/analytics/items/_stream_load",
+        "http://be.example:8040/api/analytics/items/_stream_load",
+    ]
+    assert calls[0].body == calls[1].body
+    assert calls[0].headers["label"] == calls[1].headers["label"]
+
+
+@pytest.mark.parametrize(
+    ("location", "message"),
+    [
+        ("http://evil.example:8040/api/analytics/items/_stream_load", "untrusted host"),
+        ("https://be.example:8040/api/analytics/items/_stream_load", "preserve the endpoint scheme"),
+        ("http://be.example:8040/api/other/items/_stream_load", "changed the Stream Load path"),
+        ("http://be.example:8040/api/analytics/items/_stream_load?token=secret", "must not contain a query"),
+    ],
+)
+def test_doris_sink_rejects_unsafe_redirects(location: str, message: str) -> None:
+    _Transport.responses = [_Response(307, headers={"Location": location})]
+    with pytest.raises(RuntimeError, match=message):
+        _worker().write(_table())
+    assert len(_Transport.instances[0].calls) == 1
+
+
+@pytest.mark.parametrize(
+    "response",
+    [_TransportError("connection reset"), _Response(503, b"temporarily unavailable")],
+)
+def test_doris_sink_never_retries_an_unknown_batch(response: _Response | BaseException) -> None:
+    _Transport.responses = [response, _success]
+
+    with pytest.raises(RuntimeError, match=r"label 'vane_.+'.*inspect that label"):
+        _worker().write(_table())
+
+    assert len(_Transport.instances[0].calls) == 1
+
+
+def test_doris_sink_treats_publish_timeout_as_applied_with_warning() -> None:
+    _Transport.responses = [lambda call: _success(call, status="Publish Timeout")]
+
+    result = _worker().write(_table())
+
+    assert result.rows_affected == 2
+    assert result.metadata["status"] == "Publish Timeout"
+    assert len(result.warnings) == 2
+    assert "visibility may be delayed" in result.warnings[1]
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        (_Response(401, b"unauthorized"), "HTTP 401"),
+        (_Response(200, b"not json"), "invalid JSON"),
+        (_Response(200, b"[]"), "non-object"),
+        (
+            lambda call: _Response(
+                200,
+                json.dumps({"Label": call.headers["label"], "Status": "Fail", "Message": "bad schema"}).encode(),
+            ),
+            "bad schema",
+        ),
+        (lambda call: _success(call, NumberLoadedRows=1), "row counts do not match"),
+        (lambda call: _success(call, Label="different"), "different batch label"),
+        (lambda call: _success(call, TxnId=True), "invalid TxnId"),
+        (_Response(200, b"x" * (1024 * 1024 + 1)), "exceeds 1 MiB"),
+    ],
+)
+def test_doris_sink_rejects_invalid_http_and_stream_load_responses(
+    response: _Response | _ResponseFactory,
+    message: str,
+) -> None:
+    _Transport.responses = [response]
+    with pytest.raises(RuntimeError, match=message):
+        _worker().write(_table())
+
+
+def test_doris_sink_propagates_transport_failure_and_closes_on_abort() -> None:
+    _Transport.responses = [_TransportError("connection reset")]
+    worker = _worker()
+    with pytest.raises(RuntimeError, match="connection reset"):
+        worker.write(_table())
+    worker.abort(_TransportError("connection reset"))
+    assert _Transport.instances[0].close_calls == 1
+    worker.close()
+    assert _Transport.instances[0].close_calls == 1
+
+
+def test_doris_sink_retains_transport_ownership_when_close_fails() -> None:
+    worker = _worker()
+    _Transport.close_error = RuntimeError("close failed")
+    with pytest.raises(RuntimeError, match="close failed"):
+        worker.close()
+    assert _Transport.instances[0].close_calls == 1
+
+    _Transport.close_error = None
+    worker.close()
+    assert _Transport.instances[0].close_calls == 2
+
+
+@pytest.mark.external_service
+def test_doris_sink_live_arrow_stream_load() -> None:
+    endpoint = os.environ.get("VANE_TEST_DORIS_ENDPOINT")
+    if not endpoint:
+        pytest.skip("VANE_TEST_DORIS_ENDPOINT is required for the external Doris test")
+    pymysql = pytest.importorskip("pymysql")
+    redirect_host = os.environ.get("VANE_TEST_DORIS_REDIRECT_HOST")
+    database = f"vane_sink_{uuid.uuid4().hex}"
+    connection = pymysql.connect(
+        host=os.environ.get("VANE_TEST_DORIS_MYSQL_HOST", "127.0.0.1"),
+        port=int(os.environ.get("VANE_TEST_DORIS_MYSQL_PORT", "9030")),
+        user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
+        password=os.environ.get("VANE_TEST_DORIS_PASSWORD", ""),
+        autocommit=True,
+    )
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(f"CREATE DATABASE `{database}`")
+            cursor.execute(
+                f"""
+                CREATE TABLE `{database}`.`items` (
+                    `id` BIGINT NOT NULL,
+                    `embedding` ARRAY<FLOAT> NOT NULL,
+                    `title` VARCHAR(64) NOT NULL
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`id`)
+                DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                PROPERTIES ("replication_num" = "1")
+                """
+            )
+
+        relation = vane.from_arrow(_table())
+        summary = relation.write_datasink(
+            DorisStreamLoadSink(
+                database,
+                "items",
+                endpoint=endpoint,
+                user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
+                password=(
+                    EnvironmentSecret("VANE_TEST_DORIS_PASSWORD")
+                    if "VANE_TEST_DORIS_PASSWORD" in os.environ
+                    else None
+                ),
+                field_mapping={"source_id": "id", "source_title": "title"},
+                vector_dimensions={"embedding": 3},
+                trusted_redirect_hosts=(() if redirect_host is None else (redirect_host,)),
+                timeout=60,
+            ),
+            operation_id=f"doris-live-{uuid.uuid4()}",
+        )
+        assert summary.rows_received == summary.rows_affected == 2
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT `id`, `title`, ARRAY_SIZE(`embedding`), `embedding`[1], `embedding`[3] "
+                f"FROM `{database}`.`items` ORDER BY `id`"
+            )
+            rows = cursor.fetchall()
+            assert [(row[0], row[1], row[2]) for row in rows] == [(1, "one", 3), (2, "two", 3)]
+            assert rows[0][3:] == pytest.approx((0.1, 0.3))
+            assert rows[1][3:] == pytest.approx((0.4, 0.6))
+    finally:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP DATABASE IF EXISTS `{database}` FORCE")
+        finally:
+            connection.close()

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -122,6 +122,7 @@ class _AsyncSession:
         self.put_options: list[dict[str, object]] = []
         self.written_chunks: list[list[bytes]] = []
         self.closed = False
+        self._retry_connection = True
 
     def put(self, url: str, **options: object) -> _AsyncResponseContext:
         request_options = {"url": url, **options}
@@ -138,7 +139,7 @@ class _AioHttpModule:
         self.session_options: dict[str, object] | None = None
 
     @staticmethod
-    def BasicAuth(user: str, password: str, *, encoding: str) -> tuple[str, str, str]:
+    def encode_basic_auth(user: str, password: str, *, encoding: str) -> tuple[str, str, str]:
         return user, password, encoding
 
     @staticmethod
@@ -262,12 +263,13 @@ def test_doris_transport_streams_replayable_chunks_with_real_expect_continue(
     transport.close()
 
     assert aiohttp.session_options == {
-        "auth": ("alice", "secret", "utf-8"),
+        "headers": {"Authorization": ("alice", "secret", "utf-8")},
         "auto_decompress": False,
         "skip_auto_headers": {"Accept-Encoding"},
         "timeout": (47.0, 30.0),
         "trust_env": False,
     }
+    assert aiohttp.session._retry_connection is False
     assert len(aiohttp.session.put_options) == 2
     assert all(options["allow_redirects"] is False for options in aiohttp.session.put_options)
     assert all(options["expect100"] is True for options in aiohttp.session.put_options)
@@ -311,9 +313,7 @@ def test_doris_transport_streams_replayable_chunks_with_real_expect_continue(
         ({"timeout": 259_201}, ValueError, "259200"),
     ],
 )
-def test_doris_sink_validates_constructor(
-    overrides: dict[str, object], error: type[Exception], message: str
-) -> None:
+def test_doris_sink_validates_constructor(overrides: dict[str, object], error: type[Exception], message: str) -> None:
     options: dict[str, object] = {
         "database": "analytics",
         "table": "items",
@@ -479,7 +479,9 @@ def test_doris_sink_enforces_schema_and_batch_limits_before_http() -> None:
     assert not _Transport.instances[1].calls
 
     worker = _worker()
-    bad_schema = pa.schema([("source_id", pa.int64()), ("embedding", pa.list_(pa.float32(), 3)), ("other", pa.string())])
+    bad_schema = pa.schema(
+        [("source_id", pa.int64()), ("embedding", pa.list_(pa.float32(), 3)), ("other", pa.string())]
+    )
     bad_table = pa.table(
         {"source_id": [1], "embedding": [[0.1, 0.2, 0.3]], "other": ["bad"]},
         schema=bad_schema,
@@ -650,9 +652,7 @@ def test_doris_sink_live_arrow_stream_load() -> None:
                 endpoint=endpoint,
                 user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
                 password=(
-                    EnvironmentSecret("VANE_TEST_DORIS_PASSWORD")
-                    if "VANE_TEST_DORIS_PASSWORD" in os.environ
-                    else None
+                    EnvironmentSecret("VANE_TEST_DORIS_PASSWORD") if "VANE_TEST_DORIS_PASSWORD" in os.environ else None
                 ),
                 field_mapping={"source_id": "id", "source_title": "title"},
                 vector_dimensions={"embedding": 3},

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -10,7 +10,6 @@ import threading
 import uuid
 from collections.abc import AsyncIterable, Callable, Iterator, Mapping
 from dataclasses import dataclass
-from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, cast
 
@@ -375,6 +374,44 @@ def test_doris_sink_runner_normalizes_worker_arrow_types(
     received = pa.concat_tables(batches).sort_by("id")
     expected = pa.table({"id": list(range(row_count)), column_name: values}, schema=destination_schema)
     assert received.equals(expected)
+
+
+def _live_input_relation(connection: vane.DuckDBPyConnection) -> vane.DuckDBPyRelation:
+    # An in-memory arrow_scan cannot be copied into a distributed worker plan.
+    # Share this SQL source between the live test and the service-free runner gate.
+    return connection.sql(
+        """
+        SELECT
+            i AS source_id,
+            (CASE WHEN i = 1 THEN [0.1, 0.2, 0.3] ELSE [0.4, 0.5, 0.6] END)::FLOAT[] AS embedding,
+            CASE WHEN i = 1 THEN 'one' ELSE 'two' END AS source_title
+        FROM range(1, 3) AS t(i)
+        """
+    )
+
+
+def test_doris_sink_live_input_is_distributable(
+    _stream_load_server: tuple[str, list[_Call]], _doris_runner: str
+) -> None:
+    endpoint, calls = _stream_load_server
+    with vane.connect() as connection:
+        relation = _live_input_relation(connection)
+        assert relation._arrow_schema().field("source_id").type == pa.int64()
+        summary = relation.write_datasink(
+            _sink(endpoint=endpoint, worker_count=2, max_batch_rows=1),
+            operation_id=f"doris-live-input-{_doris_runner}",
+        )
+
+    assert summary.outcome is WriteOutcome.APPLIED
+    assert summary.rows_received == summary.rows_affected == 2
+    assert len(calls) == len({call.headers["label"] for call in calls}) == 2
+    batches = [pa.ipc.open_stream(call.body).read_all() for call in calls]
+    assert all(batch.schema == _destination_schema() and batch.num_rows == 1 for batch in batches)
+    expected = pa.table(
+        {"id": [1, 2], "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], "title": ["one", "two"]},
+        schema=_destination_schema(),
+    )
+    assert pa.concat_tables(batches).sort_by("id").equals(expected)
 
 
 def test_doris_sink_is_public_without_importing_aiohttp() -> None:
@@ -1271,28 +1308,30 @@ def test_doris_sink_live_arrow_stream_load(_doris_runner: str) -> None:
                 """
             )
 
-        input_table = _table(schema=_schema(vector_type=pa.list_(pa.float32())))
-        assert input_table.schema.field("source_id").type == pa.int64()
-        relation = vane.from_arrow(input_table)
-        summary = relation.write_datasink(
-            DorisStreamLoadSink(
-                database,
-                "items",
-                endpoint=endpoint,
-                destination_schema=_destination_schema(),
-                user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
-                password=(
-                    EnvironmentSecret("VANE_TEST_DORIS_PASSWORD") if "VANE_TEST_DORIS_PASSWORD" in os.environ else None
+        with vane.connect() as source_connection:
+            relation = _live_input_relation(source_connection)
+            assert relation._arrow_schema().field("source_id").type == pa.int64()
+            summary = relation.write_datasink(
+                DorisStreamLoadSink(
+                    database,
+                    "items",
+                    endpoint=endpoint,
+                    destination_schema=_destination_schema(),
+                    user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
+                    password=(
+                        EnvironmentSecret("VANE_TEST_DORIS_PASSWORD")
+                        if "VANE_TEST_DORIS_PASSWORD" in os.environ
+                        else None
+                    ),
+                    field_mapping={"source_id": "id", "source_title": "title"},
+                    vector_dimensions={"embedding": 3},
+                    worker_count=2,
+                    max_batch_rows=1,
+                    trusted_redirect_hosts=(() if redirect_host is None else (redirect_host,)),
+                    timeout=60,
                 ),
-                field_mapping={"source_id": "id", "source_title": "title"},
-                vector_dimensions={"embedding": 3},
-                worker_count=2,
-                max_batch_rows=1,
-                trusted_redirect_hosts=(() if redirect_host is None else (redirect_host,)),
-                timeout=60,
-            ),
-            operation_id=f"doris-live-{uuid.uuid4()}",
-        )
+                operation_id=f"doris-live-{uuid.uuid4()}",
+            )
         assert summary.rows_received == summary.rows_affected == 2
         with connection.cursor() as cursor:
             cursor.execute(
@@ -1304,14 +1343,7 @@ def test_doris_sink_live_arrow_stream_load(_doris_runner: str) -> None:
             assert rows[0][3:] == pytest.approx((0.1, 0.3))
             assert rows[1][3:] == pytest.approx((0.4, 0.6))
 
-        temporal_relation = vane.from_arrow(
-            pa.table(
-                {
-                    "id": pa.array([1], type=pa.int32()),
-                    "happened_at": pa.array([datetime(2026, 9, 5)], type=pa.timestamp("us")),
-                }
-            )
-        )
+        temporal_relation = vane.sql("SELECT 1 AS id, TIMESTAMP '2026-09-05 00:00:00' AS happened_at")
         with pytest.raises(ValueError, match="unsupported temporal Arrow type"):
             temporal_relation.write_datasink(
                 DorisStreamLoadSink(

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -416,6 +416,56 @@ def test_doris_sink_live_input_is_distributable(
     assert pa.concat_tables(batches).sort_by("id").equals(expected)
 
 
+@pytest.mark.parametrize("_doris_runner", ["local-fast", "local"], indirect=True)
+def test_doris_sink_public_write_from_running_event_loop(
+    _stream_load_server: tuple[str, list[_Call]], _doris_runner: str
+) -> None:
+    endpoint, calls = _stream_load_server
+
+    async def write_from_loop() -> None:
+        assert asyncio.get_running_loop().is_running()
+        with vane.connect() as connection:
+            summary = _live_input_relation(connection).write_datasink(
+                _sink(endpoint=endpoint, worker_count=2, max_batch_rows=1),
+                operation_id=f"doris-running-loop-{_doris_runner}",
+            )
+        assert summary.outcome is WriteOutcome.APPLIED
+        assert summary.rows_received == summary.rows_affected == 2
+
+    asyncio.run(write_from_loop())
+
+    assert len(calls) == len({call.headers["label"] for call in calls}) == 2
+    batches = [pa.ipc.open_stream(call.body).read_all() for call in calls]
+    assert all(batch.schema == _destination_schema() and batch.num_rows == 1 for batch in batches)
+    assert pa.concat_tables(batches).sort_by("id").column("id").to_pylist() == [1, 2]
+
+
+def test_doris_sink_async_caller_offloads_the_synchronous_write(
+    _stream_load_server: tuple[str, list[_Call]], _doris_runner: str
+) -> None:
+    endpoint, calls = _stream_load_server
+
+    def blocking_write() -> None:
+        # Keep the connection and relation in the offloaded thread as well.
+        with vane.connect() as connection:
+            summary = _live_input_relation(connection).write_datasink(
+                _sink(endpoint=endpoint, worker_count=2, max_batch_rows=1),
+                operation_id=f"doris-offloaded-write-{_doris_runner}",
+            )
+        assert summary.outcome is WriteOutcome.APPLIED
+        assert summary.rows_received == summary.rows_affected == 2
+
+    async def write_from_loop() -> None:
+        await asyncio.to_thread(blocking_write)
+
+    asyncio.run(write_from_loop())
+
+    assert len(calls) == len({call.headers["label"] for call in calls}) == 2
+    batches = [pa.ipc.open_stream(call.body).read_all() for call in calls]
+    assert all(batch.schema == _destination_schema() and batch.num_rows == 1 for batch in batches)
+    assert pa.concat_tables(batches).sort_by("id").column("id").to_pylist() == [1, 2]
+
+
 def test_doris_sink_is_public_without_importing_aiohttp() -> None:
     assert vane.DorisStreamLoadSink is DorisStreamLoadSink
     assert doris.__all__ == ["DorisStreamLoadSink"]
@@ -602,6 +652,49 @@ def test_doris_sink_rejects_temporal_source_types_during_bind() -> None:
     )
     with pytest.raises(ValueError, match=r"source field 'source_title'.*temporal"):
         _sink().bind(schema)
+
+
+@pytest.mark.parametrize(
+    "source_type",
+    [
+        pa.dictionary(pa.int32(), pa.string()),
+        pa.list_(pa.dictionary(pa.int8(), pa.float64())),
+        pa.run_end_encoded(pa.int32(), pa.string()),
+        pa.string_view(),
+        pa.binary_view(),
+        pa.list_view(pa.int64()),
+        pa.large_list_view(pa.int64()),
+        pa.struct([("field", pa.int64())]),
+        pa.decimal128(20, 4),
+    ],
+)
+def test_doris_sink_rejects_encoded_and_non_plain_sources_before_opening_transport(source_type: pa.DataType) -> None:
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=pa.schema([("value", pa.string())])
+    )
+    with pytest.raises(ValueError, match="source field 'value.*plain scalar or standard list"):
+        sink.bind(pa.schema([("value", source_type)]))
+    assert not _Transport.instances
+
+
+def test_doris_sink_rejects_dictionary_expansion_before_decoding(monkeypatch: pytest.MonkeyPatch) -> None:
+    column = pa.DictionaryArray.from_arrays(
+        pa.array([0] * 1_000_000, type=pa.int32()),
+        pa.array(["x" * (1024 * 1024)]),
+    )
+    table = pa.table({"value": column})
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=pa.schema([("value", pa.string())])
+    )
+    assert table.nbytes < sink.max_batch_bytes
+
+    def unexpected_cast(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("must not decode a compact input before enforcing its representation contract")
+
+    monkeypatch.setattr(doris.pc, "cast", unexpected_cast)
+    with pytest.raises(ValueError, match="decode and rebatch"):
+        sink.bind(table.schema)
+    assert not _Transport.instances
 
 
 @pytest.mark.parametrize("completed_batches", [0, (1 << 63) - 3])
@@ -860,11 +953,6 @@ def test_doris_sink_checks_destination_values_after_worker_offset_normalization(
             pa.list_(pa.list_(pa.float32())),
             r"score\[\]\[\]",
         ),
-        (
-            pa.chunked_array([pa.array([0.1, None, 1e40]).dictionary_encode()]),
-            pa.float32(),
-            "score",
-        ),
     ],
     ids=[
         "scalar-positive",
@@ -873,7 +961,6 @@ def test_doris_sink_checks_destination_values_after_worker_offset_normalization(
         "large-list",
         "fixed-list",
         "nested-list",
-        "dictionary",
     ],
 )
 def test_doris_sink_rejects_float_narrowing_overflow_before_http(
@@ -948,6 +1035,47 @@ def test_doris_sink_float_narrowing_ignores_hidden_list_values() -> None:
     worker.close()
 
 
+@pytest.mark.parametrize("list_kind", ["list", "large-list", "fixed-list"])
+@pytest.mark.parametrize("nested", [False, True])
+def test_doris_sink_integer_casts_ignore_hidden_list_children(list_kind: str, nested: bool) -> None:
+    hidden = 1 << 40
+    mask = pa.array([False, True, False, False])
+    if list_kind == "fixed-list":
+        source = pa.FixedSizeListArray.from_arrays(
+            pa.array([hidden, hidden, hidden, hidden, 1, 2, hidden, hidden], type=pa.int64()),
+            2,
+            mask=mask,
+        )
+    else:
+        large = list_kind == "large-list"
+        factory = pa.LargeListArray if large else pa.ListArray
+        source = factory.from_arrays(
+            pa.array([0, 1, 2, 4, 5], type=pa.int64() if large else pa.int32()),
+            pa.array([hidden, hidden, 1, 2, hidden], type=pa.int64()),
+            mask=mask,
+        )
+    source = source.slice(1, 2)
+    target_type = pa.list_(pa.field("item", pa.int32(), nullable=False))
+    if nested:
+        source = pa.ListArray.from_arrays(pa.array([0, 2], type=pa.int32()), source)
+        target_type = pa.list_(target_type)
+    column = pa.chunked_array([source, source])
+    table = pa.table({"value": column})
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=pa.schema([("value", target_type)])
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("hidden-integer-children"))
+    _Transport.responses = [_success]
+    try:
+        result = worker.write(table)
+    finally:
+        worker.close()
+    assert result.rows_affected == table.num_rows
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    assert decoded.schema == sink.destination_schema
+    assert decoded.column("value").to_pylist() == column.to_pylist()
+
+
 def test_doris_sink_rejects_unsafe_casts_and_destination_nulls_before_http() -> None:
     worker = _worker()
     overflow = _table().set_column(
@@ -984,23 +1112,6 @@ def test_doris_sink_rejects_unsafe_casts_and_destination_nulls_before_http() -> 
     with pytest.raises(ValueError, match=r"destination field 'values\[\]'.*non-nullable"):
         worker.write(pa.table({"values": [[1, None]]}, schema=source_schema))
     assert not _Transport.instances[2].calls
-
-    dictionary_list = pa.DictionaryArray.from_arrays(
-        pa.array([1, None, 0], type=pa.int8()),
-        pa.array([[1e40], [0.1, None]], type=pa.list_(pa.float64())),
-    )
-    table = pa.table({"values": dictionary_list})
-    sink = DorisStreamLoadSink(
-        "analytics",
-        "items",
-        endpoint="http://fe.example:8030",
-        destination_schema=pa.schema([("values", pa.list_(pa.float32()))]),
-    )
-    worker = sink.bind(table.schema).open_worker(WriteContext("unsupported-dictionary-list"))
-    with pytest.raises(ValueError, match=r"values.*cannot be safely cast.*Unsupported cast"):
-        worker.write(table)
-    assert not _Transport.instances[3].calls
-    worker.close()
 
 
 def test_doris_sink_defers_endpoint_and_password_resolution_to_worker(
@@ -1119,6 +1230,117 @@ def test_doris_sink_enforces_schema_and_batch_limits_before_http() -> None:
     with pytest.raises(ValueError, match="max_request_bytes"):
         worker.write(table)
     assert not _Transport.instances[3].calls
+
+
+@pytest.mark.parametrize("shape", ["scalar", "nested", "multiple-columns", "null-list"])
+def test_doris_sink_bounds_conversion_before_allocating_cast_results(
+    monkeypatch: pytest.MonkeyPatch, shape: str
+) -> None:
+    if shape == "null-list":
+        table = pa.table({"value": [None]})
+        destination = pa.schema([("value", pa.list_(pa.list_(pa.string())))])
+        limit = 16
+    elif shape == "nested":
+        table = pa.table({"value": pa.array([[True] * 1024], type=pa.list_(pa.bool_()))})
+        destination = pa.schema([("value", pa.list_(pa.float64()))])
+        limit = 512
+    elif shape == "multiple-columns":
+        table = pa.table({"left": [True] * 8, "right": [False] * 8})
+        destination = pa.schema([("left", pa.float64()), ("right", pa.float64())])
+        limit = 100
+    else:
+        table = pa.table({"value": [True] * 64})
+        destination = pa.schema([("value", pa.float64())])
+        limit = 128
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=destination, max_request_bytes=limit
+    )
+    assert table.nbytes < limit
+    worker = sink.bind(table.schema).open_worker(WriteContext("conversion-budget"))
+
+    def unexpected_cast(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("must check the aggregate conversion budget before casting any column")
+
+    monkeypatch.setattr(doris.pc, "cast", unexpected_cast)
+    try:
+        with pytest.raises(ValueError, match="max_request_bytes before casting"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Transport.instances[0].calls
+
+
+def test_doris_sink_sizes_ipc_metadata_before_allocating_the_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = pa.table({"value": pa.chunked_array([["x"]] * 32, type=pa.string())})
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=table.schema, max_request_bytes=1024
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("ipc-metadata-budget"))
+
+    def unexpected_allocation(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("must count IPC metadata before allocating the body")
+
+    monkeypatch.setattr(doris.pa, "allocate_buffer", unexpected_allocation)
+    try:
+        with pytest.raises(ValueError, match="IPC request exceeds max_request_bytes"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Transport.instances[0].calls
+
+
+@pytest.mark.parametrize("extra_bytes", [0, -1])
+def test_doris_sink_allocates_exactly_the_preflighted_ipc_size(
+    monkeypatch: pytest.MonkeyPatch, extra_bytes: int
+) -> None:
+    table = pa.table({"value": pa.array([1, 2], type=pa.int32())})
+    output = pa.BufferOutputStream()
+    with pa.ipc.new_stream(output, table.schema) as writer:
+        writer.write_table(table)
+    expected = output.getvalue()
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=table.schema,
+        max_request_bytes=expected.size + extra_bytes,
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("exact-ipc-budget"))
+    allocations: list[int] = []
+    original_allocate = pa.allocate_buffer
+
+    def tracked_allocate(size: int) -> pa.Buffer:
+        allocations.append(size)
+        return original_allocate(size)
+
+    monkeypatch.setattr(doris.pa, "allocate_buffer", tracked_allocate)
+    _Transport.responses = [_success]
+    try:
+        if extra_bytes:
+            with pytest.raises(ValueError, match="IPC request exceeds max_request_bytes"):
+                worker.write(table)
+            assert not allocations
+            assert not _Transport.instances[0].calls
+        else:
+            worker.write(table)
+            assert allocations == [expected.size]
+            assert _Transport.instances[0].calls[0].body == expected.to_pybytes()
+    finally:
+        worker.close()
+
+
+def test_doris_sink_requires_explicit_string_conversion() -> None:
+    table = pa.table({"value": [123]})
+    sink = DorisStreamLoadSink(
+        "analytics", "items", endpoint="http://fe.example:8030", destination_schema=pa.schema([("value", pa.string())])
+    )
+    worker = sink.bind(table.schema).open_worker(WriteContext("explicit-string-cast"))
+    try:
+        with pytest.raises(ValueError, match="string or binary source"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Transport.instances[0].calls
 
 
 def test_doris_sink_skips_http_for_an_empty_batch() -> None:
@@ -1331,12 +1553,15 @@ def test_doris_sink_cancellation_after_async_body_upload_keeps_the_label(monkeyp
         with pytest.raises(asyncio.CancelledError) as exc_info:
             worker.write(_table())
 
-        assert exc_info.value is interruption
+        # asyncio may synthesize a new cancellation when retrieving a task's
+        # result; only the exception escaping the transport reaches the sink.
+        assert type(exc_info.value) is asyncio.CancelledError
+        assert datasink._is_execution_interruption(exc_info.value)
         assert len(aiohttp.session.put_options) == len(aiohttp.session.written_chunks) == 1
         headers = cast(Mapping[str, str], aiohttp.session.put_options[0]["headers"])
         assert f"label {headers['label']!r}" in exc_info.value.args[0]
         assert pa.ipc.open_stream(b"".join(aiohttp.session.written_chunks[0])).read_all().num_rows == 2
-        worker.abort(interruption)
+        worker.abort(exc_info.value)
     finally:
         worker.close()
     assert aiohttp.session.closed

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -9,6 +9,7 @@ import os
 import uuid
 from collections.abc import AsyncIterable, Callable, Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, cast
 
 import cloudpickle
@@ -171,24 +172,53 @@ def _schema(*, vector_type: pa.DataType | None = None) -> pa.Schema:
     )
 
 
+def _destination_schema(
+    *,
+    id_type: pa.DataType | None = None,
+    vector_type: pa.DataType | None = None,
+    title_type: pa.DataType | None = None,
+) -> pa.Schema:
+    return pa.schema(
+        [
+            pa.field("id", pa.int32() if id_type is None else id_type, nullable=False),
+            pa.field(
+                "embedding",
+                pa.list_(pa.float32()) if vector_type is None else vector_type,
+                nullable=False,
+            ),
+            pa.field("title", pa.string() if title_type is None else title_type, nullable=False),
+        ]
+    )
+
+
 def _table(
     *,
     vectors: list[list[float] | None] | None = None,
     schema: pa.Schema | None = None,
 ) -> pa.Table:
+    values = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] if vectors is None else vectors
+    if schema is None:
+        return pa.table(
+            {
+                "source_id": [1, 2],
+                "embedding": pa.array(values, type=pa.list_(pa.float32(), 3)),
+                "source_title": ["one", "two"],
+            }
+        )
     return pa.table(
         {
             "source_id": [1, 2],
-            "embedding": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]] if vectors is None else vectors,
+            "embedding": values,
             "source_title": ["one", "two"],
         },
-        schema=_schema() if schema is None else schema,
+        schema=schema,
     )
 
 
 def _sink(**overrides: object) -> DorisStreamLoadSink:
     options: dict[str, object] = {
         "endpoint": "http://fe.example:8030",
+        "destination_schema": _destination_schema(),
         "field_mapping": {"source_id": "id", "source_title": "title"},
         "vector_dimensions": {"embedding": 3},
         "trusted_redirect_hosts": ("be.example",),
@@ -296,6 +326,20 @@ def test_doris_transport_streams_replayable_chunks_with_real_expect_continue(
         ({"user": ""}, ValueError, "user"),
         ({"user": "domain:alice"}, ValueError, "colon"),
         ({"password": "plain-text"}, TypeError, "EnvironmentSecret"),
+        ({"destination_schema": object()}, TypeError, "pyarrow.Schema"),
+        ({"destination_schema": pa.schema([])}, ValueError, "at least one"),
+        (
+            {"destination_schema": pa.schema([("value", pa.int32()), ("VALUE", pa.int32())])},
+            ValueError,
+            "case-insensitively unique",
+        ),
+        ({"destination_schema": pa.schema([("created_at", pa.timestamp("us"))])}, ValueError, "temporal"),
+        (
+            {"destination_schema": pa.schema([("events", pa.list_(pa.timestamp("us")))])},
+            ValueError,
+            "temporal",
+        ),
+        ({"destination_schema": pa.schema([("payload", pa.binary())])}, ValueError, "unsupported Arrow type"),
         ({"field_mapping": []}, TypeError, "field_mapping"),
         ({"vector_dimensions": []}, TypeError, "vector_dimensions"),
         ({"vector_dimensions": {"embedding": 1 << 31}}, ValueError, "signed 32-bit"),
@@ -318,6 +362,7 @@ def test_doris_sink_validates_constructor(overrides: dict[str, object], error: t
         "database": "analytics",
         "table": "items",
         "endpoint": "http://doris.example:8030",
+        "destination_schema": _destination_schema(),
     }
     options.update(overrides)
     with pytest.raises(error, match=message):
@@ -325,7 +370,11 @@ def test_doris_sink_validates_constructor(overrides: dict[str, object], error: t
 
 
 def test_doris_sink_binds_mapping_vectors_and_execution_options() -> None:
-    bound = _bound(worker_count=3, max_batch_rows=17, max_batch_bytes=2_048, send_batch_parallelism=4)
+    sink = _sink(worker_count=3, max_batch_rows=17, max_batch_bytes=2_048, send_batch_parallelism=4)
+    assert sink.destination_schema == _destination_schema()
+    with pytest.raises(AttributeError):
+        setattr(sink, "destination_schema", pa.schema([("other", pa.int32())]))
+    bound = sink.bind(_schema())
 
     assert isinstance(bound, BoundDataSink)
     assert bound.execution_options.worker_count == 3
@@ -351,10 +400,30 @@ def test_doris_sink_rejects_invalid_bound_schema_and_mappings() -> None:
         _sink(field_mapping={"source_title": "标题"}).bind(_schema())
     with pytest.raises(ValueError, match="ASCII"):
         _sink(field_mapping={"source_title": "title=value"}).bind(_schema())
+    with pytest.raises(ValueError, match="exactly match destination_schema"):
+        _sink(
+            destination_schema=pa.schema(
+                [("title", pa.string()), ("embedding", pa.list_(pa.float32())), ("id", pa.int32())]
+            )
+        ).bind(_schema())
     with pytest.raises(ValueError, match="float32"):
         _sink().bind(_schema(vector_type=pa.list_(pa.float64())))
     with pytest.raises(ValueError, match="fixed dimension"):
         _sink().bind(_schema(vector_type=pa.list_(pa.float32(), 2)))
+    with pytest.raises(ValueError, match=r"destination field 'embedding'.*list<float32>"):
+        _sink(destination_schema=_destination_schema(vector_type=pa.list_(pa.float64()))).bind(_schema())
+
+
+def test_doris_sink_rejects_temporal_source_types_during_bind() -> None:
+    schema = pa.schema(
+        [
+            ("source_id", pa.int64()),
+            ("embedding", pa.list_(pa.float32(), 3)),
+            ("source_title", pa.list_(pa.timestamp("us"))),
+        ]
+    )
+    with pytest.raises(ValueError, match=r"source field 'source_title'.*temporal"):
+        _sink().bind(schema)
 
 
 def test_doris_sink_writes_arrow_stream_without_row_materialization() -> None:
@@ -384,7 +453,8 @@ def test_doris_sink_writes_arrow_stream_without_row_materialization() -> None:
     assert transport.calls[1].headers["label"] != call.headers["label"]
 
     decoded = pa.ipc.open_stream(call.body).read_all()
-    assert decoded.schema.names == ["id", "embedding", "title"]
+    assert decoded.schema == _destination_schema()
+    assert decoded.schema.field("id").type == pa.int32()
     assert decoded.schema.field("embedding").type == pa.list_(pa.float32())
     assert decoded.column("id").to_pylist() == [1, 2]
     vectors = decoded.column("embedding").to_pylist()
@@ -403,6 +473,70 @@ def test_doris_sink_writes_arrow_stream_without_row_materialization() -> None:
     assert first.metadata["wire_bytes"] == len(call.body)
     assert len(first.warnings) == 1
     assert second.warnings == ()
+
+
+def test_doris_sink_safely_casts_nested_destination_values() -> None:
+    source_schema = pa.schema([("values", pa.list_(pa.int64())), ("score", pa.float64())])
+    destination_schema = pa.schema(
+        [
+            pa.field("values", pa.list_(pa.field("item", pa.int32(), nullable=False)), nullable=False),
+            pa.field("score", pa.float32(), nullable=False),
+        ]
+    )
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=destination_schema,
+        timeout=5,
+    )
+    worker = sink.bind(source_schema).open_worker(WriteContext("nested-cast"))
+    _Transport.responses = [_success]
+
+    worker.write(pa.table({"values": [[1, 2], [3]], "score": [1.25, 2.5]}, schema=source_schema))
+
+    decoded = pa.ipc.open_stream(_Transport.instances[0].calls[0].body).read_all()
+    assert decoded.schema == destination_schema
+    assert decoded.column("values").to_pylist() == [[1, 2], [3]]
+    assert decoded.column("score").to_pylist() == pytest.approx([1.25, 2.5])
+
+
+def test_doris_sink_rejects_unsafe_casts_and_destination_nulls_before_http() -> None:
+    worker = _worker()
+    overflow = _table().set_column(
+        0,
+        "source_id",
+        pa.chunked_array([[1 << 40, 2]], type=pa.int64()),
+    )
+    with pytest.raises(ValueError, match=r"source_id.*safely cast.*int32"):
+        worker.write(overflow)
+    assert not _Transport.instances[0].calls
+
+    worker = _worker()
+    null_title = _table().set_column(
+        2,
+        "source_title",
+        pa.chunked_array([["one", None]], type=pa.string()),
+    )
+    with pytest.raises(ValueError, match=r"destination field 'title'.*non-nullable"):
+        worker.write(null_title)
+    assert not _Transport.instances[1].calls
+
+    source_schema = pa.schema([("values", pa.list_(pa.int64()))])
+    destination_schema = pa.schema(
+        [pa.field("values", pa.list_(pa.field("item", pa.int32(), nullable=False)), nullable=False)]
+    )
+    sink = DorisStreamLoadSink(
+        "analytics",
+        "items",
+        endpoint="http://fe.example:8030",
+        destination_schema=destination_schema,
+        timeout=5,
+    )
+    worker = sink.bind(source_schema).open_worker(WriteContext("nested-null"))
+    with pytest.raises(ValueError, match=r"destination field 'values\[\]'.*non-nullable"):
+        worker.write(pa.table({"values": [[1, None]]}, schema=source_schema))
+    assert not _Transport.instances[2].calls
 
 
 def test_doris_sink_defers_endpoint_and_password_resolution_to_worker(
@@ -634,7 +768,7 @@ def test_doris_sink_live_arrow_stream_load() -> None:
             cursor.execute(
                 f"""
                 CREATE TABLE `{database}`.`items` (
-                    `id` BIGINT NOT NULL,
+                    `id` INT NOT NULL,
                     `embedding` ARRAY<FLOAT> NOT NULL,
                     `title` VARCHAR(64) NOT NULL
                 ) ENGINE=OLAP
@@ -643,13 +777,27 @@ def test_doris_sink_live_arrow_stream_load() -> None:
                 PROPERTIES ("replication_num" = "1")
                 """
             )
+            cursor.execute(
+                f"""
+                CREATE TABLE `{database}`.`temporal_items` (
+                    `id` INT NOT NULL,
+                    `happened_at` DATETIME NOT NULL
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`id`)
+                DISTRIBUTED BY HASH(`id`) BUCKETS 1
+                PROPERTIES ("replication_num" = "1")
+                """
+            )
 
-        relation = vane.from_arrow(_table())
+        input_table = _table()
+        assert input_table.schema.field("source_id").type == pa.int64()
+        relation = vane.from_arrow(input_table)
         summary = relation.write_datasink(
             DorisStreamLoadSink(
                 database,
                 "items",
                 endpoint=endpoint,
+                destination_schema=_destination_schema(),
                 user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
                 password=(
                     EnvironmentSecret("VANE_TEST_DORIS_PASSWORD") if "VANE_TEST_DORIS_PASSWORD" in os.environ else None
@@ -671,6 +819,41 @@ def test_doris_sink_live_arrow_stream_load() -> None:
             assert [(row[0], row[1], row[2]) for row in rows] == [(1, "one", 3), (2, "two", 3)]
             assert rows[0][3:] == pytest.approx((0.1, 0.3))
             assert rows[1][3:] == pytest.approx((0.4, 0.6))
+
+        temporal_relation = vane.from_arrow(
+            pa.table(
+                {
+                    "id": pa.array([1], type=pa.int32()),
+                    "happened_at": pa.array([datetime(2026, 9, 5)], type=pa.timestamp("us")),
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="unsupported temporal Arrow type"):
+            temporal_relation.write_datasink(
+                DorisStreamLoadSink(
+                    database,
+                    "temporal_items",
+                    endpoint=endpoint,
+                    destination_schema=pa.schema(
+                        [
+                            pa.field("id", pa.int32(), nullable=False),
+                            pa.field("happened_at", pa.timestamp("us"), nullable=False),
+                        ]
+                    ),
+                    user=os.environ.get("VANE_TEST_DORIS_USER", "root"),
+                    password=(
+                        EnvironmentSecret("VANE_TEST_DORIS_PASSWORD")
+                        if "VANE_TEST_DORIS_PASSWORD" in os.environ
+                        else None
+                    ),
+                    trusted_redirect_hosts=(() if redirect_host is None else (redirect_host,)),
+                    timeout=60,
+                ),
+                operation_id=f"doris-temporal-live-{uuid.uuid4()}",
+            )
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM `{database}`.`temporal_items`")
+            assert cursor.fetchone() == (0,)
     finally:
         try:
             with connection.cursor() as cursor:

--- a/tests/fast/test_doris_datasink.py
+++ b/tests/fast/test_doris_datasink.py
@@ -604,6 +604,36 @@ def test_doris_sink_rejects_temporal_source_types_during_bind() -> None:
         _sink().bind(schema)
 
 
+@pytest.mark.parametrize("completed_batches", [0, (1 << 63) - 3])
+def test_doris_sink_worker_labels_keep_the_full_uuid(monkeypatch: pytest.MonkeyPatch, completed_batches: int) -> None:
+    worker_ids = (
+        uuid.UUID("01234567-89ab-4cde-8fab-0123456789ab"),
+        uuid.UUID("01234567-89ab-4cde-8fab-0123456789ac"),
+    )
+    generated_ids = iter(worker_ids)
+    monkeypatch.setattr(doris.uuid, "uuid4", lambda: next(generated_ids))
+    _Transport.responses = [_success] * 4
+    workers = [_worker(), _worker()]
+    labels: list[str] = []
+    try:
+        for worker, worker_id, transport in zip(workers, worker_ids, _Transport.instances, strict=True):
+            worker._batch_number = completed_batches
+            for batch_number in (completed_batches + 1, completed_batches + 2):
+                result = worker.write(_table())
+                label = transport.calls[-1].headers["label"]
+                assert result.metadata["label"] == label
+                assert label.endswith(f"_{worker_id.hex}_{batch_number:x}")
+                assert len(label) <= 128
+                assert doris._LABEL_PATTERN.fullmatch(label) is not None
+                labels.append(label)
+    finally:
+        for worker in workers:
+            worker.close()
+    # These UUIDs share not just the old eight-digit prefix but all except
+    # their final digit. Corresponding batches must still have distinct labels.
+    assert len(set(labels)) == 4
+
+
 def test_doris_sink_writes_arrow_stream_without_row_materialization() -> None:
     _Transport.responses = [_success, _success]
     worker = _worker()

--- a/tests/fast/test_package_metadata.py
+++ b/tests/fast/test_package_metadata.py
@@ -333,9 +333,11 @@ def test_provider_extras_match_provider_import_errors():
 
 
 def test_datasink_extras_require_supported_sdk_versions():
+    doris = _requirement_for_extra("doris", "aiohttp")
     milvus = _requirement_for_extra("milvus", "pymilvus")
     qdrant = _requirement_for_extra("qdrant", "qdrant-client")
 
+    assert doris.specifier == SpecifierSet(">=3.14.3,<4")
     assert milvus.specifier == SpecifierSet(">=3.0.1,<4")
     assert qdrant.specifier == SpecifierSet(">=1.19.0,<2")
 

--- a/vane/__init__.py
+++ b/vane/__init__.py
@@ -263,6 +263,7 @@ from vane.datasink import (
     WriteSummary,
     write_datasink,
 )
+from vane.datasink.doris import DorisStreamLoadSink
 from vane.datasink.milvus import MilvusSink
 from vane.datasink.qdrant import QdrantSink
 from vane.extensions import (
@@ -424,6 +425,7 @@ __all__: list[str] = [
     "DependencyException",
     "DBAPITypeObject",
     "DoubleValue",
+    "DorisStreamLoadSink",
     "DynamicExtensionDependency",
     "DynamicExtensionDescriptor",
     "DynamicExtensionError",

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -1,0 +1,772 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed Apache Doris Arrow Stream Load writes.
+
+Each worker converts an Arrow table directly to an Arrow IPC stream and sends
+one synchronous Stream Load request per batch. Doris commits worker batches as
+independent transactions; Vane does not provide a transaction spanning the
+complete distributed relation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import uuid
+from collections.abc import AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote, urljoin, urlsplit, urlunsplit
+
+import numpy as np
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+import pyarrow.compute as pc  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+from vane.datasink import (
+    BoundDataSink,
+    DataSink,
+    DataSinkExecutionOptions,
+    DataSinkWorker,
+    EnvironmentSecret,
+    WriteContext,
+    WriteResult,
+)
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+_MAX_INT32 = (1 << 31) - 1
+_MAX_INT64 = (1 << 63) - 1
+_DEFAULT_MAX_BATCH_ROWS = 1_000_000
+_DEFAULT_MAX_BATCH_BYTES = 128 * 1024 * 1024
+_DEFAULT_MAX_REQUEST_BYTES = 160 * 1024 * 1024
+_DEFAULT_TIMEOUT_SECONDS = 600
+_DEFAULT_SEND_BATCH_PARALLELISM = 1
+_MAX_TIMEOUT_SECONDS = 259_200
+_HTTP_TIMEOUT_GRACE_SECONDS = 30
+_HTTP_CONNECT_TIMEOUT_SECONDS = 30
+_HTTP_BODY_CHUNK_BYTES = 256 * 1024
+_HTTPS_SHUTDOWN_SECONDS = 0.250
+_MAX_RESPONSE_BYTES = 1024 * 1024
+_LABEL_PREFIX = "vane"
+_LABEL_PATTERN = re.compile(r"[-_A-Za-z0-9:]+\Z")
+_OBJECT_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_-]*\Z")
+_COLUMN_PATTERN = re.compile(r'[-.A-Za-z0-9_+/?@#$%^&*" ,:]+\Z')
+_REDIRECT_STATUS = 307
+_SUCCESS_STATUS = "Success"
+_PUBLISH_TIMEOUT_STATUS = "Publish Timeout"
+_PARTIAL_VISIBILITY_WARNING = (
+    "Doris commits worker batches independently; a later operation failure can leave this batch visible"
+)
+_PUBLISH_TIMEOUT_WARNING = (
+    "Doris committed this batch but timed out while publishing it; visibility may be delayed and the batch "
+    "must not be retried with a new label"
+)
+
+
+def _name(name: str, value: object) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value or not value.strip():
+        raise ValueError(f"{name} must not be empty")
+    if value != value.strip() or "\x00" in value or "\r" in value or "\n" in value:
+        raise ValueError(f"{name} must not contain surrounding whitespace, NUL, CR, or LF characters")
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ValueError(f"{name} must contain valid UTF-8") from error
+    return value
+
+
+def _doris_object(name: str, value: object) -> str:
+    identifier = _name(name, value)
+    if len(identifier) > 256:
+        raise ValueError(f"{name} must be at most 256 characters")
+    if _OBJECT_PATTERN.fullmatch(identifier) is None:
+        raise ValueError(f"{name} must be a standard ASCII Doris identifier beginning with a letter")
+    return identifier
+
+
+def _doris_column(name: str, value: object) -> str:
+    identifier = _name(name, value)
+    if len(identifier) > 256:
+        raise ValueError(f"{name} must be at most 256 characters")
+    if _COLUMN_PATTERN.fullmatch(identifier) is None:
+        raise ValueError(
+            f"{name} must contain only Doris column-name characters that are safe in an ASCII HTTP header"
+        )
+    return identifier
+
+
+def _header_identifier(identifier: str) -> str:
+    return f"`{identifier}`"
+
+
+def _endpoint(value: object) -> str:
+    endpoint = _name("endpoint", value)
+    try:
+        parsed = urlsplit(endpoint)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError as error:
+        raise ValueError("endpoint must be a valid HTTP or HTTPS Doris endpoint") from error
+    if parsed.scheme not in {"http", "https"} or hostname is None:
+        raise ValueError("endpoint must be an absolute HTTP or HTTPS Doris endpoint")
+    if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+        raise ValueError(
+            "endpoint must not contain credentials, query parameters, or fragments; "
+            "use password=EnvironmentSecret(...)"
+        )
+    if parsed.path not in {"", "/"}:
+        raise ValueError("endpoint must not contain a path")
+    return endpoint.rstrip("/")
+
+
+def _positive_int(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be a positive integer")
+    if value <= 0 or value > _MAX_INT64:
+        raise ValueError(f"{name} must be a positive signed 64-bit integer")
+    return value
+
+
+def _field_mapping(value: object) -> tuple[tuple[str, str], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise TypeError("field_mapping must be a mapping or None")
+    normalized: list[tuple[str, str]] = []
+    for source, target in value.items():
+        normalized.append(
+            (
+                _name("field_mapping source", source),
+                _doris_column("field_mapping target", target),
+            )
+        )
+    return tuple(normalized)
+
+
+def _vector_dimensions(value: object) -> tuple[tuple[str, int], ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, Mapping):
+        raise TypeError("vector_dimensions must be a mapping or None")
+    normalized: list[tuple[str, int]] = []
+    for source, dimension in value.items():
+        normalized_dimension = _positive_int("vector dimension", dimension)
+        if normalized_dimension > _MAX_INT32:
+            raise ValueError("vector dimension must fit in a signed 32-bit Arrow ListArray offset")
+        normalized.append((_name("vector_dimensions source", source), normalized_dimension))
+    return tuple(normalized)
+
+
+def _trusted_redirect_hosts(value: object) -> tuple[str, ...]:
+    if isinstance(value, str) or not isinstance(value, Sequence):
+        raise TypeError("trusted_redirect_hosts must be a sequence of host names")
+    normalized: list[str] = []
+    for item in value:
+        host = _name("trusted redirect host", item)
+        try:
+            parsed = urlsplit(f"//{host}")
+            parsed_host = parsed.hostname
+            parsed_port = parsed.port
+        except ValueError as error:
+            raise ValueError("trusted redirect hosts must be bare host names or IP addresses") from error
+        if parsed_host is None or parsed_port is not None or parsed.username is not None or parsed.password is not None:
+            raise ValueError("trusted redirect hosts must be bare host names or IP addresses")
+        if parsed.path not in {"", host} or parsed.query or parsed.fragment:
+            raise ValueError("trusted redirect hosts must be bare host names or IP addresses")
+        normalized.append(parsed_host.casefold())
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("trusted_redirect_hosts must not contain duplicates")
+    return tuple(normalized)
+
+
+def _load_aiohttp() -> ModuleType:
+    try:
+        import aiohttp  # type: ignore[import-not-found, import-untyped, unused-ignore]
+    except ModuleNotFoundError as error:
+        if error.name != "aiohttp":
+            raise
+        raise ImportError("DorisStreamLoadSink requires aiohttp; install vane-ai[doris]") from error
+    return aiohttp
+
+
+@dataclass(frozen=True)
+class _FieldBinding:
+    source_name: str
+    target_name: str
+    nullable: bool
+    vector_dimension: int | None
+
+
+@dataclass(frozen=True)
+class _HttpResponse:
+    status_code: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+async def _body_chunks(body: pa.Buffer) -> AsyncIterator[memoryview]:
+    """Yield bounded zero-copy views for one HTTP request body."""
+
+    view = memoryview(body)
+    for offset in range(0, len(view), _HTTP_BODY_CHUNK_BYTES):
+        yield view[offset : offset + _HTTP_BODY_CHUNK_BYTES]
+
+
+class _AioHttpTransport:
+    """Synchronous worker facade over aiohttp's real 100-continue support."""
+
+    def __init__(self, user: str, password: str, timeout: int) -> None:
+        aiohttp = _load_aiohttp()
+        self._aiohttp = aiohttp
+        self._loop = asyncio.new_event_loop()
+        self._session: Any | None = None
+        self._used_https = False
+        try:
+            self._session = self._loop.run_until_complete(self._open(user, password, timeout))
+        except BaseException:
+            self._loop.close()
+            raise
+
+    async def _open(self, user: str, password: str, timeout: int) -> Any:
+        return self._aiohttp.ClientSession(
+            auth=self._aiohttp.BasicAuth(user, password, encoding="utf-8"),
+            auto_decompress=False,
+            skip_auto_headers={"Accept-Encoding"},
+            timeout=self._aiohttp.ClientTimeout(
+                total=float(timeout + _HTTP_TIMEOUT_GRACE_SECONDS),
+                sock_connect=float(_HTTP_CONNECT_TIMEOUT_SECONDS),
+            ),
+            trust_env=False,
+        )
+
+    async def _put(self, url: str, headers: Mapping[str, str], body: pa.Buffer) -> _HttpResponse:
+        session = self._session
+        if session is None:
+            raise RuntimeError("Doris HTTP transport is closed")
+        async with session.put(
+            url,
+            headers=headers,
+            # A fresh async iterator makes the in-memory body replayable for
+            # the FE and BE requests without enqueueing one giant BytesPayload.
+            data=_body_chunks(body),
+            allow_redirects=False,
+            expect100=True,
+        ) as response:
+            response_body = bytearray()
+            async for chunk in response.content.iter_any():
+                response_body.extend(chunk)
+                if len(response_body) > _MAX_RESPONSE_BYTES:
+                    raise RuntimeError("Doris Stream Load response exceeds 1 MiB")
+            return _HttpResponse(response.status, dict(response.headers), bytes(response_body))
+
+    def put(self, url: str, headers: Mapping[str, str], body: pa.Buffer) -> _HttpResponse:
+        if urlsplit(url).scheme == "https":
+            self._used_https = True
+        return self._loop.run_until_complete(self._put(url, headers, body))
+
+    async def _close(self, session: Any) -> None:
+        await session.close()
+        await asyncio.sleep(_HTTPS_SHUTDOWN_SECONDS if self._used_https else 0)
+
+    def close(self) -> None:
+        session = self._session
+        if session is None:
+            return
+        self._loop.run_until_complete(self._close(session))
+        self._loop.close()
+        self._session = None
+
+
+def _open_http_transport(user: str, password: str, timeout: int) -> _AioHttpTransport:
+    return _AioHttpTransport(user, password, timeout)
+
+
+class DorisStreamLoadSink(DataSink):
+    """Write relation batches with Apache Doris Arrow Stream Load.
+
+    ``field_mapping`` maps input Arrow field names to Doris columns. Unmapped
+    input fields retain their names, and every resulting target name must be
+    unique. ``vector_dimensions`` maps input fields to the exact dimensions of
+    Doris ``ARRAY<FLOAT>`` vector columns. Declared vector columns must contain
+    non-null, finite float32 values and are encoded as Arrow ``ListArray``
+    columns without converting rows to Python objects.
+
+    The endpoint may address an FE or BE. FE redirects are followed only when
+    the destination host is the endpoint host or appears in
+    ``trusted_redirect_hosts``; credentials are never forwarded elsewhere.
+    HTTPS redirects may not downgrade to HTTP.
+
+    ``max_batch_bytes`` limits input Arrow data and ``max_request_bytes`` is a
+    separate hard limit on the encoded IPC request. Peak worker memory includes
+    both buffers. Vane full-operation and HTTP-body retries remain disabled
+    because the current DataSink batch contract has no replay-stable batch
+    identity. If a connection fails after upload, the reported outcome is
+    UNKNOWN and its Doris label must be inspected before any manual retry.
+    """
+
+    def __init__(
+        self,
+        database: str,
+        table: str,
+        *,
+        endpoint: str | EnvironmentSecret,
+        user: str = "root",
+        password: EnvironmentSecret | None = None,
+        field_mapping: Mapping[str, str] | None = None,
+        vector_dimensions: Mapping[str, int] | None = None,
+        trusted_redirect_hosts: Sequence[str] = (),
+        worker_count: int = 1,
+        max_batch_rows: int = _DEFAULT_MAX_BATCH_ROWS,
+        max_batch_bytes: int = _DEFAULT_MAX_BATCH_BYTES,
+        max_request_bytes: int = _DEFAULT_MAX_REQUEST_BYTES,
+        send_batch_parallelism: int = _DEFAULT_SEND_BATCH_PARALLELISM,
+        timeout: int = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.database = _doris_object("database", database)
+        self.table = _doris_object("table", table)
+        self.endpoint: str | EnvironmentSecret
+        if isinstance(endpoint, EnvironmentSecret):
+            self.endpoint = endpoint
+        else:
+            self.endpoint = _endpoint(endpoint)
+        self.user = _name("user", user)
+        if ":" in self.user:
+            raise ValueError("user must not contain a colon because HTTP Basic Auth cannot encode it")
+        if password is not None and not isinstance(password, EnvironmentSecret):
+            raise TypeError("password must be an EnvironmentSecret or None")
+        self._password = password
+        self._field_mapping = _field_mapping(field_mapping)
+        self._vector_dimensions = _vector_dimensions(vector_dimensions)
+        self._trusted_redirect_hosts = _trusted_redirect_hosts(trusted_redirect_hosts)
+        self.worker_count = _positive_int("worker_count", worker_count)
+        self.max_batch_rows = _positive_int("max_batch_rows", max_batch_rows)
+        self.max_batch_bytes = _positive_int("max_batch_bytes", max_batch_bytes)
+        self.max_request_bytes = _positive_int("max_request_bytes", max_request_bytes)
+        self.send_batch_parallelism = _positive_int("send_batch_parallelism", send_batch_parallelism)
+        self.timeout = _positive_int("timeout", timeout)
+        if self.timeout > _MAX_TIMEOUT_SECONDS:
+            raise ValueError(f"timeout must be at most {_MAX_TIMEOUT_SECONDS} seconds for Doris Stream Load")
+
+    def bind(self, schema: pa.Schema) -> BoundDataSink:
+        if not isinstance(schema, pa.Schema):
+            raise TypeError("schema must be pyarrow.Schema")
+        if not schema:
+            raise ValueError("DorisStreamLoadSink requires at least one input column")
+        if len(set(schema.names)) != len(schema.names):
+            raise ValueError("DorisStreamLoadSink requires unique input column names")
+
+        mapping = dict(self._field_mapping)
+        if len(mapping) != len(self._field_mapping):
+            raise ValueError("field_mapping sources must be unique")
+        vector_dimensions = dict(self._vector_dimensions)
+        if len(vector_dimensions) != len(self._vector_dimensions):
+            raise ValueError("vector_dimensions sources must be unique")
+        unknown_mapping = set(mapping).difference(schema.names)
+        if unknown_mapping:
+            raise ValueError(f"field_mapping contains unknown input columns: {sorted(unknown_mapping)!r}")
+        unknown_vectors = set(vector_dimensions).difference(schema.names)
+        if unknown_vectors:
+            raise ValueError(f"vector_dimensions contains unknown input columns: {sorted(unknown_vectors)!r}")
+
+        fields: list[_FieldBinding] = []
+        for field in schema:
+            target_name = _doris_column("Doris target column", mapping.get(field.name, field.name))
+            vector_dimension = vector_dimensions.get(field.name)
+            if vector_dimension is not None:
+                data_type = field.type
+                if not (
+                    pa.types.is_list(data_type)
+                    or pa.types.is_large_list(data_type)
+                    or pa.types.is_fixed_size_list(data_type)
+                ) or not pa.types.is_float32(data_type.value_type):
+                    raise ValueError(
+                        f"Doris vector source field {field.name!r} must be an Arrow list, large_list, "
+                        "or fixed_size_list of float32"
+                    )
+                if pa.types.is_fixed_size_list(data_type) and data_type.list_size != vector_dimension:
+                    raise ValueError(
+                        f"Doris vector source field {field.name!r} fixed dimension {data_type.list_size} "
+                        f"does not match vector_dimensions value {vector_dimension}"
+                    )
+            fields.append(
+                _FieldBinding(
+                    source_name=field.name,
+                    target_name=target_name,
+                    nullable=field.nullable,
+                    vector_dimension=vector_dimension,
+                )
+            )
+
+        target_names = [field.target_name for field in fields]
+        if len({name.casefold() for name in target_names}) != len(target_names):
+            raise ValueError("field_mapping must produce case-insensitively unique Doris column names")
+        return _BoundDorisStreamLoadSink(self, schema, tuple(fields))
+
+    def _resolve_endpoint(self) -> str:
+        endpoint = self.endpoint
+        if isinstance(endpoint, EnvironmentSecret):
+            return _endpoint(endpoint.resolve())
+        return endpoint
+
+
+class _BoundDorisStreamLoadSink(BoundDataSink):
+    def __init__(self, sink: DorisStreamLoadSink, schema: pa.Schema, fields: tuple[_FieldBinding, ...]) -> None:
+        self._sink = sink
+        self._schema = schema
+        self._fields = fields
+
+    @property
+    def execution_options(self) -> DataSinkExecutionOptions:
+        return DataSinkExecutionOptions(
+            worker_count=self._sink.worker_count,
+            batch_size=self._sink.max_batch_rows,
+            target_max_batch_bytes=self._sink.max_batch_bytes,
+            max_retries=0,
+        )
+
+    def open_worker(self, context: WriteContext) -> DataSinkWorker:
+        return _DorisStreamLoadWorker(self._sink, self._schema, self._fields, context)
+
+
+class _DorisStreamLoadWorker(DataSinkWorker):
+    def __init__(
+        self,
+        sink: DorisStreamLoadSink,
+        schema: pa.Schema,
+        fields: tuple[_FieldBinding, ...],
+        context: WriteContext,
+    ) -> None:
+        endpoint = sink._resolve_endpoint()
+        endpoint_parts = urlsplit(endpoint)
+        assert endpoint_parts.hostname is not None
+        trusted_hosts = set(sink._trusted_redirect_hosts)
+        trusted_hosts.add(endpoint_parts.hostname.casefold())
+        password = "" if sink._password is None else sink._password.resolve()
+
+        self._sink = sink
+        self._schema = schema
+        self._fields = fields
+        self._endpoint_scheme = endpoint_parts.scheme
+        self._trusted_hosts = frozenset(trusted_hosts)
+        self._load_path = (
+            f"/api/{quote(sink.database, safe='')}/{quote(sink.table, safe='')}/_stream_load"
+        )
+        self._url = f"{endpoint}{self._load_path}"
+        self._transport: _AioHttpTransport | None = _open_http_transport(sink.user, password, sink.timeout)
+        operation_digest = hashlib.sha256(context.operation_id.encode("utf-8")).hexdigest()[:16]
+        self._label_stem = f"{_LABEL_PREFIX}_{operation_digest}_{uuid.uuid4().hex[:8]}"
+        self._batch_number = 0
+        self._warning_pending = True
+        self._base_metadata = {
+            "provider": "doris",
+            "database": sink.database,
+            "table": sink.table,
+            "format": "arrow",
+        }
+        try:
+            WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                metadata=self._base_metadata,
+                warnings=(_PARTIAL_VISIBILITY_WARNING,),
+            )
+        except BaseException as error:
+            try:
+                self.close()
+            except BaseException as close_error:
+                add_note = getattr(error, "add_note", None)
+                if callable(add_note):
+                    try:
+                        add_note(f"Doris HTTP client cleanup also failed: {type(close_error).__name__}")
+                    except BaseException:
+                        pass
+            raise
+
+    def _transport_or_raise(self) -> _AioHttpTransport:
+        if self._transport is None:
+            raise RuntimeError("DorisStreamLoadSink worker is closed")
+        return self._transport
+
+    def _next_label(self) -> str:
+        self._batch_number += 1
+        label = f"{self._label_stem}_{self._batch_number:x}"
+        if len(label) > 128 or _LABEL_PATTERN.fullmatch(label) is None:
+            raise AssertionError("generated Doris Stream Load label is invalid")
+        return label
+
+    def _validate_table(self, table: pa.Table) -> tuple[int, int]:
+        if not isinstance(table, pa.Table):
+            raise TypeError(f"DorisStreamLoadSink expected pyarrow.Table, got {type(table).__name__}")
+        if len(table.schema) != len(self._schema) or any(
+            batch_field.name != bound_field.name or batch_field.type != bound_field.type
+            for batch_field, bound_field in zip(table.schema, self._schema, strict=True)
+        ):
+            raise ValueError("Doris Stream Load batch schema does not match the bound input schema")
+        row_count = table.num_rows
+        batch_bytes = table.nbytes
+        if row_count > self._sink.max_batch_rows:
+            raise ValueError("Doris Stream Load batch exceeds max_batch_rows")
+        if batch_bytes > self._sink.max_batch_bytes:
+            raise ValueError("Doris Stream Load batch exceeds max_batch_bytes")
+        return row_count, batch_bytes
+
+    def _vector_column(self, column: pa.ChunkedArray, binding: _FieldBinding) -> pa.ChunkedArray:
+        dimension = binding.vector_dimension
+        assert dimension is not None
+        chunks: list[pa.Array] = []
+        for chunk in column.chunks:
+            if chunk.null_count:
+                raise ValueError(f"Doris vector source field {binding.source_name!r} must not contain null vectors")
+            if not pa.types.is_fixed_size_list(chunk.type):
+                lengths = pc.list_value_length(chunk)
+                wrong_length = pc.any(pc.not_equal(lengths, pa.scalar(dimension, type=lengths.type)))
+                if wrong_length.as_py() is True:
+                    raise ValueError(
+                        f"Doris vector source field {binding.source_name!r} contains a vector with an invalid dimension"
+                    )
+            values = pc.list_flatten(chunk)
+            if values.null_count:
+                raise ValueError(
+                    f"Doris vector source field {binding.source_name!r} must not contain null elements"
+                )
+            finite = pc.all(pc.is_finite(values))
+            if finite.as_py() is False:
+                raise ValueError(
+                    f"Doris vector source field {binding.source_name!r} must contain only finite float32 values"
+                )
+            nested_count = len(chunk) * dimension
+            if nested_count > _MAX_INT32:
+                raise ValueError(f"Doris vector source field {binding.source_name!r} exceeds Arrow ListArray limits")
+            offsets = pa.array(
+                np.arange(0, nested_count + 1, dimension, dtype=np.int32),
+                type=pa.int32(),
+            )
+            chunks.append(pa.ListArray.from_arrays(offsets, values))
+        return pa.chunked_array(chunks, type=pa.list_(pa.float32()))
+
+    def _wire_table(self, table: pa.Table) -> pa.Table:
+        arrays: list[pa.ChunkedArray] = []
+        fields: list[pa.Field] = []
+        for index, binding in enumerate(self._fields):
+            column = table.column(index)
+            if binding.vector_dimension is not None:
+                column = self._vector_column(column, binding)
+            arrays.append(column)
+            fields.append(
+                pa.field(
+                    binding.target_name,
+                    column.type,
+                    nullable=binding.nullable,
+                )
+            )
+        schema = pa.schema(fields)
+        return pa.Table.from_arrays(arrays, schema=schema)
+
+    def _arrow_body(self, table: pa.Table) -> pa.Buffer:
+        output = pa.BufferOutputStream()
+        with pa.ipc.new_stream(output, table.schema) as writer:
+            writer.write_table(table)
+        body = output.getvalue()
+        if body.size > self._sink.max_request_bytes:
+            raise ValueError(
+                "Doris Arrow IPC request exceeds max_request_bytes: "
+                f"wire_bytes={body.size}, max_request_bytes={self._sink.max_request_bytes}"
+            )
+        return body
+
+    def _headers(self, label: str, body_size: int) -> dict[str, str]:
+        return {
+            "Expect": "100-continue",
+            "Content-Type": "application/vnd.apache.arrow.stream",
+            "Content-Length": str(body_size),
+            "format": "arrow",
+            "columns": ",".join(_header_identifier(field.target_name) for field in self._fields),
+            "label": label,
+            "strict_mode": "true",
+            "max_filter_ratio": "0",
+            "send_batch_parallelism": str(self._sink.send_batch_parallelism),
+            "timeout": str(self._sink.timeout),
+        }
+
+    def _request(self, url: str, headers: Mapping[str, str], body: pa.Buffer) -> _HttpResponse:
+        return self._transport_or_raise().put(url, headers, body)
+
+    def _redirect_url(self, source_url: str, response: _HttpResponse) -> str:
+        location = next(
+            (value for name, value in response.headers.items() if name.casefold() == "location"),
+            None,
+        )
+        if location is None:
+            raise RuntimeError("Doris FE redirect did not include a Location header")
+        redirect_url = urljoin(source_url, location)
+        try:
+            parsed = urlsplit(redirect_url)
+            hostname = parsed.hostname
+            _ = parsed.port
+        except ValueError as error:
+            raise RuntimeError("Doris FE returned an invalid redirect URL") from error
+        if parsed.scheme not in {"http", "https"} or hostname is None:
+            raise RuntimeError("Doris FE returned a non-HTTP redirect URL")
+        if parsed.query or parsed.fragment:
+            raise RuntimeError("Doris FE redirect URL must not contain a query or a fragment")
+        if parsed.scheme != self._endpoint_scheme:
+            raise RuntimeError("Doris FE redirect must preserve the endpoint scheme")
+        if hostname.casefold() not in self._trusted_hosts:
+            raise RuntimeError(
+                f"Doris FE redirected to untrusted host {hostname!r}; add it to trusted_redirect_hosts"
+            )
+        if parsed.path != self._load_path:
+            raise RuntimeError("Doris FE redirect changed the Stream Load path")
+        # Current Doris FEs copy the Basic Auth userinfo into Location. Never
+        # pass those URL credentials to the BE: the session attaches the
+        # configured Basic Auth after the destination checks above.
+        authority = parsed.netloc.rsplit("@", 1)[-1]
+        return urlunsplit((parsed.scheme, authority, parsed.path, "", ""))
+
+    def _put_once(self, headers: Mapping[str, str], body: pa.Buffer) -> _HttpResponse:
+        response = self._request(self._url, headers, body)
+        if response.status_code != _REDIRECT_STATUS:
+            return response
+        redirect_url = self._redirect_url(self._url, response)
+        redirected = self._request(redirect_url, headers, body)
+        if redirected.status_code == _REDIRECT_STATUS:
+            raise RuntimeError("Doris Stream Load returned more than one redirect")
+        return redirected
+
+    def _response_payload(self, response: _HttpResponse) -> Mapping[str, Any]:
+        if len(response.body) > _MAX_RESPONSE_BYTES:
+            raise RuntimeError("Doris Stream Load response exceeds 1 MiB")
+        if response.status_code < 200 or response.status_code >= 300:
+            detail = response.body.decode("utf-8", errors="replace").strip()
+            if len(detail) > 512:
+                detail = f"{detail[:512]}..."
+            raise RuntimeError(f"Doris Stream Load HTTP {response.status_code}: {detail or 'empty response'}")
+        try:
+            payload = json.loads(response.body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RuntimeError("Doris Stream Load returned invalid JSON") from error
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("Doris Stream Load returned a non-object JSON response")
+        return payload
+
+    def _put(self, label: str, body: pa.Buffer) -> Mapping[str, Any]:
+        headers = self._headers(label, body.size)
+        try:
+            return self._response_payload(self._put_once(headers, body))
+        except Exception as error:
+            raise RuntimeError(
+                f"Doris Stream Load batch label {label!r} did not produce an accepted terminal response: "
+                f"{type(error).__name__}: {error}; "
+                "inspect that label in Doris before retrying with a new label"
+            ) from error
+
+    @staticmethod
+    def _response_int(payload: Mapping[str, Any], name: str) -> int:
+        value = payload.get(name)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0 or value > _MAX_INT64:
+            raise RuntimeError(f"Doris Stream Load returned an invalid {name}")
+        return value
+
+    def _applied_result(
+        self,
+        *,
+        payload: Mapping[str, Any],
+        label: str,
+        row_count: int,
+        batch_bytes: int,
+        body_size: int,
+    ) -> WriteResult:
+        status = payload.get("Status")
+        response_label = payload.get("Label")
+        if response_label != label:
+            raise RuntimeError("Doris Stream Load returned a different batch label")
+
+        warnings: list[str] = []
+        metadata: dict[str, Any] = {
+            **self._base_metadata,
+            "label": label,
+            "status": status,
+            "wire_bytes": body_size,
+        }
+        if status in {_SUCCESS_STATUS, _PUBLISH_TIMEOUT_STATUS}:
+            total_rows = self._response_int(payload, "NumberTotalRows")
+            loaded_rows = self._response_int(payload, "NumberLoadedRows")
+            filtered_rows = self._response_int(payload, "NumberFilteredRows")
+            unselected_rows = self._response_int(payload, "NumberUnselectedRows")
+            if total_rows != row_count or loaded_rows != row_count or filtered_rows != 0 or unselected_rows != 0:
+                raise RuntimeError(
+                    "Doris Stream Load row counts do not match the Arrow batch: "
+                    f"total={total_rows}, loaded={loaded_rows}, filtered={filtered_rows}, "
+                    f"unselected={unselected_rows}, expected={row_count}"
+                )
+            txn_id = self._response_int(payload, "TxnId")
+            load_bytes = self._response_int(payload, "LoadBytes")
+            load_time_ms = self._response_int(payload, "LoadTimeMs")
+            metadata.update({"txn_id": txn_id, "load_bytes": load_bytes, "load_time_ms": load_time_ms})
+            if status == _PUBLISH_TIMEOUT_STATUS:
+                warnings.append(_PUBLISH_TIMEOUT_WARNING)
+        else:
+            message = payload.get("Message")
+            detail = message if isinstance(message, str) and message else "no error message"
+            if len(detail) > 512:
+                detail = f"{detail[:512]}..."
+            raise RuntimeError(f"Doris Stream Load was not applied: status={status!r}, message={detail}")
+
+        if self._warning_pending:
+            warnings.insert(0, _PARTIAL_VISIBILITY_WARNING)
+        result = WriteResult(
+            rows_received=row_count,
+            rows_affected=row_count,
+            bytes_received=batch_bytes,
+            metadata=metadata,
+            warnings=tuple(warnings),
+        )
+        self._warning_pending = False
+        return result
+
+    def write(self, table: pa.Table) -> WriteResult:
+        row_count, batch_bytes = self._validate_table(table)
+        if row_count == 0:
+            return WriteResult(
+                rows_received=0,
+                rows_affected=0,
+                bytes_received=batch_bytes,
+                metadata=self._base_metadata,
+            )
+        wire_table = self._wire_table(table)
+        body = self._arrow_body(wire_table)
+        label = self._next_label()
+        payload = self._put(label, body)
+        try:
+            return self._applied_result(
+                payload=payload,
+                label=label,
+                row_count=row_count,
+                batch_bytes=batch_bytes,
+                body_size=body.size,
+            )
+        except Exception as error:
+            raise RuntimeError(
+                f"Doris Stream Load batch label {label!r} returned a terminal response that Vane "
+                f"could not accept: {type(error).__name__}: {error}; inspect that label before "
+                "submitting new data"
+            ) from error
+
+    def abort(self, _error: BaseException) -> None:
+        self.close()
+
+    def close(self) -> None:
+        transport = self._transport
+        if transport is None:
+            return
+        transport.close()
+        self._transport = None
+
+
+__all__ = ["DorisStreamLoadSink"]

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -672,7 +672,9 @@ class _DorisStreamLoadWorker(DataSinkWorker):
             column = self._vector_column(column, binding)
         if column.type != binding.target_type:
             try:
-                column = pc.cast(column, binding.target_type, safe=True)
+                converted = pc.cast(column, binding.target_type, safe=True)
+                self._validate_float_overflow(column, converted, binding.target_name)
+                column = converted
             except pa.ArrowException as error:
                 raise ValueError(
                     f"Doris source field {binding.source_name!r} cannot be safely cast to destination field "
@@ -685,6 +687,30 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         )
         self._validate_nullability(column, target_field, binding.target_name)
         return column
+
+    def _validate_float_overflow(
+        self,
+        source: pa.Array | pa.ChunkedArray,
+        converted: pa.Array | pa.ChunkedArray,
+        path: str,
+    ) -> None:
+        if source.type == converted.type or pa.types.is_null(source.type):
+            return
+        if pa.types.is_list(converted.type):
+            self._validate_float_overflow(pc.list_flatten(source), pc.list_flatten(converted), f"{path}[]")
+        elif pa.types.is_float32(converted.type):
+            # Arrow's safe cast permits finite doubles to overflow to float infinity.
+            # Inspect float64 source values only when the result contains a nonfinite
+            # value, preserving existing infinities/NaNs and ordinary float rounding.
+            nonfinite = pc.invert(pc.is_finite(converted))
+            if pc.any(nonfinite).as_py() is True:
+                source_double = pc.cast(source, pa.float64(), safe=True)
+                overflow = pc.and_(pc.is_finite(source_double), nonfinite)
+                if pc.any(overflow).as_py() is True:
+                    raise ValueError(
+                        f"Doris destination field {path!r} has floating-point overflow: "
+                        "a finite source value becomes nonfinite when cast to float32"
+                    )
 
     def _wire_table(self, table: pa.Table) -> pa.Table:
         arrays: list[pa.ChunkedArray] = []

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -95,9 +95,7 @@ def _doris_column(name: str, value: object) -> str:
     if len(identifier) > 256:
         raise ValueError(f"{name} must be at most 256 characters")
     if _COLUMN_PATTERN.fullmatch(identifier) is None:
-        raise ValueError(
-            f"{name} must contain only Doris column-name characters that are safe in an ASCII HTTP header"
-        )
+        raise ValueError(f"{name} must contain only Doris column-name characters that are safe in an ASCII HTTP header")
     return identifier
 
 
@@ -117,8 +115,7 @@ def _endpoint(value: object) -> str:
         raise ValueError("endpoint must be an absolute HTTP or HTTPS Doris endpoint")
     if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
         raise ValueError(
-            "endpoint must not contain credentials, query parameters, or fragments; "
-            "use password=EnvironmentSecret(...)"
+            "endpoint must not contain credentials, query parameters, or fragments; use password=EnvironmentSecret(...)"
         )
     if parsed.path not in {"", "/"}:
         raise ValueError("endpoint must not contain a path")
@@ -234,8 +231,10 @@ class _AioHttpTransport:
             raise
 
     async def _open(self, user: str, password: str, timeout: int) -> Any:
-        return self._aiohttp.ClientSession(
-            auth=self._aiohttp.BasicAuth(user, password, encoding="utf-8"),
+        session = self._aiohttp.ClientSession(
+            headers={
+                "Authorization": self._aiohttp.encode_basic_auth(user, password, encoding="utf-8"),
+            },
             auto_decompress=False,
             skip_auto_headers={"Accept-Encoding"},
             timeout=self._aiohttp.ClientTimeout(
@@ -244,6 +243,11 @@ class _AioHttpTransport:
             ),
             trust_env=False,
         )
+        # aiohttp retries PUT once when a persistent connection fails. A
+        # Stream Load may already have committed at that point, so even this
+        # transport-level retry must remain disabled.
+        session._retry_connection = False
+        return session
 
     async def _put(self, url: str, headers: Mapping[str, str], body: pa.Buffer) -> _HttpResponse:
         session = self._session
@@ -454,9 +458,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         self._fields = fields
         self._endpoint_scheme = endpoint_parts.scheme
         self._trusted_hosts = frozenset(trusted_hosts)
-        self._load_path = (
-            f"/api/{quote(sink.database, safe='')}/{quote(sink.table, safe='')}/_stream_load"
-        )
+        self._load_path = f"/api/{quote(sink.database, safe='')}/{quote(sink.table, safe='')}/_stream_load"
         self._url = f"{endpoint}{self._load_path}"
         self._transport: _AioHttpTransport | None = _open_http_transport(sink.user, password, sink.timeout)
         operation_digest = hashlib.sha256(context.operation_id.encode("utf-8")).hexdigest()[:16]
@@ -532,9 +534,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
                     )
             values = pc.list_flatten(chunk)
             if values.null_count:
-                raise ValueError(
-                    f"Doris vector source field {binding.source_name!r} must not contain null elements"
-                )
+                raise ValueError(f"Doris vector source field {binding.source_name!r} must not contain null elements")
             finite = pc.all(pc.is_finite(values))
             if finite.as_py() is False:
                 raise ValueError(
@@ -618,9 +618,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         if parsed.scheme != self._endpoint_scheme:
             raise RuntimeError("Doris FE redirect must preserve the endpoint scheme")
         if hostname.casefold() not in self._trusted_hosts:
-            raise RuntimeError(
-                f"Doris FE redirected to untrusted host {hostname!r}; add it to trusted_redirect_hosts"
-            )
+            raise RuntimeError(f"Doris FE redirected to untrusted host {hostname!r}; add it to trusted_redirect_hosts")
         if parsed.path != self._load_path:
             raise RuntimeError("Doris FE redirect changed the Stream Load path")
         # Current Doris FEs copy the Basic Auth userinfo into Location. Never

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -201,6 +201,28 @@ def _validate_destination_type(data_type: pa.DataType, path: str) -> None:
     )
 
 
+def _validate_source_type(data_type: pa.DataType, path: str) -> None:
+    if (
+        pa.types.is_null(data_type)
+        or pa.types.is_boolean(data_type)
+        or pa.types.is_integer(data_type)
+        or pa.types.is_floating(data_type)
+        or pa.types.is_string(data_type)
+        or pa.types.is_large_string(data_type)
+        or pa.types.is_binary(data_type)
+        or pa.types.is_large_binary(data_type)
+        or pa.types.is_fixed_size_binary(data_type)
+    ):
+        return
+    if pa.types.is_list(data_type) or pa.types.is_large_list(data_type) or pa.types.is_fixed_size_list(data_type):
+        _validate_source_type(data_type.value_type, f"{path}[]")
+        return
+    raise ValueError(
+        f"Doris source field {path!r} uses unsupported Arrow type {data_type}; "
+        "use plain scalar or standard list arrays, and decode and rebatch encoded or view arrays before writing"
+    )
+
+
 def _destination_schema(value: object) -> pa.Schema:
     if not isinstance(value, pa.Schema):
         raise TypeError("destination_schema must be pyarrow.Schema")
@@ -395,6 +417,11 @@ class DorisStreamLoadSink(DataSink):
     overflow and incompatible values fail the batch without an HTTP request.
     Worker batches may use equivalent 32-bit or 64-bit string, binary, and list
     offsets; logical input types must otherwise match the bound schema.
+    Input types are null, boolean, integer, floating-point, string, binary,
+    and standard lists recursively composed from them. Encoded/view arrays and
+    other input types must be converted and rebatched before writing. String
+    destinations require string or binary input; stringify other types in the
+    input relation. Hidden children beneath null list slots are not converted.
     Temporal types are rejected because Doris 4.1.3 does not preserve Arrow's
     timestamp semantics. ``field_mapping`` maps input Arrow field names to
     Doris columns. Unmapped input fields retain their names, and the resulting
@@ -410,7 +437,9 @@ class DorisStreamLoadSink(DataSink):
     HTTPS redirects may not downgrade to HTTP.
 
     ``max_batch_bytes`` limits input Arrow data and ``max_request_bytes`` is a
-    separate hard limit on the encoded IPC request. Peak worker memory includes
+    separate hard limit on the encoded IPC request. Conversion buffers are
+    conservatively budgeted before casting, and the complete IPC size is
+    measured before allocating a fixed-size request buffer. Peak worker memory includes
     the input, safe-cast, vector-offset, and encoded buffers that apply to a
     batch. Vane full-operation and HTTP-body retries remain disabled because
     the current DataSink batch contract has no replay-stable batch identity. If
@@ -476,6 +505,7 @@ class DorisStreamLoadSink(DataSink):
                     f"Doris source field {field.name!r} uses an unsupported temporal Arrow type; "
                     "cast it to an explicitly supported non-temporal type before writing"
                 )
+            _validate_source_type(field.type, field.name)
 
         mapping = dict(self._field_mapping)
         if len(mapping) != len(self._field_mapping):
@@ -711,8 +741,6 @@ class _DorisStreamLoadWorker(DataSinkWorker):
             self._validate_nullability(pc.list_flatten(chunk), child_field, f"{path}[]")
 
     def _destination_column(self, column: pa.ChunkedArray, binding: _FieldBinding) -> pa.ChunkedArray:
-        if binding.vector_dimension is not None:
-            column = self._vector_column(column, binding)
         if column.type != binding.target_type:
             try:
                 converted = pc.cast(column, binding.target_type, safe=True)
@@ -755,22 +783,91 @@ class _DorisStreamLoadWorker(DataSinkWorker):
                         "a finite source value becomes nonfinite when cast to float32"
                     )
 
+    def _visible_list_values(self, array: pa.Array) -> pa.Array:
+        if not (
+            pa.types.is_list(array.type)
+            or pa.types.is_large_list(array.type)
+            or pa.types.is_fixed_size_list(array.type)
+        ):
+            return array
+        # Arrow's nested safe cast visits physical children even beneath null
+        # list slots. Flatten first so only logically visible values are cast.
+        values = self._visible_list_values(pc.list_flatten(array))
+        if len(values) > _MAX_INT32:
+            raise ValueError("Doris list values exceed Arrow ListArray limits")
+        lengths = pc.fill_null(pc.list_value_length(array), 0)
+        offsets = pa.concat_arrays([pa.array([0], type=lengths.type), pc.cumulative_sum(lengths)])
+        child = pa.field(array.type.value_field.name, values.type, nullable=array.type.value_field.nullable)
+        mask = array.is_null() if array.null_count else None
+        if pa.types.is_large_list(array.type):
+            return pa.LargeListArray.from_arrays(offsets, values, type=pa.large_list(child), mask=mask)
+        return pa.ListArray.from_arrays(offsets, values, type=pa.list_(child), mask=mask)
+
+    def _conversion_bytes(self, array: pa.Array, target_type: pa.DataType) -> int:
+        count = len(array)
+        # Include validity storage even when a kernel can omit it. Arithmetic
+        # stays in Python integers so a size estimate cannot silently overflow.
+        validity_bytes = (count + 7) // 8
+        if pa.types.is_list(target_type):
+            size = validity_bytes + 4 * (count + 1)
+            if pa.types.is_null(array.type):
+                return size + self._conversion_bytes(array.slice(0, 0), target_type.value_type)
+            if not (pa.types.is_list(array.type) or pa.types.is_large_list(array.type)):
+                raise ValueError("Doris list destinations require a standard list source")
+            return size + self._conversion_bytes(array.values, target_type.value_type)
+        if pa.types.is_string(target_type):
+            if count == 0 or pa.types.is_null(array.type):
+                data_bytes = 0
+            elif pa.types.is_fixed_size_binary(array.type):
+                data_bytes = count * array.type.byte_width
+            elif (
+                pa.types.is_string(array.type)
+                or pa.types.is_binary(array.type)
+                or pa.types.is_large_string(array.type)
+                or pa.types.is_large_binary(array.type)
+            ):
+                large = pa.types.is_large_string(array.type) or pa.types.is_large_binary(array.type)
+                offsets = np.frombuffer(array.buffers()[1], dtype=np.int64 if large else np.int32)
+                data_bytes = int(offsets[array.offset + count]) - int(offsets[array.offset])
+            else:
+                raise ValueError("Doris string destinations require a string or binary source")
+            return validity_bytes + 4 * (count + 1) + data_bytes
+        return validity_bytes + (count * target_type.bit_width + 7) // 8
+
     def _wire_table(self, table: pa.Table) -> pa.Table:
-        arrays: list[pa.ChunkedArray] = []
+        prepared: list[pa.ChunkedArray] = []
+        conversion_bytes = 0
         for index, binding in enumerate(self._fields):
-            arrays.append(self._destination_column(table.column(index), binding))
+            column = table.column(index)
+            if binding.vector_dimension is not None:
+                column = self._vector_column(column, binding)
+            else:
+                column = pa.chunked_array([self._visible_list_values(chunk) for chunk in column.chunks])
+            conversion_bytes += sum(self._conversion_bytes(chunk, binding.target_type) for chunk in column.chunks)
+            if conversion_bytes > self._sink.max_request_bytes:
+                raise ValueError("Doris converted Arrow data exceeds max_request_bytes before casting")
+            prepared.append(column)
+        arrays = [
+            self._destination_column(column, binding) for column, binding in zip(prepared, self._fields, strict=True)
+        ]
         return pa.Table.from_arrays(arrays, schema=self._destination_schema)
 
     def _arrow_body(self, table: pa.Table) -> pa.Buffer:
-        output = pa.BufferOutputStream()
-        with pa.ipc.new_stream(output, table.schema) as writer:
-            writer.write_table(table)
-        body = output.getvalue()
-        if body.size > self._sink.max_request_bytes:
+        # Size the complete IPC stream, including schema/chunk metadata, before
+        # allocating its body. The fixed-size writer cannot grow past this cap.
+        with pa.MockOutputStream() as sizing_output:
+            with pa.ipc.new_stream(sizing_output, table.schema) as writer:
+                writer.write_table(table)
+            wire_bytes = sizing_output.size()
+        if wire_bytes > self._sink.max_request_bytes:
             raise ValueError(
                 "Doris Arrow IPC request exceeds max_request_bytes: "
-                f"wire_bytes={body.size}, max_request_bytes={self._sink.max_request_bytes}"
+                f"wire_bytes={wire_bytes}, max_request_bytes={self._sink.max_request_bytes}"
             )
+        body = pa.allocate_buffer(wire_bytes)
+        with pa.FixedSizeBufferWriter(body) as output:
+            with pa.ipc.new_stream(output, table.schema) as writer:
+                writer.write_table(table)
         return body
 
     def _headers(self, label: str, body_size: int) -> dict[str, str]:

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -18,6 +18,7 @@ import re
 import uuid
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
+from ipaddress import IPv6Address
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urljoin, urlsplit, urlunsplit
 
@@ -113,7 +114,7 @@ def _endpoint(value: object) -> str:
         raise ValueError("endpoint must be a valid HTTP or HTTPS Doris endpoint") from error
     if parsed.scheme not in {"http", "https"} or hostname is None:
         raise ValueError("endpoint must be an absolute HTTP or HTTPS Doris endpoint")
-    if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+    if parsed.username is not None or parsed.password is not None or "?" in endpoint or "#" in endpoint:
         raise ValueError(
             "endpoint must not contain credentials, query parameters, or fragments; use password=EnvironmentSecret(...)"
         )
@@ -216,23 +217,31 @@ def _destination_schema(value: object) -> pa.Schema:
     return pa.schema(fields)
 
 
+def _canonical_host(host: str) -> str:
+    if ":" in host:
+        return str(IPv6Address(host))
+    # Full Unicode case folding can merge distinct IDNs, such as straße and strasse.
+    return host.lower()
+
+
 def _trusted_redirect_hosts(value: object) -> tuple[str, ...]:
     if isinstance(value, str) or not isinstance(value, Sequence):
         raise TypeError("trusted_redirect_hosts must be a sequence of host names")
     normalized: list[str] = []
     for item in value:
         host = _name("trusted redirect host", item)
+        if any(character in host for character in "/?#@\\") or any(character.isspace() for character in host):
+            raise ValueError("trusted redirect hosts must be bare host names or IP addresses")
         try:
-            parsed = urlsplit(f"//{host}")
-            parsed_host = parsed.hostname
-            parsed_port = parsed.port
+            if host.startswith("[") and host.endswith("]"):
+                normalized_host = str(IPv6Address(host[1:-1]))
+            else:
+                if "[" in host or "]" in host:
+                    raise ValueError("unmatched IPv6 brackets")
+                normalized_host = _canonical_host(host)
         except ValueError as error:
             raise ValueError("trusted redirect hosts must be bare host names or IP addresses") from error
-        if parsed_host is None or parsed_port is not None or parsed.username is not None or parsed.password is not None:
-            raise ValueError("trusted redirect hosts must be bare host names or IP addresses")
-        if parsed.path not in {"", host} or parsed.query or parsed.fragment:
-            raise ValueError("trusted redirect hosts must be bare host names or IP addresses")
-        normalized.append(parsed_host.casefold())
+        normalized.append(normalized_host)
     if len(set(normalized)) != len(normalized):
         raise ValueError("trusted_redirect_hosts must not contain duplicates")
     return tuple(normalized)
@@ -551,7 +560,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         endpoint_parts = urlsplit(endpoint)
         assert endpoint_parts.hostname is not None
         trusted_hosts = set(sink._trusted_redirect_hosts)
-        trusted_hosts.add(endpoint_parts.hostname.casefold())
+        trusted_hosts.add(_canonical_host(endpoint_parts.hostname))
         password = "" if sink._password is None else sink._password.resolve()
 
         self._sink = sink
@@ -767,7 +776,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
             raise RuntimeError("Doris FE redirect URL must not contain a query or a fragment")
         if parsed.scheme != self._endpoint_scheme:
             raise RuntimeError("Doris FE redirect must preserve the endpoint scheme")
-        if hostname.casefold() not in self._trusted_hosts:
+        if _canonical_host(hostname) not in self._trusted_hosts:
             raise RuntimeError(f"Doris FE redirected to untrusted host {hostname!r}; add it to trusted_redirect_hosts")
         if parsed.path != self._load_path:
             raise RuntimeError("Doris FE redirect changed the Stream Load path")

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -160,6 +160,62 @@ def _vector_dimensions(value: object) -> tuple[tuple[str, int], ...]:
     return tuple(normalized)
 
 
+def _contains_temporal(data_type: pa.DataType) -> bool:
+    if pa.types.is_temporal(data_type):
+        return True
+    storage_type = getattr(data_type, "storage_type", None)
+    if isinstance(storage_type, pa.DataType) and storage_type != data_type:
+        return _contains_temporal(storage_type)
+    if pa.types.is_dictionary(data_type):
+        return _contains_temporal(data_type.value_type)
+    if pa.types.is_run_end_encoded(data_type):
+        return _contains_temporal(data_type.run_end_type) or _contains_temporal(data_type.value_type)
+    return any(_contains_temporal(data_type.field(index).type) for index in range(data_type.num_fields))
+
+
+def _validate_destination_type(data_type: pa.DataType, path: str) -> None:
+    if _contains_temporal(data_type):
+        raise ValueError(
+            f"destination_schema field {path!r} uses an unsupported temporal Arrow type; "
+            "cast temporal values to an explicitly supported non-temporal type before writing"
+        )
+    if (
+        pa.types.is_boolean(data_type)
+        or pa.types.is_int8(data_type)
+        or pa.types.is_int16(data_type)
+        or pa.types.is_int32(data_type)
+        or pa.types.is_int64(data_type)
+        or pa.types.is_float32(data_type)
+        or pa.types.is_float64(data_type)
+        or pa.types.is_string(data_type)
+    ):
+        return
+    if pa.types.is_list(data_type):
+        _validate_destination_type(data_type.value_type, f"{path}[]")
+        return
+    raise ValueError(
+        f"destination_schema field {path!r} uses unsupported Arrow type {data_type}; "
+        "supported types are bool, signed integers, float32, float64, string, and list values composed from them"
+    )
+
+
+def _destination_schema(value: object) -> pa.Schema:
+    if not isinstance(value, pa.Schema):
+        raise TypeError("destination_schema must be pyarrow.Schema")
+    if not value:
+        raise ValueError("destination_schema must contain at least one field")
+    fields: list[pa.Field] = []
+    names: list[str] = []
+    for field in value:
+        name = _doris_column("destination_schema field name", field.name)
+        _validate_destination_type(field.type, name)
+        names.append(name)
+        fields.append(pa.field(name, field.type, nullable=field.nullable))
+    if len({name.casefold() for name in names}) != len(names):
+        raise ValueError("destination_schema field names must be case-insensitively unique")
+    return pa.schema(fields)
+
+
 def _trusted_redirect_hosts(value: object) -> tuple[str, ...]:
     if isinstance(value, str) or not isinstance(value, Sequence):
         raise TypeError("trusted_redirect_hosts must be a sequence of host names")
@@ -196,7 +252,8 @@ def _load_aiohttp() -> ModuleType:
 class _FieldBinding:
     source_name: str
     target_name: str
-    nullable: bool
+    target_type: pa.DataType
+    target_nullable: bool
     vector_dimension: int | None
 
 
@@ -294,12 +351,18 @@ def _open_http_transport(user: str, password: str, timeout: int) -> _AioHttpTran
 class DorisStreamLoadSink(DataSink):
     """Write relation batches with Apache Doris Arrow Stream Load.
 
-    ``field_mapping`` maps input Arrow field names to Doris columns. Unmapped
-    input fields retain their names, and every resulting target name must be
-    unique. ``vector_dimensions`` maps input fields to the exact dimensions of
-    Doris ``ARRAY<FLOAT>`` vector columns. Declared vector columns must contain
-    non-null, finite float32 values and are encoded as Arrow ``ListArray``
-    columns without converting rows to Python objects.
+    ``destination_schema`` is required and must declare the exact Arrow
+    physical type for each Doris column selected by this sink, in input-column
+    order. Every input column is safely cast to that schema before upload;
+    overflow and incompatible values fail the batch without an HTTP request.
+    Temporal types are rejected because Doris 4.1.3 does not preserve Arrow's
+    timestamp semantics. ``field_mapping`` maps input Arrow field names to
+    Doris columns. Unmapped input fields retain their names, and the resulting
+    names must exactly match ``destination_schema``. ``vector_dimensions``
+    maps input fields to the exact dimensions of Doris ``ARRAY<FLOAT>`` vector
+    columns. Declared vector columns must contain non-null, finite float32
+    values and are encoded as Arrow ``ListArray`` columns without converting
+    rows to Python objects.
 
     The endpoint may address an FE or BE. FE redirects are followed only when
     the destination host is the endpoint host or appears in
@@ -308,10 +371,11 @@ class DorisStreamLoadSink(DataSink):
 
     ``max_batch_bytes`` limits input Arrow data and ``max_request_bytes`` is a
     separate hard limit on the encoded IPC request. Peak worker memory includes
-    both buffers. Vane full-operation and HTTP-body retries remain disabled
-    because the current DataSink batch contract has no replay-stable batch
-    identity. If a connection fails after upload, the reported outcome is
-    UNKNOWN and its Doris label must be inspected before any manual retry.
+    the input, safe-cast, vector-offset, and encoded buffers that apply to a
+    batch. Vane full-operation and HTTP-body retries remain disabled because
+    the current DataSink batch contract has no replay-stable batch identity. If
+    a connection fails after upload, the reported outcome is UNKNOWN and its
+    Doris label must be inspected before any manual retry.
     """
 
     def __init__(
@@ -320,6 +384,7 @@ class DorisStreamLoadSink(DataSink):
         table: str,
         *,
         endpoint: str | EnvironmentSecret,
+        destination_schema: pa.Schema,
         user: str = "root",
         password: EnvironmentSecret | None = None,
         field_mapping: Mapping[str, str] | None = None,
@@ -339,6 +404,7 @@ class DorisStreamLoadSink(DataSink):
             self.endpoint = endpoint
         else:
             self.endpoint = _endpoint(endpoint)
+        self._destination_schema = _destination_schema(destination_schema)
         self.user = _name("user", user)
         if ":" in self.user:
             raise ValueError("user must not contain a colon because HTTP Basic Auth cannot encode it")
@@ -364,6 +430,12 @@ class DorisStreamLoadSink(DataSink):
             raise ValueError("DorisStreamLoadSink requires at least one input column")
         if len(set(schema.names)) != len(schema.names):
             raise ValueError("DorisStreamLoadSink requires unique input column names")
+        for field in schema:
+            if _contains_temporal(field.type):
+                raise ValueError(
+                    f"Doris source field {field.name!r} uses an unsupported temporal Arrow type; "
+                    "cast it to an explicitly supported non-temporal type before writing"
+                )
 
         mapping = dict(self._field_mapping)
         if len(mapping) != len(self._field_mapping):
@@ -378,9 +450,18 @@ class DorisStreamLoadSink(DataSink):
         if unknown_vectors:
             raise ValueError(f"vector_dimensions contains unknown input columns: {sorted(unknown_vectors)!r}")
 
+        target_names = [_doris_column("Doris target column", mapping.get(field.name, field.name)) for field in schema]
+        if len({name.casefold() for name in target_names}) != len(target_names):
+            raise ValueError("field_mapping must produce case-insensitively unique Doris column names")
+        if target_names != self._destination_schema.names:
+            raise ValueError(
+                "mapped input columns must exactly match destination_schema names and order: "
+                f"mapped={target_names!r}, destination={self._destination_schema.names!r}"
+            )
+
         fields: list[_FieldBinding] = []
-        for field in schema:
-            target_name = _doris_column("Doris target column", mapping.get(field.name, field.name))
+        for field, target_field in zip(schema, self._destination_schema, strict=True):
+            target_name = target_field.name
             vector_dimension = vector_dimensions.get(field.name)
             if vector_dimension is not None:
                 data_type = field.type
@@ -398,19 +479,25 @@ class DorisStreamLoadSink(DataSink):
                         f"Doris vector source field {field.name!r} fixed dimension {data_type.list_size} "
                         f"does not match vector_dimensions value {vector_dimension}"
                     )
+                if not pa.types.is_list(target_field.type) or not pa.types.is_float32(target_field.type.value_type):
+                    raise ValueError(
+                        f"Doris vector destination field {target_name!r} must be Arrow list<float32> "
+                        "for an ARRAY<FLOAT> column"
+                    )
             fields.append(
                 _FieldBinding(
                     source_name=field.name,
                     target_name=target_name,
-                    nullable=field.nullable,
+                    target_type=target_field.type,
+                    target_nullable=target_field.nullable,
                     vector_dimension=vector_dimension,
                 )
             )
+        return _BoundDorisStreamLoadSink(self, schema, self._destination_schema, tuple(fields))
 
-        target_names = [field.target_name for field in fields]
-        if len({name.casefold() for name in target_names}) != len(target_names):
-            raise ValueError("field_mapping must produce case-insensitively unique Doris column names")
-        return _BoundDorisStreamLoadSink(self, schema, tuple(fields))
+    @property
+    def destination_schema(self) -> pa.Schema:
+        return self._destination_schema
 
     def _resolve_endpoint(self) -> str:
         endpoint = self.endpoint
@@ -420,9 +507,16 @@ class DorisStreamLoadSink(DataSink):
 
 
 class _BoundDorisStreamLoadSink(BoundDataSink):
-    def __init__(self, sink: DorisStreamLoadSink, schema: pa.Schema, fields: tuple[_FieldBinding, ...]) -> None:
+    def __init__(
+        self,
+        sink: DorisStreamLoadSink,
+        schema: pa.Schema,
+        destination_schema: pa.Schema,
+        fields: tuple[_FieldBinding, ...],
+    ) -> None:
         self._sink = sink
         self._schema = schema
+        self._destination_schema = destination_schema
         self._fields = fields
 
     @property
@@ -435,7 +529,13 @@ class _BoundDorisStreamLoadSink(BoundDataSink):
         )
 
     def open_worker(self, context: WriteContext) -> DataSinkWorker:
-        return _DorisStreamLoadWorker(self._sink, self._schema, self._fields, context)
+        return _DorisStreamLoadWorker(
+            self._sink,
+            self._schema,
+            self._destination_schema,
+            self._fields,
+            context,
+        )
 
 
 class _DorisStreamLoadWorker(DataSinkWorker):
@@ -443,6 +543,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         self,
         sink: DorisStreamLoadSink,
         schema: pa.Schema,
+        destination_schema: pa.Schema,
         fields: tuple[_FieldBinding, ...],
         context: WriteContext,
     ) -> None:
@@ -455,6 +556,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
 
         self._sink = sink
         self._schema = schema
+        self._destination_schema = destination_schema
         self._fields = fields
         self._endpoint_scheme = endpoint_parts.scheme
         self._trusted_hosts = frozenset(trusted_hosts)
@@ -550,23 +652,45 @@ class _DorisStreamLoadWorker(DataSinkWorker):
             chunks.append(pa.ListArray.from_arrays(offsets, values))
         return pa.chunked_array(chunks, type=pa.list_(pa.float32()))
 
+    def _validate_nullability(
+        self,
+        array: pa.Array | pa.ChunkedArray,
+        field: pa.Field,
+        path: str,
+    ) -> None:
+        if not field.nullable and array.null_count:
+            raise ValueError(f"Doris destination field {path!r} is non-nullable but the batch contains null values")
+        if not pa.types.is_list(field.type):
+            return
+        child_field = field.type.value_field
+        chunks = array.chunks if isinstance(array, pa.ChunkedArray) else (array,)
+        for chunk in chunks:
+            self._validate_nullability(pc.list_flatten(chunk), child_field, f"{path}[]")
+
+    def _destination_column(self, column: pa.ChunkedArray, binding: _FieldBinding) -> pa.ChunkedArray:
+        if binding.vector_dimension is not None:
+            column = self._vector_column(column, binding)
+        if column.type != binding.target_type:
+            try:
+                column = pc.cast(column, binding.target_type, safe=True)
+            except pa.ArrowException as error:
+                raise ValueError(
+                    f"Doris source field {binding.source_name!r} cannot be safely cast to destination field "
+                    f"{binding.target_name!r} with Arrow type {binding.target_type}: {error}"
+                ) from error
+        target_field = pa.field(
+            binding.target_name,
+            binding.target_type,
+            nullable=binding.target_nullable,
+        )
+        self._validate_nullability(column, target_field, binding.target_name)
+        return column
+
     def _wire_table(self, table: pa.Table) -> pa.Table:
         arrays: list[pa.ChunkedArray] = []
-        fields: list[pa.Field] = []
         for index, binding in enumerate(self._fields):
-            column = table.column(index)
-            if binding.vector_dimension is not None:
-                column = self._vector_column(column, binding)
-            arrays.append(column)
-            fields.append(
-                pa.field(
-                    binding.target_name,
-                    column.type,
-                    nullable=binding.nullable,
-                )
-            )
-        schema = pa.schema(fields)
-        return pa.Table.from_arrays(arrays, schema=schema)
+            arrays.append(self._destination_column(table.column(index), binding))
+        return pa.Table.from_arrays(arrays, schema=self._destination_schema)
 
     def _arrow_body(self, table: pa.Table) -> pa.Buffer:
         output = pa.BufferOutputStream()

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -35,6 +35,7 @@ from vane.datasink import (
     WriteContext,
     WriteResult,
 )
+from vane.execution._diagnostics import bounded_utf8_text, exception_message_from_args, safe_exception_type_name
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -845,17 +846,6 @@ class _DorisStreamLoadWorker(DataSinkWorker):
             raise RuntimeError("Doris Stream Load returned a non-object JSON response")
         return payload
 
-    def _put(self, label: str, body: pa.Buffer) -> Mapping[str, Any]:
-        headers = self._headers(label, body.size)
-        try:
-            return self._response_payload(self._put_once(headers, body))
-        except Exception as error:
-            raise RuntimeError(
-                f"Doris Stream Load batch label {label!r} did not produce an accepted terminal response: "
-                f"{type(error).__name__}: {error}; "
-                "inspect that label in Doris before retrying with a new label"
-            ) from error
-
     @staticmethod
     def _response_int(payload: Mapping[str, Any], name: str) -> int:
         value = payload.get(name)
@@ -932,8 +922,9 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         wire_table = self._wire_table(table)
         body = self._arrow_body(wire_table)
         label = self._next_label()
-        payload = self._put(label, body)
         try:
+            headers = self._headers(label, body.size)
+            payload = self._response_payload(self._put_once(headers, body))
             return self._applied_result(
                 payload=payload,
                 label=label,
@@ -941,12 +932,21 @@ class _DorisStreamLoadWorker(DataSinkWorker):
                 batch_bytes=batch_bytes,
                 body_size=body.size,
             )
-        except Exception as error:
-            raise RuntimeError(
-                f"Doris Stream Load batch label {label!r} returned a terminal response that Vane "
-                f"could not accept: {type(error).__name__}: {error}; inspect that label before "
-                "submitting new data"
-            ) from error
+        except BaseException as error:
+            message = (
+                f"Doris Stream Load batch label {label!r} did not produce an accepted terminal response; "
+                f"inspect that label in Doris before retrying with a new label: {safe_exception_type_name(error)}"
+            )
+            detail = exception_message_from_args(error)
+            if detail:
+                message = f"{message}: {bounded_utf8_text(detail, 512)}"
+            if isinstance(error, Exception):
+                raise RuntimeError(message) from error
+            # Keep cancellation/interrupt identity and classification. DataSink
+            # diagnostics read args, not exception notes, including after upload
+            # succeeds but response validation is interrupted.
+            BaseException.__setattr__(error, "args", (message,))
+            raise
 
     def abort(self, _error: BaseException) -> None:
         self.close()

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -604,7 +604,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         self._url = f"{endpoint}{self._load_path}"
         self._transport: _AioHttpTransport | None = _open_http_transport(sink.user, password, sink.timeout)
         operation_digest = hashlib.sha256(context.operation_id.encode("utf-8")).hexdigest()[:16]
-        self._label_stem = f"{_LABEL_PREFIX}_{operation_digest}_{uuid.uuid4().hex[:8]}"
+        self._label_stem = f"{_LABEL_PREFIX}_{operation_digest}_{uuid.uuid4().hex}"
         self._batch_number = 0
         self._warning_pending = True
         self._base_metadata = {

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -217,6 +217,34 @@ def _destination_schema(value: object) -> pa.Schema:
     return pa.schema(fields)
 
 
+def _same_input_type(actual: pa.DataType, bound: pa.DataType) -> bool:
+    """Allow worker offset widths to differ without accepting logical type drift."""
+
+    if actual == bound:
+        return True
+    if (pa.types.is_string(actual) or pa.types.is_large_string(actual)) and (
+        pa.types.is_string(bound) or pa.types.is_large_string(bound)
+    ):
+        return True
+    if (pa.types.is_binary(actual) or pa.types.is_large_binary(actual)) and (
+        pa.types.is_binary(bound) or pa.types.is_large_binary(bound)
+    ):
+        return True
+    variable_lists = (pa.types.is_list(actual) or pa.types.is_large_list(actual)) and (
+        pa.types.is_list(bound) or pa.types.is_large_list(bound)
+    )
+    fixed_lists = (
+        pa.types.is_fixed_size_list(actual)
+        and pa.types.is_fixed_size_list(bound)
+        and actual.list_size == bound.list_size
+    )
+    if variable_lists or fixed_lists:
+        if actual.value_field.nullable != bound.value_field.nullable:
+            return False
+        return _same_input_type(actual.value_type, bound.value_type)
+    return False
+
+
 def _canonical_host(host: str) -> str:
     if ":" in host:
         return str(IPv6Address(host))
@@ -364,6 +392,8 @@ class DorisStreamLoadSink(DataSink):
     physical type for each Doris column selected by this sink, in input-column
     order. Every input column is safely cast to that schema before upload;
     overflow and incompatible values fail the batch without an HTTP request.
+    Worker batches may use equivalent 32-bit or 64-bit string, binary, and list
+    offsets; logical input types must otherwise match the bound schema.
     Temporal types are rejected because Doris 4.1.3 does not preserve Arrow's
     timestamp semantics. ``field_mapping`` maps input Arrow field names to
     Doris columns. Unmapped input fields retain their names, and the resulting
@@ -616,8 +646,11 @@ class _DorisStreamLoadWorker(DataSinkWorker):
     def _validate_table(self, table: pa.Table) -> tuple[int, int]:
         if not isinstance(table, pa.Table):
             raise TypeError(f"DorisStreamLoadSink expected pyarrow.Table, got {type(table).__name__}")
+        # Local/Ray workers enable arrow_large_buffer_size independently of the
+        # binding connection. Keep logical types stable, then let the existing
+        # destination safe cast normalize offsets directly to the wire schema.
         if len(table.schema) != len(self._schema) or any(
-            batch_field.name != bound_field.name or batch_field.type != bound_field.type
+            batch_field.name != bound_field.name or not _same_input_type(batch_field.type, bound_field.type)
             for batch_field, bound_field in zip(table.schema, self._schema, strict=True)
         ):
             raise ValueError("Doris Stream Load batch schema does not match the bound input schema")


### PR DESCRIPTION
## Summary

Add `DorisStreamLoadSink` so Vane can write large scalar and vector datasets to Apache Doris 4.1 over HTTP Stream Load while keeping batches in Arrow columnar form.

- Require an explicit destination Arrow schema and safely convert scalar and nested columns before upload. Inferred `int64` values become Doris `INT`'s `int32` physical representation; floating-point narrowing rejects finite values that become infinity while preserving normal rounding.
- Accept equivalent coordinator/worker Arrow offset widths, including nested `large_string` / `large_list` representations, without relaxing logical-type or destination safety checks.
- Validate `ARRAY<FLOAT>` vector dimensions, nulls, and finite values without materializing Python rows. Reject unsupported temporal source and destination types before HTTP.
- Reject compact encoded/view inputs before a worker opens; require explicit upstream conversion/rebatching and explicit stringification for non-string/binary string destinations. Normalize null-parent and sliced-out list children before safe casting.
- Preflight aggregate destination-buffer sizes before casting and measure the complete IPC stream before allocating a fixed-size body. Bound input batches, encoded requests, responses, and HTTP body chunks. Expose concurrent workers and Doris-side load parallelism independently.
- Use internal `aiohttp>=3.14.3` and its [documented `encode_basic_auth()` API](https://docs.aiohttp.org/en/v3.14.3/client_advanced.html#authentication) with `Expect: 100-continue`, configured authentication, and one validated FE-to-BE redirect. Reject endpoint query/fragment delimiters and validate trusted host entries; normalize equivalent IPv6 literal spellings without merging distinct DNS hosts. Disable automatic retries because an interrupted upload can have an unknown commit outcome; worker batches are independent transactions.
- Use the full per-worker UUID in batch labels so large worker counts do not encounter the old 32-bit collision risk, while keeping labels within Doris's 128-character limit.
- Preserve the current batch label in interruption diagnostics while retaining cancellation identity and no-retry classification, including interruptions after upload during response validation.
- Add the `doris` package extra, usage documentation, and a required integration job using the digest-pinned official Doris 4.1.3 image. The live test exercises `local-fast`, `local`, and `ray` using a distributable SQL source, round-trips int64 input IDs, strings, and variable-length vectors through an FE redirect, and verifies temporal input leaves a real `DATETIME` table empty.

## Related issue

N/A

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

README uses a distributable SQL example and covers input requirements, destination types, plain input representations, explicit async-caller offloading, worker Arrow representations, vector validation, numeric conversions, temporal rejection, memory limits, concurrency, redirect trust, transaction scope, and unknown outcomes. The sink targets Doris 4.1 Arrow Stream Load; no compatibility or fallback path is included.

## Validation

- Two consecutive clean local reviews after the final conversion, list-normalization, and test/documentation changes.
- `scripts/format root --changed` and all applicable pre-commit checks for the changed files.
- Non-editable Release package installation using the existing incremental build directory; the installed Doris module's SHA-256 matches the updated implementation in the checkout.
- `scripts/run_installed_pytest.sh tests/fast/test_doris_datasink.py tests/fast/test_datasink.py tests/fast/test_package_metadata.py tests/fast/test_expression_udf_map.py::test_vane_function_supports_multiple_and_nested_scalar_udfs -m 'not external_service and not real_ray' -q -q` — 317 passed. The previous CI scalar-UDF timeout was not reproduced; no UDF implementation was changed.
- `scripts/run_installed_pytest.sh tests/fast/test_doris_datasink.py tests/fast/test_datasink.py tests/fast/test_package_metadata.py -m 'not external_service and real_ray' -q -q` — 5 passed. External Doris cases are excluded from these local runs.
- `PYTEST_ADDOPTS="-q -q" scripts/run_release_tests.sh` — 1023 passed in the non-Ray process and 18 passed in the real-Ray process.
- [Required CI](https://github.com/AstroVela/vane/actions/runs/34025084369), including the real Doris integration job and all native/fast-test matrices, is not yet complete on `81a71fd53b`.
- GitHub `@codex review`: two consecutive clean rounds on the unchanged `81a71fd53b` head — [round 1](https://github.com/AstroVela/vane/pull/753#issuecomment-5558403550), [round 2](https://github.com/AstroVela/vane/pull/753#issuecomment-5558433458). Both reported no major issues; no unresolved review threads remain.

Public-API HTTP regressions independently exercise string and variable-length vector inputs on all three runners with two sink workers, 513 rows, and 64-row batches. Every uploaded IPC schema and exact row content is checked for omissions/duplicates. The live Doris cases use two sink workers and one-row batches, then read the committed scalar/vector values from Doris. The same live SQL input builder is also exercised through a real HTTP server on all three runners, without requiring an external service.

Additional regression coverage includes equivalent nested/sliced/chunked worker representations, strict logical-type checks, positive/negative floating-point overflow, regular/large/fixed-size/nested lists, encoded/view rejection, normal rounding near the float32 limit, existing nonfinite values, and hidden values beneath null/sliced lists. Invalid batches issue zero HTTP requests. URL regressions cover empty endpoint query/fragment delimiters (including EnvironmentSecret resolution), IPv6 trust matching, duplicate/invalid host entries, and refusal to forward an upload to an untrusted host.

Cancellation regressions cover four interruption types across upload, redirected upload, and response validation; current-vs-completed batch labels; bounded diagnostics without invoking exception formatting; async-body cancellation; and the public UNKNOWN error boundary with an injected retry budget. Cancellation preserves the exact exception and batch label, suppresses replay, and closes worker resources.

Worker-label regressions force two UUIDs to share their first 31 hex digits, then verify distinct same-operation batch labels with both initial and near-64-bit-limit counters. HTTP headers and result metadata retain the full UUID and stay within Doris's allowed label alphabet and length.

New allocation regressions reject a 1 MiB dictionary value referenced by one million rows before decoding, verify aggregate scalar/nested/multi-column conversion budgets, account for empty nested-list buffers and IPC metadata, and check exact-limit/one-byte-over-limit request allocation. Integer hidden-child regressions cover null, sliced, chunked, nested, regular/large/fixed-size lists.

Real-HTTP async-caller regressions pass for direct `local-fast`/`local` calls and explicit `asyncio.to_thread()` offloading on all three runners, including real Ray. Ray's existing driver deliberately rejects blocking calls on an event-loop thread; no transport thread or automatic fallback is added. The prior Python 3.10 CI failure was an over-strict async-task exception-identity assertion; the test now checks cancellation type, label, single upload, and cleanup without interpreter-version branches.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
