### PR TITLE
[fix](datasink) Handle worker Arrow offsets in Milvus and Qdrant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,7 +240,9 @@ include = [
 
     # Curated base-installation release gate. The larger inherited test tree
     # stays in the repository and is intentionally not part of the PyPI sdist.
+    "/tests/__init__.py",
     "/tests/conftest.py",
+    "/tests/datasink_test_helpers.py",
     "/tests/ray_test_profile.py",
     "/tests/fast/test_ai_release_contracts.py",
     "/tests/fast/test_datasink.py",

--- a/tests/datasink_test_helpers.py
+++ b/tests/datasink_test_helpers.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Service-free SDK recording across real DataSink runner boundaries."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator, Sequence
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from vane import DuckDBPyRelation
+from vane.datasink import BoundKeyedUpsertSink, DataSink, DataSinkExecutionOptions, DataSinkWorker, WriteContext
+
+
+@pytest.fixture(params=["local-fast", "local", pytest.param("ray", marks=pytest.mark.real_ray)])
+def datasink_runner(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    from vane import runners
+
+    runner_type = request.param
+    runner = None
+    if runner_type == "ray":
+        request.getfixturevalue("ray_local")
+        from vane.runners.ray.runner import RayRunner
+
+        runner = RayRunner(address=None, max_task_backlog=None)
+    elif runner_type == "local":
+        from vane.runners.local.runner import LocalRunner
+
+        monkeypatch.setenv("VANE_LOCAL_FTE_WORKERS", "2")
+        monkeypatch.setenv("VANE_LOCAL_FTE_EXECUTION_MODE", "in_process")
+        runner = LocalRunner(num_workers=2)
+    monkeypatch.setattr(runners, "get_or_infer_runner_type", lambda: runner_type)
+    if runner is not None:
+        monkeypatch.setattr(runners, "get_or_create_runner", lambda: runner)
+    try:
+        yield runner_type
+    finally:
+        if runner_type == "ray":
+            assert runner is not None
+            runner.close()
+
+
+def recording_sdk_sink(
+    sink: DataSink,
+    directory: Path,
+    *,
+    sdk_module: str,
+    sdk_loader: str,
+    sdk: tuple[type[Any], Any],
+) -> DataSink:
+    # Carry the fake SDK in the serialized bound sink so it reaches subprocesses
+    # too. Each caller's autouse SDK fixture restores the driver module, and
+    # worker actors own their SDK replacement for the duration of the operation.
+    class RecordingBound(BoundKeyedUpsertSink):
+        def __init__(self, bound: BoundKeyedUpsertSink) -> None:
+            self.bound = bound
+
+        @property
+        def execution_options(self) -> DataSinkExecutionOptions:
+            return self.bound.execution_options
+
+        @property
+        def key_columns(self) -> Sequence[str]:
+            return self.bound.key_columns
+
+        def prepare_input(self, relation: DuckDBPyRelation) -> DuckDBPyRelation:
+            return self.bound.prepare_input(relation)
+
+        def open_worker(self, context: WriteContext) -> DataSinkWorker:
+            setattr(import_module(sdk_module), sdk_loader, lambda: sdk)
+            worker = self.bound.open_worker(context)
+            write = worker.write
+
+            def record_schema(table: pa.Table) -> Any:
+                (directory / f"{uuid.uuid4().hex}.schema").write_bytes(table.schema.serialize().to_pybytes())
+                return write(table)
+
+            worker.write = record_schema
+            return worker
+
+    class RecordingSink(DataSink):
+        def bind(self, schema: pa.Schema) -> BoundKeyedUpsertSink:
+            bound = sink.bind(schema)
+            assert isinstance(bound, BoundKeyedUpsertSink)
+            return RecordingBound(bound)
+
+    return RecordingSink()

--- a/tests/fast/test_milvus_datasink.py
+++ b/tests/fast/test_milvus_datasink.py
@@ -4,11 +4,14 @@
 from __future__ import annotations
 
 import builtins
+import json
 import os
 import uuid
 from collections.abc import Mapping
 from copy import deepcopy
 from enum import IntEnum
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import cloudpickle
@@ -17,8 +20,10 @@ import pytest
 
 import vane
 import vane.datasink.milvus as milvus
+from tests.datasink_test_helpers import datasink_runner as datasink_runner
+from tests.datasink_test_helpers import recording_sdk_sink
 from vane import EnvironmentSecret, MilvusSink
-from vane.datasink import BoundKeyedUpsertSink, WriteContext
+from vane.datasink import BoundKeyedUpsertSink, WriteContext, WriteOutcome
 
 _REAL_LOAD_MILVUS_SDK = milvus._load_milvus_sdk
 
@@ -491,6 +496,141 @@ def test_milvus_sink_accepts_text_fields_and_fixed_vector_dimensions() -> None:
         _sink().bind(_arrow_schema(vector_type=pa.list_(pa.float32(), 2))).open_worker(WriteContext("bad-fixed"))
 
 
+@pytest.mark.parametrize(
+    ("field_name", "bound_type", "batch_type"),
+    [
+        ("title", pa.string(), pa.large_string()),
+        ("title", pa.large_string(), pa.string()),
+        ("id", pa.string(), pa.large_string()),
+        ("id", pa.large_string(), pa.string()),
+        ("embedding", pa.list_(pa.float32()), pa.large_list(pa.float32())),
+        ("embedding", pa.large_list(pa.float32()), pa.list_(pa.float32())),
+        ("embedding", pa.list_(pa.field("item", pa.float32()), 3), pa.list_(pa.field("l", pa.float32()), 3)),
+        (
+            "embedding",
+            pa.list_(pa.field("item", pa.float32(), nullable=False)),
+            pa.large_list(pa.field("l", pa.float32(), nullable=False)),
+        ),
+    ],
+)
+def test_milvus_sink_accepts_equivalent_worker_types(
+    field_name: str, bound_type: pa.DataType, batch_type: pa.DataType
+) -> None:
+    schema = _arrow_schema()
+    index = schema.get_field_index(field_name)
+    schema = schema.set(index, pa.field(field_name, bound_type))
+    batch_schema = schema.set(index, pa.field(field_name, batch_type))
+    if field_name == "id":
+        _Client.description = _description(primary_type=_DataType.VARCHAR)
+    values = {
+        "id": ["one", "two"] if field_name == "id" else [1, 2],
+        "embedding": [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        "title": ["one", "二"],
+    }
+    # Exercise sliced chunks as well as offset-width changes, without casting
+    # the input to the bound schema before the adapter sees it.
+    source = pa.table(values, schema=batch_schema)
+    table = pa.concat_tables([source, source]).slice(1, 2)
+    worker = _sink().bind(schema).open_worker(WriteContext("worker-offsets"))
+    try:
+        result = worker.write(table)
+    finally:
+        worker.close()
+
+    assert result.rows_received == result.rows_affected == 2
+    assert result.bytes_received == table.nbytes
+    assert _Client.instances[0].upsert_calls[0]["data"] == [source.to_pylist()[1], source.to_pylist()[0]]
+
+
+@pytest.mark.parametrize(
+    ("field_name", "bound_type", "batch_type"),
+    [
+        ("id", pa.int64(), pa.int32()),
+        ("id", pa.int64(), pa.uint64()),
+        ("title", pa.float32(), pa.float64()),
+        ("title", pa.string(), pa.large_binary()),
+        ("embedding", pa.list_(pa.float32()), pa.large_list(pa.float64())),
+        ("embedding", pa.list_(pa.float32(), 3), pa.list_(pa.float32(), 2)),
+        ("embedding", pa.list_(pa.float32(), 3), pa.large_list(pa.float32())),
+        ("embedding", pa.list_(pa.float32()), pa.list_(pa.float32(), 3)),
+        ("embedding", pa.list_(pa.field("item", pa.float32(), nullable=False)), pa.large_list(pa.float32())),
+        ("embedding", pa.list_(pa.float32()), pa.large_list(pa.field("item", pa.float32(), nullable=False))),
+    ],
+)
+def test_milvus_sink_rejects_worker_logical_type_changes_before_upsert(
+    field_name: str, bound_type: pa.DataType, batch_type: pa.DataType
+) -> None:
+    schema = _arrow_schema()
+    index = schema.get_field_index(field_name)
+    schema = schema.set(index, pa.field(field_name, bound_type))
+    if field_name == "title" and bound_type == pa.float32():
+        _Client.description = _description(title_type=_DataType.FLOAT)
+    table = pa.Table.from_batches([], schema=schema.set(index, pa.field(field_name, batch_type)))
+    worker = _sink().bind(schema).open_worker(WriteContext("worker-type-drift"))
+    try:
+        with pytest.raises(ValueError, match="bound input schema"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
+@pytest.mark.parametrize("schema_change", ["missing", "extra", "reordered", "renamed"])
+def test_milvus_sink_rejects_worker_column_changes_before_upsert(schema_change: str) -> None:
+    fields = list(_arrow_schema(vector_type=pa.large_list(pa.float32()), title_type=pa.large_string()))
+    if schema_change == "missing":
+        fields.pop()
+    elif schema_change == "extra":
+        fields.append(pa.field("extra", pa.int64()))
+    elif schema_change == "reordered":
+        fields.reverse()
+    else:
+        fields[-1] = pa.field("renamed", pa.large_string())
+    worker = _worker()
+    try:
+        with pytest.raises(ValueError, match="bound input schema"):
+            worker.write(pa.Table.from_batches([], schema=pa.schema(fields)))
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
+@pytest.mark.parametrize("invalid_value", ["dimension", "nonfinite", "null_element", "title_length", "primary_null"])
+def test_milvus_sink_checks_values_after_worker_offset_changes(invalid_value: str) -> None:
+    schema = _arrow_schema(vector_type=pa.large_list(pa.float32()), title_type=pa.large_string())
+    values = {"id": [1], "embedding": [[1.0, 2.0, 3.0]], "title": ["one"]}
+    if invalid_value == "dimension":
+        values["embedding"] = [[1.0, 2.0]]
+    elif invalid_value == "nonfinite":
+        values["embedding"] = [[1.0, float("nan"), 3.0]]
+    elif invalid_value == "null_element":
+        values["embedding"] = [[1.0, None, 3.0]]
+    elif invalid_value == "title_length":
+        values["title"] = ["你" * 6]
+    else:
+        values["id"] = [None]
+    worker = _worker()
+    try:
+        with pytest.raises(ValueError, match="invalid dimension|invalid value|exceeds max_length|does not accept null"):
+            worker.write(pa.table(values, schema=schema))
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
+def test_milvus_sink_counts_worker_large_offsets_toward_batch_byte_limit() -> None:
+    bound_table = _table()
+    table = _table(schema=_arrow_schema(vector_type=pa.large_list(pa.float32()), title_type=pa.large_string()))
+    assert table.nbytes > bound_table.nbytes
+    worker = _worker(max_batch_bytes=bound_table.nbytes)
+    try:
+        with pytest.raises(ValueError, match="max_batch_bytes"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
 def test_milvus_sink_validates_values_before_upsert() -> None:
     worker = _worker()
     with pytest.raises(ValueError, match="invalid dimension"):
@@ -631,6 +771,87 @@ def test_milvus_sink_replay_replaces_the_same_primary_keys() -> None:
     assert _Client.store == snapshot
     assert set(_Client.store) == {1, 2}
     assert sum(len(client.upsert_calls) for client in _Client.instances) == 2
+
+
+@pytest.mark.parametrize("primary_kind", ["integer", "string"])
+@pytest.mark.parametrize("fixed_vector", [False, True], ids=["list", "fixed"])
+def test_milvus_sink_runner_accepts_worker_arrow_types(
+    datasink_runner: str, tmp_path: Path, primary_kind: str, fixed_vector: bool
+) -> None:
+    # Serialize the SDK recorder with the bound sink so it also reaches Local
+    # subprocesses and real Ray actors. Binding and worker validation remain
+    # the production Milvus implementation, with no external service required.
+    description = json.loads(
+        json.dumps(_description(primary_type=_DataType.VARCHAR if primary_kind == "string" else _DataType.INT64))
+    )
+    sdk_types = SimpleNamespace(**{member.name: int(member) for member in _DataType})
+
+    class RecordingClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def describe_collection(self, **_kwargs: object) -> object:
+            return description
+
+        def upsert(self, **kwargs: Any) -> object:
+            assert kwargs["partial_update"] is False
+            rows = kwargs["data"]
+            (tmp_path / f"{uuid.uuid4().hex}.json").write_text(json.dumps(rows), encoding="utf-8")
+            return {"upsert_count": len(rows)}
+
+        def close(self) -> None:
+            pass
+
+    id_expression = "('id-' || i::VARCHAR)::VARCHAR" if primary_kind == "string" else "i::BIGINT"
+    sql_vector_type = "FLOAT[3]" if fixed_vector else "FLOAT[]"
+    with vane.connect() as connection:
+        relation = connection.sql(f"""
+            SELECT {id_expression} AS id,
+                   [i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT]::{sql_vector_type} AS embedding,
+                   ('row-' || i::VARCHAR)::VARCHAR AS title
+            FROM range(8) AS t(i)
+        """)
+        bound_schema = relation._arrow_schema()
+        assert bound_schema.field("title").type == pa.string()
+        bound_vector_type = pa.list_(pa.float32(), 3) if fixed_vector else pa.list_(pa.float32())
+        assert bound_schema.field("embedding").type == bound_vector_type
+        summary = relation.write_datasink(
+            recording_sdk_sink(
+                _sink(worker_count=2, max_batch_rows=2),
+                tmp_path,
+                sdk_module="vane.datasink.milvus",
+                sdk_loader="_load_milvus_sdk",
+                sdk=(RecordingClient, sdk_types),
+            ),
+            operation_id=f"milvus-{datasink_runner}-{primary_kind}-{fixed_vector}",
+        )
+
+    assert summary.outcome is WriteOutcome.APPLIED
+    assert summary.rows_received == summary.rows_affected == 8
+    batches = [json.loads(path.read_text(encoding="utf-8")) for path in tmp_path.glob("*.json")]
+    assert len(batches) >= 4
+    assert all(0 < len(batch) <= 2 for batch in batches)
+    records = sorted((row for batch in batches for row in batch), key=lambda row: row["id"])
+    assert records == [
+        {
+            "id": f"id-{i}" if primary_kind == "string" else i,
+            "embedding": [float(i), float(i + 1), float(i + 2)],
+            "title": f"row-{i}",
+        }
+        for i in range(8)
+    ]
+    worker_schemas = [pa.ipc.read_schema(pa.BufferReader(path.read_bytes())) for path in tmp_path.glob("*.schema")]
+    assert len(worker_schemas) == len(batches)
+    for schema in worker_schemas:
+        string_type = pa.string() if datasink_runner == "local-fast" else pa.large_string()
+        vector_type = (
+            pa.list_(pa.float32(), 3)
+            if fixed_vector
+            else (pa.list_(pa.float32()) if datasink_runner == "local-fast" else pa.large_list(pa.float32()))
+        )
+        assert schema.field("title").type == string_type
+        assert schema.field("id").type == (string_type if primary_kind == "string" else pa.int64())
+        assert schema.field("embedding").type == vector_type
 
 
 @pytest.mark.external_service

--- a/tests/fast/test_qdrant_datasink.py
+++ b/tests/fast/test_qdrant_datasink.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import builtins
+import json
 import os
 import uuid
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import cloudpickle
@@ -17,6 +19,8 @@ import pytest
 
 import vane
 import vane.datasink.qdrant as qdrant
+from tests.datasink_test_helpers import datasink_runner as datasink_runner
+from tests.datasink_test_helpers import recording_sdk_sink
 from vane import EnvironmentSecret, QdrantSink
 from vane.datasink import (
     BoundKeyedUpsertSink,
@@ -435,8 +439,9 @@ class _RejectingQdrantSink(DataSink):
         return _RejectingQdrantBound(self._sink.bind(schema))
 
 
-def test_qdrant_sink_normalizes_uuid_ids_before_global_key_validation() -> None:
-    schema = _arrow_schema(id_type=pa.string())
+@pytest.mark.parametrize("id_type", [pa.string(), pa.large_string()])
+def test_qdrant_sink_normalizes_uuid_ids_before_global_key_validation(id_type: pa.DataType) -> None:
+    schema = _arrow_schema(id_type=id_type)
     bound = _bound(schema=schema)
     relation = _ProjectionRelation()
 
@@ -558,6 +563,162 @@ def test_qdrant_sink_rejects_noncanonical_uuid_values_before_upsert() -> None:
     assert not _Client.instances[0].upsert_calls
 
 
+@pytest.mark.parametrize(
+    ("field_name", "bound_type", "batch_type"),
+    [
+        ("title", pa.string(), pa.large_string()),
+        ("title", pa.large_string(), pa.string()),
+        ("id", pa.string(), pa.large_string()),
+        ("id", pa.large_string(), pa.string()),
+        ("embedding", pa.list_(pa.float32()), pa.large_list(pa.float32())),
+        ("embedding", pa.large_list(pa.float32()), pa.list_(pa.float32())),
+        ("embedding", pa.list_(pa.field("item", pa.float32()), 3), pa.list_(pa.field("l", pa.float32()), 3)),
+    ],
+)
+def test_qdrant_sink_accepts_equivalent_worker_types(
+    field_name: str, bound_type: pa.DataType, batch_type: pa.DataType
+) -> None:
+    schema = _arrow_schema()
+    index = schema.get_field_index(field_name)
+    schema = schema.set(index, pa.field(field_name, bound_type))
+    batch_schema = schema.set(index, pa.field(field_name, batch_type))
+    ids = [str(uuid.UUID(int=i)) for i in (1, 2)] if field_name == "id" else [1, 2]
+    source = pa.table(
+        {"id": ids, "embedding": [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], "title": ["one", "二"]}, schema=batch_schema
+    )
+    table = pa.concat_tables([source, source]).slice(1, 2)
+    worker = _worker(schema=schema)
+    try:
+        result = worker.write(table)
+    finally:
+        worker.close()
+
+    assert result.rows_received == result.rows_affected == 2
+    assert result.bytes_received == table.nbytes
+    assert _Client.instances[0].upsert_calls[0]["points"] == [
+        _PointStruct(id=ids[1], vector=[4.0, 5.0, 6.0], payload={"title": "二"}),
+        _PointStruct(id=ids[0], vector=[1.0, 2.0, 3.0], payload={"title": "one"}),
+    ]
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_qdrant_sink_accepts_worker_offsets_inside_payload_structs(reverse: bool) -> None:
+    small = pa.struct(
+        [
+            ("label", pa.string()),
+            ("tags", pa.list_(pa.string())),
+            ("children", pa.list_(pa.struct([("text", pa.string())]))),
+        ]
+    )
+    large = pa.struct(
+        [
+            ("label", pa.large_string()),
+            ("tags", pa.large_list(pa.large_string())),
+            ("children", pa.large_list(pa.struct([("text", pa.large_string())]))),
+        ]
+    )
+    bound_type, batch_type = (large, small) if reverse else (small, large)
+    payloads = [{"label": "one", "tags": [None, "二"], "children": [{"text": "three"}]}, None]
+    table = _table(titles=payloads, schema=_arrow_schema(payload_type=batch_type))
+    worker = _worker(schema=_arrow_schema(payload_type=bound_type))
+    try:
+        result = worker.write(table)
+    finally:
+        worker.close()
+    assert result.rows_affected == 2
+    assert [point.payload for point in _Client.instances[0].upsert_calls[0]["points"]] == [
+        {"title": payload} for payload in payloads
+    ]
+
+
+@pytest.mark.parametrize(
+    ("bound_type", "batch_type"),
+    [
+        (pa.int64(), pa.int32()),
+        (pa.int64(), pa.uint64()),
+        (pa.float32(), pa.float64()),
+        (pa.string(), pa.large_binary()),
+        (pa.list_(pa.float32()), pa.large_list(pa.float64())),
+        (pa.list_(pa.float32(), 3), pa.list_(pa.float32(), 2)),
+        (pa.list_(pa.float32(), 3), pa.large_list(pa.float32())),
+        (pa.list_(pa.float32()), pa.list_(pa.float32(), 3)),
+        (pa.list_(pa.field("item", pa.float32(), nullable=False)), pa.large_list(pa.float32())),
+        (pa.struct([("label", pa.string())]), pa.struct([("renamed", pa.large_string())])),
+        (
+            pa.struct([("a", pa.string()), ("b", pa.string())]),
+            pa.struct([("b", pa.large_string()), ("a", pa.large_string())]),
+        ),
+        (pa.struct([("a", pa.string())]), pa.struct([("a", pa.large_string()), ("b", pa.large_string())])),
+        (pa.struct([pa.field("a", pa.string(), nullable=False)]), pa.struct([("a", pa.large_string())])),
+        (pa.struct([("a", pa.string())]), pa.struct([pa.field("a", pa.large_string(), nullable=False)])),
+        (pa.struct([("a", pa.list_(pa.int64()))]), pa.struct([("a", pa.large_list(pa.int32()))])),
+        (pa.list_(pa.struct([("a", pa.string())])), pa.large_list(pa.struct([("b", pa.large_string())]))),
+    ],
+)
+def test_qdrant_sink_rejects_worker_payload_type_changes_before_upsert(
+    bound_type: pa.DataType, batch_type: pa.DataType
+) -> None:
+    worker = _worker(schema=_arrow_schema(payload_type=bound_type))
+    table = pa.Table.from_batches([], schema=_arrow_schema(payload_type=batch_type))
+    try:
+        with pytest.raises(ValueError, match="bound input schema"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
+@pytest.mark.parametrize(
+    ("invalid_value", "error"),
+    [
+        ("dimension", "invalid dimension"),
+        ("nonfinite_vector", "contains an invalid value"),
+        ("nonfinite_payload", "non-finite float"),
+        ("uuid", "valid UUIDs"),
+    ],
+)
+def test_qdrant_sink_checks_values_after_worker_offset_changes(invalid_value: str, error: str) -> None:
+    id_type = pa.string() if invalid_value == "uuid" else pa.uint64()
+    payload_type = pa.list_(pa.float64())
+    bound_schema = _arrow_schema(id_type=id_type, payload_type=payload_type)
+    batch_schema = _arrow_schema(
+        id_type=pa.large_string() if invalid_value == "uuid" else id_type,
+        vector_type=pa.large_list(pa.float32()),
+        payload_type=pa.large_list(pa.float64()),
+    )
+    values = {
+        "id": ["not-a-uuid"] if invalid_value == "uuid" else [1],
+        "embedding": [[1.0, 2.0, 3.0]],
+        "title": [[1.0]],
+    }
+    if invalid_value == "dimension":
+        values["embedding"] = [[1.0, 2.0]]
+    elif invalid_value == "nonfinite_vector":
+        values["embedding"] = [[1.0, float("nan"), 3.0]]
+    elif invalid_value == "nonfinite_payload":
+        values["title"] = [[float("inf")]]
+    worker = _worker(schema=bound_schema)
+    try:
+        with pytest.raises(ValueError, match=error):
+            worker.write(pa.table(values, schema=batch_schema))
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
+def test_qdrant_sink_counts_worker_large_offsets_toward_batch_byte_limit() -> None:
+    bound_table = _table()
+    table = _table(schema=_arrow_schema(vector_type=pa.large_list(pa.float32()), payload_type=pa.large_string()))
+    assert table.nbytes > bound_table.nbytes
+    worker = _worker(max_batch_bytes=bound_table.nbytes)
+    try:
+        with pytest.raises(ValueError, match="max_batch_bytes"):
+            worker.write(table)
+    finally:
+        worker.close()
+    assert not _Client.instances[0].upsert_calls
+
+
 def test_qdrant_sink_enforces_batch_and_schema_limits_before_upsert() -> None:
     worker = _worker(max_batch_rows=1)
     with pytest.raises(ValueError, match="max_batch_rows"):
@@ -650,6 +811,103 @@ def test_qdrant_sink_replay_replaces_the_same_points() -> None:
     assert _Client.store == snapshot
     assert set(_Client.store) == {1, 2}
     assert sum(len(client.upsert_calls) for client in _Client.instances) == 2
+
+
+@pytest.mark.parametrize("point_kind", ["integer", "uuid"])
+@pytest.mark.parametrize("named_vectors", [False, True], ids=["unnamed", "named"])
+def test_qdrant_sink_runner_accepts_worker_arrow_types(
+    datasink_runner: str, tmp_path: Path, point_kind: str, named_vectors: bool
+) -> None:
+    collection_info = _collection_info(
+        vectors={"dense": _VectorParams(3), "summary": _VectorParams(2)} if named_vectors else _VectorParams(3)
+    )
+
+    class RecordingClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def get_collection(self, **_kwargs: object) -> object:
+            return collection_info
+
+        def upsert(self, **kwargs: Any) -> object:
+            assert kwargs["wait"] is True
+            points = [{"id": point.id, "vector": point.vector, "payload": point.payload} for point in kwargs["points"]]
+            (tmp_path / f"{uuid.uuid4().hex}.json").write_text(json.dumps(points), encoding="utf-8")
+            return _UpdateResult(_UpdateStatus.COMPLETED)
+
+        def close(self) -> None:
+            pass
+
+    # Uppercase UUID input must still pass through Qdrant's prepare_input()
+    # normalization before keyed validation and SDK point construction.
+    id_expression = (
+        "upper('123e4567-e89b-12d3-a456-' || lpad(i::VARCHAR, 12, '0'))" if point_kind == "uuid" else "i::UBIGINT"
+    )
+    sql_vector_type = "FLOAT[3]" if named_vectors else "FLOAT[]"
+    secondary = ", [i::FLOAT, (i + 1)::FLOAT]::FLOAT[] AS secondary" if named_vectors else ""
+    with vane.connect() as connection:
+        relation = connection.sql(f"""
+            SELECT {id_expression} AS id,
+                   [i::FLOAT, (i + 1)::FLOAT, (i + 2)::FLOAT]::{sql_vector_type} AS embedding,
+                   {{'label': 'row-' || i::VARCHAR,
+                     'tags': [NULL, 'tag-' || i::VARCHAR],
+                     'children': [{{'text': 'child-' || i::VARCHAR}}]}} AS attributes
+                   {secondary}
+            FROM range(8) AS t(i)
+        """)
+        assert relation._arrow_schema().field("attributes").type.field("label").type == pa.string()
+        summary = relation.write_datasink(
+            recording_sdk_sink(
+                _sink(
+                    vector_mapping={"embedding": "dense", "secondary": "summary"} if named_vectors else "embedding",
+                    payload_mapping={"attributes": "attributes"},
+                    worker_count=2,
+                    max_batch_rows=2,
+                ),
+                tmp_path,
+                sdk_module="vane.datasink.qdrant",
+                sdk_loader="_load_qdrant_sdk",
+                sdk=(RecordingClient, _Models),
+            ),
+            operation_id=f"qdrant-{datasink_runner}-{point_kind}-{named_vectors}",
+        )
+
+    assert summary.outcome is WriteOutcome.APPLIED
+    assert summary.rows_received == summary.rows_affected == 8
+    batches = [json.loads(path.read_text(encoding="utf-8")) for path in tmp_path.glob("*.json")]
+    assert len(batches) >= 4
+    assert all(0 < len(batch) <= 2 for batch in batches)
+    points = sorted((point for batch in batches for point in batch), key=lambda point: point["id"])
+    assert points == [
+        {
+            "id": f"123e4567-e89b-12d3-a456-{i:012d}" if point_kind == "uuid" else i,
+            "vector": {"dense": [float(i), float(i + 1), float(i + 2)], "summary": [float(i), float(i + 1)]}
+            if named_vectors
+            else [float(i), float(i + 1), float(i + 2)],
+            "payload": {
+                "attributes": {"label": f"row-{i}", "tags": [None, f"tag-{i}"], "children": [{"text": f"child-{i}"}]}
+            },
+        }
+        for i in range(8)
+    ]
+    worker_schemas = [pa.ipc.read_schema(pa.BufferReader(path.read_bytes())) for path in tmp_path.glob("*.schema")]
+    assert len(worker_schemas) == len(batches)
+    string_type = pa.string() if datasink_runner == "local-fast" else pa.large_string()
+    list_type = pa.list_ if datasink_runner == "local-fast" else pa.large_list
+    for schema in worker_schemas:
+        assert schema.field("id").type == (string_type if point_kind == "uuid" else pa.uint64())
+        assert schema.field("embedding").type == (
+            pa.list_(pa.float32(), 3) if named_vectors else list_type(pa.float32())
+        )
+        if named_vectors:
+            assert schema.field("secondary").type == list_type(pa.float32())
+        assert schema.field("attributes").type == pa.struct(
+            [
+                ("label", string_type),
+                ("tags", list_type(string_type)),
+                ("children", list_type(pa.struct([("text", string_type)]))),
+            ]
+        )
 
 
 @pytest.mark.external_service

--- a/vane/datasink/_arrow_schema.py
+++ b/vane/datasink/_arrow_schema.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Arrow input type checks shared by DataSink adapters."""
+
+from __future__ import annotations
+
+import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+
+def same_input_type(actual: pa.DataType, bound: pa.DataType) -> bool:
+    """Allow worker offset widths to differ without accepting logical type drift."""
+
+    if actual == bound:
+        return True
+    if (pa.types.is_string(actual) or pa.types.is_large_string(actual)) and (
+        pa.types.is_string(bound) or pa.types.is_large_string(bound)
+    ):
+        return True
+    if (pa.types.is_binary(actual) or pa.types.is_large_binary(actual)) and (
+        pa.types.is_binary(bound) or pa.types.is_large_binary(bound)
+    ):
+        return True
+    variable_lists = (pa.types.is_list(actual) or pa.types.is_large_list(actual)) and (
+        pa.types.is_list(bound) or pa.types.is_large_list(bound)
+    )
+    fixed_lists = (
+        pa.types.is_fixed_size_list(actual)
+        and pa.types.is_fixed_size_list(bound)
+        and actual.list_size == bound.list_size
+    )
+    if variable_lists or fixed_lists:
+        if actual.value_field.nullable != bound.value_field.nullable:
+            return False
+        return same_input_type(actual.value_type, bound.value_type)
+    if pa.types.is_struct(actual) and pa.types.is_struct(bound):
+        return len(actual) == len(bound) and all(
+            actual_field.name == bound_field.name
+            and actual_field.nullable == bound_field.nullable
+            and same_input_type(actual_field.type, bound_field.type)
+            for actual_field, bound_field in zip(actual, bound, strict=True)
+        )
+    return False

--- a/vane/datasink/doris.py
+++ b/vane/datasink/doris.py
@@ -35,6 +35,7 @@ from vane.datasink import (
     WriteContext,
     WriteResult,
 )
+from vane.datasink._arrow_schema import same_input_type
 from vane.execution._diagnostics import bounded_utf8_text, exception_message_from_args, safe_exception_type_name
 
 if TYPE_CHECKING:
@@ -238,34 +239,6 @@ def _destination_schema(value: object) -> pa.Schema:
     if len({name.casefold() for name in names}) != len(names):
         raise ValueError("destination_schema field names must be case-insensitively unique")
     return pa.schema(fields)
-
-
-def _same_input_type(actual: pa.DataType, bound: pa.DataType) -> bool:
-    """Allow worker offset widths to differ without accepting logical type drift."""
-
-    if actual == bound:
-        return True
-    if (pa.types.is_string(actual) or pa.types.is_large_string(actual)) and (
-        pa.types.is_string(bound) or pa.types.is_large_string(bound)
-    ):
-        return True
-    if (pa.types.is_binary(actual) or pa.types.is_large_binary(actual)) and (
-        pa.types.is_binary(bound) or pa.types.is_large_binary(bound)
-    ):
-        return True
-    variable_lists = (pa.types.is_list(actual) or pa.types.is_large_list(actual)) and (
-        pa.types.is_list(bound) or pa.types.is_large_list(bound)
-    )
-    fixed_lists = (
-        pa.types.is_fixed_size_list(actual)
-        and pa.types.is_fixed_size_list(bound)
-        and actual.list_size == bound.list_size
-    )
-    if variable_lists or fixed_lists:
-        if actual.value_field.nullable != bound.value_field.nullable:
-            return False
-        return _same_input_type(actual.value_type, bound.value_type)
-    return False
 
 
 def _canonical_host(host: str) -> str:
@@ -681,7 +654,7 @@ class _DorisStreamLoadWorker(DataSinkWorker):
         # binding connection. Keep logical types stable, then let the existing
         # destination safe cast normalize offsets directly to the wire schema.
         if len(table.schema) != len(self._schema) or any(
-            batch_field.name != bound_field.name or not _same_input_type(batch_field.type, bound_field.type)
+            batch_field.name != bound_field.name or not same_input_type(batch_field.type, bound_field.type)
             for batch_field, bound_field in zip(table.schema, self._schema, strict=True)
         ):
             raise ValueError("Doris Stream Load batch schema does not match the bound input schema")

--- a/vane/datasink/milvus.py
+++ b/vane/datasink/milvus.py
@@ -31,6 +31,7 @@ from vane.datasink import (
     WriteContext,
     WriteResult,
 )
+from vane.datasink._arrow_schema import same_input_type
 
 _MAX_INT64 = (1 << 63) - 1
 _DEFAULT_MAX_BATCH_ROWS = 1_000
@@ -282,6 +283,9 @@ class MilvusSink(DataSink):
     column. ``token`` is resolved from the worker environment and is never
     stored as plaintext in the serialized sink plan.
 
+    Worker batches may use large-offset strings and lists while retaining the
+    bound logical types, list element nullability, and fixed vector dimensions.
+
     Framework retries are disabled unless ``max_retries`` is positive. A retry
     replays the full input using the same Vane operation ID. Replaying a row
     replaces the same Milvus primary key, but Vane does not coordinate with
@@ -514,7 +518,10 @@ class _MilvusWorker(DataSinkWorker):
             raise ValueError("Milvus batch schema does not match the bound input schema")
         for index, binding in enumerate(self._bindings):
             batch_field = table.schema.field(index)
-            if batch_field.name != binding.source_name or batch_field.type != binding.data_type:
+            # Local/Ray workers enable large Arrow offsets independently of the
+            # binding connection. The records below consume the same values in
+            # either representation, while logical types must remain stable.
+            if batch_field.name != binding.source_name or not same_input_type(batch_field.type, binding.data_type):
                 raise ValueError("Milvus batch schema does not match the bound input schema")
         row_count = table.num_rows
         batch_bytes = table.nbytes

--- a/vane/datasink/qdrant.py
+++ b/vane/datasink/qdrant.py
@@ -29,6 +29,7 @@ from vane.datasink import (
     WriteContext,
     WriteResult,
 )
+from vane.datasink._arrow_schema import same_input_type
 
 if TYPE_CHECKING:
     from vane import DuckDBPyRelation
@@ -185,6 +186,10 @@ class QdrantSink(DataSink):
     source columns to payload keys. Every input column must have exactly one
     role, so callers must project away intentionally unused columns.
 
+    Worker batches may use large-offset strings and lists, including inside
+    payload structs. Logical types, nested field names and nullability, and
+    fixed vector dimensions must match the bound schema.
+
     The URL may be a public endpoint string or an ``EnvironmentSecret`` that
     is resolved on each worker. API keys must use ``EnvironmentSecret`` and
     are never stored as plaintext in the serialized sink plan.
@@ -263,7 +268,7 @@ class QdrantSink(DataSink):
             raise ValueError(f"QdrantSink requires every input column to be mapped: {sorted(unmapped_sources)!r}")
 
         point_field = schema.field(self.point_id)
-        point_id_is_uuid = pa.types.is_string(point_field.type)
+        point_id_is_uuid = pa.types.is_string(point_field.type) or pa.types.is_large_string(point_field.type)
         if not point_id_is_uuid and not pa.types.is_uint64(point_field.type):
             raise ValueError("Qdrant point_id source must be Arrow uint64 or string UUID")
 
@@ -498,8 +503,10 @@ class _QdrantWorker(DataSinkWorker):
     def _points(self, table: pa.Table) -> tuple[list[Any], int, int]:
         if not isinstance(table, pa.Table):
             raise TypeError(f"QdrantSink expected pyarrow.Table, got {type(table).__name__}")
+        # Worker connections can widen Arrow offsets throughout nested payloads.
+        # Keep their logical types stable without casting or copying the batch.
         if len(table.schema) != len(self._schema) or any(
-            batch_field.name != bound_field.name or batch_field.type != bound_field.type
+            batch_field.name != bound_field.name or not same_input_type(batch_field.type, bound_field.type)
             for batch_field, bound_field in zip(table.schema, self._schema, strict=True)
         ):
             raise ValueError("Qdrant batch schema does not match the bound input schema")


### PR DESCRIPTION
## Summary

Milvus and Qdrant upserts can fail with `outcome UNKNOWN` before reaching the SDK when Local or Ray workers export bound `string` and `list<float32>` columns as `large_string` and `large_list<float32>`. Accept these offset-width differences using one Arrow type check shared with Doris, so the same supported rows can be written through all three runners.

The check preserves scalar types, nested field names and nullability, and fixed vector dimensions. Qdrant also handles offset changes inside payload structs and accepts large-string UUID columns while retaining UUID normalization before global key validation. Validation uses each actual batch's byte size; no table cast or execution fallback is added.

Regression tests exercise real local-fast, Local, and Ray execution with recording SDKs: integer and string/UUID IDs, variable and fixed vectors, named Qdrant vectors, nested payloads, and multiple batches. Additional cases reject logical schema changes and invalid values before upserts. Include the shared test helper in the sdist.

## Related issue

close: #738

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

MilvusSink and QdrantSink docstrings explain accepted worker offset changes and the logical schema requirements.

## Validation

Two consecutive local review passes completed without findings before building or running tests. Validation uses a non-editable installation on Linux with Python 3.12.3, PyArrow 25.0.1, and Ray 2.58.0. SDK recording replaces external Milvus/Qdrant services; runner execution and adapter validation use the production implementations.

- `scripts/format root --changed` and `pre-commit run` — passed, including Ruff and mypy.
- `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release CMAKE_BUILD_PARALLEL_LEVEL=8 uv pip install . --no-build-isolation --no-deps -v` — passed. Confirmed the installed DataSink modules match the reviewed checkout.
- `python -m build --sdist --no-isolation --outdir build/sdist` and `python scripts/check_release_artifacts.py build/sdist/*.tar.gz` — passed. Also confirmed the archive contains matching copies of the new helper, tests package marker, changed Milvus/Qdrant tests, and shared Arrow type check.
- Affected tests below — **370 non-Ray and 12 real-Ray tests passed**. The new runner cases use 8 rows, 2 workers, and a maximum of 2 rows per batch, checking exact SDK values and actual worker schemas.
- `env -u VANE_RUNNER scripts/run_release_tests.sh` — **1,213 non-Ray and 30 real-Ray tests passed**, in separate pytest processes.

```bash
env -u VANE_RUNNER scripts/run_installed_pytest.sh \
  -m "not external_service and not real_ray" \
  tests/fast/test_milvus_datasink.py \
  tests/fast/test_qdrant_datasink.py \
  tests/fast/test_doris_datasink.py
env -u VANE_RUNNER scripts/run_installed_pytest.sh \
  -m "not external_service and real_ray" \
  tests/fast/test_milvus_datasink.py \
  tests/fast/test_qdrant_datasink.py \
  tests/fast/test_doris_datasink.py
```

- GitHub `@codex review` completed **two consecutive clean reviews** on unchanged commit `9884ecd99b`: [round 1](https://github.com/AstroVela/vane/pull/785#issuecomment-5580634651) and [round 2](https://github.com/AstroVela/vane/pull/785#issuecomment-5580695160). No inline review findings were posted.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
