### PR TITLE
[feat](file) Add independent native image, audio, and video extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
             curl \
             flex \
             libtool \
+            nasm \
             ninja-build \
             openssl \
             pkg-config \
@@ -153,6 +154,12 @@ jobs:
 
       - name: Install pinned native dependencies
         run: bash scripts/bootstrap_vcpkg.sh
+
+      - name: Install optional native codec dependencies
+        if: matrix.python-version == '3.12'
+        run: |
+          "$VCPKG_ROOT/vcpkg" install --triplet=x64-linux \
+            --x-feature=native-image --x-feature=native-audio --x-feature=native-video
 
       - name: Install Python build and test dependencies
         run: |
@@ -189,7 +196,7 @@ jobs:
         env:
           SKBUILD_BUILD_DIR: ${{ github.workspace }}/build
           SKBUILD_CMAKE_BUILD_TYPE: Release
-          CMAKE_ARGS: -DVANE_ENABLE_TEST_EXTENSION_SIGNING_KEY=${{ matrix.python-version == '3.12' && 'ON' || 'OFF' }}
+          CMAKE_ARGS: -DVANE_ENABLE_TEST_EXTENSION_SIGNING_KEY=${{ matrix.python-version == '3.12' && 'ON' || 'OFF' }} ${{ matrix.python-version == '3.12' && '-DVANE_LOADABLE_EXTENSIONS=image;audio;video' || '' }}
         run: python -m build --sdist --wheel --no-isolation --outdir dist
 
       - name: Validate release artifacts
@@ -256,6 +263,39 @@ jobs:
               --scan-contents-only \
               --content-rules-manifest - \
               "${extension_wheels[0]}"
+
+      - name: Exercise native image, audio, and video extensions
+        if: matrix.python-version == '3.12'
+        env:
+          VANE_TEST_NATIVE_IMAGE_EXTENSION: ${{ github.workspace }}/build/vane_extensions/image.duckdb_extension
+          VANE_TEST_NATIVE_AUDIO_EXTENSION: ${{ github.workspace }}/build/vane_extensions/audio.duckdb_extension
+          VANE_TEST_NATIVE_VIDEO_EXTENSION: ${{ github.workspace }}/build/vane_extensions/video.duckdb_extension
+          VANE_TEST_NATIVE_MEDIA_PROVIDERS: "1"
+        run: |
+          python -m pip install "av>=17.1,<18" "pillow>=11" "soundfile>=0.14" "soxr>=1,<2"
+          cmake --build build --target vane_loadable_extensions --parallel 2
+          platform_tag="$(python -I -c 'from packaging.tags import sys_tags; print(next(tag.platform for tag in sys_tags() if tag.platform.startswith("manylinux_")))')"
+          python scripts/sync_vcpkg_licenses.py \
+            --output "$RUNNER_TEMP/native-extension-notices.txt"
+          for domain in image audio video; do
+            python scripts/sign_test_dynamic_extension.py \
+              --private-key external/duckdb/test/mbedtls/private.pem \
+              "build/vane_extensions/$domain.duckdb_extension" \
+              "$RUNNER_TEMP/native-media/$domain.duckdb_extension"
+            python -I scripts/build_extension_wheel.py \
+              --artifact "$RUNNER_TEMP/native-media/$domain.duckdb_extension" \
+              --extension-name "$domain" \
+              --output-directory "$RUNNER_TEMP/native-media/wheels" \
+              --platform-tag "$platform_tag" \
+              --trust-identity vane-ci-test-key \
+              --license-expression "Apache-2.0 AND MIT AND LGPL-2.1-or-later AND Zlib" \
+              --license-file LICENSE --license-file NOTICE \
+              --license-file external/duckdb/LICENSE \
+              --license-file "$RUNNER_TEMP/native-extension-notices.txt"
+          done
+          python -m pip install "$RUNNER_TEMP"/native-media/wheels/*.whl
+          scripts/run_installed_pytest.sh tests/fast/test_native_media_extensions.py
+          scripts/run_installed_pytest.sh tests/fast/test_ray_native_media_extensions.py
 
       - name: Verify the installed native namespace typing contract
         if: matrix.python-version == '3.10'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,6 +71,9 @@ artifact self-contained and preserves Vane's private `_native` symbol boundary.
 The staging directory is configurable with
 `VANE_LOADABLE_EXTENSION_OUTPUT_DIRECTORY`.
 
+For the independently selectable image, audio, and video operators, see
+[NATIVE_MEDIA_EXTENSIONS.md](NATIVE_MEDIA_EXTENSIONS.md).
+
 ## Building an optional extension wheel
 
 The base `vane-ai` wheel must stay free of optional `.duckdb_extension`

--- a/NATIVE_MEDIA_EXTENSIONS.md
+++ b/NATIVE_MEDIA_EXTENSIONS.md
@@ -76,7 +76,9 @@ native demuxer and accepted MIME family.
   names. An exact frame count is returned only where PCM duration establishes
   it; otherwise it is NULL. Resampling uses libswresample and returns the
   existing STRUCT of interleaved Float64 samples, rate, frames, and channels.
-  Supported rates are 1..384000 Hz and channel counts are 1..64. This is
+  It uses the pinned libswresample defaults, while Python uses SoXR HQ;
+  their quality settings and numerical outputs are different. Supported rates
+  are 1..384000 Hz and channel counts are 1..64. This is
   distinct from the proposed Tensor-returning `resample` API in #755.
 * Video supports MP4/MOV, Matroska/WebM, AVI, MPEG-TS, MPEG, and Ogg containers with
   decoders in the pinned build. Metadata preserves unknown values as NULL.
@@ -191,3 +193,5 @@ operations, inputs, rows, threads, repetitions, and the loaded artifact.
 The harness records wall and process CPU times. Run `--backend python` and
 `--backend native` in separate processes to compare peak RSS; the peak includes
 imports, extension loading, and warmups and is not reset between repetitions.
+The [measured workloads and reproduction guide](benchmarking/native_media/README.md)
+include improvements and regressions; native execution is not uniformly faster.

--- a/NATIVE_MEDIA_EXTENSIONS.md
+++ b/NATIVE_MEDIA_EXTENSIONS.md
@@ -92,16 +92,18 @@ Aliases for supported containers are normalized, including `image/x-png`,
   distinct from the proposed Tensor-returning `resample` API in #755.
 * Video supports MP4/MOV, Matroska/WebM, AVI, MPEG-TS, MPEG, and Ogg containers with
   decoders in the pinned build. Metadata preserves unknown values as NULL.
-  The existing VideoFrameSource retains its RGB Tensor result schema. Its
+  Native VideoFrameSource returns RGB IMAGE values in its `frame` column.
+  Pixel buffers grow with the actual emitted frames. Python VideoFrameSource
+  tasks retain their RGB Tensor schema; `source.schema` describes those Python
+  tasks, while the bound native relation exposes IMAGE. The native source's
   source association, zero-based frame index, PTS/DTS, duration, time base,
   and keyframe flag come from the selected stream and decoded frames.
   Times are relative to stream start when known, otherwise zero. Windows
   include both endpoints. Timestamp discontinuities reset sampling targets.
   Sampling tolerates a few DOUBLE rounding units at a threshold.
 
-The video extension also registers the lower-level `native_video_frames`
-table function, with the same positional scan parameters as
-`native_video_tensor_frames`, but IMAGE output in its `frame` column. The
+The video extension registers the `native_video_frames` table function used
+by native VideoFrameSource, with IMAGE output in its `frame` column. The
 video extension can produce IMAGE without loading the image extension.
 These are extension execution entry points; the public convenience API is
 still VideoFrameSource.
@@ -125,8 +127,10 @@ filesystems before their I/O callback. Native operators preserve this restrictio
 including under `on_error='null'` or `'skip'`.
 
 Metadata probes have byte budgets (image: 1 MiB default; audio/video: 8 MiB;
-maximum: 64 MiB). FFmpeg probes additionally have a 30-second cooperative
-deadline. Decoding checks input-view size, cumulative reads, dimensions,
+maximum: 64 MiB) and a 30-second cooperative deadline. JPEG marker scanning
+shares 64 KiB read buffers within the FILE view and charges all fetched bytes
+to the budget; PNG metadata retains exact small header reads.
+Decoding checks input-view size, cumulative reads, dimensions,
 decoded frames/samples, and output sizes. Cumulative codec reads are limited
 to four times the configured input limit to account for probing and seeking.
 Image/audio input limits may be set up to 4 GiB; video up to 16 GiB. The
@@ -142,9 +146,9 @@ files can be decoded on separate threads or Workers. `read_task_count` selects
 balanced groups of files for local tasks and Ray splits, capped at the number
 of files; files within each group are processed sequentially. Its default
 creates one group per file. A global frame limit uses one ordered work unit
-regardless of `read_task_count`. Tensor output retains DuckDB's existing fixed
-ARRAY vector reservations; the scan's payload budget is not a bound on those
-engine reservations or total process RSS. Codec contexts, reference frames,
+regardless of `read_task_count`. Native IMAGE output avoids fixed ARRAY pixel
+reservations for unused vector rows, including empty scans. The payload budget
+does not bound total process RSS. Codec contexts, reference frames,
 conversion buffers, and downstream query state also consume memory.
 
 Native `max_partition_bytes` is a hard payload limit, including each row's

--- a/NATIVE_MEDIA_EXTENSIONS.md
+++ b/NATIVE_MEDIA_EXTENSIONS.md
@@ -45,6 +45,10 @@ back to `python` to select Python for newly bound queries. Python File value
 methods such as `ImageFile.decode()` and `VideoFile.frames()` continue to use
 their Python implementations; these SQL/connection settings govern SQL,
 expressions, and the connection-bound video source.
+Native video dispatch accepts the exact built-in VideoFrameSource. Selecting
+native for a subclass raises an error before reading its files or executing
+its custom tasks. Select Python explicitly when using a subclass's task/schema
+contract.
 
 The binder names native scalar functions explicitly in the plan. `EXPLAIN`
 shows `native_image_file_metadata`, `native_decode_image_file`,
@@ -67,6 +71,9 @@ native demuxer and accepted MIME family.
 Absent content types, `application/octet-stream`, and `binary/octet-stream`
 allow format detection. A matching domain wildcard (`image/*`, `audio/*`,
 or `video/*`) also permits the detected format; a different domain is rejected.
+Aliases for supported containers are normalized, including `image/x-png`,
+`audio/mp3`, `audio/x-mp3`, `audio/aif`, `video/avi`, `video/mkv`, and
+`video/x-m4v`. `application/ogg` accepts either an audio or video Ogg stream.
 
 * Image supports encoded PNG and JPEG. Metadata reads headers without pixel
   decoding. Decode returns the native IMAGE type with 8-bit `L`, `LA`, `RGB`,
@@ -139,6 +146,13 @@ regardless of `read_task_count`. Tensor output retains DuckDB's existing fixed
 ARRAY vector reservations; the scan's payload budget is not a bound on those
 engine reservations or total process RSS. Codec contexts, reference frames,
 conversion buffers, and downstream query state also consume memory.
+
+Native `max_partition_bytes` is a hard payload limit, including each row's
+FILE/provenance fields. Binding rejects a single row that exceeds it. This
+intentionally differs from Python's soft batch target; backend compatibility
+is not part of the native contract. Audio/video metadata `max_bytes` controls
+both the callback read budget and FFmpeg's format/stream probe size, up to
+64 MiB. Decode operations retain their separate 8 MiB probing limit.
 
 Cancellation is checked around I/O, packet/frame decoding, resampling, and
 pixel conversion. Codec calls are cooperative boundaries, not preemptively

--- a/NATIVE_MEDIA_EXTENSIONS.md
+++ b/NATIVE_MEDIA_EXTENSIONS.md
@@ -1,0 +1,193 @@
+# Native image, audio, and video extensions
+
+Vane provides three optional DuckDB C++ extensions: `image`, `audio`, and
+`video`. Each is a separate `.duckdb_extension` artifact and can be installed,
+loaded, and selected independently. The base runtime continues to provide
+FILE, its media subtypes, IMAGE, Tensor, FILE field access/comparison, and
+governed I/O. Loading an extension does not change those types or enable its
+backend automatically.
+
+| Extension | Setting | Native operations |
+| --- | --- | --- |
+| `image` | `image_backend` | `image_file_metadata`, `decode_image_file` |
+| `audio` | `audio_backend` | `audio_metadata`, `audio_resample` |
+| `video` | `video_backend` | `video_metadata`, `VideoFrameSource` scanning |
+
+IMAGE pixel operators belong to the image extension's domain; this change
+implements the encoded-file operations listed above. The future public video
+frame expressions and `read_video_frames` API remain tracked in #756.
+
+## Select a backend
+
+Install matching extension provider wheels using the existing optional-wheel
+workflow in [DEVELOPMENT.md](DEVELOPMENT.md), then load the desired provider:
+
+```python
+import vane
+
+con = vane.connect()
+vane.load_installed_extension("image", connection=con)
+con.execute("SET image_backend = 'native'")
+con.sql("SELECT image_file_metadata(image_file('photo.png'))").show()
+```
+
+A locally installed DuckDB artifact can also be loaded with `LOAD image`.
+Artifact names alone do not select a repository or download an unpublished
+Vane extension. Distributed jobs use installed, trusted provider wheels as
+described in [DISTRIBUTED_EXTENSIONS.md](DISTRIBUTED_EXTENSIONS.md).
+
+All three settings default to `python` and accept only `python` or `native`.
+They are also accepted by `vane.connect(config={"image_backend": "native"})`
+and the equivalent configuration for the other domains.
+A native request without its matching loaded extension fails while binding,
+before FILE I/O. There is no automatic fallback. Set the corresponding option
+back to `python` to select Python for newly bound queries. Python File value
+methods such as `ImageFile.decode()` and `VideoFile.frames()` continue to use
+their Python implementations; these SQL/connection settings govern SQL,
+expressions, and the connection-bound video source.
+
+The binder names native scalar functions explicitly in the plan. `EXPLAIN`
+shows `native_image_file_metadata`, `native_decode_image_file`,
+`native_audio_metadata`, `native_audio_resample`, or `native_video_metadata`.
+Native video sources show `NATIVE_VIDEO_TENSOR_FRAMES`. Inspect the selected
+setting with `current_setting('image_backend')`, and loaded artifacts with
+`duckdb_extensions()`. Backend selection occurs when an expression is bound;
+reusable prepared statements retain their bound implementation until rebound.
+Lazy relations may be bound again when executed, and use the setting at that
+binding. Set options before constructing and executing the query.
+
+## Native contracts
+
+The extensions call FFmpeg C libraries directly. Native media execution does
+not import Pillow, soundfile, soxr, or PyAV. Python result conversion and an
+explicitly registered Python filesystem remain separate boundaries. No
+cross-backend bitwise/numerical compatibility is promised. MIME validation
+uses container families: MP4/MOV and Matroska/WebM respectively share a
+native demuxer and accepted MIME family.
+
+* Image supports encoded PNG and JPEG. Metadata reads headers without pixel
+  decoding. Decode returns the native IMAGE type with 8-bit `L`, `LA`, `RGB`,
+  or `RGBA` pixels. With no mode, palette and alpha-bearing decoded formats use RGBA,
+  8-bit grayscale uses L, and other formats use RGB. PNG metadata may report
+  P or I;16 even though decoded output uses these 8-bit modes. Unsupported
+  formats and MIME mismatches follow `on_error='raise'|'null'`.
+* Audio supports WAV, AIFF, FLAC, MP3, AAC, Ogg, MP4, and WebM containers with
+  decoders in the pinned FFmpeg build. Metadata reports FFmpeg format/codec
+  names. An exact frame count is returned only where PCM duration establishes
+  it; otherwise it is NULL. Resampling uses libswresample and returns the
+  existing STRUCT of interleaved Float64 samples, rate, frames, and channels.
+  Supported rates are 1..384000 Hz and channel counts are 1..64. This is
+  distinct from the proposed Tensor-returning `resample` API in #755.
+* Video supports MP4/MOV, Matroska/WebM, AVI, MPEG-TS, MPEG, and Ogg containers with
+  decoders in the pinned build. Metadata preserves unknown values as NULL.
+  The existing VideoFrameSource retains its RGB Tensor result schema. Its
+  source association, zero-based frame index, PTS/DTS, duration, time base,
+  and keyframe flag come from the selected stream and decoded frames.
+  Times are relative to stream start when known, otherwise zero. Windows
+  include both endpoints. Timestamp discontinuities reset sampling targets.
+  Sampling tolerates a few DOUBLE rounding units at a threshold.
+
+The video extension also registers the lower-level `native_video_frames`
+table function, with the same positional scan parameters as
+`native_video_tensor_frames`, but IMAGE output in its `frame` column. The
+video extension can produce IMAGE without loading the image extension.
+These are extension execution entry points; the public convenience API is
+still VideoFrameSource.
+
+Exact global frame indices currently require decoding from the beginning of
+the stream, including for late time windows. This implementation does not
+claim indexed seek acceleration; #714 owns that work. It does not materialize
+non-seekable inputs to temporary files. Unsupported random access propagates
+through the existing FILE reader.
+
+## I/O and resource bounds
+
+All codecs read through the executing query's ResolvedFile. Codec libraries
+receive a logical byte stream, never the original URL. The existing FILE
+resolver enforces position/size and selects the filesystem and Secret scope
+on the executing Worker. Container-triggered external resource opens are
+rejected. Native extensions add no credential fields or credential replay
+mechanism.
+The current resolver requires nonblocking opens and rejects registered Python
+filesystems before their I/O callback. Native operators preserve this restriction,
+including under `on_error='null'` or `'skip'`.
+
+Metadata probes have byte budgets (image: 1 MiB default; audio/video: 8 MiB;
+maximum: 64 MiB). FFmpeg probes additionally have a 30-second cooperative
+deadline. Decoding checks input-view size, cumulative reads, dimensions,
+decoded frames/samples, and output sizes. Cumulative codec reads are limited
+to four times the configured input limit to account for probing and seeking.
+Image/audio input limits may be set up to 4 GiB; video up to 16 GiB. The
+hard pixel ceiling is 100 million, and decoded frame accounting allows at
+most 512 MiB (audio decoder frames: 64 MiB). Decoder plane accounting includes alignment and is
+conservative and can reject an image before its smaller converted output
+would reach the output limit.
+
+Image/audio output is bounded to 256 MiB per engine batch. Audio vector growth
+may temporarily retain old and new buffers, up to 512 MiB in total. Video
+emits bounded batches including FILE/provenance payload; source metadata is capped at 64 MiB and 100,000 FILE views. Frames from different
+files can be decoded on separate threads or Workers. A global frame limit
+uses one ordered work unit. Tensor output retains DuckDB's existing fixed
+ARRAY vector reservations; the scan's payload budget is not a bound on those
+engine reservations or total process RSS. Codec contexts, reference frames,
+conversion buffers, and downstream query state also consume memory.
+
+Cancellation is checked around I/O, packet/frame decoding, resampling, and
+pixel conversion. Codec calls are cooperative boundaries, not preemptively
+interruptible inside an individual codec call. `on_error` suppresses only
+encoded-format failures. I/O, resource limits, allocation failures, and
+cancellation propagate. Failed pixel allocations remain charged to the batch
+budget even when their row is suppressed.
+
+## Build and package
+
+Base dependency/bootstrap and base wheel commands remain unchanged. Select
+optional manifest features after bootstrapping the base dependencies. FFmpeg
+also requires NASM on x86 (for example, the `nasm` package on Ubuntu):
+
+```bash
+"$VCPKG_ROOT/vcpkg" install --triplet=x64-linux \
+  --x-feature=native-image --x-feature=native-audio --x-feature=native-video
+export SKBUILD_BUILD_DIR="$PWD/build/python-release"
+export SKBUILD_CMAKE_BUILD_TYPE=Release
+uv pip install . --no-build-isolation \
+  '-Ccmake.define.VANE_LOADABLE_EXTENSIONS=image;audio;video'
+cmake --build "$SKBUILD_BUILD_DIR" --target vane_loadable_extensions
+```
+
+Select only the manifest feature and loadable target needed for a single
+domain. Common FILE/AVIO implementation is linked internally; it is not a
+fourth loadable extension. Optional artifacts stay outside the base wheel.
+Use `scripts/build_extension_wheel.py` separately for each staged artifact.
+The pinned vcpkg feature set disables FFmpeg default features and does not
+select GPL, version3, or nonfree codecs. FFmpeg is [LGPL-2.1-or-later](https://ffmpeg.org/legal.html); zlib is
+Zlib; DuckDB and extension sources are MIT. Package their copyright records,
+Vane's LICENSE/NOTICE, and any transitive linked dependency notices explicitly.
+The base license bundle must not be regenerated from an install tree that has
+optional codecs merely because they are present there. For extension packages,
+`scripts/sync_vcpkg_licenses.py --output <extension-notices.txt>` can generate
+a separate complete installed-dependency notice bundle.
+
+Static FFmpeg redistribution also requires corresponding source and a means
+to relink the application with a modified FFmpeg, in addition to notices.
+Extension release artifacts must include that source/build and relinking
+material; this source PR does not publish binary wheels. Use the pinned vcpkg
+baseline and recorded build configuration to reproduce codec inputs.
+
+## Verify and measure
+
+```bash
+export VANE_TEST_NATIVE_IMAGE_EXTENSION="$SKBUILD_BUILD_DIR/vane_extensions/image.duckdb_extension"
+export VANE_TEST_NATIVE_AUDIO_EXTENSION="$SKBUILD_BUILD_DIR/vane_extensions/audio.duckdb_extension"
+export VANE_TEST_NATIVE_VIDEO_EXTENSION="$SKBUILD_BUILD_DIR/vane_extensions/video.duckdb_extension"
+scripts/run_installed_pytest.sh tests/fast/test_native_media_extensions.py
+```
+
+The local artifact tests permit unsigned development artifacts on their own
+connections. Distributed tests require signed installed providers and the
+normal signature policy. Run `scripts/benchmark_native_media.py` from an
+installed environment for repeatable Python/native timings; results identify
+operations, inputs, rows, threads, repetitions, and the loaded artifact.
+The harness records wall and process CPU times. Run `--backend python` and
+`--backend native` in separate processes to compare peak RSS; the peak includes
+imports, extension loading, and warmups and is not reset between repetitions.

--- a/NATIVE_MEDIA_EXTENSIONS.md
+++ b/NATIVE_MEDIA_EXTENSIONS.md
@@ -64,6 +64,9 @@ explicitly registered Python filesystem remain separate boundaries. No
 cross-backend bitwise/numerical compatibility is promised. MIME validation
 uses container families: MP4/MOV and Matroska/WebM respectively share a
 native demuxer and accepted MIME family.
+Absent content types, `application/octet-stream`, and `binary/octet-stream`
+allow format detection. A matching domain wildcard (`image/*`, `audio/*`,
+or `video/*`) also permits the detected format; a different domain is rejected.
 
 * Image supports encoded PNG and JPEG. Metadata reads headers without pixel
   decoding. Decode returns the native IMAGE type with 8-bit `L`, `LA`, `RGB`,
@@ -128,8 +131,11 @@ would reach the output limit.
 Image/audio output is bounded to 256 MiB per engine batch. Audio vector growth
 may temporarily retain old and new buffers, up to 512 MiB in total. Video
 emits bounded batches including FILE/provenance payload; source metadata is capped at 64 MiB and 100,000 FILE views. Frames from different
-files can be decoded on separate threads or Workers. A global frame limit
-uses one ordered work unit. Tensor output retains DuckDB's existing fixed
+files can be decoded on separate threads or Workers. `read_task_count` selects
+balanced groups of files for local tasks and Ray splits, capped at the number
+of files; files within each group are processed sequentially. Its default
+creates one group per file. A global frame limit uses one ordered work unit
+regardless of `read_task_count`. Tensor output retains DuckDB's existing fixed
 ARRAY vector reservations; the scan's payload budget is not a bound on those
 engine reservations or total process RSS. Codec contexts, reference frames,
 conversion buffers, and downstream query state also consume memory.

--- a/NATIVE_MEDIA_EXTENSIONS.md
+++ b/NATIVE_MEDIA_EXTENSIONS.md
@@ -53,7 +53,7 @@ contract.
 The binder names native scalar functions explicitly in the plan. `EXPLAIN`
 shows `native_image_file_metadata`, `native_decode_image_file`,
 `native_audio_metadata`, `native_audio_resample`, or `native_video_metadata`.
-Native video sources show `NATIVE_VIDEO_TENSOR_FRAMES`. Inspect the selected
+Native video sources show `NATIVE_VIDEO_FRAMES`. Inspect the selected
 setting with `current_setting('image_backend')`, and loaded artifacts with
 `duckdb_extensions()`. Backend selection occurs when an expression is bound;
 reusable prepared statements retain their bound implementation until rebound.

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -47,3 +47,14 @@ separately. Their own distributions govern their licenses.
 ## Release rule
 
 Do not publish an sdist or wheel unless `scripts/check_release_artifacts.py` succeeds. A release reviewer must also inspect the exact source and binary contents because an automated inventory cannot determine license compatibility by itself.
+
+## Optional native image, audio, and video extensions
+
+The optional extensions use FFmpeg under LGPL-2.1-or-later and zlib under the
+Zlib license. Their codec dependencies are selected by the `native-image`,
+`native-audio`, and `native-video` vcpkg manifest features, at the repository's
+pinned vcpkg baseline. They are not linked into the base Vane native module.
+These features do not enable FFmpeg's GPL, version3, or nonfree components.
+See [NATIVE_MEDIA_EXTENSIONS.md](NATIVE_MEDIA_EXTENSIONS.md) for artifact
+packaging, notices, and corresponding-source/relinking requirements, and
+[FFmpeg's license documentation](https://ffmpeg.org/legal.html) for its terms.

--- a/benchmarking/native_media/README.md
+++ b/benchmarking/native_media/README.md
@@ -1,0 +1,137 @@
+# Native extension measurements
+
+These measurements compare explicitly selected Python and native backends at
+`f7ee0fa475e21c2df48adbc2298a607714e5d349`, on 2026-09-05. They measure complete
+local queries over repeated references to synthetic files. They do not isolate
+interpreter overhead from codec algorithms, copying, or I/O behavior.
+
+## Environment and method
+
+- Intel Xeon E5-2686 v4, 18 physical cores / 36 logical CPUs, approximately
+  62.7 GiB RAM; Linux 6.17.0, glibc 2.39; local NVMe/ext4 files.
+- Release build, Vane 0.2.0.dev622, DuckDB `v1.5.5-vane.f7ee0fa475`, engine
+  SourceID prefix `bf78c89787`. Each domain is loaded from its independently
+  packaged, test-signed artifact before timing. The Python measurements also
+  load the artifact, keeping connection setup consistent.
+- Python 3.12.3, NumPy 2.5.2, Pillow 12.3.0, soundfile 0.14.0
+  (libsndfile 1.2.2), soxr 1.1.0 (libsoxr 0.1.3-14-ga66f3ee), PyAV 17.1.0.
+  Native extensions use pinned vcpkg FFmpeg 8.1.1#2. PyAV reports libavcodec
+  62.28.101, libavformat 62.12.101, and libswscale 9.5.101.
+- `local-fast` runner, one DuckDB thread unless specified; one warmup per
+  backend, then five repetitions alternating backend order. Reported wall and
+  process CPU times are medians. Input generation, imports, extension loading,
+  and the input table setup are outside the timed region; query binding and
+  execution are included. All runs use warm caches on a shared host without
+  CPU pinning, so small differences should not be treated as significant.
+- Peak RSS comes from additional fresh processes selecting only one backend.
+  It includes imports, extension loading, warmups, and all five repetitions,
+  and is sampled before hashing the files. It is not per-query allocation.
+- PNG output is RGB at source resolution. WAV inputs are stereo PCM16;
+  resampling requests interleaved Float64 at 16 kHz. Python uses SoXR HQ;
+  native uses the pinned libswresample defaults. These quality settings are
+  different, so the audio comparison does not establish equivalent fidelity.
+- MPEG-4 inputs have 30 fps, GOP size 15, and up to two B-frames. Frame output
+  is RGB Tensor at 160 by 90. Native resizing uses bilinear libswscale;
+  Python uses PyAV's default reformatter. Frame counts and sums of global
+  frame indices match for these inputs; pixel equality is not required.
+- Image decode queries aggregate byte lengths; audio resampling queries
+  aggregate frame counts; metadata queries aggregate widths or sample rates;
+  video sources aggregate frame counts and indices. Results stay
+  inside the engine until the aggregate is fetched. No decoded file export or
+  network source is measured. Read-byte counts, temporary storage, remote
+  latency, cancellation latency, and Ray scaling were not instrumented by
+  this benchmark; those measurements remain part of #764.
+
+## Reproduce
+
+Use the installed environment and extension build procedure in
+[NATIVE_MEDIA_EXTENSIONS.md](../../NATIVE_MEDIA_EXTENSIONS.md). Generate the
+inputs outside the checkout; no generated media is committed:
+
+```bash
+python -I benchmarking/native_media/generate_inputs.py /tmp/vane-media-inputs
+python -I scripts/benchmark_native_media.py image_decode \
+  /tmp/vane-media-inputs/image-large.png \
+  --extension build/python-release/vane_extensions/image.duckdb_extension \
+  --rows 8 --repetitions 5 --threads 1 \
+  --allow-unsigned-development-artifact
+```
+
+Repeat for each operation/input/row count below and its corresponding domain
+artifact. Omit the unsigned-development flag when using a signed artifact
+accepted by the runtime. The default `--backend both` alternates timings;
+run `--backend python` and `--backend native` in separate processes for the
+RSS comparison. Repeat the large-input cases with `--threads 4` for the
+second table. The benchmark emits JSON containing all samples, medians,
+aggregate results, versions, and input/artifact SHA-256 identities. Codec
+version changes can change generated file hashes, particularly for MP4.
+
+## Observations
+
+Small-file workloads improve in these runs. Native PNG metadata reads a
+smaller part of the file than the Python path, so its large-input gain cannot
+be attributed solely to removing Python calls. Larger image decoding improves
+by about 1.5 times. Larger audio resampling takes about 3.76 times as long
+with the native backend, and native image/audio decoding has higher process
+peak RSS here. These regressions are part of the result.
+
+With two larger video sources, four configured threads reduce native wall
+time from 239 ms to 152 ms; the Python path increases from 257 ms to 307 ms.
+The scalar workloads have too few rows to establish parallel scaling and
+show no consistent benefit from four threads. This is not a saturation study.
+
+A separate late video window (`--start-time 1.5 --end-time 1.9`, two larger
+files, one thread) returns 26 frames with an index sum of 1326 for each
+backend: Python 171.94 ms, native 157.38 ms. Native scanning still decodes
+from the beginning to retain exact global indices; this result does not
+demonstrate indexed seek acceleration.
+
+## Measurements
+
+Wall and CPU columns show milliseconds per query; RSS shows MiB. The
+ratio is Python wall time divided by native wall time (greater than one
+means native was faster in that run).
+
+| Operation | Input | Rows | Wall Python / native | Ratio | CPU Python / native | Peak RSS Python / native |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `image_metadata` | small | 1000 | 108.16 / 15.98 | 6.77 | 108.15 / 15.99 | 234.4 / 232.8 |
+| `image_metadata` | large | 100 | 137.85 / 2.22 | 62.22 | 137.84 / 2.22 | 234.3 / 234.0 |
+| `image_decode` | small | 100 | 31.61 / 18.42 | 1.72 | 31.62 / 18.43 | 232.6 / 247.2 |
+| `image_decode` | large | 8 | 169.09 / 113.05 | 1.50 | 169.04 / 112.74 | 265.1 / 275.1 |
+| `audio_metadata` | small | 100 | 17.74 / 12.29 | 1.44 | 17.74 / 12.30 | 229.3 / 240.0 |
+| `audio_metadata` | large | 100 | 19.26 / 16.45 | 1.17 | 19.27 / 16.45 | 232.1 / 240.0 |
+| `audio_resample` | small | 100 | 64.55 / 39.51 | 1.63 | 64.56 / 39.51 | 237.5 / 247.5 |
+| `audio_resample` | large | 4 | 35.07 / 131.73 | 0.27 | 35.08 / 131.68 | 243.3 / 253.7 |
+| `video_metadata` | small | 100 | 51.61 / 27.51 | 1.88 | 51.62 / 27.52 | 251.5 / 239.9 |
+| `video_metadata` | large | 20 | 16.81 / 9.55 | 1.76 | 16.82 / 9.56 | 251.2 / 241.2 |
+| `video_frames` | small | 10 | 62.16 / 21.05 | 2.95 | 62.15 / 21.06 | 266.9 / 251.7 |
+| `video_frames` | large | 2 | 256.82 / 239.04 | 1.07 | 256.76 / 239.04 | 275.8 / 261.0 |
+
+Four configured threads, same large inputs and row counts:
+
+| Operation | Python wall ms | Native wall ms |
+| --- | ---: | ---: |
+| `image_metadata` | 125.82 | 2.18 |
+| `image_decode` | 171.00 | 115.00 |
+| `audio_metadata` | 19.89 | 16.71 |
+| `audio_resample` | 35.23 | 131.91 |
+| `video_metadata` | 16.13 | 9.43 |
+| `video_frames` | 307.04 | 152.12 |
+
+## Input identities
+
+| File | Definition | Bytes | SHA-256 |
+| --- | --- | ---: | --- |
+| `image-small.png` | RGB 32 × 32 | 3172 | `15307ce943aad88fa626f001fdcd4396b81522d591791e1b9f5997ae0e48dec6` |
+| `image-large.png` | RGB 1280 × 720 | 2769436 | `46051e478f1da432204a70b1ca6baa7f7e6f3afb1756ee8528faa0213ca53312` |
+| `audio-small.wav` | 8 kHz stereo, 0.1 seconds | 3244 | `f8934a385ffebdaf4749c9a5e525ecf95483b0db94ee858b03efee37f78c5409` |
+| `audio-large.wav` | 48 kHz stereo, 5 seconds | 960044 | `b3e8e261d3380129d82f96156c71fadce07c176d61686da6497e723372e046f5` |
+| `video-small.mp4` | 32 × 24, 12 frames | 1337 | `e0672a2bc0c59b2d1915fadbb39a0c8d4b888ce21fbd41dbc225e2a220692060` |
+| `video-large.mp4` | 1280 × 720, 60 frames | 476083 | `3498b9a16005dc4fc443bd6e7d7beb17b40f3d731e9fbe7701629f672b15f26b` |
+
+Artifact SHA-256 identities used for these measurements (the test signature
+is included in the digest):
+
+- `image`: `10d9b52ddbd63ad767eba3414969ac6d6c173ae9dfe3a210c3993adcc0d703c2`
+- `audio`: `3afe4f0626767b6f5629ee378ecb4f300d22b6d70e674b563d722cf7a95b47da`
+- `video`: `474b62e07cc6ab5dec510f58b05dbdb3ac45e16f5d1c4347005cb76d9d629dfd`

--- a/benchmarking/native_media/README.md
+++ b/benchmarking/native_media/README.md
@@ -4,6 +4,8 @@ These measurements compare explicitly selected Python and native backends at
 `f7ee0fa475e21c2df48adbc2298a607714e5d349`, on 2026-09-05. They measure complete
 local queries over repeated references to synthetic files. They do not isolate
 interpreter overhead from codec algorithms, copying, or I/O behavior.
+The original video frame measurements below used Tensor output and predate
+the native scan's IMAGE output and the buffered JPEG header reader.
 
 ## Environment and method
 

--- a/benchmarking/native_media/README.md
+++ b/benchmarking/native_media/README.md
@@ -1,11 +1,41 @@
 # Native extension measurements
 
-These measurements compare explicitly selected Python and native backends at
+The original measurements compare explicitly selected Python and native backends at
 `f7ee0fa475e21c2df48adbc2298a607714e5d349`, on 2026-09-05. They measure complete
 local queries over repeated references to synthetic files. They do not isolate
 interpreter overhead from codec algorithms, copying, or I/O behavior.
 The original video frame measurements below used Tensor output and predate
 the native scan's IMAGE output and the buffered JPEG header reader.
+
+## Video frames with IMAGE output
+
+Video frame scans were remeasured at native commit `c5f9f08371`, using Vane
+0.2.0.dev628 and engine SourceID `b9723908b5`. These ten runs use the same host,
+inputs, codec packages, warmup, five repetitions, and 160 by 90 RGB output as
+the original runs. Native frames now use IMAGE; Python frames use Tensor.
+Four alternating-backend runs measure timing, and six additional processes
+measure each backend's peak RSS for the one-thread cases.
+
+Wall and CPU times are milliseconds; RSS is MiB for the complete process.
+
+| Input/window | Files | Threads | Wall Python / native | CPU Python / native | Peak RSS Python / native |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| small/full | 10 | 1 | 63.48 / 22.62 | 63.47 / 22.59 | 267.7 / 252.1 |
+| large/full | 2 | 1 | 246.86 / 238.81 | 246.82 / 238.78 | 273.0 / 260.4 |
+| large/full | 2 | 4 | 332.26 / 129.08 | 514.05 / 257.14 | not measured separately |
+| large/1.5–1.9 seconds | 2 | 1 | 166.62 / 155.26 | 166.61 / 155.24 | 271.2 / 254.4 |
+
+Both backends return 120 frames for each full-window case, with index sums
+660 for the small files and 3540 for the large files. The late window returns
+26 frames and an index sum of 1326. Four configured threads provide two native
+file tasks for the two-file case; these results do not establish scaling to
+four active native decoders or indexed seeking. The RSS figures include the
+runtime and loaded codec libraries and do not measure per-query allocations.
+
+The signed video artifact SHA-256 for this set is
+`808d7a981b6b70f5c900b7abe6b904aac56955a08159d286da9e516838fe8e45`.
+Reproduce with the command below using `video_frames`, the listed input/file
+counts, and `--threads`; the late case adds `--start-time 1.5 --end-time 1.9`.
 
 ## Environment and method
 

--- a/benchmarking/native_media/generate_inputs.py
+++ b/benchmarking/native_media/generate_inputs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Generate deterministic, synthetic inputs for benchmark_native_media.py."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import wave
+from pathlib import Path
+
+import av
+import numpy as np
+from PIL import Image
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    args.output.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(757)
+    paths = []
+    for label, height, width in [("small", 32, 32), ("large", 720, 1280)]:
+        path = args.output / f"image-{label}.png"
+        pixels = rng.integers(0, 256, (height, width, 3), dtype=np.uint8)
+        Image.fromarray(pixels).save(path)
+        paths.append(path)
+    for label, rate, seconds in [("small", 8000, 0.1), ("large", 48000, 5)]:
+        path = args.output / f"audio-{label}.wav"
+        t = np.arange(int(rate * seconds)) / rate
+        samples = (np.column_stack([np.sin(2 * np.pi * 440 * t), np.sin(2 * np.pi * 660 * t)]) * 12000).astype("<i2")
+        with wave.open(str(path), "wb") as output:
+            output.setparams((2, 2, rate, len(samples), "NONE", "uncompressed"))
+            output.writeframes(samples.tobytes())
+        paths.append(path)
+    for label, height, width, frames in [("small", 24, 32, 12), ("large", 720, 1280, 60)]:
+        path = args.output / f"video-{label}.mp4"
+        with av.open(str(path), "w") as output:
+            stream = output.add_stream("mpeg4", rate=30)
+            stream.height, stream.width, stream.pix_fmt = height, width, "yuv420p"
+            stream.codec_context.gop_size = 15
+            stream.codec_context.max_b_frames = 2
+            y, x = np.indices((height, width))
+            for index in range(frames):
+                pixels = np.stack([(x + index * 7) % 256, (y + index * 3) % 256, (x + y + index * 5) % 256], axis=-1)
+                frame = av.VideoFrame.from_ndarray(pixels.astype(np.uint8), format="rgb24")
+                for packet in stream.encode(frame):
+                    output.mux(packet)
+            for packet in stream.encode():
+                output.mux(packet)
+        paths.append(path)
+    print(
+        json.dumps(
+            {
+                path.name: {"bytes": path.stat().st_size, "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+                for path in paths
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/external/duckdb/extension/audio/CMakeLists.txt
+++ b/external/duckdb/extension/audio/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5...3.29)
+project(AudioExtension)
+include(../media_common/extension.cmake)
+vane_build_media_extension(audio)

--- a/external/duckdb/extension/audio/audio_extension.cpp
+++ b/external/duckdb/extension/audio/audio_extension.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+#include "audio_extension.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "media_reader.hpp"
+namespace duckdb {
+static void LoadInternal(ExtensionLoader &loader) {
+	RegisterMediaAudio(loader);
+}
+void AudioExtension::Load(ExtensionLoader &loader) {
+	LoadInternal(loader);
+}
+std::string AudioExtension::Name() {
+	return "audio";
+}
+std::string AudioExtension::Version() const {
+	return "1";
+}
+} // namespace duckdb
+extern "C" {
+DUCKDB_CPP_EXTENSION_ENTRY(audio, loader) {
+	duckdb::LoadInternal(loader);
+}
+}

--- a/external/duckdb/extension/audio/audio_functions.cpp
+++ b/external/duckdb/extension/audio/audio_functions.cpp
@@ -29,7 +29,7 @@ static void AudioMetadata(DataChunk &args, ExpressionState &state, Vector &resul
 		auto budget = args.ColumnCount() == 2 ? MediaPositive(args.data[1].GetValue(row), "max_bytes", 64 * MEDIA_MIB)
 		                                      : MEDIA_METADATA_BYTES;
 		MediaReader reader(state.GetContext(), FileReference::FromValue(value, "native_audio_metadata"),
-		                   AVMEDIA_TYPE_AUDIO, INT64_MAX, budget);
+		                   AVMEDIA_TYPE_AUDIO, INT64_MAX, budget, MEDIA_MAX_PIXELS, MEDIA_MAX_FRAME_BYTES, budget);
 		auto &stream = reader.Stream();
 		auto &parameters = *stream.codecpar;
 		ValidateAudio(parameters);

--- a/external/duckdb/extension/audio/audio_functions.cpp
+++ b/external/duckdb/extension/audio/audio_functions.cpp
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "media_reader.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+extern "C" {
+#include <libswresample/swresample.h>
+}
+
+namespace duckdb {
+namespace {
+
+static void ValidateAudio(const AVCodecParameters &parameters) {
+	if (parameters.sample_rate <= 0 || parameters.sample_rate > 384000 || parameters.ch_layout.nb_channels <= 0 ||
+	    parameters.ch_layout.nb_channels > 64) {
+		throw MediaFormatException("native audio requires 1..64 channels and a sample rate in 1..384000 Hz");
+	}
+}
+
+static void AudioMetadata(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto value = args.data[0].GetValue(row);
+		if (value.IsNull() || (args.ColumnCount() == 2 && args.data[1].GetValue(row).IsNull())) {
+			result.SetValue(row, Value(result.GetType()));
+			continue;
+		}
+		auto budget = args.ColumnCount() == 2 ? MediaPositive(args.data[1].GetValue(row), "max_bytes", 64 * MEDIA_MIB)
+		                                      : MEDIA_METADATA_BYTES;
+		MediaReader reader(state.GetContext(), FileReference::FromValue(value, "native_audio_metadata"),
+		                   AVMEDIA_TYPE_AUDIO, INT64_MAX, budget);
+		auto &stream = reader.Stream();
+		auto &parameters = *stream.codecpar;
+		ValidateAudio(parameters);
+		Value frames(LogicalType::BIGINT), duration(LogicalType::DOUBLE);
+		if (stream.duration != AV_NOPTS_VALUE && stream.duration >= 0 && stream.time_base.num > 0 &&
+		    stream.time_base.den > 0) {
+			duration = Value::DOUBLE(stream.duration * av_q2d(stream.time_base));
+			// Encoded container duration need not establish an exact sample count.
+			if (parameters.codec_id >= AV_CODEC_ID_PCM_S16LE && parameters.codec_id <= AV_CODEC_ID_PCM_SGA) {
+				frames = Value::BIGINT(
+				    av_rescale_q(stream.duration, stream.time_base, AVRational {1, parameters.sample_rate}));
+			}
+		}
+		result.SetValue(row, Value::STRUCT(result.GetType(), {Value::BIGINT(parameters.sample_rate),
+		                                                      Value::BIGINT(parameters.ch_layout.nb_channels), frames,
+		                                                      duration, Value(reader.Format().iformat->name),
+		                                                      Value(avcodec_get_name(parameters.codec_id))}));
+	}
+}
+
+struct Resampler {
+	SwrContext *context = nullptr;
+	AVChannelLayout layout {};
+	~Resampler() {
+		swr_free(&context);
+		av_channel_layout_uninit(&layout);
+	}
+};
+
+static void AudioResample(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto &children = StructVector::GetEntries(result);
+	for (auto &child : children) {
+		child->SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	auto &samples = *children[0];
+	ListVector::SetListSize(samples, 0);
+	for (idx_t row = 0; row < args.size(); row++) {
+		bool null = false;
+		for (idx_t col = 0; col < args.ColumnCount(); col++) {
+			null = null || args.data[col].GetValue(row).IsNull();
+		}
+		if (null) {
+			FlatVector::SetNull(result, row, true);
+			continue;
+		}
+		auto sample_rate = MediaPositive(args.data[1].GetValue(row), "sample_rate", 384000);
+		uint64_t limits[] = {512 * MEDIA_MIB, 100000000, 512 * MEDIA_MIB, 100000000, 512 * MEDIA_MIB};
+		if (args.ColumnCount() == 7) {
+			const char *names[] = {"max_input_bytes", "max_frames", "max_decoded_bytes", "max_output_frames",
+			                       "max_output_bytes"};
+			uint64_t maxima[] = {4 * 1024 * MEDIA_MIB, 100000000, 512 * MEDIA_MIB, 100000000, 512 * MEDIA_MIB};
+			for (idx_t index = 0; index < 5; index++) {
+				limits[index] = MediaPositive(args.data[index + 2].GetValue(row), names[index], maxima[index]);
+			}
+		}
+		auto &context = state.GetContext();
+		MediaReader reader(context, FileReference::FromValue(args.data[0].GetValue(row), "native_audio_resample"),
+		                   AVMEDIA_TYPE_AUDIO, limits[0], limits[0] * 4, MEDIA_MAX_PIXELS,
+		                   MinValue<uint64_t>(limits[2], 64 * MEDIA_MIB));
+		auto &parameters = *reader.Stream().codecpar;
+		ValidateAudio(parameters);
+		auto channels = uint64_t(parameters.ch_layout.nb_channels);
+		Resampler resampler;
+		int source_format = -1;
+		uint64_t decoded_frames = 0, output_frames = 0;
+		auto start = ListVector::GetListSize(samples);
+		auto convert = [&](const uint8_t **input, int count) {
+			MediaInterrupt(context);
+			auto upper_bound = swr_get_out_samples(resampler.context, count);
+			MediaCheck(upper_bound, "estimate resampled output");
+			if (!upper_bound) {
+				return 0;
+			}
+			auto offset = ListVector::GetListSize(samples);
+			auto row_limit = MinValue<uint64_t>(limits[3], limits[4] / (channels * sizeof(double)));
+			auto output_capacity = MinValue<uint64_t>(upper_bound, row_limit - output_frames + 1);
+			auto batch_capacity = (MEDIA_BATCH_BYTES / sizeof(double) - offset) / channels;
+			double overflow_probe[64];
+			uint8_t *target;
+			if (!batch_capacity) {
+				output_capacity = 1;
+				target = reinterpret_cast<uint8_t *>(overflow_probe);
+			} else {
+				output_capacity = MinValue<uint64_t>(output_capacity, batch_capacity);
+				ListVector::Reserve(samples, NumericCast<idx_t>(offset + output_capacity * channels));
+				target =
+				    reinterpret_cast<uint8_t *>(FlatVector::GetData<double>(ListVector::GetEntry(samples)) + offset);
+			}
+			auto written = swr_convert(resampler.context, &target, NumericCast<int>(output_capacity), input, count);
+			MediaCheck(written, "resample audio");
+			if (written && !batch_capacity) {
+				throw OutOfRangeException("native audio exceeds its batch byte limit");
+			}
+			MediaInterrupt(context);
+			if (uint64_t(written) > limits[3] - output_frames) {
+				throw OutOfRangeException("native audio exceeds max_output_frames");
+			}
+			output_frames += uint64_t(written);
+			MediaProduct(output_frames, channels * sizeof(double), limits[4], "audio output bytes");
+			ListVector::SetListSize(samples, offset + uint64_t(written) * channels);
+			return written;
+		};
+		while (reader.NextFrame()) {
+			auto &frame = reader.Frame();
+			if (frame.sample_rate != parameters.sample_rate ||
+			    frame.ch_layout.nb_channels != parameters.ch_layout.nb_channels || frame.nb_samples < 0) {
+				throw MediaFormatException("audio stream changed sample rate or channel layout");
+			}
+			if (uint64_t(frame.nb_samples) > limits[1] - decoded_frames) {
+				throw OutOfRangeException("native audio exceeds max_frames");
+			}
+			decoded_frames += uint64_t(frame.nb_samples);
+			MediaProduct(decoded_frames, channels * sizeof(double), limits[2], "decoded audio bytes");
+			if (!resampler.context) {
+				source_format = frame.format;
+				MediaCheck(av_channel_layout_copy(&resampler.layout, &frame.ch_layout), "retain channel layout");
+				MediaCheck(swr_alloc_set_opts2(&resampler.context, &frame.ch_layout, AV_SAMPLE_FMT_DBL,
+				                               NumericCast<int>(sample_rate), &frame.ch_layout,
+				                               AVSampleFormat(frame.format), frame.sample_rate, 0, nullptr),
+				           "configure resampler");
+				if (!resampler.context) {
+					throw OutOfMemoryException("Cannot allocate native resampler");
+				}
+				MediaCheck(swr_init(resampler.context), "initialize resampler");
+			} else if (source_format != frame.format ||
+			           av_channel_layout_compare(&frame.ch_layout, &resampler.layout)) {
+				throw MediaFormatException("audio stream changed sample format");
+			}
+			vector<const uint8_t *> input(av_sample_fmt_is_planar(AVSampleFormat(frame.format)) ? channels : 1);
+			for (idx_t channel = 0; channel < input.size(); channel++) {
+				input[channel] = frame.extended_data[channel];
+			}
+			convert(input.data(), frame.nb_samples);
+		}
+		if (resampler.context) {
+			while (convert(nullptr, 0)) {
+			}
+		}
+		auto &entry = FlatVector::GetData<list_entry_t>(samples)[row];
+		entry = list_entry_t(start, ListVector::GetListSize(samples) - start);
+		FlatVector::GetData<int64_t>(*children[1])[row] = NumericCast<int64_t>(sample_rate);
+		FlatVector::GetData<int64_t>(*children[2])[row] = NumericCast<int64_t>(output_frames);
+		FlatVector::GetData<int64_t>(*children[3])[row] = NumericCast<int64_t>(channels);
+		FlatVector::SetNull(result, row, false);
+		for (auto &child : children) {
+			FlatVector::SetNull(*child, row, false);
+		}
+	}
+}
+} // namespace
+
+void RegisterMediaAudio(ExtensionLoader &loader) {
+	ScalarFunctionSet metadata("native_audio_metadata");
+	metadata.AddFunction(MediaScalar("audio_metadata", {LogicalType::ANY}, MediaAudioMetadataType(), AudioMetadata));
+	metadata.AddFunction(MediaScalar("audio_metadata", {LogicalType::ANY, LogicalType::UBIGINT},
+	                                 MediaAudioMetadataType(), AudioMetadata));
+	loader.RegisterFunction(metadata);
+	ScalarFunctionSet resample("native_audio_resample");
+	resample.AddFunction(
+	    MediaScalar("audio_resample", {LogicalType::ANY, LogicalType::BIGINT}, MediaAudioResultType(), AudioResample));
+	resample.AddFunction(MediaScalar("audio_resample",
+	                                 {LogicalType::ANY, LogicalType::BIGINT, LogicalType::UBIGINT, LogicalType::UBIGINT,
+	                                  LogicalType::UBIGINT, LogicalType::UBIGINT, LogicalType::UBIGINT},
+	                                 MediaAudioResultType(), AudioResample));
+	loader.RegisterFunction(resample);
+}
+} // namespace duckdb

--- a/external/duckdb/extension/audio/include/audio_extension.hpp
+++ b/external/duckdb/extension/audio/include/audio_extension.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "duckdb.hpp"
+namespace duckdb {
+class AudioExtension : public Extension {
+public:
+	void Load(ExtensionLoader &loader) override;
+	std::string Name() override;
+	std::string Version() const override;
+};
+} // namespace duckdb

--- a/external/duckdb/extension/file/CMakeLists.txt
+++ b/external/duckdb/extension/file/CMakeLists.txt
@@ -11,7 +11,8 @@ set(FILE_EXTENSION_FILES
     file_metadata_functions.cpp
     file_mime_type.cpp
     file_resolver.cpp
-    file_value.cpp)
+    file_value.cpp
+    media_backend.cpp)
 
 build_static_extension(file ${FILE_EXTENSION_FILES})
 set(PARAMETERS "-warnings")

--- a/external/duckdb/extension/file/file_extension.cpp
+++ b/external/duckdb/extension/file/file_extension.cpp
@@ -6,13 +6,16 @@
 #include "file_functions.hpp"
 #include "file_list_function.hpp"
 #include "file_metadata_functions.hpp"
+#include "media_backend.hpp"
 
 #include "duckdb/function/scalar/nested_functions.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/config.hpp"
 
 namespace duckdb {
 
 static void LoadInternal(ExtensionLoader &loader) {
+	MediaBackend::RegisterOption(DBConfig::GetConfig(loader.GetDatabaseInstance()));
 	for (auto media_type : FileLogicalType::MEDIA_TYPES) {
 		loader.RegisterType(FileLogicalType::GetTypeName(media_type), FileLogicalType::Create(media_type));
 	}

--- a/external/duckdb/extension/file/include/media_backend.hpp
+++ b/external/duckdb/extension/file/include/media_backend.hpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/function/scalar_function.hpp"
+
+namespace duckdb {
+
+class DBConfig;
+
+//! The backend is selected while binding. A bound native expression names the
+//! extension function explicitly, including when it is serialized to a worker.
+struct MediaBackend {
+	static void RegisterOption(DBConfig &config);
+	static bool UseNative(ClientContext &context, const string &domain);
+	static unique_ptr<Expression> BindNative(FunctionBindExpressionInput &input, const string &domain,
+	                                         const string &function_name);
+};
+
+} // namespace duckdb

--- a/external/duckdb/extension/file/media_backend.cpp
+++ b/external/duckdb/extension/file/media_backend.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "media_backend.hpp"
+
+#include "duckdb/common/error_data.hpp"
+#include "duckdb/function/function_binder.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/config.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/planner/expression.hpp"
+
+namespace duckdb {
+
+static void ValidateMediaBackend(ClientContext &, SetScope, Value &value) {
+	if (value.IsNull() || (value.GetValue<string>() != "python" && value.GetValue<string>() != "native")) {
+		throw InvalidInputException("Media backend must be 'python' or 'native'");
+	}
+}
+
+void MediaBackend::RegisterOption(DBConfig &config) {
+	for (const auto &domain : {"image", "audio", "video"}) {
+		config.AddExtensionOption(string(domain) + "_backend",
+		                          "Execution backend selected when a query is bound: python or native",
+		                          LogicalType::VARCHAR, Value("python"), ValidateMediaBackend);
+	}
+}
+
+bool MediaBackend::UseNative(ClientContext &context, const string &domain) {
+	Value value;
+	if (!context.TryGetCurrentSetting(domain + "_backend", value)) {
+		throw InternalException("The FILE extension has not registered %s_backend", domain);
+	}
+	ValidateMediaBackend(context, SetScope::SESSION, value);
+	if (value.GetValue<string>() == "python") {
+		return false;
+	}
+	if (!DatabaseInstance::GetDatabase(context).ExtensionIsLoaded(domain)) {
+		throw BinderException("%s_backend='native' requires the %s extension to be loaded", domain, domain);
+	}
+	return true;
+}
+
+unique_ptr<Expression> MediaBackend::BindNative(FunctionBindExpressionInput &input, const string &domain,
+                                                const string &function_name) {
+	if (!UseNative(input.context, domain)) {
+		return nullptr;
+	}
+	FunctionBinder binder(input.context);
+	ErrorData error;
+	auto result =
+	    binder.BindScalarFunction(DEFAULT_SCHEMA, "native_" + function_name, std::move(input.children), error);
+	if (!result) {
+		error.Throw();
+	}
+	return result;
+}
+
+} // namespace duckdb

--- a/external/duckdb/extension/image/CMakeLists.txt
+++ b/external/duckdb/extension/image/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5...3.29)
+project(ImageExtension)
+include(../media_common/extension.cmake)
+vane_build_media_extension(image)

--- a/external/duckdb/extension/image/image_extension.cpp
+++ b/external/duckdb/extension/image/image_extension.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+#include "image_extension.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "media_reader.hpp"
+namespace duckdb {
+static void LoadInternal(ExtensionLoader &loader) {
+	RegisterMediaImages(loader);
+}
+void ImageExtension::Load(ExtensionLoader &loader) {
+	LoadInternal(loader);
+}
+std::string ImageExtension::Name() {
+	return "image";
+}
+std::string ImageExtension::Version() const {
+	return "1";
+}
+} // namespace duckdb
+extern "C" {
+DUCKDB_CPP_EXTENSION_ENTRY(image, loader) {
+	duckdb::LoadInternal(loader);
+}
+}

--- a/external/duckdb/extension/image/image_functions.cpp
+++ b/external/duckdb/extension/image/image_functions.cpp
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "media_reader.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+extern "C" {
+#include <libavutil/crc.h>
+}
+
+namespace duckdb {
+namespace {
+
+struct ImageHeader {
+	uint32_t width;
+	uint32_t height;
+	string format;
+	string mode;
+};
+
+// Inspect encoded headers only. Large ancillary chunks cannot turn metadata
+// inspection into a full download or pixel decode.
+static ImageHeader ReadHeader(ClientContext &context, ResolvedFile &input, const FileReference &file, uint64_t budget,
+                              uint64_t max_pixels) {
+	uint64_t consumed = 0;
+	auto read = [&](uint64_t offset, uint64_t size) {
+		if (size > budget - consumed) {
+			throw OutOfRangeException("native image metadata exceeds max_bytes");
+		}
+		if (offset > input.LogicalSize() || size > input.LogicalSize() - offset) {
+			throw MediaFormatException("truncated image header");
+		}
+		string bytes(NumericCast<idx_t>(size), '\0');
+		input.ReadExact(reinterpret_cast<data_ptr_t>(&bytes[0]), size, offset);
+		consumed += size;
+		return bytes;
+	};
+	auto byte = [](const string &s, idx_t i) {
+		return uint32_t(uint8_t(s[i]));
+	};
+	auto be16 = [&](const string &s, idx_t i) {
+		return (byte(s, i) << 8) | byte(s, i + 1);
+	};
+	auto be32 = [&](const string &s, idx_t i) {
+		return (be16(s, i) << 16) | be16(s, i + 2);
+	};
+	auto signature = read(0, 8);
+	ImageHeader result;
+	if (signature == string("\x89PNG\r\n\x1a\n", 8)) {
+		auto ihdr = read(8, 25);
+		if (be32(ihdr, 0) != 13 || ihdr.substr(4, 4) != "IHDR" || byte(ihdr, 18) || byte(ihdr, 19) ||
+		    byte(ihdr, 20) > 1) {
+			throw MediaFormatException("invalid PNG IHDR");
+		}
+		auto depth = byte(ihdr, 16), color = byte(ihdr, 17);
+		bool valid_depth = depth == 8 || (depth == 16 && color != 3) ||
+		                   ((color == 0 || color == 3) && (depth == 1 || depth == 2 || depth == 4));
+		auto crc = av_crc(av_crc_get_table(AV_CRC_32_IEEE_LE), UINT32_MAX,
+		                  reinterpret_cast<const uint8_t *>(ihdr.data() + 4), 17) ^
+		           UINT32_MAX;
+		if (!valid_depth || crc != be32(ihdr, 21)) {
+			throw MediaFormatException("invalid PNG bit depth or IHDR checksum");
+		}
+		result = {be32(ihdr, 8), be32(ihdr, 12), "PNG", ""};
+		switch (byte(ihdr, 17)) {
+		case 0:
+			result.mode = byte(ihdr, 16) == 16 ? "I;16" : "L";
+			break;
+		case 2:
+			result.mode = "RGB";
+			break;
+		case 3:
+			result.mode = "P";
+			break;
+		case 4:
+			result.mode = "LA";
+			break;
+		case 6:
+			result.mode = "RGBA";
+			break;
+		default:
+			throw MediaFormatException("unsupported PNG color type");
+		}
+		MediaValidateMIME(file, "image/png");
+	} else if (byte(signature, 0) == 0xff && byte(signature, 1) == 0xd8) {
+		uint64_t offset = 2;
+		for (;;) {
+			auto marker = read(offset++, 1);
+			if (byte(marker, 0) != 0xff) {
+				throw MediaFormatException("invalid JPEG marker");
+			}
+			do {
+				marker = read(offset++, 1);
+			} while (byte(marker, 0) == 0xff);
+			auto code = byte(marker, 0);
+			if (!code || code == 0xda || code == 0xd9) {
+				throw MediaFormatException("JPEG is missing its frame header");
+			}
+			if (code == 0x01 || (code >= 0xd0 && code <= 0xd7)) {
+				continue;
+			}
+			auto length = be16(read(offset, 2), 0);
+			if (length < 2 || offset > input.LogicalSize() || length > input.LogicalSize() - offset) {
+				throw MediaFormatException("invalid JPEG segment length");
+			}
+			if (code >= 0xc0 && code <= 0xcf && code != 0xc4 && code != 0xc8 && code != 0xcc) {
+				if (length < 8) {
+					throw MediaFormatException("invalid JPEG frame header");
+				}
+				auto sof = read(offset + 2, 6);
+				auto components = byte(sof, 5);
+				if ((components != 1 && components != 3 && components != 4) || length != 8 + 3 * components) {
+					throw MediaFormatException("unsupported JPEG components");
+				}
+				result = {be16(sof, 3), be16(sof, 1), "JPEG", components == 1 ? "L" : components == 4 ? "CMYK" : "RGB"};
+				break;
+			}
+			offset += length;
+		}
+		MediaValidateMIME(file, "image/jpeg");
+	} else {
+		throw MediaFormatException("native image supports PNG and JPEG encoded files");
+	}
+	if (!result.width || !result.height) {
+		throw MediaFormatException("invalid image dimensions");
+	}
+	MediaProduct(result.width, result.height, max_pixels, "image pixels");
+	MediaInterrupt(context);
+	return result;
+}
+
+static void ImageMetadata(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto file = args.data[0].GetValue(row);
+		if (file.IsNull() ||
+		    (args.ColumnCount() == 3 && (args.data[1].GetValue(row).IsNull() || args.data[2].GetValue(row).IsNull()))) {
+			result.SetValue(row, Value(result.GetType()));
+			continue;
+		}
+		auto budget = args.ColumnCount() == 3 ? MediaPositive(args.data[1].GetValue(row), "max_bytes", 64 * MEDIA_MIB)
+		                                      : MEDIA_MIB;
+		auto pixels = args.ColumnCount() == 3
+		                  ? MediaPositive(args.data[2].GetValue(row), "max_pixels", MEDIA_MAX_PIXELS)
+		                  : MEDIA_MAX_PIXELS;
+		auto reference = FileReference::FromValue(file, "native_image_file_metadata");
+		auto resolved = ResolvedFile::Open(state.GetContext(), reference);
+		auto header = ReadHeader(state.GetContext(), *resolved, reference, budget, pixels);
+		result.SetValue(row,
+		                Value::STRUCT(result.GetType(), {Value::UINTEGER(header.width), Value::UINTEGER(header.height),
+		                                                 Value(header.format), Value(header.mode)}));
+	}
+}
+
+static void DecodeImage(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (auto &child : StructVector::GetEntries(result)) {
+		child->SetVectorType(VectorType::FLAT_VECTOR);
+	}
+	uint64_t batch_bytes = 0;
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto value = args.data[0].GetValue(row);
+		bool null = value.IsNull();
+		if (args.ColumnCount() == 6) {
+			for (idx_t col = 3; col < 6; col++) {
+				null = null || args.data[col].GetValue(row).IsNull();
+			}
+		}
+		if (args.ColumnCount() >= 3 && args.data[2].GetValue(row).IsNull()) {
+			null = true;
+		}
+		if (null) {
+			FlatVector::SetNull(result, row, true);
+			continue;
+		}
+		string mode;
+		bool has_mode = args.ColumnCount() >= 2 && !args.data[1].GetValue(row).IsNull();
+		if (has_mode) {
+			mode = args.data[1].GetValue(row).GetValue<string>();
+		}
+		if (has_mode && mode != "L" && mode != "LA" && mode != "RGB" && mode != "RGBA") {
+			throw InvalidInputException("native image mode must be L, LA, RGB, or RGBA");
+		}
+		auto on_error = args.ColumnCount() >= 3 ? args.data[2].GetValue(row).GetValue<string>() : "raise";
+		if (on_error != "raise" && on_error != "null") {
+			throw InvalidInputException("on_error must be raise or null");
+		}
+		auto input_bytes = args.ColumnCount() == 6
+		                       ? MediaPositive(args.data[3].GetValue(row), "max_input_bytes", 4 * 1024 * MEDIA_MIB)
+		                       : 256 * MEDIA_MIB;
+		auto pixels = args.ColumnCount() == 6
+		                  ? MediaPositive(args.data[4].GetValue(row), "max_pixels", MEDIA_MAX_PIXELS)
+		                  : MEDIA_MAX_PIXELS;
+		auto output_bytes = args.ColumnCount() == 6
+		                        ? MediaPositive(args.data[5].GetValue(row), "max_decoded_bytes", MEDIA_MAX_FRAME_BYTES)
+		                        : MEDIA_MAX_FRAME_BYTES;
+		auto &context = state.GetContext();
+		try {
+			auto file = FileReference::FromValue(value, "native_decode_image_file");
+			auto resolved = ResolvedFile::Open(context, file);
+			if (resolved->LogicalSize() > input_bytes) {
+				throw OutOfRangeException("native image exceeds max_input_bytes");
+			}
+			auto header = ReadHeader(context, *resolved, file, MinValue<uint64_t>(input_bytes, 64 * MEDIA_MIB), pixels);
+			// Enforce the decoder's conservative budget before FFmpeg can report
+			// an internal pixel-limit rejection as an encoded-format error.
+			MediaProduct(uint64_t(header.width) * header.height, 8, output_bytes, "decoded frame bytes");
+			MediaReader reader(context, file, std::move(resolved), AVMEDIA_TYPE_VIDEO, input_bytes, input_bytes * 4,
+			                   pixels, output_bytes);
+			if (!reader.NextFrame()) {
+				throw MediaFormatException("image has no decodable frame");
+			}
+			auto &frame = reader.Frame();
+			if (frame.width != int64_t(header.width) || frame.height != int64_t(header.height)) {
+				throw MediaFormatException("decoded dimensions differ from image header");
+			}
+			if (mode.empty()) {
+				auto descriptor = av_pix_fmt_desc_get(AVPixelFormat(frame.format));
+				mode = (descriptor && (descriptor->flags & AV_PIX_FMT_FLAG_ALPHA)) || header.mode == "P" ? "RGBA"
+				       : header.mode == "L"                                                              ? "L"
+				                                                                                         : "RGB";
+			}
+			auto bytes =
+			    MediaProduct(uint64_t(header.width) * header.height, ImageLogicalType::ChannelsForMode(mode),
+			                 MinValue<uint64_t>(output_bytes, MEDIA_BATCH_BYTES - batch_bytes), "image batch bytes");
+			// Charge the allocation even if pixel conversion later fails under on_error=null.
+			batch_bytes += bytes;
+			MediaWriteImage(context, frame, mode, header.width, header.height, result, row, bytes);
+		} catch (const MediaFormatException &) {
+			MediaInterrupt(context);
+			if (on_error != "null") {
+				throw;
+			}
+			FlatVector::SetNull(result, row, true);
+		}
+	}
+}
+} // namespace
+
+void RegisterMediaImages(ExtensionLoader &loader) {
+	ScalarFunctionSet metadata("native_image_file_metadata");
+	metadata.AddFunction(
+	    MediaScalar("image_file_metadata", {LogicalType::ANY}, MediaImageMetadataType(), ImageMetadata));
+	metadata.AddFunction(MediaScalar("image_file_metadata",
+	                                 {LogicalType::ANY, LogicalType::UBIGINT, LogicalType::UBIGINT},
+	                                 MediaImageMetadataType(), ImageMetadata));
+	loader.RegisterFunction(metadata);
+	ScalarFunctionSet decode("native_decode_image_file");
+	for (auto &args :
+	     vector<vector<LogicalType>> {{LogicalType::ANY},
+	                                  {LogicalType::ANY, LogicalType::VARCHAR},
+	                                  {LogicalType::ANY, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	                                  {LogicalType::ANY, LogicalType::VARCHAR, LogicalType::VARCHAR,
+	                                   LogicalType::UBIGINT, LogicalType::UBIGINT, LogicalType::UBIGINT}}) {
+		decode.AddFunction(MediaScalar("decode_image_file", args, ImageLogicalType::Create(), DecodeImage));
+	}
+	loader.RegisterFunction(decode);
+}
+} // namespace duckdb

--- a/external/duckdb/extension/image/image_functions.cpp
+++ b/external/duckdb/extension/image/image_functions.cpp
@@ -23,17 +23,36 @@ struct ImageHeader {
 static ImageHeader ReadHeader(ClientContext &context, ResolvedFile &input, const FileReference &file, uint64_t budget,
                               uint64_t max_pixels) {
 	uint64_t consumed = 0;
+	uint64_t buffer_offset = 0;
+	string buffer;
+	bool buffered = false;
+	auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
 	auto read = [&](uint64_t offset, uint64_t size) {
-		if (size > budget - consumed) {
-			throw OutOfRangeException("native image metadata exceeds max_bytes");
-		}
+		MediaInterrupt(context);
 		if (offset > input.LogicalSize() || size > input.LogicalSize() - offset) {
 			throw MediaFormatException("truncated image header");
 		}
-		string bytes(NumericCast<idx_t>(size), '\0');
-		input.ReadExact(reinterpret_cast<data_ptr_t>(&bytes[0]), size, offset);
-		consumed += size;
-		return bytes;
+		if (offset < buffer_offset || offset - buffer_offset > buffer.size() ||
+		    size > buffer.size() - (offset - buffer_offset)) {
+			if (std::chrono::steady_clock::now() >= deadline) {
+				throw OutOfRangeException("native image metadata probe exceeded its time budget");
+			}
+			if (size > budget - consumed) {
+				throw OutOfRangeException("native image metadata exceeds max_bytes");
+			}
+			// JPEG marker bytes share bounded range reads. PNG's fixed header
+			// still uses exact small reads without fetching encoded pixels.
+			auto count = buffered ? MinValue<uint64_t>(64 * 1024, input.LogicalSize() - offset) : size;
+			count = MinValue<uint64_t>(count, budget - consumed);
+			buffer.resize(NumericCast<idx_t>(count));
+			input.ReadExact(reinterpret_cast<data_ptr_t>(&buffer[0]), count, offset);
+			buffer_offset = offset;
+			consumed += count;
+			if (std::chrono::steady_clock::now() >= deadline) {
+				throw OutOfRangeException("native image metadata probe exceeded its time budget");
+			}
+		}
+		return buffer.substr(NumericCast<idx_t>(offset - buffer_offset), NumericCast<idx_t>(size));
 	};
 	auto byte = [](const string &s, idx_t i) {
 		return uint32_t(uint8_t(s[i]));
@@ -83,6 +102,7 @@ static ImageHeader ReadHeader(ClientContext &context, ResolvedFile &input, const
 		}
 		MediaValidateMIME(file, "image/png");
 	} else if (byte(signature, 0) == 0xff && byte(signature, 1) == 0xd8) {
+		buffered = true;
 		uint64_t offset = 2;
 		for (;;) {
 			auto marker = read(offset++, 1);

--- a/external/duckdb/extension/image/include/image_extension.hpp
+++ b/external/duckdb/extension/image/include/image_extension.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "duckdb.hpp"
+namespace duckdb {
+class ImageExtension : public Extension {
+public:
+	void Load(ExtensionLoader &loader) override;
+	std::string Name() override;
+	std::string Version() const override;
+};
+} // namespace duckdb

--- a/external/duckdb/extension/media_common/extension.cmake
+++ b/external/duckdb/extension/media_common/extension.cmake
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors SPDX-License-Identifier: MIT
+
+function(vane_build_media_extension domain)
+  # vcpkg's FFmpeg package supplies FindFFMPEG rather than a config package.
+  find_path(VANE_FFMPEG_CMAKE_DIR FindFFMPEG.cmake PATH_SUFFIXES share/ffmpeg
+                                                                 REQUIRED)
+  list(APPEND CMAKE_MODULE_PATH "${VANE_FFMPEG_CMAKE_DIR}")
+  find_package(FFMPEG REQUIRED)
+  set(components libavformat libavcodec libavutil)
+  set(sources ${domain}_extension.cpp ${domain}_functions.cpp
+              ../media_common/media_reader.cpp)
+  if(domain STREQUAL "audio")
+    list(APPEND components libswresample)
+  else()
+    list(APPEND components libswscale)
+    list(APPEND sources ../media_common/image_convert.cpp)
+  endif()
+  foreach(component IN LISTS components)
+    if(NOT FFMPEG_${component}_LIBRARY)
+      message(
+        FATAL_ERROR "The ${domain} extension requires FFmpeg ${component}")
+    endif()
+  endforeach()
+  include_directories(include ../media_common/include ../file/include
+                      ${FFMPEG_INCLUDE_DIRS})
+  build_static_extension(${domain} ${sources})
+  build_loadable_extension(${domain} "-warnings" ${sources})
+  foreach(target IN ITEMS ${domain}_extension ${domain}_loadable_extension)
+    target_link_libraries(${target} file_extension ${FFMPEG_LIBRARIES})
+  endforeach()
+endfunction()

--- a/external/duckdb/extension/media_common/image_convert.cpp
+++ b/external/duckdb/extension/media_common/image_convert.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "media_reader.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+extern "C" {
+#include <libswscale/swscale.h>
+}
+
+namespace duckdb {
+
+void MediaConvertPixels(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
+                        uint32_t height, data_ptr_t destination) {
+	MediaInterrupt(context);
+	AVPixelFormat pixel_format;
+	if (mode == "L") {
+		pixel_format = AV_PIX_FMT_GRAY8;
+	} else if (mode == "LA") {
+		pixel_format = AV_PIX_FMT_RGBA;
+	} else if (mode == "RGB") {
+		pixel_format = AV_PIX_FMT_RGB24;
+	} else if (mode == "RGBA") {
+		pixel_format = AV_PIX_FMT_RGBA;
+	} else {
+		throw InvalidInputException("native image mode must be L, LA, RGB, or RGBA");
+	}
+	if (!width || !height || width > INT_MAX || height > INT_MAX || frame.width <= 0 || frame.height <= 0) {
+		throw MediaFormatException("invalid decoded image dimensions");
+	}
+	auto size = av_image_get_buffer_size(pixel_format, NumericCast<int>(width), NumericCast<int>(height), 1);
+	if (size < 0) {
+		throw OutOfRangeException("native output image buffer size is not representable");
+	}
+	auto padded_size = av_image_get_buffer_size(pixel_format, NumericCast<int>(width), NumericCast<int>(height), 32);
+	if (padded_size < 0) {
+		throw OutOfRangeException("native aligned output image size is not representable");
+	}
+	MediaProduct(1, uint64_t(padded_size) + 32, MEDIA_MAX_FRAME_BYTES, "pixel conversion buffer bytes");
+	if (!sws_isSupportedInput(AVPixelFormat(frame.format)) || !sws_isSupportedOutput(pixel_format)) {
+		throw MediaFormatException("unsupported native pixel format");
+	}
+	auto converter = sws_getContext(frame.width, frame.height, AVPixelFormat(frame.format), NumericCast<int>(width),
+	                                NumericCast<int>(height), pixel_format, SWS_BILINEAR, nullptr, nullptr, nullptr);
+	if (!converter) {
+		throw OutOfMemoryException("Cannot allocate native pixel converter");
+	}
+	uint8_t *planes[4] = {};
+	int strides[4] = {};
+	try {
+		// swscale SIMD requires padded, aligned planes. Never let it write past
+		// an engine BLOB/ARRAY allocation, including for narrow images.
+		MediaCheck(av_image_alloc(planes, strides, width, height, pixel_format, 32),
+		           "allocate pixel conversion buffer");
+		auto coefficients =
+		    sws_getCoefficients(frame.colorspace == AVCOL_SPC_UNSPECIFIED ? SWS_CS_DEFAULT : frame.colorspace);
+		MediaCheck(sws_setColorspaceDetails(converter, coefficients, frame.color_range == AVCOL_RANGE_JPEG,
+		                                    coefficients, 1, 0, 1 << 16, 1 << 16),
+		           "configure image colorspace");
+		auto rows = sws_scale(converter, frame.data, frame.linesize, 0, frame.height, planes, strides);
+		MediaInterrupt(context);
+		if (rows != NumericCast<int>(height)) {
+			throw MediaFormatException("pixel conversion returned an incomplete image");
+		}
+		if (mode == "LA") {
+			for (uint32_t y = 0; y < height; y++) {
+				MediaInterrupt(context);
+				auto source = planes[0] + uint64_t(y) * strides[0];
+				auto target = destination + uint64_t(y) * width * 2;
+				for (uint32_t x = 0; x < width; x++) {
+					target[2 * x] =
+					    uint8_t((299 * source[4 * x] + 587 * source[4 * x + 1] + 114 * source[4 * x + 2] + 500) / 1000);
+					target[2 * x + 1] = source[4 * x + 3];
+				}
+			}
+		} else {
+			const uint8_t *source[4] = {planes[0], planes[1], planes[2], planes[3]};
+			MediaCheck(av_image_copy_to_buffer(destination, size, source, strides, pixel_format, width, height, 1),
+			           "copy image pixels");
+		}
+	} catch (...) {
+		av_freep(&planes[0]);
+		sws_freeContext(converter);
+		throw;
+	}
+	av_freep(&planes[0]);
+	sws_freeContext(converter);
+}
+
+uint64_t MediaWriteImage(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
+                         uint32_t height, Vector &result, idx_t row, uint64_t remaining_bytes) {
+	auto channels = ImageLogicalType::ChannelsForMode(mode);
+	auto pixels = MediaProduct(width, height, MEDIA_MAX_PIXELS, "output pixels");
+	auto size = MediaProduct(pixels, channels, MinValue<uint64_t>(remaining_bytes, string_t::MAX_STRING_SIZE),
+	                         "output image bytes");
+	auto &children = StructVector::GetEntries(result);
+	auto &data = *children[ImageLogicalType::DATA];
+	auto bytes = StringVector::EmptyString(data, NumericCast<idx_t>(size));
+	MediaConvertPixels(context, frame, mode, width, height, reinterpret_cast<data_ptr_t>(bytes.GetDataWriteable()));
+	bytes.Finalize();
+	FlatVector::GetData<string_t>(data)[row] = bytes;
+	FlatVector::GetData<uint32_t>(*children[ImageLogicalType::WIDTH])[row] = width;
+	FlatVector::GetData<uint32_t>(*children[ImageLogicalType::HEIGHT])[row] = height;
+	FlatVector::GetData<uint8_t>(*children[ImageLogicalType::CHANNELS])[row] = channels;
+	children[ImageLogicalType::MODE]->SetValue(row, Value(mode));
+	FlatVector::SetNull(result, row, false);
+	for (auto &child : children) {
+		FlatVector::SetNull(*child, row, false);
+	}
+	return size;
+}
+} // namespace duckdb

--- a/external/duckdb/extension/media_common/include/media_reader.hpp
+++ b/external/duckdb/extension/media_common/include/media_reader.hpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/function/function_set.hpp"
+#include "duckdb/execution/expression_executor_state.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "file_resolver.hpp"
+
+#include <chrono>
+#include <exception>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/pixdesc.h>
+}
+
+namespace duckdb {
+
+class ExtensionLoader;
+
+static constexpr uint64_t MEDIA_MIB = 1024 * 1024;
+static constexpr uint64_t MEDIA_BATCH_BYTES = 256 * MEDIA_MIB;
+static constexpr uint64_t MEDIA_MAX_PIXELS = 100000000;
+static constexpr uint64_t MEDIA_MAX_FRAME_BYTES = 512 * MEDIA_MIB;
+static constexpr uint64_t MEDIA_METADATA_BYTES = 8 * MEDIA_MIB;
+
+//! Only encoded-content failures may be suppressed by a media on_error policy.
+class MediaFormatException : public InvalidInputException {
+public:
+	explicit MediaFormatException(const string &message) : InvalidInputException("native media: %s", message) {
+	}
+};
+
+void MediaInterrupt(ClientContext &context);
+uint64_t MediaProduct(uint64_t left, uint64_t right, uint64_t limit, const char *description);
+uint64_t MediaPositive(const Value &value, const char *name, uint64_t maximum);
+void MediaCheck(int code, const char *operation);
+void MediaValidateMIME(const FileReference &file, const string &detected);
+unique_ptr<FunctionData> BindMediaFile(ClientContext &context, ScalarFunction &function,
+                                       vector<unique_ptr<Expression>> &arguments);
+ScalarFunction MediaScalar(const string &name, vector<LogicalType> arguments, LogicalType result,
+                           scalar_function_t implementation);
+LogicalType MediaImageMetadataType();
+LogicalType MediaAudioMetadataType();
+LogicalType MediaAudioResultType();
+LogicalType MediaVideoMetadataType();
+LogicalType MediaVideoFrameType();
+void RegisterMediaImages(ExtensionLoader &loader);
+void RegisterMediaAudio(ExtensionLoader &loader);
+void RegisterMediaVideo(ExtensionLoader &loader);
+
+//! One governed logical FILE view. AVIO never receives a URL or an ambient
+//! filesystem: all reads and seeks remain inside ResolvedFile's byte window.
+class MediaReader {
+public:
+	MediaReader(ClientContext &context, const FileReference &file, AVMediaType kind, uint64_t input_limit,
+	            uint64_t read_limit, uint64_t max_pixels = MEDIA_MAX_PIXELS,
+	            uint64_t frame_bytes = MEDIA_MAX_FRAME_BYTES);
+	MediaReader(ClientContext &context, const FileReference &file, unique_ptr<ResolvedFile> resolved, AVMediaType kind,
+	            uint64_t input_limit, uint64_t read_limit, uint64_t max_pixels, uint64_t frame_bytes);
+	~MediaReader();
+	MediaReader(const MediaReader &) = delete;
+	MediaReader &operator=(const MediaReader &) = delete;
+
+	AVStream &Stream();
+	AVFormatContext &Format();
+	AVFrame &Frame();
+	bool NextFrame();
+	void Seek(int64_t timestamp);
+	void CheckIO();
+	uint64_t BytesRead() const;
+	uint64_t FrameBytes() const;
+
+private:
+	static int GetBuffer(AVCodecContext *decoder, AVFrame *frame, int flags) noexcept;
+	static int Read(void *opaque, uint8_t *target, int size) noexcept;
+	static int64_t SeekIO(void *opaque, int64_t offset, int whence) noexcept;
+	static int Interrupt(void *opaque) noexcept;
+	static int DenyNestedIO(AVFormatContext *format, AVIOContext **io, const char *url, int flags,
+	                        AVDictionary **options) noexcept;
+	void OpenDecoder();
+	void Close() noexcept;
+
+	ClientContext &context;
+	unique_ptr<ResolvedFile> file;
+	uint64_t position = 0;
+	uint64_t bytes_read = 0;
+	uint64_t read_limit;
+	uint64_t max_pixels;
+	uint64_t frame_bytes;
+	std::exception_ptr io_error;
+	std::chrono::steady_clock::time_point probe_deadline;
+	bool probing = true;
+	bool source_eof = false;
+	bool decoder_flushed = false;
+	AVFormatContext *format = nullptr;
+	AVIOContext *io = nullptr;
+	AVCodecContext *decoder = nullptr;
+	AVPacket *packet = nullptr;
+	AVFrame *frame = nullptr;
+	int stream_index = -1;
+};
+
+void MediaConvertPixels(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
+                        uint32_t height, data_ptr_t destination);
+
+//! Converted pixels are written into the engine-owned IMAGE vector.
+uint64_t MediaWriteImage(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
+                         uint32_t height, Vector &result, idx_t row, uint64_t remaining_bytes);
+
+} // namespace duckdb

--- a/external/duckdb/extension/media_common/include/media_reader.hpp
+++ b/external/duckdb/extension/media_common/include/media_reader.hpp
@@ -63,9 +63,10 @@ class MediaReader {
 public:
 	MediaReader(ClientContext &context, const FileReference &file, AVMediaType kind, uint64_t input_limit,
 	            uint64_t read_limit, uint64_t max_pixels = MEDIA_MAX_PIXELS,
-	            uint64_t frame_bytes = MEDIA_MAX_FRAME_BYTES);
+	            uint64_t frame_bytes = MEDIA_MAX_FRAME_BYTES, uint64_t probe_limit = MEDIA_METADATA_BYTES);
 	MediaReader(ClientContext &context, const FileReference &file, unique_ptr<ResolvedFile> resolved, AVMediaType kind,
-	            uint64_t input_limit, uint64_t read_limit, uint64_t max_pixels, uint64_t frame_bytes);
+	            uint64_t input_limit, uint64_t read_limit, uint64_t max_pixels, uint64_t frame_bytes,
+	            uint64_t probe_limit = MEDIA_METADATA_BYTES);
 	~MediaReader();
 	MediaReader(const MediaReader &) = delete;
 	MediaReader &operator=(const MediaReader &) = delete;

--- a/external/duckdb/extension/media_common/media_reader.cpp
+++ b/external/duckdb/extension/media_common/media_reader.cpp
@@ -88,7 +88,11 @@ void MediaValidateMIME(const FileReference &file, const string &detected) {
 		return;
 	}
 	auto declared = CanonicalMIME(file.content_type);
-	if (declared == "application/octet-stream") {
+	if (declared == "application/octet-stream" || declared == "binary/octet-stream") {
+		return;
+	}
+	auto separator = detected.find('/');
+	if (separator != string::npos && declared == detected.substr(0, separator) + "/*") {
 		return;
 	}
 	if (declared != detected) {
@@ -427,7 +431,7 @@ int MediaReader::DenyNestedIO(AVFormatContext *format, AVIOContext **, const cha
 	}
 	auto &self = *static_cast<MediaReader *>(format->opaque);
 	try {
-		throw MediaFormatException("container requested an external resource outside its FILE view");
+		throw PermissionException("container requested an external resource outside its FILE view");
 	} catch (...) {
 		self.io_error = std::current_exception();
 	}

--- a/external/duckdb/extension/media_common/media_reader.cpp
+++ b/external/duckdb/extension/media_common/media_reader.cpp
@@ -1,0 +1,595 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "media_reader.hpp"
+
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/planner/expression.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+namespace duckdb {
+
+void MediaInterrupt(ClientContext &context) {
+	if (context.IsInterrupted()) {
+		throw InterruptException();
+	}
+}
+
+uint64_t MediaProduct(uint64_t left, uint64_t right, uint64_t limit, const char *description) {
+	if (right && left > limit / right) {
+		throw OutOfRangeException("native media %s exceeds its limit of %llu", description, limit);
+	}
+	return left * right;
+}
+
+uint64_t MediaPositive(const Value &value, const char *name, uint64_t maximum) {
+	if (value.IsNull()) {
+		throw InvalidInputException("native media %s cannot be NULL", name);
+	}
+	auto result = value.GetValue<uint64_t>();
+	if (!result || result > maximum) {
+		throw InvalidInputException("native media %s must be between 1 and %llu", name, maximum);
+	}
+	return result;
+}
+
+void MediaCheck(int code, const char *operation) {
+	if (code >= 0) {
+		return;
+	}
+	if (code == AVERROR(ENOMEM)) {
+		throw OutOfMemoryException("native media %s ran out of memory", operation);
+	}
+	char message[AV_ERROR_MAX_STRING_SIZE];
+	av_strerror(code, message, sizeof(message));
+	throw MediaFormatException(string(operation) + ": " + message);
+}
+
+static string CanonicalMIME(string value) {
+	value = value.substr(0, value.find(';'));
+	StringUtil::Trim(value);
+	value = StringUtil::Lower(value);
+	if (value == "image/jpg" || value == "image/pjpeg") {
+		return "image/jpeg";
+	}
+	if (value == "audio/x-wav" || value == "audio/wave" || value == "audio/vnd.wave") {
+		return "audio/wav";
+	}
+	if (value == "audio/x-flac") {
+		return "audio/flac";
+	}
+	if (value == "audio/x-aiff") {
+		return "audio/aiff";
+	}
+	if (value == "video/x-matroska") {
+		return "video/webm";
+	}
+	if (value == "audio/x-matroska") {
+		return "audio/webm";
+	}
+	if (value == "video/quicktime") {
+		return "video/mp4";
+	}
+	if (value == "audio/x-m4a") {
+		return "audio/mp4";
+	}
+	return value;
+}
+
+void MediaValidateMIME(const FileReference &file, const string &detected) {
+	if (!file.has_content_type) {
+		return;
+	}
+	auto declared = CanonicalMIME(file.content_type);
+	if (declared == "application/octet-stream") {
+		return;
+	}
+	if (declared != detected) {
+		throw MediaFormatException("content_type '" + file.content_type + "' does not match '" + detected + "'");
+	}
+}
+
+unique_ptr<FunctionData> BindMediaFile(ClientContext &, ScalarFunction &function,
+                                       vector<unique_ptr<Expression>> &arguments) {
+	FileMediaType media_type;
+	if (function.name.find("image") != string::npos) {
+		media_type = FileMediaType::IMAGE;
+	} else if (function.name.find("audio") != string::npos) {
+		media_type = FileMediaType::AUDIO;
+	} else {
+		media_type = FileMediaType::VIDEO;
+	}
+	auto type = arguments[0]->return_type;
+	if (type.id() == LogicalTypeId::SQLNULL || type.id() == LogicalTypeId::UNKNOWN) {
+		type = FileLogicalType::Create(media_type);
+	}
+	if (!FileLogicalType::IsFile(type) || FileLogicalType::GetMediaType(type) != media_type) {
+		throw BinderException("%s requires %s", function.name, FileLogicalType::GetTypeName(media_type));
+	}
+	function.arguments[0] = type;
+	return nullptr;
+}
+
+ScalarFunction MediaScalar(const string &name, vector<LogicalType> arguments, LogicalType result,
+                           scalar_function_t implementation) {
+	ScalarFunction function(
+	    "native_" + name, std::move(arguments), std::move(result),
+	    [implementation](DataChunk &args, ExpressionState &state, Vector &output) {
+		    try {
+			    implementation(args, state, output);
+		    } catch (...) {
+			    MediaInterrupt(state.GetContext());
+			    throw;
+		    }
+	    },
+	    BindMediaFile);
+	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	function.SetStability(FunctionStability::VOLATILE);
+	function.SetFallible();
+	return function;
+}
+
+LogicalType MediaImageMetadataType() {
+	return LogicalType::STRUCT({{"width", LogicalType::UINTEGER},
+	                            {"height", LogicalType::UINTEGER},
+	                            {"format", LogicalType::VARCHAR},
+	                            {"mode", LogicalType::VARCHAR}});
+}
+
+LogicalType MediaAudioMetadataType() {
+	return LogicalType::STRUCT({{"sample_rate", LogicalType::BIGINT},
+	                            {"channels", LogicalType::BIGINT},
+	                            {"frames", LogicalType::BIGINT},
+	                            {"duration", LogicalType::DOUBLE},
+	                            {"format", LogicalType::VARCHAR},
+	                            {"subtype", LogicalType::VARCHAR}});
+}
+
+LogicalType MediaAudioResultType() {
+	return LogicalType::STRUCT({{"samples", LogicalType::LIST(LogicalType::DOUBLE)},
+	                            {"sample_rate", LogicalType::BIGINT},
+	                            {"frames", LogicalType::BIGINT},
+	                            {"channels", LogicalType::BIGINT}});
+}
+
+LogicalType MediaVideoMetadataType() {
+	return LogicalType::STRUCT({{"width", LogicalType::UINTEGER},
+	                            {"height", LogicalType::UINTEGER},
+	                            {"fps", LogicalType::DOUBLE},
+	                            {"duration", LogicalType::DOUBLE},
+	                            {"frame_count", LogicalType::BIGINT},
+	                            {"time_base", LogicalType::STRUCT({{"numerator", LogicalType::BIGINT},
+	                                                               {"denominator", LogicalType::BIGINT}})}});
+}
+
+LogicalType MediaVideoFrameType() {
+	return LogicalType::STRUCT({{"frame_index", LogicalType::BIGINT},
+	                            {"frame_time", LogicalType::DOUBLE},
+	                            {"frame_time_base_numerator", LogicalType::BIGINT},
+	                            {"frame_time_base_denominator", LogicalType::BIGINT},
+	                            {"frame_pts", LogicalType::BIGINT},
+	                            {"frame_dts", LogicalType::BIGINT},
+	                            {"frame_duration", LogicalType::BIGINT},
+	                            {"is_key_frame", LogicalType::BOOLEAN},
+	                            {"data", ImageLogicalType::Create()}});
+}
+
+static string StreamMIME(const AVInputFormat &format, AVMediaType kind) {
+	string name(format.name);
+	if (name.find("mov") != string::npos) {
+		return kind == AVMEDIA_TYPE_AUDIO ? "audio/mp4" : "video/mp4";
+	}
+	if (name.find("matroska") != string::npos) {
+		return kind == AVMEDIA_TYPE_AUDIO ? "audio/webm" : "video/webm";
+	}
+	if (name == "ogg") {
+		return kind == AVMEDIA_TYPE_AUDIO ? "audio/ogg" : "video/ogg";
+	}
+	if (name == "wav") {
+		return "audio/wav";
+	}
+	if (name == "aiff") {
+		return "audio/aiff";
+	}
+	if (name == "flac") {
+		return "audio/flac";
+	}
+	if (name == "mp3") {
+		return "audio/mpeg";
+	}
+	if (name == "aac") {
+		return "audio/aac";
+	}
+	if (name == "avi") {
+		return "video/x-msvideo";
+	}
+	if (name == "mpegts") {
+		return "video/mp2t";
+	}
+	if (name == "mpeg") {
+		return "video/mpeg";
+	}
+	if (name == "png_pipe") {
+		return "image/png";
+	}
+	if (name == "jpeg_pipe") {
+		return "image/jpeg";
+	}
+	throw MediaFormatException("unsupported container '" + name + "'");
+}
+
+MediaReader::MediaReader(ClientContext &context_p, const FileReference &reference, AVMediaType kind,
+                         uint64_t input_limit, uint64_t read_limit_p, uint64_t max_pixels_p, uint64_t frame_bytes_p)
+    : MediaReader(context_p, reference, ResolvedFile::Open(context_p, reference), kind, input_limit, read_limit_p,
+                  max_pixels_p, frame_bytes_p) {
+}
+
+MediaReader::MediaReader(ClientContext &context_p, const FileReference &reference, unique_ptr<ResolvedFile> resolved,
+                         AVMediaType kind, uint64_t input_limit, uint64_t read_limit_p, uint64_t max_pixels_p,
+                         uint64_t frame_bytes_p)
+    : context(context_p), file(std::move(resolved)), read_limit(read_limit_p),
+      max_pixels(MinValue<uint64_t>(max_pixels_p, frame_bytes_p / 8)), frame_bytes(frame_bytes_p),
+      probe_deadline(std::chrono::steady_clock::now() + std::chrono::seconds(30)) {
+	if (!file->LogicalSize()) {
+		throw MediaFormatException("empty FILE view");
+	}
+	if (file->LogicalSize() > input_limit || file->LogicalSize() > uint64_t(INT64_MAX)) {
+		throw OutOfRangeException("native media input exceeds max_input_bytes");
+	}
+	try {
+		format = avformat_alloc_context();
+		if (!format) {
+			throw OutOfMemoryException("Cannot allocate native media format context");
+		}
+		auto buffer = static_cast<uint8_t *>(av_malloc(64 * 1024));
+		if (!buffer) {
+			throw OutOfMemoryException("Cannot allocate native media read buffer");
+		}
+		io = avio_alloc_context(buffer, 64 * 1024, 0, this, Read, nullptr, SeekIO);
+		if (!io) {
+			av_free(buffer);
+			throw OutOfMemoryException("Cannot allocate native media I/O context");
+		}
+		format->pb = io;
+		format->opaque = this;
+		format->flags |= AVFMT_FLAG_CUSTOM_IO;
+		format->io_open = DenyNestedIO;
+		format->interrupt_callback = {Interrupt, this};
+		format->probesize = NumericCast<int64_t>(MinValue<uint64_t>(read_limit, MEDIA_METADATA_BYTES));
+		format->max_analyze_duration = AV_TIME_BASE;
+		format->max_streams = 16;
+		format->max_probe_packets = 256;
+		AVDictionary *options = nullptr;
+		struct DictionaryGuard {
+			AVDictionary **values;
+			unsigned count;
+			~DictionaryGuard() {
+				for (unsigned i = 0; i < count; i++) {
+					av_dict_free(&values[i]);
+				}
+			}
+		};
+		DictionaryGuard options_guard {&options, 1};
+		MediaCheck(av_dict_set(&options, "format_whitelist",
+		                       "wav,aiff,flac,mp3,aac,ogg,mov,matroska,webm,avi,mpegts,mpeg,png_pipe,jpeg_pipe", 0),
+		           "set container allowlist");
+		MediaCheck(av_dict_set(&options, "protocol_whitelist", "", 0), "set protocol policy");
+		auto code = avformat_open_input(&format, nullptr, nullptr, &options);
+		av_dict_free(&options);
+		CheckIO();
+		MediaCheck(code, "open container");
+		AVDictionary *stream_options[16] = {};
+		DictionaryGuard stream_options_guard {stream_options, 16};
+		auto stream_count = format->nb_streams;
+		if (stream_count > 16) {
+			throw OutOfRangeException("native media container exceeds the stream limit");
+		}
+		for (unsigned index = 0; index < stream_count; index++) {
+			MediaCheck(av_dict_set_int(&stream_options[index], "max_pixels", NumericCast<int64_t>(max_pixels), 0),
+			           "set probe pixel limit");
+			MediaCheck(av_dict_set_int(&stream_options[index], "threads", 1, 0), "set probe thread limit");
+			MediaCheck(av_dict_set_int(&stream_options[index], "max_samples", int64_t(frame_bytes / sizeof(double)), 0),
+			           "set probe sample limit");
+		}
+		bool have_parameters = reference.media_type == FileMediaType::IMAGE;
+		for (unsigned index = 0; index < stream_count; index++) {
+			auto &parameters = *format->streams[index]->codecpar;
+			if (parameters.codec_type != kind || parameters.codec_id == AV_CODEC_ID_NONE ||
+			    (kind == AVMEDIA_TYPE_VIDEO && (format->streams[index]->disposition & AV_DISPOSITION_ATTACHED_PIC))) {
+				continue;
+			}
+			have_parameters =
+			    have_parameters ||
+			    (kind == AVMEDIA_TYPE_AUDIO ? parameters.sample_rate > 0 && parameters.ch_layout.nb_channels > 0
+			                                : parameters.width > 0 && parameters.height > 0);
+		}
+		// Container headers often establish the stream contract. Avoid decoding
+		// a frame during probing and then decoding the same packet again.
+		if (!have_parameters) {
+			code = avformat_find_stream_info(format, stream_options);
+			CheckIO();
+			MediaCheck(code, "inspect container");
+		}
+		for (unsigned index = 0; index < format->nb_streams; index++) {
+			auto stream = format->streams[index];
+			if (stream->codecpar->codec_type == kind && !(reference.media_type == FileMediaType::VIDEO &&
+			                                              (stream->disposition & AV_DISPOSITION_ATTACHED_PIC))) {
+				stream_index = NumericCast<int>(index);
+				break;
+			}
+		}
+		if (stream_index < 0) {
+			throw MediaFormatException("container does not contain the requested media stream");
+		}
+		auto mime = StreamMIME(*format->iformat, kind);
+		if ((reference.media_type == FileMediaType::VIDEO && !StringUtil::StartsWith(mime, "video/")) ||
+		    (reference.media_type == FileMediaType::AUDIO && !StringUtil::StartsWith(mime, "audio/"))) {
+			throw MediaFormatException("container does not belong to the requested FILE media type");
+		}
+		MediaValidateMIME(reference, mime);
+		probing = false;
+	} catch (...) {
+		Close();
+		throw;
+	}
+}
+
+MediaReader::~MediaReader() {
+	Close();
+}
+
+void MediaReader::Close() noexcept {
+	av_frame_free(&frame);
+	av_packet_free(&packet);
+	avcodec_free_context(&decoder);
+	avformat_close_input(&format);
+	if (io) {
+		av_freep(&io->buffer);
+		avio_context_free(&io);
+	}
+}
+
+int MediaReader::Read(void *opaque, uint8_t *target, int size) noexcept {
+	auto &self = *static_cast<MediaReader *>(opaque);
+	try {
+		self.CheckIO();
+		if (size <= 0) {
+			return AVERROR(EINVAL);
+		}
+		if (self.position == self.file->LogicalSize()) {
+			return AVERROR_EOF;
+		}
+		if (self.bytes_read >= self.read_limit) {
+			throw OutOfRangeException("native media exceeded its read/probe byte budget");
+		}
+		auto count = MinValue<uint64_t>(uint64_t(size), self.file->LogicalSize() - self.position);
+		count = MinValue<uint64_t>(count, self.read_limit - self.bytes_read);
+		self.file->ReadExact(target, count, self.position);
+		self.position += count;
+		self.bytes_read += count;
+		return NumericCast<int>(count);
+	} catch (...) {
+		self.io_error = std::current_exception();
+		return AVERROR_EXTERNAL;
+	}
+}
+
+int64_t MediaReader::SeekIO(void *opaque, int64_t offset, int whence) noexcept {
+	auto &self = *static_cast<MediaReader *>(opaque);
+	try {
+		self.CheckIO();
+		whence &= ~AVSEEK_FORCE;
+		if (whence == AVSEEK_SIZE) {
+			return NumericCast<int64_t>(self.file->LogicalSize());
+		}
+		uint64_t origin;
+		switch (whence) {
+		case SEEK_SET:
+			origin = 0;
+			break;
+		case SEEK_CUR:
+			origin = self.position;
+			break;
+		case SEEK_END:
+			origin = self.file->LogicalSize();
+			break;
+		default:
+			return AVERROR(EINVAL);
+		}
+		if ((offset < 0 && uint64_t(-(offset + 1)) + 1 > origin) ||
+		    (offset >= 0 && uint64_t(offset) > self.file->LogicalSize() - origin)) {
+			return AVERROR(EINVAL);
+		}
+		self.position = offset < 0 ? origin - (uint64_t(-(offset + 1)) + 1) : origin + uint64_t(offset);
+		return NumericCast<int64_t>(self.position);
+	} catch (...) {
+		self.io_error = std::current_exception();
+		return AVERROR_EXTERNAL;
+	}
+}
+
+int MediaReader::Interrupt(void *opaque) noexcept {
+	auto &self = *static_cast<MediaReader *>(opaque);
+	return self.context.IsInterrupted() || bool(self.io_error) ||
+	       (self.probing && std::chrono::steady_clock::now() >= self.probe_deadline);
+}
+
+int MediaReader::DenyNestedIO(AVFormatContext *format, AVIOContext **, const char *, int, AVDictionary **) noexcept {
+	if (!format || !format->opaque) {
+		return AVERROR(EACCES);
+	}
+	auto &self = *static_cast<MediaReader *>(format->opaque);
+	try {
+		throw MediaFormatException("container requested an external resource outside its FILE view");
+	} catch (...) {
+		self.io_error = std::current_exception();
+	}
+	return AVERROR_EXTERNAL;
+}
+
+void MediaReader::CheckIO() {
+	MediaInterrupt(context);
+	if (io_error) {
+		std::rethrow_exception(io_error);
+	}
+	if (probing && std::chrono::steady_clock::now() >= probe_deadline) {
+		throw OutOfRangeException("native media metadata probe exceeded its time budget");
+	}
+}
+
+AVStream &MediaReader::Stream() {
+	return *format->streams[stream_index];
+}
+
+AVFormatContext &MediaReader::Format() {
+	return *format;
+}
+
+AVFrame &MediaReader::Frame() {
+	return *frame;
+}
+
+uint64_t MediaReader::BytesRead() const {
+	return bytes_read;
+}
+
+uint64_t MediaReader::FrameBytes() const {
+	return frame_bytes;
+}
+
+int MediaReader::GetBuffer(AVCodecContext *decoder, AVFrame *frame, int flags) noexcept {
+	auto &self = *static_cast<MediaReader *>(decoder->opaque);
+	try {
+		self.CheckIO();
+		if (frame->width > 0 && frame->height > 0) {
+			auto pixels = MediaProduct(frame->width, frame->height, self.max_pixels, "decoded pixels");
+			MediaProduct(pixels, 8, self.frame_bytes, "decoded frame bytes");
+			int width = frame->width, height = frame->height;
+			int alignments[AV_NUM_DATA_POINTERS] = {};
+			avcodec_align_dimensions2(decoder, &width, &height, alignments);
+			int alignment = 1;
+			for (auto value : alignments) {
+				alignment = MaxValue(alignment, value);
+			}
+			auto padded_size = av_image_get_buffer_size(AVPixelFormat(frame->format), width, height, alignment);
+			MediaCheck(padded_size, "calculate decoder buffer size");
+			MediaProduct(1, uint64_t(padded_size) + 4 * AV_INPUT_BUFFER_PADDING_SIZE, self.frame_bytes,
+			             "padded decoder frame bytes");
+		}
+		if (frame->nb_samples > 0) {
+			MediaProduct(frame->nb_samples, uint64_t(frame->ch_layout.nb_channels) * sizeof(double), self.frame_bytes,
+			             "decoded audio frame bytes");
+		}
+		return avcodec_default_get_buffer2(decoder, frame, flags);
+	} catch (...) {
+		self.io_error = std::current_exception();
+		return AVERROR_EXTERNAL;
+	}
+}
+
+void MediaReader::OpenDecoder() {
+	if (decoder) {
+		return;
+	}
+	auto &parameters = *Stream().codecpar;
+	if (parameters.width > 0 && parameters.height > 0) {
+		MediaProduct(parameters.width, parameters.height, max_pixels, "decoded pixels");
+		MediaProduct(uint64_t(parameters.width) * parameters.height, 8, frame_bytes, "decoded frame bytes");
+	}
+	const auto codec = avcodec_find_decoder(parameters.codec_id);
+	if (!codec) {
+		throw MediaFormatException("decoder is unavailable for the selected codec");
+	}
+	decoder = avcodec_alloc_context3(codec);
+	packet = av_packet_alloc();
+	frame = av_frame_alloc();
+	if (!decoder || !packet || !frame) {
+		throw OutOfMemoryException("Cannot allocate native media decoder state");
+	}
+	MediaCheck(avcodec_parameters_to_context(decoder, &parameters), "configure decoder");
+	decoder->thread_count = 1;
+	decoder->opaque = this;
+	decoder->get_buffer2 = GetBuffer;
+	decoder->max_pixels = NumericCast<int64_t>(max_pixels);
+	decoder->max_samples = NumericCast<int64_t>(frame_bytes / sizeof(double));
+	auto code = avcodec_open2(decoder, codec, nullptr);
+	CheckIO();
+	MediaCheck(code, "open decoder");
+}
+
+bool MediaReader::NextFrame() {
+	OpenDecoder();
+	av_frame_unref(frame);
+	for (;;) {
+		CheckIO();
+		auto code = avcodec_receive_frame(decoder, frame);
+		CheckIO();
+		if (code >= 0) {
+			if (frame->width > 0 && frame->height > 0) {
+				MediaProduct(frame->width, frame->height, max_pixels, "decoded pixels");
+				MediaProduct(uint64_t(frame->width) * frame->height, 8, frame_bytes, "decoded frame bytes");
+			}
+			if (frame->nb_samples > 0) {
+				MediaProduct(frame->nb_samples, uint64_t(frame->ch_layout.nb_channels) * sizeof(double), frame_bytes,
+				             "decoded audio frame bytes");
+			}
+			return true;
+		}
+		if (code == AVERROR_EOF) {
+			return false;
+		}
+		if (code != AVERROR(EAGAIN)) {
+			MediaCheck(code, "decode frame");
+		}
+		if (source_eof) {
+			if (decoder_flushed) {
+				throw MediaFormatException("decoder requested packets after end of stream");
+			}
+			auto flush_code = avcodec_send_packet(decoder, nullptr);
+			CheckIO();
+			MediaCheck(flush_code, "flush decoder");
+			decoder_flushed = true;
+			continue;
+		}
+		for (;;) {
+			MediaInterrupt(context);
+			code = av_read_frame(format, packet);
+			CheckIO();
+			if (code == AVERROR_EOF) {
+				source_eof = true;
+				break;
+			}
+			MediaCheck(code, "read packet");
+			if (packet->stream_index == stream_index) {
+				code = avcodec_send_packet(decoder, packet);
+				CheckIO();
+				av_packet_unref(packet);
+				MediaCheck(code, "submit packet");
+				break;
+			}
+			av_packet_unref(packet);
+		}
+	}
+}
+
+void MediaReader::Seek(int64_t timestamp) {
+	OpenDecoder();
+	MediaInterrupt(context);
+	const auto code = av_seek_frame(format, stream_index, timestamp, AVSEEK_FLAG_BACKWARD);
+	CheckIO();
+	MediaCheck(code, "seek to keyframe");
+	avcodec_flush_buffers(decoder);
+	av_packet_unref(packet);
+	av_frame_unref(frame);
+	source_eof = false;
+	decoder_flushed = false;
+}
+
+} // namespace duckdb

--- a/external/duckdb/extension/media_common/media_reader.cpp
+++ b/external/duckdb/extension/media_common/media_reader.cpp
@@ -59,22 +59,31 @@ static string CanonicalMIME(string value) {
 	if (value == "image/jpg" || value == "image/pjpeg") {
 		return "image/jpeg";
 	}
+	if (value == "image/x-png") {
+		return "image/png";
+	}
 	if (value == "audio/x-wav" || value == "audio/wave" || value == "audio/vnd.wave") {
 		return "audio/wav";
 	}
 	if (value == "audio/x-flac") {
 		return "audio/flac";
 	}
-	if (value == "audio/x-aiff") {
+	if (value == "audio/x-aiff" || value == "audio/aif") {
 		return "audio/aiff";
 	}
-	if (value == "video/x-matroska") {
+	if (value == "audio/mp3" || value == "audio/x-mp3") {
+		return "audio/mpeg";
+	}
+	if (value == "video/avi") {
+		return "video/x-msvideo";
+	}
+	if (value == "video/x-matroska" || value == "video/mkv") {
 		return "video/webm";
 	}
 	if (value == "audio/x-matroska") {
 		return "audio/webm";
 	}
-	if (value == "video/quicktime") {
+	if (value == "video/quicktime" || value == "video/x-m4v") {
 		return "video/mp4";
 	}
 	if (value == "audio/x-m4a") {
@@ -89,6 +98,9 @@ void MediaValidateMIME(const FileReference &file, const string &detected) {
 	}
 	auto declared = CanonicalMIME(file.content_type);
 	if (declared == "application/octet-stream" || declared == "binary/octet-stream") {
+		return;
+	}
+	if (declared == "application/ogg" && (detected == "audio/ogg" || detected == "video/ogg")) {
 		return;
 	}
 	auto separator = detected.find('/');
@@ -230,14 +242,15 @@ static string StreamMIME(const AVInputFormat &format, AVMediaType kind) {
 }
 
 MediaReader::MediaReader(ClientContext &context_p, const FileReference &reference, AVMediaType kind,
-                         uint64_t input_limit, uint64_t read_limit_p, uint64_t max_pixels_p, uint64_t frame_bytes_p)
+                         uint64_t input_limit, uint64_t read_limit_p, uint64_t max_pixels_p, uint64_t frame_bytes_p,
+                         uint64_t probe_limit)
     : MediaReader(context_p, reference, ResolvedFile::Open(context_p, reference), kind, input_limit, read_limit_p,
-                  max_pixels_p, frame_bytes_p) {
+                  max_pixels_p, frame_bytes_p, probe_limit) {
 }
 
 MediaReader::MediaReader(ClientContext &context_p, const FileReference &reference, unique_ptr<ResolvedFile> resolved,
                          AVMediaType kind, uint64_t input_limit, uint64_t read_limit_p, uint64_t max_pixels_p,
-                         uint64_t frame_bytes_p)
+                         uint64_t frame_bytes_p, uint64_t probe_limit)
     : context(context_p), file(std::move(resolved)), read_limit(read_limit_p),
       max_pixels(MinValue<uint64_t>(max_pixels_p, frame_bytes_p / 8)), frame_bytes(frame_bytes_p),
       probe_deadline(std::chrono::steady_clock::now() + std::chrono::seconds(30)) {
@@ -266,7 +279,11 @@ MediaReader::MediaReader(ClientContext &context_p, const FileReference &referenc
 		format->flags |= AVFMT_FLAG_CUSTOM_IO;
 		format->io_open = DenyNestedIO;
 		format->interrupt_callback = {Interrupt, this};
-		format->probesize = NumericCast<int64_t>(MinValue<uint64_t>(read_limit, MEDIA_METADATA_BYTES));
+		auto probe_bytes = MinValue<uint64_t>(read_limit, probe_limit);
+		format->probesize = NumericCast<int64_t>(probe_bytes);
+		// FFmpeg requires at least 2048 for format detection. Read still enforces
+		// smaller caller budgets and preserves their resource-limit exception.
+		format->format_probesize = NumericCast<int>(MaxValue<uint64_t>(probe_bytes, 2048));
 		format->max_analyze_duration = AV_TIME_BASE;
 		format->max_streams = 16;
 		format->max_probe_packets = 256;

--- a/external/duckdb/extension/video/CMakeLists.txt
+++ b/external/duckdb/extension/video/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5...3.29)
+project(VideoExtension)
+include(../media_common/extension.cmake)
+vane_build_media_extension(video)

--- a/external/duckdb/extension/video/include/video_extension.hpp
+++ b/external/duckdb/extension/video/include/video_extension.hpp
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "duckdb.hpp"
+namespace duckdb {
+class VideoExtension : public Extension {
+public:
+	void Load(ExtensionLoader &loader) override;
+	std::string Name() override;
+	std::string Version() const override;
+};
+} // namespace duckdb

--- a/external/duckdb/extension/video/video_extension.cpp
+++ b/external/duckdb/extension/video/video_extension.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+#include "video_extension.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "media_reader.hpp"
+namespace duckdb {
+static void LoadInternal(ExtensionLoader &loader) {
+	RegisterMediaVideo(loader);
+}
+void VideoExtension::Load(ExtensionLoader &loader) {
+	LoadInternal(loader);
+}
+std::string VideoExtension::Name() {
+	return "video";
+}
+std::string VideoExtension::Version() const {
+	return "1";
+}
+} // namespace duckdb
+extern "C" {
+DUCKDB_CPP_EXTENSION_ENTRY(video, loader) {
+	duckdb::LoadInternal(loader);
+}
+}

--- a/external/duckdb/extension/video/video_functions.cpp
+++ b/external/duckdb/extension/video/video_functions.cpp
@@ -1,0 +1,446 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+
+#include "media_reader.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include "duckdb/function/distributed_table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <atomic>
+#include <cmath>
+#include <limits>
+#include "duckdb/common/unordered_set.hpp"
+
+namespace duckdb {
+namespace {
+
+static void VideoMetadata(DataChunk &args, ExpressionState &state, Vector &result) {
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	for (idx_t row = 0; row < args.size(); row++) {
+		auto value = args.data[0].GetValue(row);
+		if (value.IsNull() || (args.ColumnCount() == 2 && args.data[1].GetValue(row).IsNull())) {
+			result.SetValue(row, Value(result.GetType()));
+			continue;
+		}
+		auto budget = args.ColumnCount() == 2 ? MediaPositive(args.data[1].GetValue(row), "max_bytes", 64 * MEDIA_MIB)
+		                                      : MEDIA_METADATA_BYTES;
+		MediaReader reader(state.GetContext(), FileReference::FromValue(value, "native_video_metadata"),
+		                   AVMEDIA_TYPE_VIDEO, INT64_MAX, budget);
+		auto &stream = reader.Stream();
+		auto &parameters = *stream.codecpar;
+		if (parameters.width <= 0 || parameters.height <= 0) {
+			throw MediaFormatException("unknown video dimensions");
+		}
+		MediaProduct(parameters.width, parameters.height, MEDIA_MAX_PIXELS, "video pixels");
+		auto fps = av_guess_frame_rate(&reader.Format(), &stream, nullptr);
+		Value duration(LogicalType::DOUBLE), frame_count(LogicalType::BIGINT), rate(LogicalType::DOUBLE);
+		if (stream.duration != AV_NOPTS_VALUE && stream.duration >= 0 && stream.time_base.num > 0 &&
+		    stream.time_base.den > 0) {
+			duration = Value::DOUBLE(stream.duration * av_q2d(stream.time_base));
+		}
+		if (stream.nb_frames > 0) {
+			frame_count = Value::BIGINT(stream.nb_frames);
+		}
+		if (fps.num > 0 && fps.den > 0) {
+			rate = Value::DOUBLE(av_q2d(fps));
+		}
+		auto time_base_type = StructType::GetChildType(result.GetType(), 5);
+		Value time_base(time_base_type);
+		if (stream.time_base.num > 0 && stream.time_base.den > 0) {
+			time_base = Value::STRUCT(time_base_type,
+			                          {Value::BIGINT(stream.time_base.num), Value::BIGINT(stream.time_base.den)});
+		}
+		result.SetValue(
+		    row, Value::STRUCT(result.GetType(), {Value::UINTEGER(parameters.width), Value::UINTEGER(parameters.height),
+		                                          rate, duration, frame_count, time_base}));
+	}
+}
+
+// Parameters are portable values only. Opening files is execution-time work.
+struct VideoBind : public TableFunctionData {
+	vector<Value> parameters;
+	vector<Value> files;
+	bool tensor = false;
+	bool worker = false;
+	bool assigned = false;
+	uint64_t row_bytes = 0;
+	uint64_t RowBytes() const {
+		uint64_t file_bytes = 0;
+		for (auto &value : files) {
+			auto file = FileReference::FromValue(value, "native_video_frames");
+			file_bytes =
+			    MaxValue<uint64_t>(file_bytes, file.url.size() + file.content_type.size() + file.checksum.size());
+		}
+		return parameters[0].GetValue<uint64_t>() * parameters[1].GetValue<uint64_t>() * 3 + file_bytes + 160;
+	}
+	unique_ptr<FunctionData> Copy() const override {
+		return make_uniq<VideoBind>(*this);
+	}
+	bool Equals(const FunctionData &other) const override {
+		auto value = dynamic_cast<const VideoBind *>(&other);
+		return value && parameters == value->parameters && files == value->files && tensor == value->tensor &&
+		       worker == value->worker && assigned == value->assigned;
+	}
+};
+
+static void ValidateVideoBind(VideoBind &bind) {
+	auto &p = bind.parameters;
+	if (p.size() != 12) {
+		throw InvalidInputException("native video requires twelve scan options");
+	}
+	const idx_t integer_indices[] = {0, 1, 6, 7, 8, 9};
+	const char *names[] = {
+	    "height", "width", "max_input_bytes", "max_decoded_frames", "max_pixels", "max_partition_bytes"};
+	const uint64_t maxima[] = {100000, 100000, 16 * 1024 * MEDIA_MIB, 100000000, MEDIA_MAX_PIXELS, MEDIA_BATCH_BYTES};
+	for (idx_t i = 0; i < 6; i++) {
+		MediaPositive(p[integer_indices[i]], names[i], maxima[i]);
+	}
+	MediaProduct(p[0].GetValue<uint64_t>(), p[1].GetValue<uint64_t>(), p[8].GetValue<uint64_t>(),
+	             "video output pixels");
+	auto pixels = p[0].GetValue<uint64_t>() * p[1].GetValue<uint64_t>();
+	MediaProduct(pixels, 3, p[9].GetValue<uint64_t>(), "video output frame bytes");
+	if (p[2].IsNull()) {
+		throw InvalidInputException("start_time cannot be NULL");
+	}
+	for (auto i : {2, 3, 5}) {
+		if (!p[i].IsNull() && (!std::isfinite(p[i].GetValue<double>()) || p[i].GetValue<double>() < 0)) {
+			throw InvalidInputException("video times must be finite and nonnegative");
+		}
+	}
+	if (!p[3].IsNull() && p[3].GetValue<double>() < p[2].GetValue<double>()) {
+		throw InvalidInputException("end_time must be at least start_time");
+	}
+	if (!p[5].IsNull() && p[5].GetValue<double>() == 0) {
+		throw InvalidInputException("sample_interval_seconds must be positive");
+	}
+	if (!p[10].IsNull() && p[10].GetValue<int64_t>() < 0) {
+		throw InvalidInputException("frame_limit must be nonnegative");
+	}
+	if (p[11].IsNull() || (p[11].GetValue<string>() != "raise" && p[11].GetValue<string>() != "skip")) {
+		throw InvalidInputException("video on_error must be raise or skip");
+	}
+	if (bind.files.size() > 100000) {
+		throw OutOfRangeException("native video source exceeds 100000 FILE views");
+	}
+	uint64_t source_bytes = 0;
+	for (auto &file : bind.files) {
+		if (file.IsNull() || !FileLogicalType::IsFile(file.type()) ||
+		    FileLogicalType::GetMediaType(file.type()) != FileMediaType::VIDEO) {
+			throw InvalidInputException("native video source requires non-NULL VIDEOFILE views");
+		}
+		auto reference = FileReference::FromValue(file, "native_video_frames");
+		uint64_t bytes = reference.url.size() + reference.content_type.size() + reference.checksum.size() + 512;
+		if (bytes > 64 * MEDIA_MIB - source_bytes) {
+			throw OutOfRangeException("native video source metadata exceeds 64 MiB");
+		}
+		source_bytes += bytes;
+	}
+	bind.row_bytes = bind.RowBytes();
+	if (bind.row_bytes > p[9].GetValue<uint64_t>()) {
+		throw OutOfRangeException("native video row exceeds max_partition_bytes");
+	}
+}
+
+static unique_ptr<FunctionData> BindVideo(ClientContext &, TableFunctionBindInput &input, vector<LogicalType> &types,
+                                          vector<string> &names) {
+	auto result = make_uniq<VideoBind>();
+	result->parameters.assign(input.inputs.begin() + 1, input.inputs.end());
+	if (!input.inputs[0].IsNull()) {
+		if (input.inputs[0].type().id() != LogicalTypeId::LIST) {
+			throw BinderException("native video source requires a list of VIDEOFILE views");
+		}
+		result->files = ListValue::GetChildren(input.inputs[0]);
+	}
+	result->tensor = input.table_function.name == "native_video_tensor_frames";
+	ValidateVideoBind(*result);
+	types.push_back(FileLogicalType::Create(FileMediaType::VIDEO));
+	names.push_back("file");
+	auto frame_type = MediaVideoFrameType();
+	for (auto &field : StructType::GetChildTypes(frame_type)) {
+		names.push_back(field.first);
+		types.push_back(field.second);
+	}
+	names.back() = "frame";
+	if (result->tensor) {
+		types.back() = TensorType::Create(LogicalType::UTINYINT, {result->parameters[0].GetValue<idx_t>(),
+		                                                          result->parameters[1].GetValue<idx_t>(), 3});
+	}
+	return std::move(result);
+}
+
+struct VideoGlobal : public GlobalTableFunctionState {
+	std::atomic<idx_t> next_file {0};
+	idx_t thread_count = 1;
+	uint64_t emitted = 0; // Used only in the explicitly serial, globally limited scan.
+	idx_t MaxThreads() const override {
+		return thread_count;
+	}
+};
+struct VideoLocal : public LocalTableFunctionState {
+	unique_ptr<MediaReader> reader;
+	idx_t file_index = 0;
+	uint64_t decoded = 0;
+	int64_t origin = AV_NOPTS_VALUE;
+	long double next_sample = 0;
+	long double last_time = 0;
+	bool have_last_time = false;
+};
+static unique_ptr<GlobalTableFunctionState> InitVideo(ClientContext &, TableFunctionInitInput &input) {
+	auto &bind = input.bind_data->Cast<VideoBind>();
+	if (bind.worker && !bind.assigned) {
+		throw InvalidInputException("native video worker has no split assignment");
+	}
+	auto result = make_uniq<VideoGlobal>();
+	result->thread_count = bind.parameters[10].IsNull() ? MaxValue<idx_t>(1, bind.files.size()) : 1;
+	return std::move(result);
+}
+static unique_ptr<LocalTableFunctionState> InitVideoLocal(ExecutionContext &, TableFunctionInitInput &,
+                                                          GlobalTableFunctionState *) {
+	return make_uniq<VideoLocal>();
+}
+
+static void ScanVideo(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &bind = input.bind_data->Cast<VideoBind>();
+	auto &p = bind.parameters;
+	auto &global = input.global_state->Cast<VideoGlobal>();
+	auto &local = input.local_state->Cast<VideoLocal>();
+	auto height = p[0].GetValue<uint32_t>(), width = p[1].GetValue<uint32_t>();
+	auto frame_bytes = uint64_t(height) * width * 3;
+	auto limit = MinValue<idx_t>(STANDARD_VECTOR_SIZE, p[9].GetValue<uint64_t>() / bind.row_bytes);
+	bool limited = !p[10].IsNull();
+	if (limited && global.emitted >= p[10].GetValue<uint64_t>()) {
+		return;
+	}
+	idx_t row = 0;
+	uint64_t allocated_pixels = 0;
+	while (row < limit) {
+		MediaInterrupt(context);
+		if (limited && global.emitted >= p[10].GetValue<uint64_t>()) {
+			local.reader.reset();
+			break;
+		}
+		try {
+			if (!local.reader) {
+				local.file_index = global.next_file.fetch_add(1);
+				if (local.file_index >= bind.files.size()) {
+					break;
+				}
+				auto file = FileReference::FromValue(bind.files[local.file_index], "native_video_frames");
+				auto input_bytes = p[6].GetValue<uint64_t>();
+				local.reader = make_uniq<MediaReader>(context, file, AVMEDIA_TYPE_VIDEO, input_bytes, input_bytes * 4,
+				                                      p[8].GetValue<uint64_t>());
+				local.origin = local.reader->Stream().start_time;
+				if (local.origin == AV_NOPTS_VALUE) {
+					local.origin = 0;
+				}
+				local.have_last_time = false;
+				local.decoded = 0;
+				local.next_sample = p[2].GetValue<double>();
+			}
+			if (!local.reader->NextFrame()) {
+				local.reader.reset();
+				continue;
+			}
+			if (local.decoded >= p[7].GetValue<uint64_t>()) {
+				throw OutOfRangeException("native video exceeds max_decoded_frames");
+			}
+			auto frame_index = local.decoded++;
+			auto &frame = local.reader->Frame();
+			auto base = local.reader->Stream().time_base;
+			auto pts = frame.pts;
+			bool has_time = pts != AV_NOPTS_VALUE && base.num > 0 && base.den > 0;
+			long double time = has_time ? (static_cast<long double>(pts) - local.origin) * base.num / base.den : 0;
+			if (!has_time && (p[2].GetValue<double>() > 0 || !p[3].IsNull() || !p[5].IsNull())) {
+				throw MediaFormatException("video time selection requires presentation timestamps");
+			}
+			if (has_time) {
+				if (local.have_last_time && time < local.last_time) {
+					local.next_sample = p[2].GetValue<double>();
+				}
+				local.last_time = time;
+				local.have_last_time = true;
+				// A later timestamp discontinuity may return to this inclusive window.
+				if (!p[3].IsNull() && double(time) > p[3].GetValue<double>()) {
+					continue;
+				}
+				if (double(time) < p[2].GetValue<double>()) {
+					continue;
+				}
+			}
+			bool key = (frame.flags & AV_FRAME_FLAG_KEY) != 0;
+			if (!p[4].IsNull() && key != p[4].GetValue<bool>()) {
+				continue;
+			}
+			if (!p[5].IsNull()) {
+				auto tolerance =
+				    4 * std::numeric_limits<double>::epsilon() *
+				    MaxValue<long double>(1, MaxValue<long double>(std::abs(time), std::abs(local.next_sample)));
+				if (time + tolerance < local.next_sample) {
+					continue;
+				}
+				auto interval = static_cast<long double>(p[5].GetValue<double>());
+				local.next_sample += (std::floor((time + tolerance - local.next_sample) / interval) + 1) * interval;
+			}
+			output.SetValue(0, row, bind.files[local.file_index]);
+			output.SetValue(1, row, Value::BIGINT(NumericCast<int64_t>(frame_index)));
+			output.SetValue(2, row, has_time ? Value::DOUBLE(double(time)) : Value(LogicalType::DOUBLE));
+			output.SetValue(3, row, base.num > 0 ? Value::BIGINT(base.num) : Value(LogicalType::BIGINT));
+			output.SetValue(4, row, base.den > 0 ? Value::BIGINT(base.den) : Value(LogicalType::BIGINT));
+			output.SetValue(5, row, pts != AV_NOPTS_VALUE ? Value::BIGINT(pts) : Value(LogicalType::BIGINT));
+			output.SetValue(
+			    6, row, frame.pkt_dts != AV_NOPTS_VALUE ? Value::BIGINT(frame.pkt_dts) : Value(LogicalType::BIGINT));
+			output.SetValue(7, row, frame.duration > 0 ? Value::BIGINT(frame.duration) : Value(LogicalType::BIGINT));
+			output.SetValue(8, row, Value::BOOLEAN(key));
+			if (bind.tensor) {
+				auto &data = ArrayVector::GetEntry(output.data[9]);
+				MediaConvertPixels(context, frame, "RGB", width, height,
+				                   FlatVector::GetData<uint8_t>(data) + row * frame_bytes);
+				FlatVector::SetNull(output.data[9], row, false);
+			} else {
+				if (frame_bytes > p[9].GetValue<uint64_t>() - allocated_pixels) {
+					throw OutOfRangeException("native video failed conversions exhausted the batch byte budget");
+				}
+				allocated_pixels += frame_bytes;
+				MediaWriteImage(context, frame, "RGB", width, height, output.data[9], row, frame_bytes);
+			}
+			row++;
+			if (limited) {
+				global.emitted++;
+			}
+		} catch (const MediaFormatException &) {
+			MediaInterrupt(context);
+			if (p[11].GetValue<string>() != "skip") {
+				throw;
+			}
+			local.reader.reset();
+		}
+	}
+	output.SetCardinality(row);
+}
+
+static string EncodeFiles(const vector<Value> &files) {
+	MemoryStream stream;
+	BinarySerializer serializer(stream);
+	serializer.Begin();
+	serializer.WriteProperty(1, "files", files);
+	serializer.End();
+	return string(const_char_ptr_cast(stream.GetData()), stream.GetPosition());
+}
+static vector<Value> DecodeFiles(const string &bytes) {
+	MemoryStream stream(data_ptr_cast(const_cast<char *>(bytes.data())), bytes.size());
+	BinaryDeserializer deserializer(stream);
+	deserializer.Begin();
+	auto files = deserializer.ReadProperty<vector<Value>>(1, "files");
+	deserializer.End();
+	if (stream.GetPosition() != bytes.size()) {
+		throw SerializationException("native video split has trailing bytes");
+	}
+	return files;
+}
+static vector<DistributedScanSplit> PlanVideoSplits(const TableFunctionDistributedScanPlanningInput &input) {
+	auto &bind = input.bind_data->Cast<VideoBind>();
+	vector<DistributedScanSplit> splits;
+	auto append = [&](const vector<Value> &files) {
+		DistributedScanSplit split;
+		split.split_id = std::to_string(splits.size());
+		split.payload = EncodeFiles(files);
+		split.Validate();
+		splits.push_back(std::move(split));
+	};
+	if (!bind.parameters[10].IsNull()) {
+		if (!bind.files.empty()) {
+			append(bind.files);
+		}
+	} else {
+		for (auto &file : bind.files) {
+			append({file});
+		}
+	}
+	return splits;
+}
+static unique_ptr<FunctionData> WorkerVideoBind(const TableFunctionDistributedScanInput &input) {
+	auto result = input.bind_data->Cast<VideoBind>().Copy();
+	auto &bind = result->Cast<VideoBind>();
+	bind.files.clear();
+	bind.worker = true;
+	bind.assigned = false;
+	return result;
+}
+static void ApplyVideoSplits(optional_ptr<FunctionData> data, const vector<DistributedScanSplit> &splits) {
+	auto &bind = data->Cast<VideoBind>();
+	if (!bind.worker) {
+		throw SerializationException("native video splits require a worker bind");
+	}
+	bind.files.clear();
+	if (!bind.parameters[10].IsNull() && (splits.size() > 1 || (!splits.empty() && splits[0].split_id != "0"))) {
+		throw SerializationException("globally limited native video requires one canonical split");
+	}
+	unordered_set<string> seen;
+	for (auto &split : splits) {
+		split.Validate();
+		if (!seen.insert(split.split_id).second) {
+			throw SerializationException("duplicate native video split");
+		}
+		auto files = DecodeFiles(split.payload);
+		if (bind.parameters[10].IsNull() && files.size() != 1) {
+			throw SerializationException("native video split must contain one FILE view");
+		}
+		bind.files.insert(bind.files.end(), files.begin(), files.end());
+	}
+	ValidateVideoBind(bind);
+	bind.assigned = true;
+}
+static void SerializeVideo(Serializer &serializer, optional_ptr<FunctionData> data, const TableFunction &) {
+	auto &bind = data->Cast<VideoBind>();
+	serializer.WriteProperty(101, "parameters", bind.parameters);
+	serializer.WriteProperty(102, "files", bind.files);
+	serializer.WriteProperty(103, "tensor", bind.tensor);
+	serializer.WriteProperty(104, "worker", bind.worker);
+	serializer.WriteProperty(105, "assigned", bind.assigned);
+}
+static unique_ptr<FunctionData> DeserializeVideo(Deserializer &deserializer, TableFunction &function) {
+	auto result = make_uniq<VideoBind>();
+	result->parameters = deserializer.ReadProperty<vector<Value>>(101, "parameters");
+	result->files = deserializer.ReadProperty<vector<Value>>(102, "files");
+	result->tensor = deserializer.ReadProperty<bool>(103, "tensor");
+	if (result->tensor != (function.name == "native_video_tensor_frames")) {
+		throw SerializationException("native video output type does not match its registered function");
+	}
+	result->worker = deserializer.ReadProperty<bool>(104, "worker");
+	result->assigned = deserializer.ReadProperty<bool>(105, "assigned");
+	if ((!result->worker && result->assigned) || (result->worker && !result->assigned && !result->files.empty())) {
+		throw SerializationException("native video contains invalid worker assignment state");
+	}
+	ValidateVideoBind(*result);
+	return std::move(result);
+}
+} // namespace
+
+void RegisterMediaVideo(ExtensionLoader &loader) {
+	ScalarFunctionSet metadata("native_video_metadata");
+	metadata.AddFunction(MediaScalar("video_metadata", {LogicalType::ANY}, MediaVideoMetadataType(), VideoMetadata));
+	metadata.AddFunction(MediaScalar("video_metadata", {LogicalType::ANY, LogicalType::UBIGINT},
+	                                 MediaVideoMetadataType(), VideoMetadata));
+	loader.RegisterFunction(metadata);
+	for (const auto &name : {"native_video_frames", "native_video_tensor_frames"}) {
+		TableFunction function(name,
+		                       {LogicalType::ANY, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE,
+		                        LogicalType::DOUBLE, LogicalType::BOOLEAN, LogicalType::DOUBLE, LogicalType::BIGINT,
+		                        LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
+		                        LogicalType::VARCHAR},
+		                       ScanVideo, BindVideo, InitVideo, InitVideoLocal);
+		function.serialize = SerializeVideo;
+		function.deserialize = DeserializeVideo;
+		TableFunctionDistributedScanCallbacks callbacks;
+		callbacks.protocol_version = 1;
+		callbacks.split_codec = {"vane.native-video-files", 1};
+		callbacks.plan_splits = PlanVideoSplits;
+		callbacks.create_worker_bind = WorkerVideoBind;
+		callbacks.apply_splits = ApplyVideoSplits;
+		function.SetDistributedScanCallbacks(std::move(callbacks));
+		loader.RegisterFunction(function);
+	}
+}
+} // namespace duckdb

--- a/external/duckdb/extension/video/video_functions.cpp
+++ b/external/duckdb/extension/video/video_functions.cpp
@@ -58,6 +58,15 @@ static void VideoMetadata(DataChunk &args, ExpressionState &state, Vector &resul
 	}
 }
 
+static uint64_t VideoFileBytes(const Value &file) {
+	if (file.IsNull() || !FileLogicalType::IsFile(file.type()) ||
+	    FileLogicalType::GetMediaType(file.type()) != FileMediaType::VIDEO) {
+		throw InvalidInputException("native video source requires non-NULL VIDEOFILE views");
+	}
+	auto reference = FileReference::FromValue(file, "native_video_frames");
+	return reference.url.size() + reference.content_type.size() + reference.checksum.size() + 512;
+}
+
 // Parameters are portable values only. Opening files is execution-time work.
 struct VideoBind : public TableFunctionData {
 	vector<Value> parameters;
@@ -66,6 +75,22 @@ struct VideoBind : public TableFunctionData {
 	bool worker = false;
 	bool assigned = false;
 	uint64_t row_bytes = 0;
+	idx_t TaskCount() const {
+		if (files.empty()) {
+			return 0;
+		}
+		if (worker || !parameters[10].IsNull()) {
+			return 1;
+		}
+		return parameters[12].IsNull() ? files.size() : MinValue<idx_t>(files.size(), parameters[12].GetValue<idx_t>());
+	}
+	pair<idx_t, idx_t> FileRange(idx_t task) const {
+		auto count = TaskCount();
+		auto size = files.size() / count;
+		auto larger_groups = files.size() % count;
+		auto start = task * size + MinValue(task, larger_groups);
+		return {start, start + size + (task < larger_groups ? 1 : 0)};
+	}
 	uint64_t RowBytes() const {
 		uint64_t file_bytes = 0;
 		for (auto &value : files) {
@@ -87,8 +112,8 @@ struct VideoBind : public TableFunctionData {
 
 static void ValidateVideoBind(VideoBind &bind) {
 	auto &p = bind.parameters;
-	if (p.size() != 12) {
-		throw InvalidInputException("native video requires twelve scan options");
+	if (p.size() != 13) {
+		throw InvalidInputException("native video requires thirteen scan options");
 	}
 	const idx_t integer_indices[] = {0, 1, 6, 7, 8, 9};
 	const char *names[] = {
@@ -121,17 +146,15 @@ static void ValidateVideoBind(VideoBind &bind) {
 	if (p[11].IsNull() || (p[11].GetValue<string>() != "raise" && p[11].GetValue<string>() != "skip")) {
 		throw InvalidInputException("video on_error must be raise or skip");
 	}
+	if (!p[12].IsNull()) {
+		MediaPositive(p[12], "read_task_count", NumericLimits<int64_t>::Maximum());
+	}
 	if (bind.files.size() > 100000) {
 		throw OutOfRangeException("native video source exceeds 100000 FILE views");
 	}
 	uint64_t source_bytes = 0;
 	for (auto &file : bind.files) {
-		if (file.IsNull() || !FileLogicalType::IsFile(file.type()) ||
-		    FileLogicalType::GetMediaType(file.type()) != FileMediaType::VIDEO) {
-			throw InvalidInputException("native video source requires non-NULL VIDEOFILE views");
-		}
-		auto reference = FileReference::FromValue(file, "native_video_frames");
-		uint64_t bytes = reference.url.size() + reference.content_type.size() + reference.checksum.size() + 512;
+		auto bytes = VideoFileBytes(file);
 		if (bytes > 64 * MEDIA_MIB - source_bytes) {
 			throw OutOfRangeException("native video source metadata exceeds 64 MiB");
 		}
@@ -171,7 +194,7 @@ static unique_ptr<FunctionData> BindVideo(ClientContext &, TableFunctionBindInpu
 }
 
 struct VideoGlobal : public GlobalTableFunctionState {
-	std::atomic<idx_t> next_file {0};
+	std::atomic<idx_t> next_task {0};
 	idx_t thread_count = 1;
 	uint64_t emitted = 0; // Used only in the explicitly serial, globally limited scan.
 	idx_t MaxThreads() const override {
@@ -181,6 +204,8 @@ struct VideoGlobal : public GlobalTableFunctionState {
 struct VideoLocal : public LocalTableFunctionState {
 	unique_ptr<MediaReader> reader;
 	idx_t file_index = 0;
+	idx_t next_file = 0;
+	idx_t end_file = 0;
 	uint64_t decoded = 0;
 	int64_t origin = AV_NOPTS_VALUE;
 	long double next_sample = 0;
@@ -193,7 +218,7 @@ static unique_ptr<GlobalTableFunctionState> InitVideo(ClientContext &, TableFunc
 		throw InvalidInputException("native video worker has no split assignment");
 	}
 	auto result = make_uniq<VideoGlobal>();
-	result->thread_count = bind.parameters[10].IsNull() ? MaxValue<idx_t>(1, bind.files.size()) : 1;
+	result->thread_count = MaxValue<idx_t>(1, bind.TaskCount());
 	return std::move(result);
 }
 static unique_ptr<LocalTableFunctionState> InitVideoLocal(ExecutionContext &, TableFunctionInitInput &,
@@ -223,10 +248,16 @@ static void ScanVideo(ClientContext &context, TableFunctionInput &input, DataChu
 		}
 		try {
 			if (!local.reader) {
-				local.file_index = global.next_file.fetch_add(1);
-				if (local.file_index >= bind.files.size()) {
-					break;
+				if (local.next_file == local.end_file) {
+					auto task = global.next_task.fetch_add(1);
+					if (task >= bind.TaskCount()) {
+						break;
+					}
+					auto range = bind.FileRange(task);
+					local.next_file = range.first;
+					local.end_file = range.second;
 				}
+				local.file_index = local.next_file++;
 				auto file = FileReference::FromValue(bind.files[local.file_index], "native_video_frames");
 				auto input_bytes = p[6].GetValue<uint64_t>();
 				local.reader = make_uniq<MediaReader>(context, file, AVMEDIA_TYPE_VIDEO, input_bytes, input_bytes * 4,
@@ -349,14 +380,9 @@ static vector<DistributedScanSplit> PlanVideoSplits(const TableFunctionDistribut
 		split.Validate();
 		splits.push_back(std::move(split));
 	};
-	if (!bind.parameters[10].IsNull()) {
-		if (!bind.files.empty()) {
-			append(bind.files);
-		}
-	} else {
-		for (auto &file : bind.files) {
-			append({file});
-		}
+	for (idx_t task = 0; task < bind.TaskCount(); task++) {
+		auto range = bind.FileRange(task);
+		append(vector<Value>(bind.files.begin() + range.first, bind.files.begin() + range.second));
 	}
 	return splits;
 }
@@ -378,14 +404,25 @@ static void ApplyVideoSplits(optional_ptr<FunctionData> data, const vector<Distr
 		throw SerializationException("globally limited native video requires one canonical split");
 	}
 	unordered_set<string> seen;
+	uint64_t source_bytes = 0;
 	for (auto &split : splits) {
 		split.Validate();
 		if (!seen.insert(split.split_id).second) {
 			throw SerializationException("duplicate native video split");
 		}
 		auto files = DecodeFiles(split.payload);
-		if (bind.parameters[10].IsNull() && files.size() != 1) {
-			throw SerializationException("native video split must contain one FILE view");
+		if (files.empty() || (bind.parameters[10].IsNull() && bind.parameters[12].IsNull() && files.size() != 1)) {
+			throw SerializationException("native video split has an invalid FILE group");
+		}
+		if (files.size() > 100000 - bind.files.size()) {
+			throw OutOfRangeException("native video source exceeds 100000 FILE views");
+		}
+		for (auto &file : files) {
+			auto bytes = VideoFileBytes(file);
+			if (bytes > 64 * MEDIA_MIB - source_bytes) {
+				throw OutOfRangeException("native video source metadata exceeds 64 MiB");
+			}
+			source_bytes += bytes;
 		}
 		bind.files.insert(bind.files.end(), files.begin(), files.end());
 	}
@@ -429,7 +466,7 @@ void RegisterMediaVideo(ExtensionLoader &loader) {
 		                       {LogicalType::ANY, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE,
 		                        LogicalType::DOUBLE, LogicalType::BOOLEAN, LogicalType::DOUBLE, LogicalType::BIGINT,
 		                        LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
-		                        LogicalType::VARCHAR},
+		                        LogicalType::VARCHAR, LogicalType::BIGINT},
 		                       ScanVideo, BindVideo, InitVideo, InitVideoLocal);
 		function.serialize = SerializeVideo;
 		function.deserialize = DeserializeVideo;

--- a/external/duckdb/extension/video/video_functions.cpp
+++ b/external/duckdb/extension/video/video_functions.cpp
@@ -71,7 +71,6 @@ static uint64_t VideoFileBytes(const Value &file) {
 struct VideoBind : public TableFunctionData {
 	vector<Value> parameters;
 	vector<Value> files;
-	bool tensor = false;
 	bool worker = false;
 	bool assigned = false;
 	uint64_t row_bytes = 0;
@@ -105,8 +104,8 @@ struct VideoBind : public TableFunctionData {
 	}
 	bool Equals(const FunctionData &other) const override {
 		auto value = dynamic_cast<const VideoBind *>(&other);
-		return value && parameters == value->parameters && files == value->files && tensor == value->tensor &&
-		       worker == value->worker && assigned == value->assigned;
+		return value && parameters == value->parameters && files == value->files && worker == value->worker &&
+		       assigned == value->assigned;
 	}
 };
 
@@ -176,7 +175,6 @@ static unique_ptr<FunctionData> BindVideo(ClientContext &, TableFunctionBindInpu
 		}
 		result->files = ListValue::GetChildren(input.inputs[0]);
 	}
-	result->tensor = input.table_function.name == "native_video_tensor_frames";
 	ValidateVideoBind(*result);
 	types.push_back(FileLogicalType::Create(FileMediaType::VIDEO));
 	names.push_back("file");
@@ -186,10 +184,6 @@ static unique_ptr<FunctionData> BindVideo(ClientContext &, TableFunctionBindInpu
 		types.push_back(field.second);
 	}
 	names.back() = "frame";
-	if (result->tensor) {
-		types.back() = TensorType::Create(LogicalType::UTINYINT, {result->parameters[0].GetValue<idx_t>(),
-		                                                          result->parameters[1].GetValue<idx_t>(), 3});
-	}
 	return std::move(result);
 }
 
@@ -239,7 +233,7 @@ static void ScanVideo(ClientContext &context, TableFunctionInput &input, DataChu
 		return;
 	}
 	idx_t row = 0;
-	uint64_t allocated_pixels = 0;
+	uint64_t allocated_payload = 0;
 	while (row < limit) {
 		MediaInterrupt(context);
 		if (limited && global.emitted >= p[10].GetValue<uint64_t>()) {
@@ -314,6 +308,12 @@ static void ScanVideo(ClientContext &context, TableFunctionInput &input, DataChu
 				auto interval = static_cast<long double>(p[5].GetValue<double>());
 				local.next_sample += (std::floor((time + tolerance - local.next_sample) / interval) + 1) * interval;
 			}
+			// Reserve the complete row before any output allocation. Suppressed
+			// conversion failures can retain both FILE strings and image buffers.
+			if (bind.row_bytes > p[9].GetValue<uint64_t>() - allocated_payload) {
+				throw OutOfRangeException("native video failed conversions exhausted the batch byte budget");
+			}
+			allocated_payload += bind.row_bytes;
 			output.SetValue(0, row, bind.files[local.file_index]);
 			output.SetValue(1, row, Value::BIGINT(NumericCast<int64_t>(frame_index)));
 			output.SetValue(2, row, has_time ? Value::DOUBLE(double(time)) : Value(LogicalType::DOUBLE));
@@ -324,18 +324,7 @@ static void ScanVideo(ClientContext &context, TableFunctionInput &input, DataChu
 			    6, row, frame.pkt_dts != AV_NOPTS_VALUE ? Value::BIGINT(frame.pkt_dts) : Value(LogicalType::BIGINT));
 			output.SetValue(7, row, frame.duration > 0 ? Value::BIGINT(frame.duration) : Value(LogicalType::BIGINT));
 			output.SetValue(8, row, Value::BOOLEAN(key));
-			if (bind.tensor) {
-				auto &data = ArrayVector::GetEntry(output.data[9]);
-				MediaConvertPixels(context, frame, "RGB", width, height,
-				                   FlatVector::GetData<uint8_t>(data) + row * frame_bytes);
-				FlatVector::SetNull(output.data[9], row, false);
-			} else {
-				if (frame_bytes > p[9].GetValue<uint64_t>() - allocated_pixels) {
-					throw OutOfRangeException("native video failed conversions exhausted the batch byte budget");
-				}
-				allocated_pixels += frame_bytes;
-				MediaWriteImage(context, frame, "RGB", width, height, output.data[9], row, frame_bytes);
-			}
+			MediaWriteImage(context, frame, "RGB", width, height, output.data[9], row, frame_bytes);
 			row++;
 			if (limited) {
 				global.emitted++;
@@ -433,20 +422,15 @@ static void SerializeVideo(Serializer &serializer, optional_ptr<FunctionData> da
 	auto &bind = data->Cast<VideoBind>();
 	serializer.WriteProperty(101, "parameters", bind.parameters);
 	serializer.WriteProperty(102, "files", bind.files);
-	serializer.WriteProperty(103, "tensor", bind.tensor);
-	serializer.WriteProperty(104, "worker", bind.worker);
-	serializer.WriteProperty(105, "assigned", bind.assigned);
+	serializer.WriteProperty(103, "worker", bind.worker);
+	serializer.WriteProperty(104, "assigned", bind.assigned);
 }
-static unique_ptr<FunctionData> DeserializeVideo(Deserializer &deserializer, TableFunction &function) {
+static unique_ptr<FunctionData> DeserializeVideo(Deserializer &deserializer, TableFunction &) {
 	auto result = make_uniq<VideoBind>();
 	result->parameters = deserializer.ReadProperty<vector<Value>>(101, "parameters");
 	result->files = deserializer.ReadProperty<vector<Value>>(102, "files");
-	result->tensor = deserializer.ReadProperty<bool>(103, "tensor");
-	if (result->tensor != (function.name == "native_video_tensor_frames")) {
-		throw SerializationException("native video output type does not match its registered function");
-	}
-	result->worker = deserializer.ReadProperty<bool>(104, "worker");
-	result->assigned = deserializer.ReadProperty<bool>(105, "assigned");
+	result->worker = deserializer.ReadProperty<bool>(103, "worker");
+	result->assigned = deserializer.ReadProperty<bool>(104, "assigned");
 	if ((!result->worker && result->assigned) || (result->worker && !result->assigned && !result->files.empty())) {
 		throw SerializationException("native video contains invalid worker assignment state");
 	}
@@ -461,23 +445,21 @@ void RegisterMediaVideo(ExtensionLoader &loader) {
 	metadata.AddFunction(MediaScalar("video_metadata", {LogicalType::ANY, LogicalType::UBIGINT},
 	                                 MediaVideoMetadataType(), VideoMetadata));
 	loader.RegisterFunction(metadata);
-	for (const auto &name : {"native_video_frames", "native_video_tensor_frames"}) {
-		TableFunction function(name,
-		                       {LogicalType::ANY, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE,
-		                        LogicalType::DOUBLE, LogicalType::BOOLEAN, LogicalType::DOUBLE, LogicalType::BIGINT,
-		                        LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
-		                        LogicalType::VARCHAR, LogicalType::BIGINT},
-		                       ScanVideo, BindVideo, InitVideo, InitVideoLocal);
-		function.serialize = SerializeVideo;
-		function.deserialize = DeserializeVideo;
-		TableFunctionDistributedScanCallbacks callbacks;
-		callbacks.protocol_version = 1;
-		callbacks.split_codec = {"vane.native-video-files", 1};
-		callbacks.plan_splits = PlanVideoSplits;
-		callbacks.create_worker_bind = WorkerVideoBind;
-		callbacks.apply_splits = ApplyVideoSplits;
-		function.SetDistributedScanCallbacks(std::move(callbacks));
-		loader.RegisterFunction(function);
-	}
+	TableFunction function("native_video_frames",
+	                       {LogicalType::ANY, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::DOUBLE,
+	                        LogicalType::DOUBLE, LogicalType::BOOLEAN, LogicalType::DOUBLE, LogicalType::BIGINT,
+	                        LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::BIGINT,
+	                        LogicalType::VARCHAR, LogicalType::BIGINT},
+	                       ScanVideo, BindVideo, InitVideo, InitVideoLocal);
+	function.serialize = SerializeVideo;
+	function.deserialize = DeserializeVideo;
+	TableFunctionDistributedScanCallbacks callbacks;
+	callbacks.protocol_version = 1;
+	callbacks.split_codec = {"vane.native-video-files", 1};
+	callbacks.plan_splits = PlanVideoSplits;
+	callbacks.create_worker_bind = WorkerVideoBind;
+	callbacks.apply_splits = ApplyVideoSplits;
+	function.SetDistributedScanCallbacks(std::move(callbacks));
+	loader.RegisterFunction(function);
 }
 } // namespace duckdb

--- a/external/duckdb/extension/video/video_functions.cpp
+++ b/external/duckdb/extension/video/video_functions.cpp
@@ -27,7 +27,7 @@ static void VideoMetadata(DataChunk &args, ExpressionState &state, Vector &resul
 		auto budget = args.ColumnCount() == 2 ? MediaPositive(args.data[1].GetValue(row), "max_bytes", 64 * MEDIA_MIB)
 		                                      : MEDIA_METADATA_BYTES;
 		MediaReader reader(state.GetContext(), FileReference::FromValue(value, "native_video_metadata"),
-		                   AVMEDIA_TYPE_VIDEO, INT64_MAX, budget);
+		                   AVMEDIA_TYPE_VIDEO, INT64_MAX, budget, MEDIA_MAX_PIXELS, MEDIA_MAX_FRAME_BYTES, budget);
 		auto &stream = reader.Stream();
 		auto &parameters = *stream.codecpar;
 		if (parameters.width <= 0 || parameters.height <= 0) {

--- a/external/duckdb/src/include/duckdb/main/extension_entries.hpp
+++ b/external/duckdb/src/include/duckdb/main/extension_entries.hpp
@@ -1071,6 +1071,7 @@ static constexpr ExtensionFunctionOverloadEntry EXTENSION_FUNCTION_OVERLOADS[] =
 
 static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"allow_asterisks_in_http_paths", "httpfs"},
+    {"audio_backend", "file"},
     {"auto_fallback_to_full_download", "httpfs"},
     {"azure_account_name", "azure"},
     {"azure_context_caching", "azure"},
@@ -1124,6 +1125,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"iceberg_via_aws_sdk_for_catalog_interactions", "iceberg"},
     {"ignore_row_group_size_for_partitioned_tables", "iceberg"},
     {"ignore_target_file_size_for_partitioned_tables", "iceberg"},
+    {"image_backend", "file"},
     {"merge_http_secret_into_s3_request", "httpfs"},
     {"mysql_adaptive_replan_enabled", "mysql_scanner"},
     {"mysql_aggregate_pushdown_enabled", "mysql_scanner"},
@@ -1213,6 +1215,7 @@ static constexpr ExtensionEntry EXTENSION_SETTINGS[] = {
     {"unsafe_disable_etag_checks", "httpfs"},
     {"unsafe_enable_version_guessing", "iceberg"},
     {"unsafe_iceberg_ignore_sort_order", "iceberg"},
+    {"video_backend", "file"},
     {"whoami_hostname", "quack"},
     {"whoami_meta", "quack"},
     {"whoami_name", "quack"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ include = [
     "/CODE_OF_CONDUCT.md",
     "/DEVELOPMENT.md",
     "/DISTRIBUTED_EXTENSIONS.md",
+    "/NATIVE_MEDIA_EXTENSIONS.md",
     "/GOVERNANCE.md",
     "/MAINTAINERS.md",
     "/RELEASE.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,7 +300,7 @@ include = [
     "external/duckdb/third_party/yyjson/**",
     "external/duckdb/third_party/zstd/**",
 
-    # Only the extensions statically linked into vane-ai.
+    # Base extensions and the source of independently loadable codec extensions.
     "external/duckdb/extension/CMakeLists.txt",
     "external/duckdb/extension/extension_build_tools.cmake",
     "external/duckdb/extension/extension_config.cmake",
@@ -309,6 +309,10 @@ include = [
     "external/duckdb/extension/loader/**",
     "external/duckdb/extension/core_functions/**",
     "external/duckdb/extension/file/**",
+    "external/duckdb/extension/image/**",
+    "external/duckdb/extension/audio/**",
+    "external/duckdb/extension/video/**",
+    "external/duckdb/extension/media_common/**",
     "external/duckdb/extension/icu/**",
     "external/duckdb/third_party/jemalloc/**",
     "external/duckdb/extension/json/**",

--- a/scripts/benchmark_native_media.py
+++ b/scripts/benchmark_native_media.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+"""Measure explicitly selected Python/native media execution on the same input.
+
+Run with the installed Vane package. Input generation and extension loading
+are outside the timed region. Repetitions alternate backend order after one
+warmup per backend; this measures warm-cache execution, not cold remote I/O.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+import platform
+import resource
+import statistics
+import time
+from pathlib import Path
+
+OPERATIONS = {
+    "image_metadata": ("image", "sum((image_file_metadata(image_file(url))).width)"),
+    "image_decode": ("image", "sum(octet_length((decode_image_file(image_file(url))).data))"),
+    "audio_metadata": ("audio", "sum((audio_metadata(audio_file(url))).sample_rate)"),
+    "audio_resample": ("audio", "sum((audio_resample(audio_file(url), 16000)).frames)"),
+    "video_metadata": ("video", "sum((video_metadata(video_file(url))).width)"),
+    "video_frames": ("video", None),
+}
+
+
+def main() -> None:
+    os.environ["VANE_RUNNER"] = "local-fast"
+    import vane
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=OPERATIONS)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--extension", type=Path, required=True)
+    parser.add_argument("--rows", type=int, default=100)
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--backend", choices=("both", "python", "native"), default="both")
+    parser.add_argument("--start-time", type=float, default=0)
+    parser.add_argument("--end-time", type=float)
+    parser.add_argument("--allow-unsigned-development-artifact", action="store_true")
+    args = parser.parse_args()
+    if min(args.rows, args.repetitions, args.threads) < 1:
+        parser.error("rows, repetitions, and threads must be positive")
+    domain, expression = OPERATIONS[args.operation]
+    source = args.input.resolve(strict=True)
+    artifact = args.extension.resolve(strict=True)
+    versions = {"vane": vane.__version__}
+    for name in ("pillow", "soundfile", "soxr", "av"):
+        try:
+            versions[name] = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            versions[name] = None
+    backends = ("python", "native") if args.backend == "both" else (args.backend,)
+    timings: dict[str, list[float]] = {backend: [] for backend in backends}
+    cpu_timings: dict[str, list[float]] = {backend: [] for backend in backends}
+    results: dict[str, object] = {}
+    with vane.connect(
+        config={"allow_unsigned_extensions": str(args.allow_unsigned_development_artifact).lower()}
+    ) as con:
+        con.load_extension(str(artifact))
+        con.execute("SET threads=?", [args.threads])
+        con.execute("CREATE TEMP TABLE inputs AS SELECT ?::VARCHAR AS url FROM range(?)", [str(source), args.rows])
+        engine = con.execute("PRAGMA version").fetchall()
+
+        def run(backend: str) -> object:
+            con.execute(f"SET {domain}_backend='{backend}'")
+            if expression:
+                return con.execute(f"SELECT {expression} FROM inputs").fetchone()
+            from vane.datasource.video_reader import VideoFrameSource
+
+            scan = VideoFrameSource(
+                [str(source)] * args.rows, height=90, width=160, start_time=args.start_time, end_time=args.end_time
+            )
+            return con.from_datasource(scan).aggregate("count(*), sum(frame_index)").fetchone()
+
+        for backend in timings:
+            results[backend] = run(backend)
+        for repetition in range(args.repetitions):
+            order = backends if repetition % 2 == 0 else tuple(reversed(backends))
+            for backend in order:
+                usage = resource.getrusage(resource.RUSAGE_SELF)
+                cpu_started = usage.ru_utime + usage.ru_stime
+                started = time.perf_counter()
+                results[backend] = run(backend)
+                timings[backend].append(time.perf_counter() - started)
+                usage = resource.getrusage(resource.RUSAGE_SELF)
+                cpu_timings[backend].append(usage.ru_utime + usage.ru_stime - cpu_started)
+    # Capture before hashing large inputs/artifacts. Use --backend in separate
+    # processes to compare peaks; ru_maxrss cannot be reset between backends.
+    peak_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    report = {
+        "operation": args.operation,
+        "input_name": source.name,
+        "input_bytes": source.stat().st_size,
+        "input_sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+        "artifact_sha256": hashlib.sha256(artifact.read_bytes()).hexdigest(),
+        "rows": args.rows,
+        "threads": args.threads,
+        "backends": backends,
+        "repetitions": args.repetitions,
+        "start_time": args.start_time,
+        "end_time": args.end_time,
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "package_versions": versions,
+        "engine": engine,
+        "cache": "warm; one warmup per backend; alternating measurement order",
+        "seconds": timings,
+        "cpu_seconds": cpu_timings,
+        "process_peak_rss_bytes": peak_rss if platform.system() == "Darwin" else peak_rss * 1024,
+        "peak_rss_scope": "whole process through query completion, including imports, loading, and warmups",
+        "median_seconds": {key: statistics.median(value) for key, value in timings.items()},
+        "results": results,
+    }
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -794,6 +794,19 @@ def _check_sdist(artifact: SdistArtifact, layout: DistributionLayout) -> None:
     for relative_path in required_paths:
         _require_sdist_path(names, relative_path, artifact.path)
 
+    # Optional codecs stay outside the base wheel, but their sources must be
+    # available when a user builds the corresponding extension from an sdist.
+    for domain in ("image", "audio", "video"):
+        for relative_path in (
+            "CMakeLists.txt",
+            f"{domain}_extension.cpp",
+            f"{domain}_functions.cpp",
+            f"include/{domain}_extension.hpp",
+        ):
+            _require_sdist_path(names, f"external/duckdb/extension/{domain}/{relative_path}", artifact.path)
+    for relative_path in ("extension.cmake", "media_reader.cpp", "image_convert.cpp", "include/media_reader.hpp"):
+        _require_sdist_path(names, f"external/duckdb/extension/media_common/{relative_path}", artifact.path)
+
     source_id_name = _require_sdist_path(names, "DUCKDB_SOURCE_ID", artifact.path)
     source_id = artifact.read(source_id_name).decode("ascii").strip()
     if GIT_OBJECT_ID.fullmatch(source_id) is None:

--- a/src/vane_py/audio_file_functions.cpp
+++ b/src/vane_py/audio_file_functions.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression.hpp"
 #include "file_resolver.hpp"
 #include "file_value.hpp"
+#include "media_backend.hpp"
 #include "vane_python/pybind11/gil_wrapper.hpp"
 
 #include <cmath>
@@ -528,6 +529,8 @@ static ScalarFunction MakeAudioMetadataFunction(vector<LogicalType> arguments) {
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetStability(FunctionStability::VOLATILE);
 	function.SetFallible();
+	function.SetBindExpressionCallback(
+	    [](FunctionBindExpressionInput &input) { return MediaBackend::BindNative(input, "audio", "audio_metadata"); });
 	return function;
 }
 
@@ -537,6 +540,8 @@ static ScalarFunction MakeAudioResampleFunction(vector<LogicalType> arguments) {
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetStability(FunctionStability::VOLATILE);
 	function.SetFallible();
+	function.SetBindExpressionCallback(
+	    [](FunctionBindExpressionInput &input) { return MediaBackend::BindNative(input, "audio", "audio_resample"); });
 	return function;
 }
 

--- a/src/vane_py/datasource_function.cpp
+++ b/src/vane_py/datasource_function.cpp
@@ -459,6 +459,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 	// DataSource implementations keep their own task and schema contracts.
 	auto video_source = py::module_::import("vane.datasource.video_reader").attr("VideoFrameSource");
 	if (py::isinstance(source, video_source) && MediaBackend::UseNative(*connection.context, "video")) {
+		if (!py::type::of(source).is(video_source)) {
+			throw InvalidInputException("native video supports only the built-in VideoFrameSource, not subclasses");
+		}
 		return TableFunction("native_video_tensor_frames", source.attr("_native_parameters")());
 	}
 

--- a/src/vane_py/datasource_function.cpp
+++ b/src/vane_py/datasource_function.cpp
@@ -462,7 +462,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &sour
 		if (!py::type::of(source).is(video_source)) {
 			throw InvalidInputException("native video supports only the built-in VideoFrameSource, not subclasses");
 		}
-		return TableFunction("native_video_tensor_frames", source.attr("_native_parameters")());
+		return TableFunction("native_video_frames", source.attr("_native_parameters")());
 	}
 
 	// 1. Convert DataSource schema (dict[str, str]) to Arrow schema

--- a/src/vane_py/datasource_function.cpp
+++ b/src/vane_py/datasource_function.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Vane contributors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "media_backend.hpp"
 #include "datasource_function.hpp"
 #include "vane_python/datasource_execution_context.hpp"
 #include "vane_python/pybind11/gil_wrapper.hpp"
@@ -453,6 +454,13 @@ void DataSourceStreamFactory::ReleaseSource(const char *pickled_source, idx_t pi
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::FromDataSource(py::object &source) {
 	auto &connection = con.GetConnection();
+
+	// Only the built-in video source opts into native scan dispatch. Other
+	// DataSource implementations keep their own task and schema contracts.
+	auto video_source = py::module_::import("vane.datasource.video_reader").attr("VideoFrameSource");
+	if (py::isinstance(source, video_source) && MediaBackend::UseNative(*connection.context, "video")) {
+		return TableFunction("native_video_tensor_frames", source.attr("_native_parameters")());
+	}
 
 	// 1. Convert DataSource schema (dict[str, str]) to Arrow schema
 	auto schema_dict = py::cast<py::dict>(source.attr("schema"));

--- a/src/vane_py/image_file_functions.cpp
+++ b/src/vane_py/image_file_functions.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/planner/expression.hpp"
 #include "file_resolver.hpp"
 #include "file_value.hpp"
+#include "media_backend.hpp"
 #include "vane_python/pybind11/gil_wrapper.hpp"
 
 #include <exception>
@@ -513,6 +514,9 @@ static ScalarFunction MakeImageMetadataFunction(vector<LogicalType> arguments) {
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetStability(FunctionStability::VOLATILE);
 	function.SetFallible();
+	function.SetBindExpressionCallback([](FunctionBindExpressionInput &input) {
+		return MediaBackend::BindNative(input, "image", "image_file_metadata");
+	});
 	return function;
 }
 
@@ -522,6 +526,9 @@ static ScalarFunction MakeDecodeImageFileFunction(vector<LogicalType> arguments)
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetStability(FunctionStability::VOLATILE);
 	function.SetFallible();
+	function.SetBindExpressionCallback([](FunctionBindExpressionInput &input) {
+		return MediaBackend::BindNative(input, "image", "decode_image_file");
+	});
 	return function;
 }
 

--- a/src/vane_py/video_file_functions.cpp
+++ b/src/vane_py/video_file_functions.cpp
@@ -11,6 +11,7 @@
 #include "duckdb/planner/expression.hpp"
 #include "file_resolver.hpp"
 #include "file_value.hpp"
+#include "media_backend.hpp"
 #include "vane_python/pybind11/gil_wrapper.hpp"
 
 #include <cmath>
@@ -260,6 +261,8 @@ static ScalarFunction MakeVideoMetadataFunction(vector<LogicalType> arguments) {
 	function.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
 	function.SetStability(FunctionStability::VOLATILE);
 	function.SetFallible();
+	function.SetBindExpressionCallback(
+	    [](FunctionBindExpressionInput &input) { return MediaBackend::BindNative(input, "video", "video_metadata"); });
 	return function;
 }
 

--- a/tests/fast/test_native_media_extensions.py
+++ b/tests/fast/test_native_media_extensions.py
@@ -155,6 +155,29 @@ def test_native_image_modes(image_path, mode, channels):
         assert len(result) == 15 * channels
 
 
+@pytest.mark.parametrize(
+    "domain,fixture,function,field,expected",
+    [
+        ("image", "image_path", "image_file_metadata", "width", 5),
+        ("audio", "audio_path", "audio_metadata", "sample_rate", 8000),
+        ("video", "video_path", "video_metadata", "width", 16),
+    ],
+)
+def test_native_generic_mime_declarations(domain, fixture, function, field, expected, request):
+    path = request.getfixturevalue(fixture)
+    query = f"SELECT {function}({domain}_file(file(?, ?, NULL, NULL, NULL)))"
+    with _connect(domain) as con:
+        for declared in (
+            "application/octet-stream",
+            "binary/octet-stream",
+            f"{domain}/*",
+            f" {domain.upper()}/*; hint=1 ",
+        ):
+            assert con.execute(query, [str(path), declared]).fetchone()[0][field] == expected
+        with pytest.raises(vane.InvalidInputException, match="content_type"):
+            con.execute(query, [str(path), "text/*"])
+
+
 def test_native_image_errors_and_limits(tmp_path, image_path):
     broken = tmp_path / "bad.png"
     broken.write_bytes(b"not an image")
@@ -254,6 +277,17 @@ def test_native_video_empty_and_format_error_policy(tmp_path, video_path):
         limited = VideoFrameSource([str(video_path)], width=8, height=6, max_decoded_frames=1, on_error="skip")
         with pytest.raises(vane.OutOfRangeException, match="max_decoded_frames"):
             con.from_datasource(limited).fetchall()
+
+
+@pytest.mark.parametrize("task_count", [None, 1, 2, 20])
+def test_native_video_grouped_local_scan(video_path, task_count):
+    with _connect("video") as con:
+        con.execute("SET threads=4")
+        source = VideoFrameSource([str(video_path)] * 5, width=8, height=6, read_task_count=task_count)
+        rows = con.from_datasource(source).project("file.url, frame_index").fetchall()
+        assert len(rows) == 60
+        assert sorted(index for _, index in rows) == sorted(list(range(12)) * 5)
+        assert all(url == str(video_path) for url, _ in rows)
 
 
 @pytest.mark.parametrize(

--- a/tests/fast/test_native_media_extensions.py
+++ b/tests/fast/test_native_media_extensions.py
@@ -187,6 +187,53 @@ def test_native_image_mime_alias(image_path):
         )
 
 
+def test_native_jpeg_header_uses_bounded_http_reads(monkeypatch):
+    image = pytest.importorskip("PIL.Image")
+    from tests.fast.test_file_reader import _start_object_server
+
+    encoded = io.BytesIO()
+    image.new("RGB", (5, 3), (20, 80, 160)).save(encoded, format="JPEG")
+    # Legal fill bytes and empty application segments precede the frame header.
+    jpeg = b"\xff\xd8" + b"\xff" * (128 * 1024) + b"\xff\xee\x00\x02" * 8192 + encoded.getvalue()[2:]
+    prefix = b"unrelated bundle prefix"
+    server, thread, handler = _start_object_server(prefix + jpeg + b"unrelated suffix")
+    original_send = handler._send_object
+
+    def bounded_send(self, include_body):
+        # Fail quickly if a regression starts issuing per-marker requests.
+        if len(handler.requests) >= 16:
+            self.send_response(400)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        original_send(self, include_body)
+
+    monkeypatch.setattr(handler, "_send_object", bounded_send)
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/bucket/object.bin"
+        with _connect("image") as con:
+            value = con.execute(
+                "SELECT image_file_metadata(image_file(file(?, 'image/jpeg', ?, ?, NULL)))",
+                [url, len(prefix), len(jpeg)],
+            ).fetchone()[0]
+            assert (value["width"], value["height"], value["format"]) == (5, 3, "JPEG")
+            with pytest.raises(vane.OutOfRangeException, match="max_bytes"):
+                con.execute(
+                    "SELECT image_file_metadata(image_file(file(?, 'image/jpeg', ?, ?, NULL)), "
+                    "65536::UBIGINT, 100::UBIGINT)",
+                    [url, len(prefix), len(jpeg)],
+                )
+        ranges = [request["range"] for request in handler.requests if request["range"] is not None]
+        assert 1 <= len(ranges) <= 12
+        for requested in ranges:
+            start, end = map(int, requested.removeprefix("bytes=").split("-"))
+            assert len(prefix) <= start <= end < len(prefix) + len(jpeg)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 @pytest.mark.parametrize(
     "format,subtype,declared",
     [
@@ -319,14 +366,49 @@ def test_native_video_metadata_and_streamed_frames(video_path, monkeypatch):
             [str(video_path)], width=8, height=6, start_time=0.5, end_time=2, sample_interval_seconds=0.5
         )
         for relation in (read_datasource(source, con=con), con.from_datasource(source)):
-            assert "NATIVE_VIDEO_TENSOR_FRAMES" in relation.explain().upper()
-            rows = relation.project("file.url, frame_index, frame_time, frame_time_base_denominator, frame").fetchall()
+            assert "NATIVE_VIDEO_FRAMES" in relation.explain().upper()
+            assert relation.types[-1].is_image()
+            rows = relation.project(
+                "file.url, frame_index, frame_time, frame_time_base_denominator, frame.data"
+            ).fetchall()
             assert [(r[1], r[2]) for r in rows] == [(2, 0.5), (4, 1.0), (6, 1.5), (8, 2.0)]
             assert all(r[0] == str(video_path) and r[3] > 0 and len(r[4]) == 144 for r in rows)
         limited = VideoFrameSource([str(video_path)] * 2, width=8, height=6, frame_limit=3)
         assert con.from_datasource(limited).project("frame_index").fetchall() == [(0,), (1,), (2,)]
         image_relation = con.table_function("native_video_frames", source._native_parameters())
         assert image_relation.project("frame.width, frame.height, frame.channels").fetchall() == [(8, 6, 3)] * 4
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="uses Linux address-space accounting")
+def test_native_video_allocates_only_actual_image_payload(video_path):
+    script = """
+import resource, sys
+from pathlib import Path
+import vane
+from vane.datasource.video_reader import VideoFrameSource
+with vane.connect(config={'allow_unsigned_extensions': 'true', 'memory_limit': '128MB', 'threads': 4}) as con:
+    con.load_extension(sys.argv[1])
+    con.execute("SET video_backend='native'")
+    vm_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
+                      if line.startswith('VmSize:')))
+    _, hard = resource.getrlimit(resource.RLIMIT_AS)
+    ceiling = vm_kib * 1024 + 256 * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (ceiling if hard < 0 else min(ceiling, hard), hard))
+    for source in (VideoFrameSource([]),
+                   VideoFrameSource([], width=5000, height=5000, max_partition_bytes=256 * 1024 * 1024)):
+        assert con.from_datasource(source).count('*').fetchone() == (0,)
+    source = VideoFrameSource([sys.argv[2]] * 4, max_partition_bytes=2 * 1024 * 1024)
+    relation = con.from_datasource(source)
+    assert relation.types[-1].is_image()
+    assert relation.count('*').fetchone() == (48,)
+    frame = relation.project('frame').limit(1).fetchone()[0]
+    assert isinstance(frame, vane.Image)
+    assert (frame.width, frame.height, frame.mode) == (480, 640, 'RGB')
+    assert len(frame.data) == 480 * 640 * 3
+"""
+    subprocess.run(
+        [sys.executable, "-I", "-c", script, str(_artifact("video")), str(video_path)], check=True, timeout=60
+    )
 
 
 def test_native_video_empty_and_format_error_policy(tmp_path, video_path):

--- a/tests/fast/test_native_media_extensions.py
+++ b/tests/fast/test_native_media_extensions.py
@@ -382,13 +382,16 @@ def test_native_video_metadata_and_streamed_frames(video_path, monkeypatch):
 @pytest.mark.skipif(sys.platform != "linux", reason="uses Linux address-space accounting")
 def test_native_video_allocates_only_actual_image_payload(video_path):
     script = """
-import resource, sys
+import os, resource, sys
+os.environ['VANE_RUNNER'] = 'local-fast'
 from pathlib import Path
 import vane
 from vane.datasource.video_reader import VideoFrameSource
 with vane.connect(config={'allow_unsigned_extensions': 'true', 'memory_limit': '128MB', 'threads': 4}) as con:
     con.load_extension(sys.argv[1])
     con.execute("SET video_backend='native'")
+    # Initialize executor threads with tiny frames before measuring allocation headroom.
+    assert con.from_datasource(VideoFrameSource([sys.argv[2]] * 4, width=1, height=1)).count('*').fetchone() == (48,)
     vm_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
                       if line.startswith('VmSize:')))
     _, hard = resource.getrlimit(resource.RLIMIT_AS)

--- a/tests/fast/test_native_media_extensions.py
+++ b/tests/fast/test_native_media_extensions.py
@@ -178,6 +178,68 @@ def test_native_generic_mime_declarations(domain, fixture, function, field, expe
             con.execute(query, [str(path), "text/*"])
 
 
+def test_native_image_mime_alias(image_path):
+    with _connect("image") as con:
+        query = "image_file(file(?, 'image/x-png', NULL, NULL, NULL))"
+        assert con.execute(f"SELECT image_file_metadata({query})", [str(image_path)]).fetchone()[0]["width"] == 5
+        assert con.execute(f"SELECT (decode_image_file({query})).data", [str(image_path)]).fetchone() == (
+            bytes((20, 80, 160)) * 15,
+        )
+
+
+@pytest.mark.parametrize(
+    "format,subtype,declared",
+    [
+        ("MP3", "MPEG_LAYER_III", "audio/mp3"),
+        ("MP3", "MPEG_LAYER_III", "audio/x-mp3"),
+        ("OGG", "VORBIS", "application/ogg"),
+        ("AIFF", "PCM_16", "audio/aif"),
+    ],
+)
+def test_native_audio_mime_aliases(tmp_path, format, subtype, declared):
+    np = pytest.importorskip("numpy")
+    soundfile = pytest.importorskip("soundfile")
+    path = tmp_path / ("audio." + format.lower())
+    soundfile.write(path, np.zeros((3200, 2)), 8000, format=format, subtype=subtype)
+    with _connect("audio") as con:
+        value = "audio_file(file(?, ?, NULL, NULL, NULL))"
+        metadata = con.execute(f"SELECT audio_metadata({value})", [str(path), declared]).fetchone()[0]
+        assert (metadata["sample_rate"], metadata["channels"]) == (8000, 2)
+        result = con.execute(f"SELECT audio_resample({value}, 16000)", [str(path), declared]).fetchone()[0]
+        assert result["sample_rate"] == 16000 and result["frames"] > 0
+
+
+@pytest.mark.parametrize("container,declared", [("mp4", "video/x-m4v"), ("matroska", "video/mkv")])
+def test_native_video_mime_aliases(tmp_path, video_path, container, declared):
+    av = pytest.importorskip("av")
+    path = tmp_path / "remuxed.bin"
+    with av.open(str(video_path)) as source, av.open(str(path), "w", format=container) as output:
+        stream = output.add_stream_from_template(source.streams.video[0])
+        for packet in source.demux(video=0):
+            if packet.dts is not None:
+                packet.stream = stream
+                output.mux(packet)
+    with _connect("video") as con:
+        metadata = con.execute(
+            "SELECT video_metadata(video_file(file(?, ?, NULL, NULL, NULL)))", [str(path), declared]
+        ).fetchone()[0]
+        assert (metadata["width"], metadata["height"]) == (16, 12)
+        source = VideoFrameSource([vane.VideoFile(str(path), declared)], width=8, height=6)
+        assert con.from_datasource(source).count("*").fetchone() == (12,)
+
+
+@pytest.mark.parametrize("domain,fixture", [("audio", "audio_path"), ("video", "video_path")])
+def test_native_metadata_read_budgets(domain, fixture, request):
+    path = request.getfixturevalue(fixture)
+    query = f"SELECT {domain}_metadata({domain}_file(?), ?)"
+    with _connect(domain) as con:
+        with pytest.raises(vane.OutOfRangeException, match="read/probe byte budget"):
+            con.execute(query, [str(path), 1])
+        assert con.execute(query, [str(path), 64 * 1024 * 1024]).fetchone()[0] is not None
+        with pytest.raises(vane.InvalidInputException, match="max_bytes"):
+            con.execute(query, [str(path), 64 * 1024 * 1024 + 1])
+
+
 def test_native_image_errors_and_limits(tmp_path, image_path):
     broken = tmp_path / "bad.png"
     broken.write_bytes(b"not an image")
@@ -277,6 +339,41 @@ def test_native_video_empty_and_format_error_policy(tmp_path, video_path):
         limited = VideoFrameSource([str(video_path)], width=8, height=6, max_decoded_frames=1, on_error="skip")
         with pytest.raises(vane.OutOfRangeException, match="max_decoded_frames"):
             con.from_datasource(limited).fetchall()
+
+
+@pytest.mark.parametrize("on_error", ["raise", "skip"])
+@pytest.mark.parametrize("budget,message", [(1, "video output frame bytes"), (144, "row exceeds max_partition_bytes")])
+def test_native_video_partition_limit_is_hard(video_path, on_error, budget, message):
+    with _connect("video") as con:
+        source = VideoFrameSource([str(video_path)], width=8, height=6, max_partition_bytes=budget, on_error=on_error)
+        with pytest.raises(vane.OutOfRangeException, match=message):
+            con.from_datasource(source)
+
+
+def test_native_video_rejects_subclasses_without_bypassing_custom_tasks(video_path):
+    pa = pytest.importorskip("pyarrow")
+    from vane.datasource import DataSourceTask
+
+    class CustomTask(DataSourceTask):
+        def execute(self):
+            yield pa.record_batch([pa.array([42], type=pa.int64())], names=["custom_value"])
+
+    class CustomVideoSource(VideoFrameSource):
+        @property
+        def schema(self):
+            return {"custom_value": "BIGINT"}
+
+        def get_tasks(self):
+            yield CustomTask()
+
+    source = CustomVideoSource([str(video_path)], width=8, height=6)
+    with _connect("video") as con:
+        with pytest.raises(vane.InvalidInputException, match="built-in VideoFrameSource, not subclasses"):
+            con.from_datasource(source)
+        con.execute("SET video_backend='python'")
+        relation = con.from_datasource(source)
+        assert relation.columns == ["custom_value"]
+        assert relation.fetchall() == [(42,)]
 
 
 @pytest.mark.parametrize("task_count", [None, 1, 2, 20])

--- a/tests/fast/test_native_media_extensions.py
+++ b/tests/fast/test_native_media_extensions.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import math
+import os
+import struct
+import subprocess
+import sys
+import wave
+import zlib
+from pathlib import Path
+
+import pytest
+
+import vane
+from vane.datasource.video_reader import VideoFrameSource
+
+
+def _artifact(domain: str) -> Path:
+    variable = f"VANE_TEST_NATIVE_{domain.upper()}_EXTENSION"
+    path = os.environ.get(variable)
+    if not path:
+        pytest.skip(f"set {variable} to test the optional {domain} artifact")
+    result = Path(path).resolve()
+    assert result.is_file(), result
+    return result
+
+
+def _connect(domain: str):
+    artifact = _artifact(domain)
+    connection = vane.connect(config={"allow_unsigned_extensions": "true"})
+    connection.load_extension(str(artifact))
+    connection.execute(f"SET {domain}_backend='native'")
+    return connection
+
+
+def _png(width: int = 5, height: int = 3) -> bytes:
+    def chunk(name: bytes, content: bytes) -> bytes:
+        return struct.pack(">I", len(content)) + name + content + struct.pack(">I", zlib.crc32(name + content))
+
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    pixels = (b"\0" + bytes((20, 80, 160)) * width) * height
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header) + chunk(b"IDAT", zlib.compress(pixels)) + chunk(b"IEND", b"")
+
+
+def _wav(frames: int = 800, sample_rate: int = 8000) -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as output:
+        output.setparams((2, 2, sample_rate, frames, "NONE", "not compressed"))
+        output.writeframes(
+            b"".join(
+                struct.pack("<hh", int(12000 * math.sin(i / 8)), -int(12000 * math.sin(i / 8))) for i in range(frames)
+            )
+        )
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def image_path(tmp_path):
+    path = tmp_path / "image.png"
+    path.write_bytes(_png())
+    return path
+
+
+@pytest.fixture
+def audio_path(tmp_path):
+    path = tmp_path / "audio.wav"
+    path.write_bytes(_wav())
+    return path
+
+
+@pytest.fixture
+def video_path(tmp_path):
+    av = pytest.importorskip("av")
+    np = pytest.importorskip("numpy")
+    path = tmp_path / "video.mp4"
+    with av.open(str(path), "w") as output:
+        stream = output.add_stream("mpeg4", rate=4)
+        stream.width, stream.height, stream.pix_fmt = 16, 12, "yuv420p"
+        stream.codec_context.gop_size = 3
+        stream.codec_context.max_b_frames = 2
+        for index in range(12):
+            frame = av.VideoFrame.from_ndarray(np.full((12, 16, 3), index * 15, dtype=np.uint8), format="rgb24")
+            for packet in stream.encode(frame):
+                output.mux(packet)
+        for packet in stream.encode():
+            output.mux(packet)
+    return path
+
+
+@pytest.mark.parametrize(
+    "domain,function", [("image", "image_file_metadata"), ("audio", "audio_metadata"), ("video", "video_metadata")]
+)
+def test_backend_is_explicit_and_requires_matching_extension(domain, function):
+    with vane.connect() as con:
+        assert con.execute(f"SELECT current_setting('{domain}_backend')").fetchone() == ("python",)
+        with pytest.raises(vane.InvalidInputException, match="python.*native"):
+            con.execute(f"SET {domain}_backend='automatic'")
+        con.execute(f"SET {domain}_backend='native'")
+        with pytest.raises(vane.BinderException, match=f"requires the {domain} extension"):
+            con.sql(f"SELECT {function}({domain}_file('unopened://file'))")
+
+
+@pytest.mark.parametrize("domain", ["image", "audio", "video"])
+def test_backend_connection_configuration_is_validated(domain):
+    option = f"{domain}_backend"
+    for backend in ("python", "native"):
+        with vane.connect(config={option: backend}) as con:
+            assert con.execute(f"SELECT current_setting('{option}')").fetchone() == (backend,)
+    for invalid in ("automatic", None):
+        with pytest.raises(vane.InvalidInputException, match="python.*native"):
+            vane.connect(config={option: invalid})
+
+
+def test_image_native_decode_metadata_nulls_and_backend_switch(image_path, monkeypatch):
+    import vane._image_file as helper
+
+    with _connect("image") as con:
+        monkeypatch.setattr(
+            helper, "_probe_image_metadata", lambda *a, **kw: pytest.fail("Python metadata helper called")
+        )
+        monkeypatch.setattr(helper, "_decode_image_stream", lambda *a, **kw: pytest.fail("Python decode helper called"))
+        assert con.execute("SELECT image_file_metadata(image_file(?))", [str(image_path)]).fetchone()[0] == {
+            "width": 5,
+            "height": 3,
+            "format": "PNG",
+            "mode": "RGB",
+        }
+        rows = con.execute(
+            "SELECT (decode_image_file(image_file(url), 'RGB')).data FROM (VALUES (?), (NULL), (?)) t(url)",
+            [str(image_path), str(image_path)],
+        ).fetchall()
+        assert rows == [(bytes((20, 80, 160)) * 15,), (None,), (bytes((20, 80, 160)) * 15,)]
+        quoted_path = str(image_path).replace("'", "''")
+        query = f"SELECT image_file_metadata(image_file(url)) FROM (SELECT '{quoted_path}' AS url FROM range(1))"
+        native_plan = con.sql(query)
+        assert "native_image_file_metadata" in native_plan.explain()
+        con.execute(f"PREPARE native_metadata AS SELECT image_file_metadata(image_file('{quoted_path}'))")
+        con.execute("SET image_backend='python'")
+        assert con.execute("EXECUTE native_metadata").fetchone()[0]["width"] == 5
+        assert "native_image_file_metadata" not in con.sql(query).explain()
+        assert con.execute("SELECT current_setting('audio_backend'), current_setting('video_backend')").fetchone() == (
+            "python",
+            "python",
+        )
+
+
+@pytest.mark.parametrize("mode,channels", [("L", 1), ("LA", 2), ("RGB", 3), ("RGBA", 4)])
+def test_native_image_modes(image_path, mode, channels):
+    with _connect("image") as con:
+        result = con.execute("SELECT (decode_image_file(image_file(?), ?)).data", [str(image_path), mode]).fetchone()[0]
+        assert len(result) == 15 * channels
+
+
+def test_native_image_errors_and_limits(tmp_path, image_path):
+    broken = tmp_path / "bad.png"
+    broken.write_bytes(b"not an image")
+    with _connect("image") as con:
+        assert con.execute("SELECT decode_image_file(image_file(?), NULL, 'null')", [str(broken)]).fetchone() == (None,)
+        with pytest.raises(vane.InvalidInputException, match="native"):
+            con.execute("SELECT decode_image_file(image_file(?))", [str(broken)])
+        with pytest.raises(Exception, match="does not exist|No such file|Cannot open"):
+            con.execute("SELECT decode_image_file(image_file(?), NULL, 'null')", [str(tmp_path / "absent.png")])
+        with pytest.raises(vane.OutOfRangeException, match="pixels"):
+            con.execute("SELECT decode_image_file(image_file(?), NULL, 'null', 1024, 1, 1024)", [str(image_path)])
+        with pytest.raises(vane.OutOfRangeException, match="decoded frame bytes"):
+            con.execute("SELECT decode_image_file(image_file(?), NULL, 'null', 1024, 100, 16)", [str(image_path)])
+        with pytest.raises(vane.OutOfRangeException, match="max_bytes"):
+            con.execute("SELECT image_file_metadata(image_file(?), 8, 100)", [str(image_path)])
+        with pytest.raises(vane.InvalidInputException, match="content_type"):
+            con.execute(
+                "SELECT decode_image_file(image_file(file(?, 'image/jpeg', NULL, NULL, NULL)))", [str(image_path)]
+            )
+
+
+@pytest.mark.parametrize(
+    "domain,mime,function,payload",
+    [
+        ("image", "image/png", "image_file_metadata", _png),
+        ("audio", "audio/wav", "audio_metadata", _wav),
+    ],
+)
+def test_native_uses_exact_file_window(tmp_path, domain, mime, function, payload):
+    encoded = payload()
+    prefix = b"unrelated prefix" * 20
+    path = tmp_path / "bundle.bin"
+    path.write_bytes(prefix + encoded + b"unrelated suffix" * 20)
+    with _connect(domain) as con:
+        value = con.execute(
+            f"SELECT {function}({domain}_file(file(?, ?, ?, ?, NULL)))", [str(path), mime, len(prefix), len(encoded)]
+        ).fetchone()[0]
+        assert value is not None
+        if domain == "image":
+            assert con.execute(
+                "SELECT (decode_image_file(image_file(file(?, ?, ?, ?, NULL)))).data",
+                [str(path), mime, len(prefix), len(encoded)],
+            ).fetchone() == (bytes((20, 80, 160)) * 15,)
+        with pytest.raises(vane.InvalidInputException):
+            con.execute(f"SELECT {function}({domain}_file(file(?, ?, ?, ?, NULL)))", [str(path), mime, len(prefix), 8])
+
+
+def test_native_audio_resamples_without_python_helpers(audio_path, monkeypatch):
+    import vane._audio_file as helper
+
+    with _connect("audio") as con:
+        monkeypatch.setattr(helper, "_probe_audio_metadata", lambda *a, **kw: pytest.fail("Python probe called"))
+        monkeypatch.setattr(helper, "_resample_audio_stream", lambda *a, **kw: pytest.fail("Python resampler called"))
+        metadata = con.execute("SELECT audio_metadata(audio_file(?))", [str(audio_path)]).fetchone()[0]
+        assert (metadata["sample_rate"], metadata["channels"], metadata["frames"]) == (8000, 2, 800)
+        result = con.execute("SELECT audio_resample(audio_file(?), 16000)", [str(audio_path)]).fetchone()[0]
+        assert (result["sample_rate"], result["frames"], result["channels"]) == (16000, 1600, 2)
+        assert len(result["samples"]) == 3200
+        assert max(abs(a + b) for a, b in zip(result["samples"][::2], result["samples"][1::2])) < 1e-10
+        assert con.execute("SELECT audio_resample(NULL::AUDIOFILE, 16000)").fetchone() == (None,)
+        with pytest.raises(vane.OutOfRangeException, match="max_frames"):
+            con.execute(
+                "SELECT audio_resample(audio_file(?), 16000, 100000, 10, 100000, 100000, 100000)", [str(audio_path)]
+            )
+
+
+def test_native_video_metadata_and_streamed_frames(video_path, monkeypatch):
+    import vane._video_file as helper
+    from vane.datasource import read_datasource
+
+    with _connect("video") as con:
+        monkeypatch.setattr(helper, "_probe_video_metadata", lambda *a, **kw: pytest.fail("Python video probe called"))
+        monkeypatch.setattr(vane.VideoFile, "frames", lambda *a, **kw: pytest.fail("Python frame decoder called"))
+        metadata = con.execute("SELECT video_metadata(video_file(?))", [str(video_path)]).fetchone()[0]
+        assert (metadata["width"], metadata["height"], metadata["frame_count"]) == (16, 12, 12)
+        source = VideoFrameSource(
+            [str(video_path)], width=8, height=6, start_time=0.5, end_time=2, sample_interval_seconds=0.5
+        )
+        for relation in (read_datasource(source, con=con), con.from_datasource(source)):
+            assert "NATIVE_VIDEO_TENSOR_FRAMES" in relation.explain().upper()
+            rows = relation.project("file.url, frame_index, frame_time, frame_time_base_denominator, frame").fetchall()
+            assert [(r[1], r[2]) for r in rows] == [(2, 0.5), (4, 1.0), (6, 1.5), (8, 2.0)]
+            assert all(r[0] == str(video_path) and r[3] > 0 and len(r[4]) == 144 for r in rows)
+        limited = VideoFrameSource([str(video_path)] * 2, width=8, height=6, frame_limit=3)
+        assert con.from_datasource(limited).project("frame_index").fetchall() == [(0,), (1,), (2,)]
+        image_relation = con.table_function("native_video_frames", source._native_parameters())
+        assert image_relation.project("frame.width, frame.height, frame.channels").fetchall() == [(8, 6, 3)] * 4
+
+
+def test_native_video_empty_and_format_error_policy(tmp_path, video_path):
+    broken = tmp_path / "broken.mp4"
+    broken.write_bytes(b"invalid")
+    with _connect("video") as con:
+        assert con.from_datasource(VideoFrameSource([], width=8, height=6)).fetchall() == []
+        source = VideoFrameSource([str(broken), str(video_path)], width=8, height=6, on_error="skip", frame_limit=2)
+        assert con.from_datasource(source).project("frame_index").fetchall() == [(0,), (1,)]
+        limited = VideoFrameSource([str(video_path)], width=8, height=6, max_decoded_frames=1, on_error="skip")
+        with pytest.raises(vane.OutOfRangeException, match="max_decoded_frames"):
+            con.from_datasource(limited).fetchall()
+
+
+@pytest.mark.parametrize(
+    "domain,function,fixture",
+    [
+        ("image", "decode_image_file", "image_path"),
+        ("audio", "audio_resample", "audio_path"),
+        ("video", "video_metadata", "video_path"),
+    ],
+)
+def test_native_does_not_import_python_codec_packages(domain, function, fixture, request):
+    path = request.getfixturevalue(fixture)
+    suffix = ", 16000" if domain == "audio" else ""
+    script = """
+import importlib.abc, sys
+class BlockCodecs(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split('.')[0] in {'PIL', 'av', 'soundfile', 'soxr'}:
+            raise AssertionError('native execution imported ' + fullname)
+sys.meta_path.insert(0, BlockCodecs())
+import vane
+with vane.connect(config={'allow_unsigned_extensions': 'true'}) as con:
+    con.load_extension(sys.argv[1])
+    con.execute('SET ' + sys.argv[2] + "_backend='native'")
+    con.execute(sys.argv[3], [sys.argv[4]]).fetchall()
+"""
+    subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            script,
+            str(_artifact(domain)),
+            domain,
+            f"SELECT {function}({domain}_file(?){suffix})",
+            str(path),
+        ],
+        check=True,
+        timeout=60,
+    )
+
+
+@pytest.mark.parametrize("format,mode", [("JPEG", "RGB"), ("JPEG", "L"), ("PNG", "RGBA")])
+def test_native_encoded_modes_and_jpeg_headers(tmp_path, format, mode):
+    image = pytest.importorskip("PIL.Image")
+    color = 80 if mode == "L" else (20, 80, 160, 78) if mode == "RGBA" else (20, 80, 160)
+    path = tmp_path / ("picture." + format.lower())
+    image.new(mode, (5, 3), color).save(path, format=format)
+    with _connect("image") as con:
+        result = con.execute("SELECT image_file_metadata(image_file(?))", [str(path)]).fetchone()[0]
+        assert (result["width"], result["height"], result["format"], result["mode"]) == (5, 3, format, mode)
+        pixels, channels = con.execute(
+            "SELECT decoded.data, decoded.channels FROM (SELECT decode_image_file(image_file(?)) AS decoded)",
+            [str(path)],
+        ).fetchone()
+        assert len(pixels) == 15 * channels
+        if mode == "RGBA":
+            assert pixels == bytes(color) * 15
+        else:
+            expected = [color] if mode == "L" else color
+            assert max(abs(actual - target) for actual, target in zip(pixels[:channels], expected)) <= 3
+
+
+def test_native_file_adapter_preserves_registered_filesystem_rejection():
+    fsspec = pytest.importorskip("fsspec")
+
+    class GuardedFS(fsspec.AbstractFileSystem):
+        protocol = "nativeguard"
+        cachable = False
+
+        def __init__(self):
+            super().__init__()
+            self.opens = 0
+
+        def _open(self, path, mode="rb", **kwargs):
+            self.opens += 1
+            pytest.fail("Native FILE resolver attempted unsupported Python filesystem I/O")
+
+    fs = GuardedFS()
+    with _connect("image") as con:
+        con.register_filesystem(fs)
+        with pytest.raises(vane.NotImplementedException, match="Nonblocking opens are not supported"):
+            con.execute("SELECT decode_image_file(image_file('nativeguard://image'), NULL, 'null')")
+        assert fs.opens == 0

--- a/tests/fast/test_native_media_extensions.py
+++ b/tests/fast/test_native_media_extensions.py
@@ -231,7 +231,7 @@ def test_native_video_mime_aliases(tmp_path, video_path, container, declared):
 @pytest.mark.parametrize("domain,fixture", [("audio", "audio_path"), ("video", "video_path")])
 def test_native_metadata_read_budgets(domain, fixture, request):
     path = request.getfixturevalue(fixture)
-    query = f"SELECT {domain}_metadata({domain}_file(?), ?)"
+    query = f"SELECT {domain}_metadata({domain}_file(?), ?::UBIGINT)"
     with _connect(domain) as con:
         with pytest.raises(vane.OutOfRangeException, match="read/probe byte budget"):
             con.execute(query, [str(path), 1])

--- a/tests/fast/test_ray_native_media_extensions.py
+++ b/tests/fast/test_ray_native_media_extensions.py
@@ -37,6 +37,7 @@ def test_ray_executes_native_scalar_with_exact_installed_provider(
     ray_local, request, domain, fixture, expression, expected
 ):
     import pyarrow as pa
+
     from vane.runners.ray.runner import RayRunner
 
     path = request.getfixturevalue(fixture)
@@ -57,14 +58,16 @@ def test_ray_executes_native_scalar_with_exact_installed_provider(
 
 
 @pytest.mark.real_ray
-def test_ray_native_video_splits_preserve_files_and_frames(ray_local, video_path):
+def test_ray_native_video_splits_preserve_files_and_frames(ray_local, request):
     import pyarrow as pa
+
     from vane.datasource.video_reader import VideoFrameSource
     from vane.runners.ray.runner import RayRunner
 
+    path = request.getfixturevalue("video_path")
     with vane.connect(config={"video_backend": "native"}) as con:
         _load_provider(con, "video")
-        source = VideoFrameSource([str(video_path)] * 3, width=8, height=6, start_time=0.5, end_time=1.0)
+        source = VideoFrameSource([str(path)] * 3, width=8, height=6, start_time=0.5, end_time=1.0)
         relation = con.from_datasource(source).project("file, frame_index, frame_time")
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
@@ -73,6 +76,6 @@ def test_ray_native_video_splits_preserve_files_and_frames(ray_local, video_path
             assert table.num_columns == 3
             assert sorted(table.column(1).to_pylist()) == [2] * 3 + [3] * 3 + [4] * 3
             assert set(table.column(2).to_pylist()) == {0.5, 0.75, 1.0}
-            assert all(value["url"] == str(video_path) for value in table.column(0).to_pylist())
+            assert all(value["url"] == str(path) for value in table.column(0).to_pylist())
         finally:
             runner.close()

--- a/tests/fast/test_ray_native_media_extensions.py
+++ b/tests/fast/test_ray_native_media_extensions.py
@@ -81,17 +81,22 @@ def test_ray_native_video_splits_preserve_files_and_frames(
             read_task_count=task_count,
             frame_limit=frame_limit,
         )
-        relation = con.from_datasource(source).project("file, frame_index, frame_time")
+        relation = con.from_datasource(source).project("file, frame_index, frame_time, frame")
+        assert relation.types[-1].is_image()
         plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "native-video-groups").to_physical_plan(con)
         assert [len(batches) for batches in plan.scan_split_batch_map().values()] == [expected_splits]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
             parts = list(runner.run_iter_tables(relation))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
-            assert table.num_columns == 3
+            assert table.num_columns == 4
             repeats = 1 if frame_limit is not None else 5
             assert sorted(table.column(1).to_pylist()) == [2] * repeats + [3] * repeats + [4] * repeats
             assert set(table.column(2).to_pylist()) == {0.5, 0.75, 1.0}
             assert all(value["url"] == str(path) for value in table.column(0).to_pylist())
+            assert all(
+                value["width"] == 8 and value["height"] == 6 and value["mode"] == "RGB" and len(value["data"]) == 144
+                for value in table.column(3).to_pylist()
+            )
         finally:
             runner.close()

--- a/tests/fast/test_ray_native_media_extensions.py
+++ b/tests/fast/test_ray_native_media_extensions.py
@@ -58,7 +58,12 @@ def test_ray_executes_native_scalar_with_exact_installed_provider(
 
 
 @pytest.mark.real_ray
-def test_ray_native_video_splits_preserve_files_and_frames(ray_local, request):
+@pytest.mark.parametrize(
+    "task_count,frame_limit,expected_splits", [(None, None, 5), (1, None, 1), (2, None, 2), (20, None, 5), (2, 3, 1)]
+)
+def test_ray_native_video_splits_preserve_files_and_frames(
+    ray_local, request, task_count, frame_limit, expected_splits
+):
     import pyarrow as pa
 
     from vane.datasource.video_reader import VideoFrameSource
@@ -67,14 +72,25 @@ def test_ray_native_video_splits_preserve_files_and_frames(ray_local, request):
     path = request.getfixturevalue("video_path")
     with vane.connect(config={"video_backend": "native"}) as con:
         _load_provider(con, "video")
-        source = VideoFrameSource([str(path)] * 3, width=8, height=6, start_time=0.5, end_time=1.0)
+        source = VideoFrameSource(
+            [str(path)] * 5,
+            width=8,
+            height=6,
+            start_time=0.5,
+            end_time=1.0,
+            read_task_count=task_count,
+            frame_limit=frame_limit,
+        )
         relation = con.from_datasource(source).project("file, frame_index, frame_time")
+        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "native-video-groups").to_physical_plan(con)
+        assert [len(batches) for batches in plan.scan_split_batch_map().values()] == [expected_splits]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
             parts = list(runner.run_iter_tables(relation))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
             assert table.num_columns == 3
-            assert sorted(table.column(1).to_pylist()) == [2] * 3 + [3] * 3 + [4] * 3
+            repeats = 1 if frame_limit is not None else 5
+            assert sorted(table.column(1).to_pylist()) == [2] * repeats + [3] * repeats + [4] * repeats
             assert set(table.column(2).to_pylist()) == {0.5, 0.75, 1.0}
             assert all(value["url"] == str(path) for value in table.column(0).to_pylist())
         finally:

--- a/tests/fast/test_ray_native_media_extensions.py
+++ b/tests/fast/test_ray_native_media_extensions.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from importlib.metadata import entry_points
+
+import pytest
+
+import vane
+from tests.fast.test_native_media_extensions import audio_path, image_path, video_path  # noqa: F401
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("VANE_TEST_NATIVE_MEDIA_PROVIDERS") != "1",
+    reason="requires signed native image/audio/video provider wheels",
+)
+
+
+def _load_provider(con, name):
+    if os.environ.get("VANE_TEST_NATIVE_MEDIA_PROVIDERS") != "1":
+        pytest.skip("set VANE_TEST_NATIVE_MEDIA_PROVIDERS=1 with signed image/audio/video provider wheels installed")
+    assert len([ep for ep in entry_points(group="vane.dynamic_extension_providers") if ep.name == name]) == 1
+    vane.load_installed_extension(name, connection=con)
+
+
+@pytest.mark.real_ray
+@pytest.mark.parametrize(
+    "domain,fixture,expression,expected",
+    [
+        ("image", "image_path", "(image_file_metadata(image_file(url))).width", 5),
+        ("audio", "audio_path", "(audio_resample(audio_file(url), 16000)).frames", 1600),
+        ("video", "video_path", "(video_metadata(video_file(url))).frame_count", 12),
+    ],
+)
+def test_ray_executes_native_scalar_with_exact_installed_provider(
+    ray_local, request, domain, fixture, expression, expected
+):
+    import pyarrow as pa
+    from vane.runners.ray.runner import RayRunner
+
+    path = request.getfixturevalue(fixture)
+    with vane.connect(config={f"{domain}_backend": "native"}) as con:
+        _load_provider(con, domain)
+        quoted_path = str(path).replace("'", "''")
+        relation = con.sql(f"SELECT {expression} AS result FROM (SELECT '{quoted_path}' AS url FROM range(8)) inputs")
+        assert "RANGE" in relation.explain()
+        runner = RayRunner(address=None, max_task_backlog=None)
+        try:
+            for _ in range(2):
+                parts = list(runner.run_iter_tables(relation))
+                table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
+                assert table.num_columns == 1
+                assert table.column(0).to_pylist() == [expected] * 8
+        finally:
+            runner.close()
+
+
+@pytest.mark.real_ray
+def test_ray_native_video_splits_preserve_files_and_frames(ray_local, video_path):
+    import pyarrow as pa
+    from vane.datasource.video_reader import VideoFrameSource
+    from vane.runners.ray.runner import RayRunner
+
+    with vane.connect(config={"video_backend": "native"}) as con:
+        _load_provider(con, "video")
+        source = VideoFrameSource([str(video_path)] * 3, width=8, height=6, start_time=0.5, end_time=1.0)
+        relation = con.from_datasource(source).project("file, frame_index, frame_time")
+        runner = RayRunner(address=None, max_task_backlog=None)
+        try:
+            parts = list(runner.run_iter_tables(relation))
+            table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
+            assert table.num_columns == 3
+            assert sorted(table.column(1).to_pylist()) == [2] * 3 + [3] * 3 + [4] * 3
+            assert set(table.column(2).to_pylist()) == {0.5, 0.75, 1.0}
+            assert all(value["url"] == str(video_path) for value in table.column(0).to_pylist())
+        finally:
+            runner.close()

--- a/vane/datasource/video_reader.py
+++ b/vane/datasource/video_reader.py
@@ -986,6 +986,7 @@ class VideoFrameSource(DataSource):
             self.max_partition_bytes,
             self.frame_limit,
             self.on_error,
+            self.read_task_count,
         ]
 
     def to_udf_relation(self, con: Any) -> Any:

--- a/vane/datasource/video_reader.py
+++ b/vane/datasource/video_reader.py
@@ -836,6 +836,10 @@ class _EmptyVideoFrameTask(DataSourceTask):
 class VideoFrameSource(DataSource):
     """Stream selected VIDEOFILE frames as bounded distributed rows.
 
+    With ``video_backend='native'``, the bound relation contains RGB IMAGE
+    values in ``frame``. The explicit Python backend runs these tasks using
+    the RGB Tensor schema exposed by ``schema``.
+
     Strings and path-like values are convenience inputs and become VIDEOFILE
     values without I/O. Generic FILE values preserve all five fields while
     acquiring video semantics. IMAGEFILE and AUDIOFILE values are rejected.

--- a/vane/datasource/video_reader.py
+++ b/vane/datasource/video_reader.py
@@ -970,6 +970,24 @@ class VideoFrameSource(DataSource):
             else:
                 yield _VideoFrameGroupTask(group, self.options)
 
+    def _native_parameters(self) -> list[object]:
+        # Parameters describe values and selection only; workers resolve FILE I/O.
+        return [
+            list(self.files),
+            self.height,
+            self.width,
+            self.start_time,
+            self.end_time,
+            self.is_key_frame,
+            self.sample_interval_seconds,
+            self.max_input_bytes,
+            self.max_decoded_frames,
+            self.max_pixels,
+            self.max_partition_bytes,
+            self.frame_limit,
+            self.on_error,
+        ]
+
     def to_udf_relation(self, con: Any) -> Any:
         relation = con.from_datasource(self)
         return relation.project(

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,5 +16,52 @@
     "glog",
     "grpc",
     "openssl"
-  ]
+  ],
+  "features": {
+    "native-image": {
+      "description": "Optional native image extension codecs",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "avcodec",
+            "avformat",
+            "swscale",
+            "zlib"
+          ]
+        }
+      ]
+    },
+    "native-audio": {
+      "description": "Optional native audio extension codecs",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "avcodec",
+            "avformat",
+            "swresample",
+            "zlib"
+          ]
+        }
+      ]
+    },
+    "native-video": {
+      "description": "Optional native video extension codecs",
+      "dependencies": [
+        {
+          "name": "ffmpeg",
+          "default-features": false,
+          "features": [
+            "avcodec",
+            "avformat",
+            "swscale",
+            "zlib"
+          ]
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Image, audio, and video SQL operators currently enter Python media helpers for every file. This change adds three independent DuckDB C++ extensions (`image`, `audio`, `video`) and independently selectable `image_backend`, `audio_backend`, and `video_backend` settings. After loading a domain's extension, selecting `native` binds its operators directly to FFmpeg-backed execution through the executing query's governed `ResolvedFile`.

Python remains the explicit default. Loading an extension does not select it; selecting an unavailable native backend fails before file I/O. There is no compatibility layer or automatic fallback. Native video uses a hard `max_partition_bytes` payload limit and rejects custom `VideoFrameSource` subclasses; custom task/schema behavior requires explicitly selecting Python. Audio/video metadata `max_bytes` controls callback reads and both FFmpeg probe budgets, with a 64 MiB maximum. FILE/media subtypes, IMAGE, Tensor, and governed I/O remain base capabilities. Each optional extension has its own artifact/provider wheel; the video extension can produce IMAGE without loading the image extension.

The implemented native surface is ImageFile metadata/decode (PNG/JPEG), AudioFile metadata/resampling with the existing STRUCT result, VideoFile metadata, and native VideoFrameSource with IMAGE frames. Python source tasks retain their Tensor schema. It includes logical byte windows, MIME checks, bounded probes/output, cancellation checks, narrow format-error suppression, and balanced native video task groups controlled by `read_task_count` for local/Ray execution. CI builds and packages all three test-signed providers and exercises local and real-Ray execution. Optional codec artifacts stay outside the base wheel.

Video currently decodes sequentially to preserve exact global frame indices. Indexed seeking, the proposed public video/Image APIs, Tensor-returning audio resampling, and stronger shared credential infrastructure remain separate work. Benchmarks show workload-dependent improvements and regressions: larger image decoding improved about 1.5×, while larger audio resampling took 132 ms versus Python's 35 ms with different resampler quality settings. The performance report includes all measured cases and the higher native image/audio peak RSS.

## Related issue

close: #759

Related: #757, #758, #760, #761, #762, #763, #764. These broader tracking issues remain open for their remaining distribution, coverage, and measurement requirements.

Separate API/infrastructure work: #661, #714, #755, #756. This PR builds on #752's governed Flight types.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`NATIVE_MEDIA_EXTENSIONS.md` documents architecture, loading, selection, native contracts, supported formats, limits, and packaging. `DEVELOPMENT.md` links that guide. `THIRD_PARTY.md` records optional FFmpeg/zlib dependencies. `benchmarking/native_media/README.md` records measured results and reproduction commands; its generator creates synthetic inputs outside the repository.

## Validation

- Two consecutive clean local static reviews before the final native build/test cycle; further benchmark/documentation reviews after measurement.
- Two consecutive GitHub `@codex review` passes on unchanged commit `c1746cd769`: [first result](https://github.com/AstroVela/vane/pull/765#issuecomment-5550772559), [second result](https://github.com/AstroVela/vane/pull/765#issuecomment-5550814999). Both reported no major issues and produced no review findings. All 11 findings from earlier rounds are addressed and resolved.
- Native sources built at `c5f9f08371`; subsequent commits change tests and documentation only. Incremental Release installation with `uv pip install . --no-build-isolation`, `SKBUILD_BUILD_DIR=build/python-release`, and `VANE_LOADABLE_EXTENSIONS=image;audio;video`; `cmake --build build/python-release --target vane_loadable_extensions --parallel 8` passed. Development test signing was enabled for local/CI provider verification only.
- Signed and packaged each artifact with `scripts/sign_test_dynamic_extension.py` and `scripts/build_extension_wheel.py`, then installed all three providers. Packaging identity, dependency, and ELF policy checks passed.
- `scripts/run_installed_pytest.sh tests/fast/test_native_media_extensions.py`: **47 passed**, including native execution with Python media imports blocked, JPEG HTTP range-request bounds, and default-size video scans under memory/address-space limits.
- Affected Image, ImageFile, AudioFile, VideoFile, video source, and filesystem tests through `scripts/run_installed_pytest.sh`: **418 passed, 1 skipped, 3 deselected**. The skipped test requires a loadable httpfs fixture.
- `scripts/run_installed_pytest.sh tests/fast/test_ray_native_media_extensions.py tests/fast/test_file_ray.py`: **15 passed**, using signed installed providers and normal signature policy.
- `scripts/run_release_tests.sh`: **839 non-Ray + 14 real-Ray passed, 1 skipped** (optional ADBC dependency absent). Three existing bounded-exception-detail assertions failed under the long worktree path because their exception text exceeded 4096 bytes; the complete launcher passed through a short alias to the same worktree/installation without changing assertions.
- Generated and validated `vane_ai-0.2.0.dev628.tar.gz`; CMake successfully configured all three optional extension targets from its extracted sources. `scripts/run_installed_pytest.sh tests/fast/test_release_artifact_security.py`: **114 passed** at `b482f31acf`; packaging code has not changed since that run.
- Root/DuckDB formatting and `git diff --check` passed. `pre-commit run --from-ref upstream/main --to-ref HEAD` passed, including Ruff, mypy, and workflow validation; the affected real-Ray fixture test passed again after its lint correction.
- **43 benchmark runs** at `f7ee0fa475` (before the subsequent MIME, packaging, task-group, probe-budget, JPEG-buffer, and video-output corrections): six operations, small/larger synthetic PNG/PCM16 WAV/MPEG-4 inputs, one/four DuckDB threads, five warm-cache repetitions, separate processes for Python/native peak RSS, plus a late video window. Hardware: Xeon E5-2686 v4, 18 cores/36 logical CPUs, approximately 62.7 GiB RAM, local NVMe/ext4, Linux/glibc, Python 3.12.3, Release build. Exact row counts, codec versions, quality differences, timings, CPU, RSS, and input/artifact hashes are in the benchmark report. These measurements do not establish remote-I/O or Ray scaling gains.
- **10 additional video frame benchmark runs** with native IMAGE output at `c5f9f08371`, Vane 0.2.0.dev628, on the same host and inputs: small/full, large/full with one/four configured threads, and a late window; five repetitions and separate one-backend RSS processes. Large/full wall medians were Python/native **246.86/238.81 ms** with one thread and **332.26/129.08 ms** with four configured threads (two file tasks). Counts and frame-index sums matched; the report includes CPU, RSS, codec/output differences, and artifact identity.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
