### PR TITLE
[feat](python) Route parameterized SQL relations through the selected runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,27 @@ Ray uses the same source support as the Relation runner: scans of ordinary
 in-memory tables and temporary tables are rejected. Select `local-fast` for
 those queries, or use a distributed source such as Parquet.
 
+`conn.sql()` (also `query()` and `from_query()`) returns a lazy relation for
+`SELECT`, including when `params` supplies positional or named values. Values
+are captured when the relation is created; modifying the original parameter
+container does not change the query. Filtering, joining, exporting SQL, or
+creating a view preserves those values. Reading the result uses the configured
+runner and does not first materialize the SELECT on the coordinator:
+
+```python
+with vane.connect() as conn:
+    relation = conn.sql(
+        "SELECT i + $offset AS value FROM range($rows) AS t(i)",
+        params={"offset": 10, "rows": 5},
+    )
+    rows = relation.filter("value >= 12").order("value").fetchall()
+```
+
+The final SELECT remains lazy; preceding statements in the same call execute
+in order, with SELECTs using the runner. Parameters belong only to the final
+statement. Ray result consumption rejects an explicit transaction, including
+one started after the relation was created.
+
 Call `conn.interrupt()` from another thread to cancel an active Ray result wait.
 Row consumers raise `InterruptException` after query cleanup; exported Arrow
 readers report interruption through the Arrow stream error. The connection can

--- a/external/duckdb/src/include/duckdb/parser/parsed_expression.hpp
+++ b/external/duckdb/src/include/duckdb/parser/parsed_expression.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -11,10 +17,18 @@
 #include "duckdb/parser/base_expression.hpp"
 #include "duckdb/common/vector.hpp"
 #include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 
 namespace duckdb {
 class Deserializer;
 class Serializer;
+
+//! QueryRelation's first bind records names that depend on argument expansion.
+//! This transient capture is shared by AST copies and is not serialized.
+struct UnpackedColumnNameCapture {
+	bool active = true;
+	string name;
+};
 
 //!  The ParsedExpression class is a base class that can represent any expression
 //!  part of a SQL statement.
@@ -32,6 +46,8 @@ public:
 	}
 
 public:
+	shared_ptr<UnpackedColumnNameCapture> unpacked_column_name;
+
 	bool IsAggregate() const override;
 	bool IsWindow() const override;
 	bool HasSubquery() const override;
@@ -59,6 +75,7 @@ protected:
 		expression_class = other.expression_class;
 		alias = other.alias;
 		query_location = other.query_location;
+		unpacked_column_name = other.unpacked_column_name;
 	}
 };
 

--- a/external/duckdb/src/include/duckdb/parser/parsed_expression_iterator.hpp
+++ b/external/duckdb/src/include/duckdb/parser/parsed_expression_iterator.hpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
@@ -25,11 +31,13 @@ public:
 
 	static void EnumerateTableRefChildren(TableRef &ref,
 	                                      const std::function<void(unique_ptr<ParsedExpression> &child)> &expr_callback,
-	                                      const std::function<void(TableRef &ref)> &ref_callback = DefaultRefCallback);
+	                                      const std::function<void(TableRef &ref)> &ref_callback = DefaultRefCallback,
+	                                      const std::function<void(QueryNode &node)> &node_callback = nullptr);
 	static void
 	EnumerateQueryNodeChildren(QueryNode &node,
 	                           const std::function<void(unique_ptr<ParsedExpression> &child)> &expr_callback,
-	                           const std::function<void(TableRef &ref)> &ref_callback = DefaultRefCallback);
+	                           const std::function<void(TableRef &ref)> &ref_callback = DefaultRefCallback,
+	                           const std::function<void(QueryNode &node)> &node_callback = nullptr);
 
 	static void
 	EnumerateQueryNodeModifiers(QueryNode &node,

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -17,6 +17,8 @@
 #include "duckdb/parser/tableref/joinref.hpp"
 #include "duckdb/parser/tableref/pivotref.hpp"
 #include "duckdb/parser/tableref/showref.hpp"
+#include "duckdb/parser/tableref/basetableref.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/bound_statement.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -111,6 +113,26 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 		    }
 	    },
 	    [&](TableRef &ref) {
+		    if (ref.type == TableReferenceType::BASE_TABLE) {
+			    auto &table = ref.Cast<BaseTableRef>();
+			    if (table.at_clause) {
+				    CaptureExpressionParameters(table.at_clause->ExpressionMutable(), parameters);
+			    }
+			    return;
+		    }
+		    if (ref.type == TableReferenceType::TABLE_FUNCTION) {
+			    auto &function = ref.Cast<TableFunctionRef>();
+			    if (function.subquery) {
+				    CaptureQueryParameters(*function.subquery->node, parameters);
+			    }
+			    return;
+		    }
+		    if (ref.type == TableReferenceType::JOIN) {
+			    for (auto &expression : ref.Cast<JoinRef>().duplicate_eliminated_columns) {
+				    CaptureExpressionParameters(expression, parameters);
+			    }
+			    return;
+		    }
 		    if (ref.type == TableReferenceType::SHOW_REF) {
 			    auto &show = ref.Cast<ShowRef>();
 			    if (show.query) {

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -8,6 +8,11 @@
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/cast_expression.hpp"
+#include "duckdb/parser/expression/parameter_expression.hpp"
+#include "duckdb/parser/expression/subquery_expression.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -48,8 +53,57 @@ unique_ptr<SelectStatement> QueryRelation::ParseStatement(ClientContext &context
 	return unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
 }
 
+static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters);
+
+static void CaptureExpressionParameters(unique_ptr<ParsedExpression> &expression,
+                                        const case_insensitive_map_t<BoundParameterData> &parameters) {
+	if (expression->GetExpressionClass() == ExpressionClass::PARAMETER) {
+		auto &parameter = expression->Cast<ParameterExpression>();
+		auto entry = parameters.find(parameter.identifier);
+		if (entry == parameters.end()) {
+			throw InvalidInputException("Value was not provided for parameter %s", parameter.identifier);
+		}
+		auto &data = entry->second;
+		unique_ptr<ParsedExpression> constant = make_uniq<ConstantExpression>(data.GetValue());
+		if (data.return_type != data.GetValue().type() && data.return_type.id() != LogicalTypeId::STRING_LITERAL &&
+		    data.return_type.id() != LogicalTypeId::INTEGER_LITERAL) {
+			constant = make_uniq<CastExpression>(data.return_type, std::move(constant));
+		}
+		constant->SetAlias(expression->GetAlias());
+		constant->SetQueryLocation(expression->GetQueryLocation());
+		expression = std::move(constant);
+		return;
+	}
+	if (expression->GetExpressionClass() == ExpressionClass::SUBQUERY) {
+		auto &subquery = expression->Cast<SubqueryExpression>();
+		CaptureQueryParameters(*subquery.subquery->node, parameters);
+	}
+	ParsedExpressionIterator::EnumerateChildren(
+	    *expression, [&](unique_ptr<ParsedExpression> &child) { CaptureExpressionParameters(child, parameters); });
+}
+
+static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters) {
+	ParsedExpressionIterator::EnumerateQueryNodeChildren(node, [&](unique_ptr<ParsedExpression> &expression) {
+		// Keep SQL output names such as "($1 + 1)" stable when the value replaces
+		// its placeholder. Nested expressions retain their own original aliases.
+		auto name = expression->GetName();
+		CaptureExpressionParameters(expression, parameters);
+		if (expression->GetAlias().empty() && expression->GetExpressionClass() != ExpressionClass::STAR) {
+			expression->SetAlias(std::move(name));
+		}
+	});
+}
+
 unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {
-	return unique_ptr_cast<SQLStatement, SelectStatement>(select_stmt->Copy());
+	auto statement = unique_ptr_cast<SQLStatement, SelectStatement>(select_stmt->Copy());
+	if (!parameters.empty()) {
+		// Query nodes escape this relation when composing, creating views, or
+		// exporting SQL. Capture typed values in the AST so independent relations
+		// cannot lose or overwrite each other's parameter bindings.
+		CaptureQueryParameters(*statement->node, parameters);
+		statement->named_param_map.clear();
+	}
+	return statement;
 }
 
 unique_ptr<QueryNode> QueryRelation::GetQueryNode() {
@@ -83,7 +137,15 @@ BoundStatement QueryRelation::Bind(Binder &binder) {
 	auto saved_binding_mode = binder.GetBindingMode();
 	binder.SetBindingMode(BindingMode::EXTRACT_REPLACEMENT_SCANS);
 	bool first_bind = columns.empty();
-	auto result = Relation::Bind(binder);
+	// Validate the original prepared statement with DuckDB's normal parameter
+	// rules before any query-node export replaces placeholders with constants.
+	BoundStatement result;
+	if (parameters.empty()) {
+		result = Relation::Bind(binder);
+	} else {
+		auto statement = select_stmt->Copy();
+		result = binder.Bind(*statement);
+	}
 	auto &replacements = binder.GetReplacementScans();
 	if (first_bind) {
 		for (auto &kv : replacements) {

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
+#include "duckdb/parser/tableref/pivotref.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/bound_statement.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -83,15 +84,39 @@ static void CaptureExpressionParameters(unique_ptr<ParsedExpression> &expression
 }
 
 static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters) {
-	ParsedExpressionIterator::EnumerateQueryNodeChildren(node, [&](unique_ptr<ParsedExpression> &expression) {
-		// Keep SQL output names such as "($1 + 1)" stable when the value replaces
-		// its placeholder. Nested expressions retain their own original aliases.
-		auto name = expression->GetName();
-		CaptureExpressionParameters(expression, parameters);
-		if (expression->GetAlias().empty() && expression->GetExpressionClass() != ExpressionClass::STAR) {
-			expression->SetAlias(std::move(name));
-		}
-	});
+	ParsedExpressionIterator::EnumerateQueryNodeChildren(
+	    node,
+	    [&](unique_ptr<ParsedExpression> &expression) {
+		    // Keep SQL output names such as "($1 + 1)" stable when the value replaces
+		    // its placeholder. Nested expressions retain their own original aliases.
+		    auto name = expression->GetName();
+		    CaptureExpressionParameters(expression, parameters);
+		    if (expression->GetAlias().empty() && expression->GetExpressionClass() != ExpressionClass::STAR) {
+			    expression->SetAlias(std::move(name));
+		    }
+	    },
+	    [&](TableRef &ref) {
+		    if (ref.type != TableReferenceType::PIVOT) {
+			    return;
+		    }
+		    // The shared iterator omits pivot keys and entries: unlike ordinary
+		    // expressions, names in a PIVOT IN list can represent literal values.
+		    // Capture parameters here without changing other visitors' treatment of
+		    // those names or synthesizing aliases for pivot keys and entries.
+		    for (auto &pivot : ref.Cast<PivotRef>().pivots) {
+			    for (auto &expression : pivot.pivot_expressions) {
+				    CaptureExpressionParameters(expression, parameters);
+			    }
+			    for (auto &entry : pivot.entries) {
+				    if (entry.expr) {
+					    CaptureExpressionParameters(entry.expr, parameters);
+				    }
+			    }
+			    if (pivot.subquery) {
+				    CaptureQueryParameters(*pivot.subquery, parameters);
+			    }
+		    }
+	    });
 }
 
 unique_ptr<SelectStatement> QueryRelation::GetSelectStatement() {

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -104,11 +104,15 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 		    // its placeholder. Nested expressions retain their own original aliases.
 		    auto name = expression->GetName();
 		    const bool preserve_name = pivot_aggregates.find(expression.get()) == pivot_aggregates.end();
+		    bool has_star = false;
+		    ParsedExpressionIterator::VisitExpression<StarExpression>(*expression,
+		                                                              [&](const StarExpression &) { has_star = true; });
 		    CaptureExpressionParameters(expression, parameters);
 		    // Giving a PIVOT aggregate an implicit alias changes its output column
 		    // names (e.g. "1" becomes "1_count_star()"). Preserve explicit aliases only.
-		    if (preserve_name && expression->GetAlias().empty() &&
-		        expression->GetExpressionClass() != ExpressionClass::STAR) {
+		    // COLUMNS can be nested inside operators, functions or casts. Leave their
+		    // aliases implicit so the binder can name each expanded output column.
+		    if (preserve_name && !has_star && expression->GetAlias().empty()) {
 			    expression->SetAlias(std::move(name));
 		    }
 	    },

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/tableref/joinref.hpp"
 #include "duckdb/parser/tableref/pivotref.hpp"
+#include "duckdb/parser/tableref/showref.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/planner/bound_statement.hpp"
 #include "duckdb/planner/binder.hpp"
@@ -110,6 +111,13 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 		    }
 	    },
 	    [&](TableRef &ref) {
+		    if (ref.type == TableReferenceType::SHOW_REF) {
+			    auto &show = ref.Cast<ShowRef>();
+			    if (show.query) {
+				    CaptureQueryParameters(*show.query, parameters);
+			    }
+			    return;
+		    }
 		    if (ref.type != TableReferenceType::PIVOT) {
 			    return;
 		    }

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -88,7 +88,7 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 	ParsedExpressionIterator::EnumerateQueryNodeChildren(
 	    node, [](unique_ptr<ParsedExpression> &) {},
 	    [&](TableRef &ref) {
-		    if (ref.type == TableReferenceType::PIVOT) {
+		    if (ref.type == TableReferenceType::PIVOT && ref.Cast<PivotRef>().aggregates.size() == 1) {
 			    for (auto &aggregate : ref.Cast<PivotRef>().aggregates) {
 				    pivot_aggregates.insert(aggregate.get());
 			    }

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -84,14 +84,28 @@ static void CaptureExpressionParameters(unique_ptr<ParsedExpression> &expression
 }
 
 static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters) {
+	unordered_set<const ParsedExpression *> pivot_aggregates;
+	ParsedExpressionIterator::EnumerateQueryNodeChildren(
+	    node, [](unique_ptr<ParsedExpression> &) {},
+	    [&](TableRef &ref) {
+		    if (ref.type == TableReferenceType::PIVOT) {
+			    for (auto &aggregate : ref.Cast<PivotRef>().aggregates) {
+				    pivot_aggregates.insert(aggregate.get());
+			    }
+		    }
+	    });
 	ParsedExpressionIterator::EnumerateQueryNodeChildren(
 	    node,
 	    [&](unique_ptr<ParsedExpression> &expression) {
 		    // Keep SQL output names such as "($1 + 1)" stable when the value replaces
 		    // its placeholder. Nested expressions retain their own original aliases.
 		    auto name = expression->GetName();
+		    const bool preserve_name = pivot_aggregates.find(expression.get()) == pivot_aggregates.end();
 		    CaptureExpressionParameters(expression, parameters);
-		    if (expression->GetAlias().empty() && expression->GetExpressionClass() != ExpressionClass::STAR) {
+		    // Giving a PIVOT aggregate an implicit alias changes its output column
+		    // names (e.g. "1" becomes "1_count_star()"). Preserve explicit aliases only.
+		    if (preserve_name && expression->GetAlias().empty() &&
+		        expression->GetExpressionClass() != ExpressionClass::STAR) {
 			    expression->SetAlias(std::move(name));
 		    }
 	    },

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -30,6 +30,11 @@
 
 namespace duckdb {
 
+using UnpackedColumnNameCaptures = vector<shared_ptr<UnpackedColumnNameCapture>>;
+
+static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters,
+                                   optional_ptr<UnpackedColumnNameCaptures> name_captures = nullptr);
+
 QueryRelation::QueryRelation(const shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt_p,
                              string alias_p, const string &query_p,
                              case_insensitive_map_t<BoundParameterData> parameters_p)
@@ -38,7 +43,16 @@ QueryRelation::QueryRelation(const shared_ptr<ClientContext> &context, unique_pt
 	if (query.empty()) {
 		query = select_stmt->ToString();
 	}
+	UnpackedColumnNameCaptures name_captures;
+	if (!parameters.empty()) {
+		// Bind an unchanged statement while observing names produced by *COLUMNS.
+		// AST copies share the captures; subsequent binds only read the snapshot.
+		CaptureQueryParameters(*select_stmt->node, parameters, name_captures);
+	}
 	TryBindRelation(columns);
+	for (auto &capture : name_captures) {
+		capture->active = false;
+	}
 }
 
 QueryRelation::~QueryRelation() {
@@ -57,11 +71,10 @@ unique_ptr<SelectStatement> QueryRelation::ParseStatement(ClientContext &context
 	return unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
 }
 
-static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters);
-
 static void CaptureExpressionParameters(unique_ptr<ParsedExpression> &expression,
-                                        const case_insensitive_map_t<BoundParameterData> &parameters) {
-	if (expression->GetExpressionClass() == ExpressionClass::PARAMETER) {
+                                        const case_insensitive_map_t<BoundParameterData> &parameters,
+                                        optional_ptr<UnpackedColumnNameCaptures> name_captures) {
+	if (!name_captures && expression->GetExpressionClass() == ExpressionClass::PARAMETER) {
 		auto &parameter = expression->Cast<ParameterExpression>();
 		auto entry = parameters.find(parameter.identifier);
 		if (entry == parameters.end()) {
@@ -80,13 +93,15 @@ static void CaptureExpressionParameters(unique_ptr<ParsedExpression> &expression
 	}
 	if (expression->GetExpressionClass() == ExpressionClass::SUBQUERY) {
 		auto &subquery = expression->Cast<SubqueryExpression>();
-		CaptureQueryParameters(*subquery.subquery->node, parameters);
+		CaptureQueryParameters(*subquery.subquery->node, parameters, name_captures);
 	}
-	ParsedExpressionIterator::EnumerateChildren(
-	    *expression, [&](unique_ptr<ParsedExpression> &child) { CaptureExpressionParameters(child, parameters); });
+	ParsedExpressionIterator::EnumerateChildren(*expression, [&](unique_ptr<ParsedExpression> &child) {
+		CaptureExpressionParameters(child, parameters, name_captures);
+	});
 }
 
-static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters) {
+static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters,
+                                   optional_ptr<UnpackedColumnNameCaptures> name_captures) {
 	unordered_set<const ParsedExpression *> pivot_aggregates;
 	ParsedExpressionIterator::EnumerateQueryNodeChildren(
 	    node, [](unique_ptr<ParsedExpression> &) {},
@@ -100,19 +115,26 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 	ParsedExpressionIterator::EnumerateQueryNodeChildren(
 	    node,
 	    [&](unique_ptr<ParsedExpression> &expression) {
+		    if (name_captures) {
+			    CaptureExpressionParameters(expression, parameters, name_captures);
+			    return;
+		    }
 		    // Keep SQL output names such as "($1 + 1)" stable when the value replaces
 		    // its placeholder. Nested expressions retain their own original aliases.
-		    auto name = expression->GetName();
+		    auto &capture = expression->unpacked_column_name;
+		    const bool has_unpacked_name = capture && !capture->name.empty();
+		    auto name = has_unpacked_name ? capture->name : expression->GetName();
 		    const bool preserve_name = pivot_aggregates.find(expression.get()) == pivot_aggregates.end();
 		    bool has_star = false;
 		    ParsedExpressionIterator::VisitExpression<StarExpression>(*expression,
 		                                                              [&](const StarExpression &) { has_star = true; });
-		    CaptureExpressionParameters(expression, parameters);
+		    CaptureExpressionParameters(expression, parameters, nullptr);
 		    // Giving a PIVOT aggregate an implicit alias changes its output column
 		    // names (e.g. "1" becomes "1_count_star()"). Preserve explicit aliases only.
 		    // COLUMNS can be nested inside operators, functions or casts. Leave their
 		    // aliases implicit so the binder can name each expanded output column.
-		    if (preserve_name && !has_star && expression->GetAlias().empty()) {
+		    // Argument unpacking keeps one output, named after expanding arguments.
+		    if (preserve_name && (!has_star || has_unpacked_name) && expression->GetAlias().empty()) {
 			    expression->SetAlias(std::move(name));
 		    }
 	    },
@@ -120,27 +142,27 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 		    if (ref.type == TableReferenceType::BASE_TABLE) {
 			    auto &table = ref.Cast<BaseTableRef>();
 			    if (table.at_clause) {
-				    CaptureExpressionParameters(table.at_clause->ExpressionMutable(), parameters);
+				    CaptureExpressionParameters(table.at_clause->ExpressionMutable(), parameters, name_captures);
 			    }
 			    return;
 		    }
 		    if (ref.type == TableReferenceType::TABLE_FUNCTION) {
 			    auto &function = ref.Cast<TableFunctionRef>();
 			    if (function.subquery) {
-				    CaptureQueryParameters(*function.subquery->node, parameters);
+				    CaptureQueryParameters(*function.subquery->node, parameters, name_captures);
 			    }
 			    return;
 		    }
 		    if (ref.type == TableReferenceType::JOIN) {
 			    for (auto &expression : ref.Cast<JoinRef>().duplicate_eliminated_columns) {
-				    CaptureExpressionParameters(expression, parameters);
+				    CaptureExpressionParameters(expression, parameters, name_captures);
 			    }
 			    return;
 		    }
 		    if (ref.type == TableReferenceType::SHOW_REF) {
 			    auto &show = ref.Cast<ShowRef>();
 			    if (show.query) {
-				    CaptureQueryParameters(*show.query, parameters);
+				    CaptureQueryParameters(*show.query, parameters, name_captures);
 			    }
 			    return;
 		    }
@@ -153,15 +175,33 @@ static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t
 		    // those names or synthesizing aliases for pivot keys and entries.
 		    for (auto &pivot : ref.Cast<PivotRef>().pivots) {
 			    for (auto &expression : pivot.pivot_expressions) {
-				    CaptureExpressionParameters(expression, parameters);
+				    CaptureExpressionParameters(expression, parameters, name_captures);
 			    }
 			    for (auto &entry : pivot.entries) {
 				    if (entry.expr) {
-					    CaptureExpressionParameters(entry.expr, parameters);
+					    CaptureExpressionParameters(entry.expr, parameters, name_captures);
 				    }
 			    }
 			    if (pivot.subquery) {
-				    CaptureQueryParameters(*pivot.subquery, parameters);
+				    CaptureQueryParameters(*pivot.subquery, parameters, name_captures);
+			    }
+		    }
+	    },
+	    [&](QueryNode &query_node) {
+		    if (!name_captures || query_node.type != QueryNodeType::SELECT_NODE) {
+			    return;
+		    }
+		    for (auto &expression : query_node.Cast<SelectNode>().select_list) {
+			    if (!expression->GetAlias().empty()) {
+				    continue;
+			    }
+			    bool has_star = false;
+			    ParsedExpressionIterator::VisitExpression<StarExpression>(
+			        *expression, [&](const StarExpression &) { has_star = true; });
+			    if (has_star) {
+				    auto capture = make_shared_ptr<UnpackedColumnNameCapture>();
+				    expression->unpacked_column_name = capture;
+				    name_captures->push_back(std::move(capture));
 			    }
 		    }
 	    });

--- a/external/duckdb/src/parser/parsed_expression_iterator.cpp
+++ b/external/duckdb/src/parser/parsed_expression_iterator.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 
 #include "duckdb/parser/expression/list.hpp"
@@ -214,7 +220,7 @@ void ParsedExpressionIterator::EnumerateQueryNodeModifiers(
 
 void ParsedExpressionIterator::EnumerateTableRefChildren(
     TableRef &ref, const std::function<void(unique_ptr<ParsedExpression> &child)> &expr_callback,
-    const std::function<void(TableRef &ref)> &ref_callback) {
+    const std::function<void(TableRef &ref)> &ref_callback, const std::function<void(QueryNode &node)> &node_callback) {
 	switch (ref.type) {
 	case TableReferenceType::EXPRESSION_LIST: {
 		auto &el_ref = ref.Cast<ExpressionListRef>();
@@ -227,8 +233,8 @@ void ParsedExpressionIterator::EnumerateTableRefChildren(
 	}
 	case TableReferenceType::JOIN: {
 		auto &j_ref = ref.Cast<JoinRef>();
-		EnumerateTableRefChildren(*j_ref.left, expr_callback, ref_callback);
-		EnumerateTableRefChildren(*j_ref.right, expr_callback, ref_callback);
+		EnumerateTableRefChildren(*j_ref.left, expr_callback, ref_callback, node_callback);
+		EnumerateTableRefChildren(*j_ref.right, expr_callback, ref_callback, node_callback);
 		if (j_ref.condition) {
 			expr_callback(j_ref.condition);
 		}
@@ -236,7 +242,7 @@ void ParsedExpressionIterator::EnumerateTableRefChildren(
 	}
 	case TableReferenceType::PIVOT: {
 		auto &p_ref = ref.Cast<PivotRef>();
-		EnumerateTableRefChildren(*p_ref.source, expr_callback, ref_callback);
+		EnumerateTableRefChildren(*p_ref.source, expr_callback, ref_callback, node_callback);
 		for (auto &aggr : p_ref.aggregates) {
 			expr_callback(aggr);
 		}
@@ -244,7 +250,7 @@ void ParsedExpressionIterator::EnumerateTableRefChildren(
 	}
 	case TableReferenceType::SUBQUERY: {
 		auto &sq_ref = ref.Cast<SubqueryRef>();
-		EnumerateQueryNodeChildren(*sq_ref.subquery->node, expr_callback, ref_callback);
+		EnumerateQueryNodeChildren(*sq_ref.subquery->node, expr_callback, ref_callback, node_callback);
 		break;
 	}
 	case TableReferenceType::TABLE_FUNCTION: {
@@ -269,12 +275,15 @@ void ParsedExpressionIterator::EnumerateTableRefChildren(
 
 void ParsedExpressionIterator::EnumerateQueryNodeChildren(
     QueryNode &node, const std::function<void(unique_ptr<ParsedExpression> &child)> &expr_callback,
-    const std::function<void(TableRef &ref)> &ref_callback) {
+    const std::function<void(TableRef &ref)> &ref_callback, const std::function<void(QueryNode &node)> &node_callback) {
+	if (node_callback) {
+		node_callback(node);
+	}
 	switch (node.type) {
 	case QueryNodeType::RECURSIVE_CTE_NODE: {
 		auto &rcte_node = node.Cast<RecursiveCTENode>();
-		EnumerateQueryNodeChildren(*rcte_node.left, expr_callback, ref_callback);
-		EnumerateQueryNodeChildren(*rcte_node.right, expr_callback, ref_callback);
+		EnumerateQueryNodeChildren(*rcte_node.left, expr_callback, ref_callback, node_callback);
+		EnumerateQueryNodeChildren(*rcte_node.right, expr_callback, ref_callback, node_callback);
 		break;
 	}
 	case QueryNodeType::SELECT_NODE: {
@@ -295,13 +304,13 @@ void ParsedExpressionIterator::EnumerateQueryNodeChildren(
 			expr_callback(sel_node.qualify);
 		}
 
-		EnumerateTableRefChildren(*sel_node.from_table.get(), expr_callback, ref_callback);
+		EnumerateTableRefChildren(*sel_node.from_table.get(), expr_callback, ref_callback, node_callback);
 		break;
 	}
 	case QueryNodeType::SET_OPERATION_NODE: {
 		auto &setop_node = node.Cast<SetOperationNode>();
 		for (auto &child : setop_node.children) {
-			EnumerateQueryNodeChildren(*child, expr_callback, ref_callback);
+			EnumerateQueryNodeChildren(*child, expr_callback, ref_callback, node_callback);
 		}
 		break;
 	}
@@ -314,7 +323,7 @@ void ParsedExpressionIterator::EnumerateQueryNodeChildren(
 	}
 
 	for (auto &kv : node.cte_map.map) {
-		EnumerateQueryNodeChildren(*kv.second->query->node, expr_callback, ref_callback);
+		EnumerateQueryNodeChildren(*kv.second->query->node, expr_callback, ref_callback, node_callback);
 	}
 }
 

--- a/external/duckdb/src/planner/binder/expression/bind_star_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_star_expression.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/planner/binder.hpp"
 #include "duckdb/parser/expression/star_expression.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
@@ -383,6 +389,11 @@ void Binder::ExpandStarExpression(unique_ptr<ParsedExpression> expr,
 			throw BinderException("*COLUMNS not allowed at the root level, use COLUMNS instead");
 		}
 		ReplaceUnpackedStarExpression(expr, star_list, copied_star, regex.get());
+		if (expr->unpacked_column_name && expr->unpacked_column_name->active) {
+			// Unpacking changes arguments, while this expression remains one output.
+			// Record the same name BindSelectNode will use, before parameters change.
+			expr->unpacked_column_name->name = expr->GetName();
+		}
 		new_select_list.push_back(std::move(expr));
 		return;
 	}

--- a/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_select_node.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/common/limits.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/exception/parser_exception.hpp"
@@ -584,6 +590,7 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 		bool is_window = statement.select_list[i]->IsWindow();
 		idx_t unnest_count = result.unnests.size();
 		LogicalType result_type;
+		auto unpacked_column_name = statement.select_list[i]->unpacked_column_name;
 		auto expr = select_binder.Bind(statement.select_list[i], &result_type, true);
 		bool is_original_column = i < result.column_count;
 		bool can_group_by_all =
@@ -591,6 +598,10 @@ BoundStatement Binder::BindSelectNode(SelectNode &statement, BoundStatement from
 		result.bound_column_count++;
 
 		if (expr->GetExpressionType() == ExpressionType::BOUND_EXPANDED) {
+			if (unpacked_column_name && unpacked_column_name->active) {
+				// Struct UNNEST assigns a name to each expanded field instead.
+				unpacked_column_name->name.clear();
+			}
 			if (!is_original_column) {
 				throw BinderException("UNNEST of struct cannot be used in ORDER BY/DISTINCT ON clause");
 			}

--- a/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
+++ b/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
@@ -292,6 +292,8 @@ public:
 	shared_ptr<DuckDBPyConnection> ExecuteMany(const py::object &query, py::object params = py::list());
 
 	void ExecuteImmediately(vector<unique_ptr<SQLStatement>> statements);
+	void ExecutePrecedingStatements(vector<unique_ptr<SQLStatement>> statements, bool use_ray,
+	                                const py::object &interrupt_check);
 	unique_ptr<PreparedStatement> PrepareQuery(unique_ptr<SQLStatement> statement);
 	unique_ptr<QueryResult> ExecuteInternal(PreparedStatement &prep, py::object params = py::list());
 	unique_ptr<QueryResult> PrepareAndExecuteInternal(unique_ptr<SQLStatement> statement,

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -789,16 +789,16 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	m.def("extract_statements", &DuckDBPyConnection::ExtractStatements,
 	      "Parse the query string and extract the Statement object(s) produced", py::arg("query"));
 	m.def("sql", &DuckDBPyConnection::RunQuery,
-	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	      "run the query as-is.",
+	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
+	      "runner when consumed. Non-SELECT statements execute on the connection.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("query", &DuckDBPyConnection::RunQuery,
-	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	      "run the query as-is.",
+	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
+	      "runner when consumed. Non-SELECT statements execute on the connection.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("from_query", &DuckDBPyConnection::RunQuery,
-	      "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	      "run the query as-is.",
+	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
+	      "runner when consumed. Non-SELECT statements execute on the connection.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("read_csv", &DuckDBPyConnection::ReadCSV, "Create a relation object from the CSV file in 'name'",
 	      py::arg("path_or_buffer"), py::kw_only());
@@ -1559,29 +1559,10 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Execute(const py::object &que
 	// First immediately execute any preceding statements (if any)
 	// FIXME: SQLites implementation says to not accept an 'execute' call with multiple statements
 	const bool use_ray = ResolveRunnerTypeFromEnvironment() == "ray";
-	if (use_ray) {
-		for (auto &statement : statements) {
-			if (!statement->named_param_map.empty()) {
-				throw NotImplementedException(
-				    "Prepared parameters are only supported for the last statement, please split your query up into "
-				    "separate 'execute' calls if you want to use prepared parameters");
-			}
-			if (statement->type == StatementType::SELECT_STATEMENT) {
-				auto discarded_result = ExecuteSelectOnRay(std::move(statement), py::none(), interrupt_check);
-				while (py::len(discarded_result->FetchMany(STANDARD_VECTOR_SIZE)) != 0) {
-				}
-			} else {
-				vector<unique_ptr<SQLStatement>> immediate;
-				immediate.push_back(std::move(statement));
-				ExecuteImmediately(std::move(immediate));
-			}
-		}
-		if (last_statement->type == StatementType::SELECT_STATEMENT) {
-			con.SetResult(ExecuteSelectOnRay(std::move(last_statement), std::move(params), interrupt_check));
-			return shared_from_this();
-		}
-	} else {
-		ExecuteImmediately(std::move(statements));
+	ExecutePrecedingStatements(std::move(statements), use_ray, interrupt_check);
+	if (use_ray && last_statement->type == StatementType::SELECT_STATEMENT) {
+		con.SetResult(ExecuteSelectOnRay(std::move(last_statement), std::move(params), interrupt_check));
+		return shared_from_this();
 	}
 
 	auto res = PrepareAndExecuteInternal(std::move(last_statement), std::move(params));
@@ -2458,8 +2439,32 @@ void DuckDBPyConnection::ExecuteImmediately(vector<unique_ptr<SQLStatement>> sta
 	}
 }
 
+void DuckDBPyConnection::ExecutePrecedingStatements(vector<unique_ptr<SQLStatement>> statements, bool use_ray,
+                                                    const py::object &interrupt_check) {
+	if (!use_ray) {
+		ExecuteImmediately(std::move(statements));
+		return;
+	}
+	for (auto &statement : statements) {
+		if (!statement->named_param_map.empty()) {
+			throw NotImplementedException("Prepared parameters are only supported for the last statement, please "
+			                              "split your query up into separate calls");
+		}
+		if (statement->type == StatementType::SELECT_STATEMENT) {
+			auto discarded_result = ExecuteSelectOnRay(std::move(statement), py::none(), interrupt_check);
+			while (py::len(discarded_result->FetchMany(STANDARD_VECTOR_SIZE)) != 0) {
+			}
+		} else {
+			vector<unique_ptr<SQLStatement>> immediate;
+			immediate.push_back(std::move(statement));
+			ExecuteImmediately(std::move(immediate));
+		}
+	}
+}
+
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const py::object &query, string alias, py::object params) {
 	auto &connection = con.GetConnection();
+	auto interrupt_check = CreateQueryInterruptCheck();
 	if (alias.empty()) {
 		alias = "unnamed_relation_" + StringUtil::GenerateRandomName(16);
 	}
@@ -2473,31 +2478,23 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const py::object &quer
 	auto last_statement = std::move(statements.back());
 	statements.pop_back();
 	// First immediately execute any preceding statements (if any)
-	ExecuteImmediately(std::move(statements));
+	ExecutePrecedingStatements(std::move(statements), ResolveRunnerTypeFromEnvironment() == "ray", interrupt_check);
 
-	// Attempt to create a Relation for lazy execution if possible
 	shared_ptr<Relation> relation;
-	bool has_params = !py::none().is(params) && py::len(params) > 0;
-	if (!has_params) {
-		// No params (or empty params) — use lazy QueryRelation path
-		{
-			D_ASSERT(py::gil_check());
-			py::gil_scoped_release gil;
-			auto statement_type = last_statement->type;
-			switch (statement_type) {
-			case StatementType::SELECT_STATEMENT: {
-				auto select_statement = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(last_statement));
-				relation = connection.RelationFromQuery(std::move(select_statement), alias);
-				break;
-			}
-			default:
-				break;
-			}
-		}
-	}
-
-	if (!relation) {
-		// Could not create a relation, resort to direct execution
+	if (last_statement->type == StatementType::SELECT_STATEMENT) {
+		// Bind values without executing: every SELECT uses the relation's runner
+		// when consumed, including prepared queries and their derived relations.
+		auto named_values = TransformPreparedParameters(params.is_none() ? py::object(py::list()) : params);
+		PreparedStatement::VerifyParameters(named_values, last_statement->named_param_map);
+		// Python parameter conversion can close the connection. Revalidate it
+		// before releasing the GIL and binding the captured native values.
+		auto context = con.GetConnection().context;
+		py::gil_scoped_release release;
+		unique_lock<mutex> lock(py_connection_lock);
+		auto select = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(last_statement));
+		relation = make_shared_ptr<QueryRelation>(context, std::move(select), alias, "", std::move(named_values));
+	} else {
+		// Non-SELECT statements execute on the connection.
 		unique_ptr<QueryResult> res;
 
 		res = PrepareAndExecuteInternal(std::move(last_statement), std::move(params));
@@ -2628,7 +2625,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::ReadVideoFrames(py::object para
 		named_parameters[py::cast<string>(entry.first)] = TransformPythonValue(entry.second);
 	}
 	// Retain constant arguments in the relation so execution and Ray planning
-	// see the scan itself. RunQuery(params=...) materializes a result instead.
+	// see the scan itself.
 	auto &connection = con.GetConnection();
 	return CreateRelation(
 	    connection.TableFunction("read_video_frames", TransformPythonParamList(params), named_parameters));

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -1320,6 +1320,10 @@ void DuckDBPyRelation::ExecuteOrThrow(bool stream_result, const string &runner_t
 			check();
 		}
 		auto context = rel->context->GetContext();
+		if (!context->transaction.IsAutoCommit()) {
+			throw InvalidInputException("Ray SELECT requires DuckDB auto-commit mode because distributed execution "
+			                            "cannot participate in the caller's explicit transaction");
+		}
 		ValidateDistributedResultTypes(types, *context);
 		auto &client_config = ClientConfig::GetConfig(*context);
 		auto result_collector = client_config.get_result_collector;

--- a/src/vane_py/vane_python.cpp
+++ b/src/vane_py/vane_python.cpp
@@ -717,8 +717,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 		    }
 		    return conn->RunQuery(query, alias, params);
 	    },
-	    "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	    "run the query as-is.",
+	    "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
+	    "runner when consumed. Non-SELECT statements execute on the connection.",
 	    py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none(),
 	    py::arg("connection") = py::none());
 	m.def(
@@ -730,8 +730,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 		    }
 		    return conn->RunQuery(query, alias, params);
 	    },
-	    "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	    "run the query as-is.",
+	    "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
+	    "runner when consumed. Non-SELECT statements execute on the connection.",
 	    py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none(),
 	    py::arg("connection") = py::none());
 	m.def(
@@ -743,8 +743,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 		    }
 		    return conn->RunQuery(query, alias, params);
 	    },
-	    "Run a SQL query. If it is a SELECT statement, create a relation object from the given SQL query, otherwise "
-	    "run the query as-is.",
+	    "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
+	    "runner when consumed. Non-SELECT statements execute on the connection.",
 	    py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none(),
 	    py::arg("connection") = py::none());
 	m.def(

--- a/tests/fast/api/test_vane_connection.py
+++ b/tests/fast/api/test_vane_connection.py
@@ -155,8 +155,9 @@ class TestVaneConnection:
         ):
             vane.query(statements)
 
-        with pytest.raises(vane.BinderException, match="This type of statement can't be prepared!"):
+        with pytest.raises(vane.InvalidInputException, match="Values were not provided.*parameters: 1"):
             vane.query(statements[0])
+        assert vane.query(statements[0], params=[42]).fetchall() == [(42,)]
 
         assert vane.query(statements[1]).fetchall() == [(21,)]
         assert vane.execute(statements[1]).fetchall() == [(21,)]

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -235,7 +235,7 @@ def test_parameterized_sql_keeps_independent_values_through_composition(monkeypa
         elif operation == "project":
             relation, expected = left.project("value * 2 AS doubled").order("doubled"), [(2,), (4,), (6,)]
         elif operation == "aggregate":
-            relation, expected = left.aggregate("sum(value) AS total"), [(6,)]
+            relation, expected = left.aggregate("sum(value)::BIGINT AS total"), [(6,)]
         elif operation == "limit":
             relation, expected = left.order("value DESC").limit(1, 1), [(2,)]
         elif operation == "join":
@@ -275,7 +275,7 @@ def test_parameterized_sql_keeps_independent_values_through_composition(monkeypa
             "SELECT i + (SELECT $offset::BIGINT) AS value FROM data WHERE i >= $start ORDER BY i LIMIT $limit",
             {"rows": 5, "offset": 10, "start": 2, "limit": 2},
         ),
-        ("SELECT sum(i) OVER (ORDER BY i ROWS ? PRECEDING) AS total FROM range(3) t(i) ORDER BY i", [1]),
+        ("SELECT (sum(i) OVER (ORDER BY i ROWS ? PRECEDING))::BIGINT AS total FROM range(3) t(i) ORDER BY i", [1]),
     ],
 )
 def test_parameterized_sql_composition_preserves_types_names_and_nested_queries(

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -377,7 +377,7 @@ def test_parameterized_sql_special_table_refs_preserve_values_through_compositio
         ("greatest(*COLUMNS(*)) + ? AS explicit_name", [10]),
         ("first_value(greatest(*COLUMNS(*))) OVER () + ?", [10]),
         ("unnest(struct_pack(*COLUMNS(*), extra := ?), recursive := true)", [10]),
-        ("(SELECT greatest(*COLUMNS(*)) + ? FROM (VALUES (1), (2)) t(a))", [10]),
+        ("(SELECT greatest(*COLUMNS(*)) + ? FROM (VALUES (1, 2)) t(a, b))", [10]),
     ],
 )
 def test_parameterized_columns_preserve_expanded_names(monkeypatch, configured, operation, expression, parameters):

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -134,6 +134,7 @@ class _TransportedPlanRunner:
                 self.closed_iterators += 1
 
 
+@pytest.mark.parametrize("method", ["execute", "sql"])
 @pytest.mark.parametrize(
     ("query", "parameters"),
     [
@@ -153,7 +154,7 @@ class _TransportedPlanRunner:
         ),
     ],
 )
-def test_connection_execute_ray_binds_parameters_before_plan_transport(monkeypatch, query, parameters):
+def test_connection_query_ray_binds_parameters_before_plan_transport(monkeypatch, query, parameters, method):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     with vane.connect() as reference:
         expected = reference.execute(query, parameters).fetchall()
@@ -162,12 +163,16 @@ def test_connection_execute_ray_binds_parameters_before_plan_transport(monkeypat
     runner = _TransportedPlanRunner()
     _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
-        assert connection.execute(query, parameters).fetchall() == expected
-        assert connection.description == expected_description
+        result = (
+            connection.execute(query, parameters) if method == "execute" else connection.sql(query, params=parameters)
+        )
+        assert result.fetchall() == expected
+        assert result.description == expected_description
         assert len(runner.plans) == 1
         assert runner.closed_iterators == 1
 
 
+@pytest.mark.parametrize("method", ["execute", "sql"])
 @pytest.mark.parametrize(
     ("query", "parameters", "message"),
     [
@@ -177,14 +182,181 @@ def test_connection_execute_ray_binds_parameters_before_plan_transport(monkeypat
         ("SELECT ?", object(), "list or a dictionary"),
     ],
 )
-def test_connection_execute_ray_rejects_invalid_parameters_before_runner(monkeypatch, query, parameters, message):
+def test_connection_query_ray_rejects_invalid_parameters_before_runner(monkeypatch, query, parameters, message, method):
     runner = _FakeRayRunner([])
     factory_calls = _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
         with pytest.raises(vane.InvalidInputException, match=message):
-            connection.execute(query, parameters)
+            if method == "execute":
+                connection.execute(query, parameters)
+            else:
+                connection.sql(query, params=parameters)
         assert connection.description is None
     assert factory_calls == []
+
+
+@pytest.mark.parametrize("configured", ["local-fast", "ray", "", None])
+@pytest.mark.parametrize("method", ["sql", "query", "from_query", "module_sql"])
+def test_parameterized_sql_entrypoints_are_lazy_and_select_the_runner(monkeypatch, configured, method):
+    runner = _FakeRayRunner([pa.table({"value": pa.array([42], pa.int64())})])
+    factory_calls = _install_fake_ray_runner(monkeypatch, runner)
+    if configured is None:
+        monkeypatch.delenv("VANE_RUNNER")
+    else:
+        monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        if method == "module_sql":
+            relation = vane.sql("SELECT ?::BIGINT AS value", params=[7], connection=connection)
+        else:
+            relation = getattr(connection, method)("SELECT ?::BIGINT AS value", params=[7], alias="captured")
+            assert relation.alias == "captured"
+        assert relation.columns == ["value"]
+        assert factory_calls == []
+        assert relation.fetchall() == [(7 if configured == "local-fast" else 42,)]
+        assert len(runner.calls) == (0 if configured == "local-fast" else 1)
+
+
+@pytest.mark.parametrize("configured", ["local-fast", "ray"])
+@pytest.mark.parametrize(
+    "operation", ["filter", "project", "aggregate", "limit", "join", "union", "view", "query", "sql_text"]
+)
+def test_parameterized_sql_keeps_independent_values_through_composition(monkeypatch, configured, operation):
+    runner = _TransportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        parameters = {"offset": 1, "count": 3}
+        left = connection.sql("SELECT i + $offset AS value FROM range($count) t(i)", params=parameters, alias="lhs")
+        parameters.update(offset=11, count=2)
+        right = connection.sql("SELECT i + $offset AS value FROM range($count) t(i)", params=parameters, alias="rhs")
+        parameters.clear()
+        if operation == "filter":
+            relation, expected = left.filter("value >= 2").order("value"), [(2,), (3,)]
+        elif operation == "project":
+            relation, expected = left.project("value * 2 AS doubled").order("doubled"), [(2,), (4,), (6,)]
+        elif operation == "aggregate":
+            relation, expected = left.aggregate("sum(value) AS total"), [(6,)]
+        elif operation == "limit":
+            relation, expected = left.order("value DESC").limit(1, 1), [(2,)]
+        elif operation == "join":
+            relation = (
+                left.join(right, "lhs.value + 10 = rhs.value")
+                .project("lhs.value AS left_value, rhs.value AS right_value")
+                .order("left_value")
+            )
+            expected = [(1, 11), (2, 12)]
+        elif operation == "union":
+            relation, expected = left.union(right).order("value"), [(1,), (2,), (3,), (11,), (12,)]
+        elif operation == "view":
+            left.create_view("captured_parameters")
+            relation = connection.sql("SELECT value FROM captured_parameters ORDER BY value")
+            expected = [(1,), (2,), (3,)]
+        elif operation == "query":
+            relation = left.query("captured_parameters", "SELECT value FROM captured_parameters ORDER BY value")
+            expected = [(1,), (2,), (3,)]
+        else:
+            relation = connection.sql(left.order("value").sql_query())
+            expected = [(1,), (2,), (3,)]
+        assert runner.plans == []
+        assert relation.fetchall() == expected
+        assert len(runner.plans) == (1 if configured == "ray" else 0)
+
+
+@pytest.mark.parametrize("configured", ["local-fast", "ray"])
+@pytest.mark.parametrize(
+    ("query", "parameters"),
+    [
+        ("SELECT ? + 1, typeof(?)", [7, "text"]),
+        ("SELECT ? AS same, ? AS same", [3, 4]),
+        ("SELECT ?::BLOB AS payload, ?::DECIMAL(8,2) AS amount", [b"\x00'\xff", "12.50"]),
+        ("SELECT ? AS data", [{"values": [1, None, 3], "label": "a'; SELECT 99; --"}]),
+        (
+            "WITH data AS (SELECT i FROM range($rows) t(i)) "
+            "SELECT i + (SELECT $offset::BIGINT) AS value FROM data WHERE i >= $start ORDER BY i LIMIT $limit",
+            {"rows": 5, "offset": 10, "start": 2, "limit": 2},
+        ),
+        ("SELECT sum(i) OVER (ORDER BY i ROWS ? PRECEDING) AS total FROM range(3) t(i) ORDER BY i", [1]),
+    ],
+)
+def test_parameterized_sql_composition_preserves_types_names_and_nested_queries(
+    monkeypatch, configured, query, parameters
+):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as reference:
+        expected = reference.execute(query, parameters).fetchall()
+        description = reference.description
+    runner = _TransportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        relation = connection.sql(query, params=parameters).limit(100)
+        assert relation.fetchall() == expected
+        assert relation.description == description
+
+
+def test_parameterized_sql_remains_lazy_for_local_tables(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE items(value INTEGER)")
+        relation = connection.sql("SELECT value FROM items WHERE value >= ? ORDER BY value", params=[2])
+        connection.execute("INSERT INTO items VALUES (1), (2), (3)")
+        assert relation.fetchall() == [(2,), (3,)]
+
+
+def test_parameterized_sql_revalidates_connection_after_parameter_conversion(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    connection = vane.connect()
+
+    class ClosingParameters(list):
+        def __len__(self):
+            connection.close()
+            return super().__len__()
+
+    with pytest.raises(vane.ConnectionException, match="closed"):
+        connection.sql("SELECT ?", params=ClosingParameters([1]))
+
+
+def test_parameterized_sql_drains_preceding_ray_selects_and_keeps_final_query_lazy(monkeypatch):
+    runner = _FakeRayRunner([pa.table({"value": pa.array([42], pa.int64())})])
+    _install_fake_ray_runner(monkeypatch, runner)
+    with vane.connect() as connection:
+        relation = connection.sql("SELECT 1::BIGINT; SET threads=2; SELECT ?::BIGINT AS value", params=[7])
+        assert len(runner.calls) == 1
+        assert runner.closed_iterators == 1
+        assert relation.fetchall() == [(42,)]
+        assert len(runner.calls) == 2
+        with pytest.raises(vane.NotImplementedException, match="only supported for the last statement"):
+            connection.sql("SELECT ?; SELECT 1", params=[1])
+
+
+@pytest.mark.parametrize("begin_before_binding", [False, True])
+def test_parameterized_sql_ray_rejects_explicit_transaction_at_consumption(monkeypatch, begin_before_binding):
+    runner = _FakeRayRunner([])
+    factory_calls = _install_fake_ray_runner(monkeypatch, runner)
+    with vane.connect() as connection:
+        if begin_before_binding:
+            connection.begin()
+        relation = connection.sql("SELECT ? AS value", params=[7])
+        if not begin_before_binding:
+            connection.begin()
+        try:
+            with pytest.raises(vane.InvalidInputException, match="cannot participate.*explicit transaction"):
+                relation.fetchall()
+            assert factory_calls == []
+        finally:
+            connection.rollback()
+
+
+def test_parameterized_sql_ray_failure_does_not_execute_locally(monkeypatch):
+    class FailingRunner:
+        def run_iter_tables(self, relation):
+            raise RuntimeError("parameterized Ray query failed")
+
+    _install_fake_ray_runner(monkeypatch, FailingRunner())
+    with vane.connect() as connection:
+        relation = connection.sql("SELECT ? AS value", params=[7])
+        with pytest.raises(RuntimeError, match="parameterized Ray query failed"):
+            relation.fetchall()
 
 
 def test_connection_execute_ray_keeps_control_and_write_statements_on_connection(monkeypatch):
@@ -358,7 +530,8 @@ def test_module_arrow_reader_pins_replaced_default_connection(monkeypatch):
         vane.set_default_connection(previous)
 
 
-def test_connection_execute_ray_does_not_evaluate_parameterized_udf_locally(monkeypatch):
+@pytest.mark.parametrize("method", ["execute", "sql"])
+def test_connection_query_ray_does_not_evaluate_parameterized_udf_locally(monkeypatch, method):
     runner = _FakeRayRunner([pa.table({"value": pa.array([42], pa.int64())})])
     _install_fake_ray_runner(monkeypatch, runner)
 
@@ -373,7 +546,12 @@ def test_connection_execute_ray_does_not_evaluate_parameterized_udf_locally(monk
             parameters=["BIGINT"],
             return_dtype="BIGINT",
         )
-        assert connection.execute("SELECT must_run_on_ray(?) AS value", [7]).fetchone() == (42,)
+        if method == "execute":
+            result = connection.execute("SELECT must_run_on_ray(?) AS value", [7])
+        else:
+            result = connection.sql("SELECT must_run_on_ray(?) AS value", params=[7]).project("value")
+            assert runner.calls == []
+        assert result.fetchone() == (42,)
         assert len(runner.calls) == 1
 
 
@@ -551,7 +729,8 @@ def test_connection_execute_retains_interrupt_during_parameter_conversion(monkey
         assert factory_calls == []
 
 
-def test_connection_execute_uses_real_ray_runner(ray_local, monkeypatch, tmp_path):
+@pytest.mark.parametrize("method", ["execute", "sql"])
+def test_connection_query_uses_real_ray_runner(ray_local, monkeypatch, tmp_path, method):
     import ray
 
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
@@ -569,13 +748,16 @@ def test_connection_execute_uses_real_ray_runner(ray_local, monkeypatch, tmp_pat
             runner = vane.set_runner_ray(noop_if_initialized=True)
             assert ray.is_initialized()
             assert runner.name == "ray"
-            rows = connection.execute(
-                "SELECT value, worker_pid(value) AS pid FROM read_parquet(?) WHERE value >= ? ORDER BY value",
-                [str(data), 97],
-            ).fetchall()
+            query = "SELECT value, worker_pid(value) AS pid FROM read_parquet(?) WHERE value >= ? ORDER BY value"
+            if method == "execute":
+                result = connection.execute(query, [str(data), 97])
+            else:
+                result = connection.sql(query, params=[str(data), 97]).filter("value < 100").order("value")
+            rows = result.fetchall()
             assert [row[0] for row in rows] == [97, 98, 99]
             assert all(row[1] != os.getpid() for row in rows)
-            assert connection.fetchall() == []
+            if method == "execute":
+                assert connection.fetchall() == []
         finally:
             vane.teardown_runner()
 

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -356,6 +356,51 @@ def test_parameterized_sql_special_table_refs_preserve_values_through_compositio
 
 @pytest.mark.parametrize("configured", ["local-fast", "ray"])
 @pytest.mark.parametrize("operation", ["derive", "view", "sql_export"])
+@pytest.mark.parametrize(
+    ("expression", "parameters"),
+    [
+        ("COLUMNS(*) + ?", [10]),
+        ("min(COLUMNS(*)) + ?", [10]),
+        ("CAST(COLUMNS(*) + $offset AS BIGINT)", {"offset": 10}),
+        ("coalesce(COLUMNS(*), ?) + COLUMNS(*)", [10]),
+        ("COLUMNS($selected) + $offset", {"selected": ["a", "b"], "offset": 10}),
+        (r"COLUMNS('^(a|b)$') + ? AS 'value_\1'", [10]),
+        ("COLUMNS('a') + ? AS fixed", [10]),
+        ("COLUMNS(*) + ?, ? + 1", [10, 20]),
+        ("* REPLACE (a + ? AS a)", [10]),
+        ("(SELECT min(COLUMNS('a')) + ? FROM (VALUES (1), (2)) t(a))", [10]),
+    ],
+)
+def test_parameterized_columns_preserve_expanded_names(monkeypatch, configured, operation, expression, parameters):
+    query = f"SELECT {expression} FROM (SELECT 1::BIGINT AS a, 2::BIGINT AS b)"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as reference:
+        # Native execute supplies the output names assigned during expansion.
+        expected = reference.execute(query, parameters).fetchall()
+        description = reference.description
+    runner = _TransportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        relation = connection.sql(query, params=parameters)
+        assert relation.description == description
+        if operation == "view":
+            relation.create_view("parameterized_columns")
+            relation = connection.sql("SELECT * FROM parameterized_columns")
+        elif operation == "sql_export":
+            relation = connection.sql(relation.sql_query())
+        else:
+            relation = relation.filter("true")
+        assert relation.description == description
+        if relation.columns == ["a", "b"]:
+            relation = relation.project("a, b")
+        assert runner.plans == []
+        assert relation.fetchall() == expected
+        assert len(runner.plans) == (1 if configured == "ray" else 0)
+
+
+@pytest.mark.parametrize("configured", ["local-fast", "ray"])
+@pytest.mark.parametrize("operation", ["derive", "view", "sql_export"])
 @pytest.mark.parametrize("unit", ["VERSION", "TIMESTAMP"])
 def test_parameterized_sql_captures_table_at_expressions(monkeypatch, configured, operation, unit):
     runner = _TransportedPlanRunner()
@@ -844,6 +889,27 @@ def test_connection_query_uses_real_ray_runner(ray_local, monkeypatch, tmp_path,
             assert all(row[1] != os.getpid() for row in rows)
             if method == "execute":
                 assert connection.fetchall() == []
+        finally:
+            vane.teardown_runner()
+
+
+def test_parameterized_columns_view_and_sql_export_use_real_ray_runner(ray_local, monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    with vane.connect() as connection:
+        try:
+            vane.set_runner_ray(noop_if_initialized=True)
+            relation = connection.sql(
+                "SELECT min(COLUMNS(*)) + ? FROM (VALUES (1::BIGINT, 2::BIGINT), (3, 4)) t(a, b)",
+                params=[10],
+            )
+            relation.create_view("parameterized_columns")
+            results = [
+                connection.sql("SELECT a, b FROM parameterized_columns"),
+                connection.sql(relation.sql_query()).project("a, b"),
+            ]
+            for result in results:
+                assert result.columns == ["a", "b"]
+                assert result.fetchall() == [(11, 12)]
         finally:
             vane.teardown_runner()
 

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -308,6 +308,10 @@ def test_parameterized_sql_composition_preserves_types_names_and_nested_queries(
             {"first": 0, "second": 1},
         ),
         (
+            "PIVOT (SELECT i % 2 AS key FROM range(4) t(i)) ON key IN (0, 1) USING count(*) + $extra",
+            {"extra": 10},
+        ),
+        (
             "UNPIVOT (SELECT 2 AS a, 3 AS b) ON (a + $offset) AS a, (b + $offset) AS b INTO NAME field VALUE value",
             {"offset": 10},
         ),

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -369,6 +369,15 @@ def test_parameterized_sql_special_table_refs_preserve_values_through_compositio
         ("COLUMNS(*) + ?, ? + 1", [10, 20]),
         ("* REPLACE (a + ? AS a)", [10]),
         ("(SELECT min(COLUMNS('a')) + ? FROM (VALUES (1), (2)) t(a))", [10]),
+        ("greatest(*COLUMNS(*)) + ?", [10]),
+        ("coalesce(*COLUMNS(*), ?)", [10]),
+        ("CAST(greatest(*COLUMNS(*)) + ? AS BIGINT)", [10]),
+        ("greatest(*COLUMNS($selected)) + $offset", {"selected": ["a", "b"], "offset": 10}),
+        ("COLUMNS(*), greatest(*COLUMNS(*)) + ?", [10]),
+        ("greatest(*COLUMNS(*)) + ? AS explicit_name", [10]),
+        ("first_value(greatest(*COLUMNS(*))) OVER () + ?", [10]),
+        ("unnest(struct_pack(*COLUMNS(*), extra := ?), recursive := true)", [10]),
+        ("(SELECT greatest(*COLUMNS(*)) + ? FROM (VALUES (1), (2)) t(a))", [10]),
     ],
 )
 def test_parameterized_columns_preserve_expanded_names(monkeypatch, configured, operation, expression, parameters):
@@ -392,9 +401,47 @@ def test_parameterized_columns_preserve_expanded_names(monkeypatch, configured, 
         else:
             relation = relation.filter("true")
         assert relation.description == description
-        if relation.columns == ["a", "b"]:
-            relation = relation.project("a, b")
+        projection = ", ".join('"' + column[0].replace('"', '""') + '"' for column in description)
+        relation = relation.project(projection)
         assert runner.plans == []
+        assert relation.fetchall() == expected
+        assert relation.description == description
+        assert len(runner.plans) == (1 if configured == "ray" else 0)
+
+
+@pytest.mark.parametrize("configured", ["local-fast", "ray"])
+@pytest.mark.parametrize("operation", ["project", "view", "sql_export"])
+@pytest.mark.parametrize("wrapper", ["subquery", "cte", "materialized_cte", "union", "summarize"])
+def test_parameterized_unpacked_columns_keep_names_in_nested_queries(monkeypatch, configured, operation, wrapper):
+    inner = "SELECT greatest(*COLUMNS(*)) + $offset FROM (VALUES (1::BIGINT, 2::BIGINT)) t(a, b)"
+    if wrapper == "subquery":
+        query = f"SELECT * FROM ({inner})"
+    elif wrapper in {"cte", "materialized_cte"}:
+        materialization = "MATERIALIZED " if wrapper == "materialized_cte" else ""
+        query = f"WITH data AS {materialization}({inner}) SELECT * FROM data"
+    elif wrapper == "union":
+        query = f"{inner} UNION ALL {inner}"
+    else:
+        query = f"SUMMARIZE {inner}"
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as reference:
+        expected = reference.execute(query, {"offset": 10}).fetchall()
+        description = reference.description
+    runner = _TransportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        relation = connection.sql(query, params={"offset": 10})
+        assert relation.description == description
+        if operation == "view":
+            relation.create_view("unpacked_columns")
+            relation = connection.sql("SELECT * FROM unpacked_columns")
+        elif operation == "sql_export":
+            relation = connection.sql(relation.sql_query())
+        projection = ", ".join('"' + column[0].replace('"', '""') + '"' for column in description)
+        relation = relation.project(projection)
+        assert runner.plans == []
+        assert relation.description == description
         assert relation.fetchall() == expected
         assert len(runner.plans) == (1 if configured == "ray" else 0)
 
@@ -893,23 +940,25 @@ def test_connection_query_uses_real_ray_runner(ray_local, monkeypatch, tmp_path,
             vane.teardown_runner()
 
 
-def test_parameterized_columns_view_and_sql_export_use_real_ray_runner(ray_local, monkeypatch):
+@pytest.mark.parametrize("unpack", [False, True], ids=["output-columns", "function-arguments"])
+def test_parameterized_columns_view_and_sql_export_use_real_ray_runner(ray_local, monkeypatch, unpack):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     with vane.connect() as connection:
         try:
             vane.set_runner_ray(noop_if_initialized=True)
-            relation = connection.sql(
-                "SELECT min(COLUMNS(*)) + ? FROM (VALUES (1::BIGINT, 2::BIGINT), (3, 4)) t(a, b)",
-                params=[10],
-            )
+            expression = "greatest(*COLUMNS(*)) + ?" if unpack else "min(COLUMNS(*)) + ?"
+            relation = connection.sql(f"SELECT {expression} FROM (VALUES (1::BIGINT, 2::BIGINT)) t(a, b)", params=[10])
+            names = relation.columns
+            projection = ", ".join('"' + name.replace('"', '""') + '"' for name in names)
             relation.create_view("parameterized_columns")
             results = [
-                connection.sql("SELECT a, b FROM parameterized_columns"),
-                connection.sql(relation.sql_query()).project("a, b"),
+                relation.project(projection),
+                connection.sql(f"SELECT {projection} FROM parameterized_columns"),
+                connection.sql(relation.sql_query()).project(projection),
             ]
             for result in results:
-                assert result.columns == ["a", "b"]
-                assert result.fetchall() == [(11, 12)]
+                assert result.columns == names
+                assert result.fetchall() == ([(12,)] if unpack else [(11, 12)])
         finally:
             vane.teardown_runner()
 

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -294,6 +294,49 @@ def test_parameterized_sql_composition_preserves_types_names_and_nested_queries(
         assert relation.description == description
 
 
+@pytest.mark.parametrize("configured", ["local-fast", "ray"])
+@pytest.mark.parametrize("operation", ["derive", "view", "sql_export"])
+@pytest.mark.parametrize(
+    ("query", "parameters"),
+    [
+        (
+            "PIVOT (SELECT i % 2 AS key FROM range(4) t(i)) ON (key + $offset) IN (1, 2) USING count(*)",
+            {"offset": 1},
+        ),
+        (
+            "PIVOT (SELECT i % 2 AS key FROM range(4) t(i)) ON key IN ($first, $second) USING count(*)",
+            {"first": 0, "second": 1},
+        ),
+        (
+            "UNPIVOT (SELECT 2 AS a, 3 AS b) ON (a + $offset) AS a, (b + $offset) AS b INTO NAME field VALUE value",
+            {"offset": 10},
+        ),
+    ],
+)
+def test_parameterized_sql_pivot_preserves_values_through_composition(
+    monkeypatch, configured, operation, query, parameters
+):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as reference:
+        expected = reference.execute(query, parameters).fetchall()
+        description = reference.description
+    runner = _TransportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        relation = connection.sql(query, params=parameters)
+        if operation == "view":
+            relation.create_view("parameterized_pivot")
+            relation = connection.sql("SELECT * FROM parameterized_pivot")
+        elif operation == "sql_export":
+            relation = connection.sql(relation.sql_query())
+        else:
+            relation = relation.limit(100)
+        assert runner.plans == []
+        assert relation.fetchall() == expected
+        assert relation.description == description
+
+
 def test_parameterized_sql_remains_lazy_for_local_tables(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     with vane.connect() as connection:

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -324,9 +324,13 @@ def test_parameterized_sql_composition_preserves_types_names_and_nested_queries(
             "UNPIVOT (SELECT 2 AS a, 3 AS b) ON (a + $offset) AS a, (b + $offset) AS b INTO NAME field VALUE value",
             {"offset": 10},
         ),
+        ("SUMMARIZE SELECT ? AS x", [7]),
+        ("DESCRIBE SELECT ? AS x", [7]),
+        ("SUMMARIZE SELECT $value + 1", {"value": 7}),
+        ("DESCRIBE SELECT $value + 1", {"value": 7}),
     ],
 )
-def test_parameterized_sql_pivot_preserves_values_through_composition(
+def test_parameterized_sql_special_table_refs_preserve_values_through_composition(
     monkeypatch, configured, operation, query, parameters
 ):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -354,6 +354,32 @@ def test_parameterized_sql_special_table_refs_preserve_values_through_compositio
         assert relation.description == description
 
 
+@pytest.mark.parametrize("configured", ["local-fast", "ray"])
+@pytest.mark.parametrize("operation", ["derive", "view", "sql_export"])
+@pytest.mark.parametrize("unit", ["VERSION", "TIMESTAMP"])
+def test_parameterized_sql_captures_table_at_expressions(monkeypatch, configured, operation, unit):
+    runner = _TransportedPlanRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    monkeypatch.setenv("VANE_RUNNER", configured)
+    with vane.connect() as connection:
+        # A CTE bypasses catalog time travel, so this isolates AST capture
+        # without requiring an optional time-travel catalog extension.
+        query = f"WITH history AS (SELECT 1::BIGINT AS value) SELECT * FROM history AT ({unit} => $version)"
+        value = 7 if unit == "VERSION" else "2026-01-01"
+        relation = connection.sql(query, params={"version": value})
+        exported = relation.sql_query()
+        assert "$version" not in exported.lower()
+        assert str(value) in exported
+        if operation == "view":
+            relation.create_view("captured_table_version")
+            relation = connection.sql("SELECT * FROM captured_table_version")
+        elif operation == "sql_export":
+            relation = connection.sql(exported)
+        else:
+            relation = relation.filter("value > 0")
+        assert relation.fetchall() == [(1,)]
+
+
 def test_parameterized_sql_remains_lazy_for_local_tables(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     with vane.connect() as connection:

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -312,6 +312,15 @@ def test_parameterized_sql_composition_preserves_types_names_and_nested_queries(
             {"extra": 10},
         ),
         (
+            "PIVOT (SELECT i % 2 AS key FROM range(4) t(i)) ON key IN (0, 1) "
+            "USING count(*) + $extra, max(key) + $extra",
+            {"extra": 10},
+        ),
+        (
+            "PIVOT (SELECT i % 2 AS key FROM range(4) t(i)) ON key IN (0, 1) USING count(*) + $extra AS total",
+            {"extra": 10},
+        ),
+        (
             "UNPIVOT (SELECT 2 AS a, 3 AS b) ON (a + $offset) AS a, (b + $offset) AS b INTO NAME field VALUE value",
             {"offset": 10},
         ),

--- a/tests/fast/test_image.py
+++ b/tests/fast/test_image.py
@@ -342,11 +342,10 @@ assert 'PIL' not in sys.modules
     subprocess.run([sys.executable, "-I", "-c", program], check=True, capture_output=True, text=True)
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="uses Linux address-space accounting")
+@pytest.mark.skipif(sys.platform != "linux", reason="uses Linux resident-memory accounting")
 def test_hd_image_scalars_keep_dense_pixel_buffers():
     pytest.importorskip("PIL.Image")
     program = """
-import resource
 from pathlib import Path
 import numpy as np
 from PIL import Image
@@ -355,11 +354,11 @@ with vane.connect(config={'threads': 1}) as con:
     con.execute('SELECT $1', [vane.Value(np.zeros((1, 1, 3), dtype=np.uint8), vane.image_type())]).fetchone()
     pixels = np.arange(1080 * 1920 * 3, dtype=np.uint8).reshape(1080, 1920, 3)
     pil = Image.fromarray(pixels)
-    vm_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
-                      if line.startswith('VmSize:')))
-    _, hard = resource.getrlimit(resource.RLIMIT_AS)
-    ceiling = vm_kib * 1024 + 192 * 1024 * 1024
-    resource.setrlimit(resource.RLIMIT_AS, (ceiling if hard < 0 else min(ceiling, hard), hard))
+    # Allocator reservations are not resident pixels. VmHWM also excludes the
+    # spawning pytest process's peak, which resource.getrusage() can inherit.
+    Path('/proc/self/clear_refs').write_text('5')
+    peak_before_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
+                               if line.startswith('VmHWM:')))
     # ConstantExpression binds a native scalar, including fixed Image inputs.
     for dtype in (vane.image_type(), vane.image_type('RGB'), vane.image_type('RGB', 1080, 1920)):
         expression = vane.ConstantExpression(vane.Value(pixels, dtype))
@@ -375,17 +374,20 @@ with vane.connect(config={'threads': 1}) as con:
             np.testing.assert_array_equal(result[row:row + 16], image[row:row + 16])
         assert result.flags.c_contiguous
         del result
+    peak_after_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
+                              if line.startswith('VmHWM:')))
+    growth_kib = peak_after_kib - peak_before_kib
+    assert growth_kib <= 192 * 1024, f'Image scalar peak RSS grew by {growth_kib / 1024:.1f} MiB (budget: 192 MiB)'
 """
     completed = subprocess.run([sys.executable, "-I", "-c", program], capture_output=True, text=True, timeout=60)
     assert completed.returncode == 0, completed.stderr
 
 
-@pytest.mark.skipif(sys.platform != "linux", reason="uses Linux address-space accounting")
+@pytest.mark.skipif(sys.platform != "linux", reason="uses Linux resident-memory accounting")
 @pytest.mark.parametrize("declared", ["IMAGE", "IMAGE('RGBA')", "IMAGE('RGBA', 2160, 3840)"])
 def test_4k_image_udf_inputs_and_outputs_keep_dense_pixel_buffers(declared):
     pytest.importorskip("PIL.Image")
     program = """
-import resource
 import sys
 from pathlib import Path
 import numpy as np
@@ -399,11 +401,11 @@ dtype = vane.sqltype(sys.argv[1])
 contract = FileUDFContract('image_roundtrip', (dtype,), (dtype,))
 pixels = np.arange(2160 * 3840 * 4, dtype=np.uint8).reshape(2160, 3840, 4)
 pil = Image.fromarray(pixels)
-vm_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
-                  if line.startswith('VmSize:')))
-_, hard = resource.getrlimit(resource.RLIMIT_AS)
-ceiling = vm_kib * 1024 + 192 * 1024 * 1024
-resource.setrlimit(resource.RLIMIT_AS, (ceiling if hard < 0 else min(ceiling, hard), hard))
+# Measure this process's resident pixels, not allocator address reservations or
+# a peak inherited from the spawning pytest process through getrusage().
+Path('/proc/self/clear_refs').write_text('5')
+peak_before_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
+                           if line.startswith('VmHWM:')))
 for image, expected in ((pixels, pixels), (pixels[:, ::-1, :], pixels[:, ::-1, :]), (pil, pixels)):
     output = contract.normalize_scalar_arrow_output(contract.scalar_outputs_to_array([image]))
     storage = output.storage if dtype.is_fixed_shape_image() else output.storage.field('data')
@@ -418,6 +420,10 @@ for image, expected in ((pixels, pixels), (pixels[:, ::-1, :], pixels[:, ::-1, :
         np.testing.assert_array_equal(restored[row:row + 16], expected[row:row + 16])
     assert restored.flags.c_contiguous and restored.flags.writeable
     del restored, output
+peak_after_kib = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
+                          if line.startswith('VmHWM:')))
+growth_kib = peak_after_kib - peak_before_kib
+assert growth_kib <= 192 * 1024, f'Image UDF peak RSS grew by {growth_kib / 1024:.1f} MiB (budget: 192 MiB)'
 """
     completed = subprocess.run(
         [sys.executable, "-I", "-c", program, declared], capture_output=True, text=True, timeout=60

--- a/tests/fast/test_relation.py
+++ b/tests/fast/test_relation.py
@@ -588,7 +588,7 @@ class TestRelation:
         limited_rel = rel.limit(50)
         assert len(limited_rel.fetchall()) == 50
 
-        # Using parameters also results in a MaterializedRelation
+        # A parameterized lazy relation composes with a materialized CALL result
         materialized_one = duckdb_cursor.sql("select * from range(?)", params=[10]).project(
             ColumnExpression("range").cast(str).alias("range")
         )
@@ -646,17 +646,15 @@ class TestRelation:
         assert res == ("test",)
 
     def test_materialized_relation_view2(self, duckdb_cursor):
-        # This creates a MaterializedRelation
+        # Parameter values must survive a projection and view creation.
         rel = duckdb_cursor.sql("select * from (values ($1, $2))", params=[(2,), ("Alice",)])
 
-        # This creates a ProjectionRelation, wrapping the materialized rel
+        # This creates a ProjectionRelation, wrapping the parameterized query
         rel = rel.project("col0, col1")
 
-        # Create a VIEW that contains a ColumnDataRef
+        # Capture the parameter values in the view query.
         rel.create_view("test", True)
-        # Override the existing relation, the original MaterializedRelation has now gone out of scope
-        # The VIEW still works because the CDC that is being referenced is kept alive through the
-        # MaterializedDependency item
+        # The view retains the values after the original relation goes out of scope.
         rel = duckdb_cursor.sql("select * from test")
         res = rel.fetchall()
         assert res == [([2], ["Alice"])]

--- a/tests/fast/test_vane_config.py
+++ b/tests/fast/test_vane_config.py
@@ -142,8 +142,8 @@ else:
     def identity(value):
         return value
 
-    relation = vane.connect().sql("SELECT 1::INTEGER AS value")
     with pytest.raises(vane.InvalidInputException, match=re.escape(expected)):
+        relation = vane.connect().sql("SELECT 1::INTEGER AS value")
         relation.select(identity(vane.col("value"))).explain()
 
 

--- a/tests/fast/test_write_local_default_runner.py
+++ b/tests/fast/test_write_local_default_runner.py
@@ -470,12 +470,6 @@ def test_invalid_runner_env_raises_clear_error(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "rya")
     import vane
 
-    conn = vane.connect()
-
-    @vane.func(return_dtype="INTEGER")
-    def add_one(value):
-        return value + 1
-
-    rel = conn.sql("select 1::INTEGER as x")
-    with pytest.raises(Exception, match="[Ii]nvalid runner"):
-        rel.select(add_one(vane.col("x")).alias("y")).fetchall()
+    with vane.connect() as conn:
+        with pytest.raises(vane.InvalidInputException, match="[Ii]nvalid runner"):
+            conn.sql("select 1::INTEGER as x")


### PR DESCRIPTION
## Summary

Parameterized `conn.sql()` SELECTs currently execute eagerly in DuckDB, so adding `params` changes both laziness and runner routing. Bind and retain native parameter values in a lazy QueryRelation so `sql()`, `query()`, and `from_query()` follow the configured runner when consumed: local-fast uses DuckDB and Ray uses the distributed query path without fallback.

Capture typed values when exporting the relation's query AST so filtering, aggregation, joins, unions, PIVOT/UNPIVOT, DESCRIBE/SUMMARIZE, AT clauses, COLUMNS output expansion and argument unpacking, views, and SQL export preserve independent bindings and output names. Share preceding-statement dispatch with `execute()` and reject Ray SELECT consumption inside an explicit transaction. README and API docstrings describe the behavior.

Connection-lifetime runner binding and a shared SELECT/COPY statement entry follow in #792 under #192 and #790. That follow-up retains client binding and bound logical-plan transport; ATTACH, DDL, SET, transaction control, and other SQL DML remain on the client coordinator connection.

## Related issue

Refs #192. Follow-up to #780; foundation for #790.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

README and the connection/module SQL entry-point docstrings are updated.

## Validation

The latest test-only correction (`9987624b4d`) addresses the two image allocation failures in [CI non-Ray shard 2/2](https://github.com/AstroVela/vane/actions/runs/34313285320/job/102358351118). The tests measure the child process's peak resident growth instead of restricting allocator virtual-address reservations. The 192 MiB additional-memory budget, image sizes, pixel/layout assertions and timeouts remain unchanged. Two consecutive clean local reviews preceded runtime validation; no package sources changed, so no native rebuild was needed.

- Root formatting, `git diff --check` and applicable pre-commit checks passed.
- `scripts/run_installed_pytest.sh -q tests/fast/test_image.py tests/fast/test_fixed_shape_image.py`: 202 passed using the failed run's wheel, Python 3.12.14 and CI merge checkout with the reviewed test patch.
- Nine diagnostic controls passed: dense scalar/UDF paths grew about 90–97 MiB; all three intentionally boxed per-pixel UDF variants were rejected at about 350 MiB. Untouched 1 GiB virtual mappings did not inflate the metric, and a 512 MiB parent allocation did not mask child peaks. The exact original allocation failure was not reproduced locally.
- Full CI non-Ray shard 2/2 replay with that wheel/runtime/source: 4,571 passed, 518 skipped, 5 expected failures; 1 failure in the existing native vLLM `NextBatch` issue tracked by #797 (`INSERT SELECT` variant). Both originally failing image tests passed. No vLLM assertion or timeout was changed.
- `scripts/run_release_tests.sh` on that CI merge/runtime: 1,215 non-Ray + 30 real-Ray tests passed in separate processes.

The underlying SQL changes were previously built with a non-editable incremental Release install (`SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation --no-deps -v`, native commit `43e868e11a`). At `e00d969357`, the affected SQL/Relation/parameter/API tests passed with 1,230 passed, 3 skipped and 1 expected failure; 6 actual-Ray tests passed separately. The latest correction changes tests only.

Two consecutive manual GitHub `@codex review` rounds passed on the unchanged head `9987624b4d`: [round 1](https://github.com/AstroVela/vane/pull/791#issuecomment-5597775195), [round 2](https://github.com/AstroVela/vane/pull/791#issuecomment-5597896857). No unresolved review threads remain. The [replacement CI run](https://github.com/AstroVela/vane/actions/runs/34322002995) is still building the native matrix; full CI is not yet reported as green.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependencies or assets.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered. Parameters remain typed native values; they are not interpolated into SQL strings.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.
