### PR TITLE
[fix](video) Align native RGB conversion with Python

### DIFF
--- a/VIDEO_FRAME_API.md
+++ b/VIDEO_FRAME_API.md
@@ -93,7 +93,19 @@ Without an explicit index, exact frame indices use sequential decoding from
 stream start, including for late time windows. The native backend also accepts
 reusable indexes for keyframe seeking, as described below. There is no
 temporary-file materialization fallback. Python and native codecs do not
-promise identical pixels or container-specific metadata.
+promise identical container-specific metadata.
+
+Both backends resize and convert decoded video frames directly to RGB with
+FFmpeg's frame-aware scaler, bilinear interpolation, and one scaling thread.
+The conversion retains the source YUV matrix, range, and chroma location;
+transfer-function and color-primary conversion is not requested. Vane requests
+resizing and RGB conversion together in one scaler call. Scalar expressions,
+streaming reads, and native indexed reads share this pixel conversion policy. Regression tests
+require byte-identical RGB output between backends for the supported test
+fixtures, including odd dimensions, full/limited-range color, 10-bit video,
+and interlaced frames. Interlaced field layout is retained during scaling.
+Decoder-specific metadata such as DTS and differences between FFmpeg releases
+are separate from this conversion policy.
 
 Rows from independent file tasks have no global order. Use `ORDER BY` when
 consuming ordered results. An explicit `frame_limit` creates one ordered task

--- a/external/duckdb/extension/media_common/image_convert.cpp
+++ b/external/duckdb/extension/media_common/image_convert.cpp
@@ -86,8 +86,67 @@ void MediaConvertPixels(ClientContext &context, const AVFrame &frame, const stri
 	sws_freeContext(converter);
 }
 
+void MediaConvertVideoPixels(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
+                             uint32_t height, data_ptr_t destination) {
+	MediaInterrupt(context);
+	if (mode != "RGB") {
+		throw InternalException("video pixel conversion requires RGB output");
+	}
+	if (!width || !height || width > INT_MAX || height > INT_MAX || frame.width <= 0 || frame.height <= 0) {
+		throw MediaFormatException("invalid decoded video dimensions");
+	}
+	// av_frame_get_buffer pads rows as well as strides. Bound that allocation
+	// before invoking FFmpeg, including for very narrow or short RGB outputs.
+	auto padded_width = (uint64_t(width) + 31) & ~uint64_t(31);
+	auto padded_height = (uint64_t(height) + 31) & ~uint64_t(31);
+	MediaProduct(padded_width * 3, padded_height, MEDIA_MAX_FRAME_BYTES - 4 * AV_INPUT_BUFFER_PADDING_SIZE,
+	             "video conversion buffer bytes");
+	auto size = av_image_get_buffer_size(AV_PIX_FMT_RGB24, int(width), int(height), 1);
+	MediaCheck(size, "calculate video RGB buffer size");
+	auto output = av_frame_alloc();
+	auto converter = sws_alloc_context();
+	if (!output || !converter) {
+		av_frame_free(&output);
+		sws_freeContext(converter);
+		throw OutOfMemoryException("Cannot allocate video pixel converter");
+	}
+	try {
+		// Keep the decoder-owned frame and its provenance unchanged. Match
+		// _frame_to_image: preserve the YUV matrix/range and chroma location,
+		// but do not request a transfer-function or color-primary conversion.
+		AVFrame source = frame;
+		source.color_trc = AVCOL_TRC_UNSPECIFIED;
+		source.color_primaries = AVCOL_PRI_UNSPECIFIED;
+		// PyAV copies frame properties before allocating the destination. In
+		// particular, keep interlaced field layout and color side data intact.
+		MediaCheck(av_frame_copy_props(output, &source), "copy video frame properties");
+		output->format = AV_PIX_FMT_RGB24;
+		output->width = int(width);
+		output->height = int(height);
+		MediaCheck(av_frame_get_buffer(output, 32), "allocate video RGB buffer");
+		converter->flags = SWS_BILINEAR;
+		converter->threads = 1;
+		// An uninitialized context selects FFmpeg's frame-aware scaler, as
+		// PyAV does. Initializing with sws_getContext instead selects the
+		// legacy scaler and changes resized chroma pixels for the same flags.
+		MediaCheck(sws_scale_frame(converter, output, &source), "convert video RGB pixels");
+		MediaInterrupt(context);
+		const uint8_t *planes[4] = {output->data[0], output->data[1], output->data[2], output->data[3]};
+		MediaCheck(av_image_copy_to_buffer(destination, size, planes, output->linesize, AV_PIX_FMT_RGB24, int(width),
+		                                   int(height), 1),
+		           "copy video RGB pixels");
+	} catch (...) {
+		av_frame_free(&output);
+		sws_freeContext(converter);
+		throw;
+	}
+	av_frame_free(&output);
+	sws_freeContext(converter);
+}
+
 uint64_t MediaWriteImage(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
-                         uint32_t height, Vector &result, idx_t row, uint64_t remaining_bytes) {
+                         uint32_t height, Vector &result, idx_t row, uint64_t remaining_bytes,
+                         media_pixel_converter_t convert) {
 	auto channels = ImageLogicalType::ChannelsForMode(mode);
 	auto pixels = MediaProduct(width, height, MEDIA_MAX_PIXELS, "output pixels");
 	auto size = MediaProduct(pixels, channels, MinValue<uint64_t>(remaining_bytes, string_t::MAX_STRING_SIZE),
@@ -95,7 +154,7 @@ uint64_t MediaWriteImage(ClientContext &context, const AVFrame &frame, const str
 	auto &children = StructVector::GetEntries(result);
 	auto &data = *children[ImageLogicalType::DATA];
 	auto bytes = StringVector::EmptyString(data, NumericCast<idx_t>(size));
-	MediaConvertPixels(context, frame, mode, width, height, reinterpret_cast<data_ptr_t>(bytes.GetDataWriteable()));
+	convert(context, frame, mode, width, height, reinterpret_cast<data_ptr_t>(bytes.GetDataWriteable()));
 	bytes.Finalize();
 	FlatVector::GetData<string_t>(data)[row] = bytes;
 	FlatVector::GetData<uint32_t>(*children[ImageLogicalType::WIDTH])[row] = width;

--- a/external/duckdb/extension/media_common/include/media_reader.hpp
+++ b/external/duckdb/extension/media_common/include/media_reader.hpp
@@ -152,8 +152,16 @@ private:
 void MediaConvertPixels(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
                         uint32_t height, data_ptr_t destination);
 
+//! Video uses the same frame-aware RGB conversion as the PyAV backend.
+void MediaConvertVideoPixels(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
+                             uint32_t height, data_ptr_t destination);
+
+using media_pixel_converter_t = void (*)(ClientContext &, const AVFrame &, const string &, uint32_t, uint32_t,
+                                         data_ptr_t);
+
 //! Converted pixels are written into the engine-owned IMAGE vector.
 uint64_t MediaWriteImage(ClientContext &context, const AVFrame &frame, const string &mode, uint32_t width,
-                         uint32_t height, Vector &result, idx_t row, uint64_t remaining_bytes);
+                         uint32_t height, Vector &result, idx_t row, uint64_t remaining_bytes,
+                         media_pixel_converter_t convert = MediaConvertPixels);
 
 } // namespace duckdb

--- a/external/duckdb/extension/video/video_frame_functions.cpp
+++ b/external/duckdb/extension/video/video_frame_functions.cpp
@@ -73,7 +73,7 @@ static void VideoFramesScalar(DataChunk &args, ExpressionState &state, Vector &r
 						image = StructVector::GetEntries(*image).back().get();
 					}
 				}
-				MediaWriteImage(context, frame, "RGB", width, height, *image, target, bytes);
+				MediaWriteImage(context, frame, "RGB", width, height, *image, target, bytes, MediaConvertVideoPixels);
 				found = true;
 				if (OPERATION == VideoFrameOperation::FRAME_BY_INDEX) {
 					break;

--- a/external/duckdb/extension/video/video_functions.cpp
+++ b/external/duckdb/extension/video/video_functions.cpp
@@ -321,7 +321,8 @@ static void ScanVideo(ClientContext &context, TableFunctionInput &input, DataChu
 			    6, row, frame.pkt_dts != AV_NOPTS_VALUE ? Value::BIGINT(frame.pkt_dts) : Value(LogicalType::BIGINT));
 			output.SetValue(7, row, frame.duration > 0 ? Value::BIGINT(frame.duration) : Value(LogicalType::BIGINT));
 			output.SetValue(8, row, Value::BOOLEAN(key));
-			MediaWriteImage(context, frame, "RGB", width, height, output.data[9], row, frame_bytes);
+			MediaWriteImage(context, frame, "RGB", width, height, output.data[9], row, frame_bytes,
+			                MediaConvertVideoPixels);
 			row++;
 			if (limited) {
 				global.emitted++;

--- a/tests/fast/test_video_expressions.py
+++ b/tests/fast/test_video_expressions.py
@@ -12,6 +12,114 @@ video_path = streaming.video_path
 video_connection = streaming.video_connection
 
 
+@pytest.fixture(
+    params=[
+        ("libx264", "yuv420p", None),
+        ("libx264", "yuv420p", (1, 1, 1, 1)),
+        ("libx264", "yuv420p", (1, 1, 1, 2)),
+        ("libx264", "yuv444p", (1, 1, 1, 1)),
+        ("ffv1", "yuv420p10le", (9, 9, 16, 1)),
+        ("ffv1", "bgr0", None),
+    ],
+    ids=["420", "709-limited", "709-full", "444", "2020-10bit", "rgb"],
+)
+def detailed_video(request, tmp_path):
+    return _detailed_video(tmp_path, *request.param)
+
+
+def _detailed_video(tmp_path, codec, pixel_format, color, *, interlaced=False):
+    av = pytest.importorskip("av")
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("PIL.Image")
+    pytest.importorskip("psutil")
+    path = tmp_path / ("details.mp4" if codec == "libx264" else "details.mkv")
+    with av.open(str(path), "w") as output:
+        stream = output.add_stream(codec, rate=8)
+        stream.width, stream.height, stream.pix_fmt = 64, 48, pixel_format
+        if codec == "libx264":
+            stream.codec_context.gop_size = 3
+            stream.codec_context.max_b_frames = 2
+            stream.options = {"crf": "18", "sc_threshold": "0", "threads": "1"}
+            if interlaced:
+                stream.options["x264-params"] = "interlaced=1:tff=1"
+        if color is not None:
+            context = stream.codec_context
+            context.colorspace, context.color_primaries, context.color_trc, context.color_range = color
+        y, x = np.indices((48, 64))
+        for index in range(6):
+            # Spatial color detail exposes chroma interpolation differences that
+            # the small, uniform grayscale streaming fixture cannot detect.
+            pixels = np.stack(
+                ((x * 7 + index * 19) % 256, (y * 11 + index * 31) % 256, ((x ^ y) * 13 + index * 47) % 256),
+                axis=-1,
+            ).astype("uint8")
+            frame = av.VideoFrame.from_ndarray(pixels, format="rgb24")
+            for packet in stream.encode(frame):
+                output.mux(packet)
+        for packet in stream.encode():
+            output.mux(packet)
+    return vane.VideoFile(str(path))
+
+
+@pytest.mark.parametrize("width,height", [(64, 48), (23, 17), (97, 65), (1, 1), (1, 17), (23, 1)])
+def test_video_pixels_match_across_backends(detailed_video, width, height):
+    _assert_video_pixels_match_across_backends(detailed_video, width, height)
+
+
+@pytest.mark.parametrize("width,height", [(64, 48), (23, 17), (97, 65), (1, 17)])
+def test_video_interlaced_pixels_match_across_backends(tmp_path, width, height):
+    file = _detailed_video(tmp_path, "libx264", "yuv420p", (1, 1, 1, 1), interlaced=True)
+    import av
+
+    with av.open(file.url) as container:
+        assert all(frame.interlaced_frame for frame in container.decode(video=0))
+    _assert_video_pixels_match_across_backends(file, width, height)
+
+
+def _assert_video_pixels_match_across_backends(detailed_video, width, height):
+    from tests.fast import test_native_media_extensions as media
+
+    def pixels(image):
+        return image.mode, image.width, image.height, image.data
+
+    # A backend change must preserve all RGB bytes, including on odd and narrow
+    # output sizes. DTS is decoder provenance and is tested separately.
+    with media._connect("video") as native, vane.connect(config={"video_backend": "python"}) as python:
+        frames = list(detailed_video.frames(width=width, height=height))
+        expected = [
+            (frame.frame_index, frame.frame_pts, ("RGB", width, height, frame.data.tobytes())) for frame in frames
+        ]
+        assert len(expected) == 6
+        query = "SELECT video_frames($1, width => $2, height => $3, index => $4)"
+        index = native.execute("SELECT build_video_index($1)", [detailed_video]).fetchone()[0]
+        for connection, seek_index in [(python, None), (native, None), (native, index)]:
+            actual = connection.execute(query, [detailed_video, width, height, seek_index]).fetchone()[0]
+            assert [(frame["frame_index"], frame["frame_pts"], pixels(frame["data"])) for frame in actual] == expected
+            if (width, height) == (64, 48):
+                for target in (0, 5):
+                    image = connection.execute(
+                        "SELECT get_video_frame_by_idx($1, $2, index => $3)",
+                        [detailed_video, target, seek_index],
+                    ).fetchone()[0]
+                    assert pixels(image) == expected[target][2]
+            keyframes = connection.execute(
+                "SELECT video_keyframes($1, width => $2, height => $3, index => $4)",
+                [detailed_video, width, height, seek_index],
+            ).fetchone()[0]
+            assert [pixels(image) for image in keyframes] == [
+                expected[i][2] for i, frame in enumerate(frames) if frame.is_key_frame
+            ]
+            relation = vane.read_video_frames(
+                detailed_video,
+                height,
+                width,
+                connection=connection,
+                indexes=[seek_index] if seek_index is not None else None,
+            )
+            actual = relation.project("frame_index, frame_pts, data").fetchall()
+            assert [(ordinal, pts, pixels(image)) for ordinal, pts, image in actual] == expected
+
+
 def test_native_video_scalar_requires_the_loaded_extension():
     with vane.connect(config={"video_backend": "native"}) as con:
         for expression in ["video_frames(NULL)", "video_keyframes(NULL)", "get_video_frame_by_idx(NULL, 0)"]:

--- a/vane/_video_file.py
+++ b/vane/_video_file.py
@@ -1159,6 +1159,7 @@ def _frame_to_image(
                     width=output_width,
                     height=output_height,
                     format="rgb24",
+                    interpolation="BILINEAR",
                     threads=1,
                 )
             check_interrupted()


### PR DESCRIPTION
## Summary

Resizing the same video through the Python and native backends could produce different RGB pixels despite matching frame selection and public parameters. Native video conversion now uses FFmpeg's frame-aware `sws_scale_frame` path with bilinear interpolation and one thread, matching the supported PyAV backend. The legacy native path did not configure chroma siting from the decoded frame. Frame properties, including chroma location and interlaced field layout, are now retained; transfer/primary conversion remains unrequested.

Scalar frames, keyframes, exact-index access, and streaming/indexed reads share the video converter. Add 40 regression cases comparing complete RGB bytes across backends, including odd/narrow sizes, enlargement, full/limited range, 10-bit color, and interlaced input. The video path has no compatibility mode or fallback.

## Related issue

close: #774

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

`VIDEO_FRAME_API.md` documents the shared pixel-conversion policy. Native RGB values can change to match Python; decoder-specific DTS differences remain outside this change.

## Validation

- Two consecutive local static-review rounds found no remaining issues before the consolidated build/test phase. Workspace formatting checks, Ruff, and `git diff --check` passed.
- Two consecutive manual GitHub `@codex review` rounds on unchanged commit `73e5650e7406790946f72ed97b728b85fd682f74` reported no major issues and no inline findings: [round 1](https://github.com/AstroVela/vane/pull/776#issuecomment-5566831037), [round 2](https://github.com/AstroVela/vane/pull/776#issuecomment-5566941270).
- Non-editable incremental Release build with the optional image/video artifacts; signed test provider wheels were installed for native Ray coverage. The integration-test signing key was enabled only in this local test build.

```bash
SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release \
CMAKE_BUILD_PARALLEL_LEVEL=12 uv pip install --python .venv/bin/python . \
  --no-build-isolation --no-deps \
  '-Ccmake.define.VANE_LOADABLE_EXTENSIONS=image;video' \
  '-Ccmake.define.VANE_ENABLE_TEST_EXTENSION_SIGNING_KEY=ON'
cmake --build build/python-release --target vane_loadable_extensions --parallel 12
```

- `scripts/run_installed_pytest.sh tests/fast/test_video_file.py tests/fast/test_video_reader.py tests/fast/test_video_optional_deps.py tests/fast/test_video_expressions.py tests/fast/test_read_video_frames.py tests/fast/test_video_index.py -m "not real_ray" --tb=short`: **448 passed**, one Ray test selected in the separate process below.
- `scripts/run_installed_pytest.sh tests/fast/test_native_media_extensions.py tests/fast/test_native_media_validation.py -k "not audio" --tb=short`: **38 passed**, covering native image/video behavior, limits, and cancellation.
- Native artifact paths were supplied through `VANE_TEST_NATIVE_IMAGE_EXTENSION` and `VANE_TEST_NATIVE_VIDEO_EXTENSION`.
- Differential audit of seven synthetic clips: all 99 jointly successful Python/native cases now have identical RGB bytes. Ten cases still differ only in DTS. Native sequential/indexed successful outputs match in all 99 cases; all 197 successful Python outputs match the pre-change baseline. Shared out-of-range errors are counted separately.

- With `VANE_TEST_NATIVE_MEDIA_PROVIDERS=1`, `scripts/run_installed_pytest.sh tests/fast/test_video_reader.py tests/fast/test_ray_video_expressions.py tests/fast/test_ray_read_video_frames.py tests/fast/test_ray_video_index.py tests/fast/test_ray_native_media_extensions.py -m real_ray -k video --tb=short`: **18 passed, no skips**, including signed native provider execution, indexed reads, and partitioned scans.
- The exact issue #774 reproduction passes with complete RGB-byte equality.
- Environment: Linux x86-64, Python 3.12.3, PyAV 17.1.0, native FFmpeg 8.1.1. Installed runtime matches this commit; all **504 affected tests pass**.

- `scripts/run_release_tests.sh`: the non-Ray shard has **1020 passed, 3 failed**. The same three failures were already reproduced on unchanged upstream/main `3f6e4a3acc`: `test_ray_worker_manager_drop_fans_out_after_result_payload_release_failure`, `test_wait_fte_query_propagates_status_errors`, and `test_wait_fte_query_release_failure_preserves_failed_handle_and_releases_rest`. They expect injected exception text but receive `error detail exceeds 4096 bytes and was omitted`; this unrelated exception-text behavior is not modified here. The release gate is **not green** in this environment.
- The release launcher stops on the failing first shard, so the same release file list was subsequently run with its real-Ray selection: **18 passed, 1032 deselected**. The launcher excludes 9 external-service cases. The three baseline failures are tracked separately in #775.
- An additional control fixed the decoded YUV, FFmpeg libraries, frame-aware conversion path, and resize parameters, changing only chroma location: `left` matches Python exactly; `center` matches the old native output exactly.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

No new dependencies or bundled assets; fixtures are generated during tests. Existing input/output budgets and interruption checks remain in the conversion path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/astrovela/vane/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->