### PR TITLE
[chore](ci) Double CI timeout limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -345,7 +345,7 @@ jobs:
         # This normally takes under a minute. Bound a stuck pytest/Ray teardown
         # and signal its whole process group so it cannot block the fast-test
         # jobs that consume the Python 3.12 artifact.
-        timeout-minutes: 12
+        timeout-minutes: 24
         run: timeout --signal=INT --kill-after=30s 600s scripts/run_release_tests.sh
 
       - name: Verify coexistence with the official DuckDB distribution
@@ -369,7 +369,7 @@ jobs:
       - native-fast-tests
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 50
+    timeout-minutes: 100
     strategy:
       fail-fast: false
       matrix:
@@ -515,7 +515,7 @@ jobs:
       - native-fast-tests
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       VANE_TEST_MILVUS_URI: http://127.0.0.1:19530
@@ -614,7 +614,7 @@ jobs:
       - native-fast-tests
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       VANE_TEST_QDRANT_URL: http://127.0.0.1:6333
@@ -692,7 +692,7 @@ jobs:
       - native-fast-tests
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 50
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       VANE_TEST_DORIS_ENDPOINT: http://127.0.0.1:8030
@@ -775,7 +775,7 @@ jobs:
       - native-fast-tests
     if: needs.changes.outputs.run_full == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
     steps:


### PR DESCRIPTION
## Summary

Native build jobs can exhaust their 90-minute limit while installing dependencies and compiling. Double all seven explicit `timeout-minutes` values in `.github/workflows/ci.yml`: native builds 90 → 180, release-test step 12 → 24, fast tests 50 → 100, Milvus 20 → 40, Qdrant and AI 15 → 30, and Doris 25 → 50 minutes.

## Related issue

N/A

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

## Validation

- `scripts/format root --changed` — passed; no applicable formatter changes.
- `pre-commit run check-yaml --files .github/workflows/ci.yml` — passed.
- `pre-commit run check-github-workflows --files .github/workflows/ci.yml` — passed.
- `git diff --check` — passed.
- Verified all seven timeout values are exactly doubled and the diff contains only those changes.
- `scripts/run_release_tests.sh` — non-Ray phase: **1019 passed, 119 failed, 31 deselected** in 130.19 seconds, using the existing installed Python 3.12 package. Failures include package metadata/engine identity checks and Ray diagnostics/result-handling checks. The launcher exited before the real-Ray phase, so the base suite did not pass.

## Checklist

- [x] The change is focused; configuration validation covers this numeric workflow change, so no new tests are needed.
- [x] Public behavior and compatibility impact are documented: CI time budgets only.
- [x] No new dependencies, copied code, model assets, or datasets are added.
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] No UDF, serialization, remote code, network, or untrusted-input behavior changes.
- [x] Workflow changes passed the relevant YAML and GitHub Actions schema checks; no native changes require compilation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/astrovela/vane/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
