### PR TITLE
[feat](sql) Route INSERT through the connection write runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,18 @@ with `safe_to_retry=False`; an uncertain outcome remains
 every parameter set and retains the final result. The `local` FTE runner
 supports writes; its SELECT result consumption continues to use native DuckDB.
 
-Session configuration, `ATTACH`, transaction control, DDL, and other SQL DML
+SQL `INSERT VALUES` and `INSERT SELECT` share the Relation `insert()` and
+`insert_into()` write runner. Parameters, target column lists, `BY NAME`, defaults,
+and qualified/quoted table names retain SQL binding semantics. `execute()` returns
+the committed `Count`; `sql()` completes the write and returns `None`.
+Ray INSERT requires auto-commit and a target with distributed-write support.
+`RETURNING`, conflict actions (`ON CONFLICT`, `OR IGNORE`, `OR REPLACE`), and the
+local FTE runner are rejected before INSERT execution. Local-fast uses DuckDB.
+`append()` also follows this policy because it issues an INSERT SELECT.
+Writes use the existing writer's committed-result and unknown-outcome errors;
+failures never trigger local fallback or implicit resubmission.
+
+Session configuration, `ATTACH`, transaction control, DDL, and remaining SQL DML
 continue executing on the client coordinator connection. SQL is bound there;
 Ray receives serialized bound logical plans for both SQL and Relation queries
 and writes. Moving catalog and session operations to the driver is outside

--- a/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/insert_relation.hpp
@@ -15,19 +15,28 @@
 #pragma once
 
 #include "duckdb/main/relation.hpp"
+#include "duckdb/planner/expression/bound_parameter_data.hpp"
 
 namespace duckdb {
+
+class InsertStatement;
 
 class InsertRelation : public Relation {
 public:
 	InsertRelation(shared_ptr<Relation> child, string schema_name, string table_name);
 	InsertRelation(shared_ptr<Relation> child, string catalog_name, string schema_name, string table_name);
+	InsertRelation(const shared_ptr<ClientContext> &context, unique_ptr<InsertStatement> statement,
+	               case_insensitive_map_t<BoundParameterData> parameters);
+	~InsertRelation() override;
 
 	shared_ptr<Relation> child;
 	string catalog_name;
 	string schema_name;
 	string table_name;
 	vector<ColumnDefinition> columns;
+	unique_ptr<InsertStatement> statement;
+	case_insensitive_map_t<BoundParameterData> parameters;
+	case_insensitive_map_t<unique_ptr<TableRef>> replacement_scans;
 
 public:
 	BoundStatement Bind(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/planner/binder.hpp
+++ b/external/duckdb/src/include/duckdb/planner/binder.hpp
@@ -182,6 +182,8 @@ struct GlobalBinderState {
 	unordered_set<string> table_names;
 	//! Replacement Scans extracted for BindingMode::EXTRACT_REPLACEMENT_SCANS
 	case_insensitive_map_t<unique_ptr<TableRef>> replacement_scans;
+	//! Relation-owned external scans captured before entering a Python runner.
+	optional_ptr<const case_insensitive_map_t<unique_ptr<TableRef>>> replacement_scan_bindings;
 	//! Using column sets
 	vector<unique_ptr<UsingColumnSet>> using_column_sets;
 	//! The set of parameter expressions bound by this binder
@@ -327,6 +329,12 @@ public:
 	void AddReplacementScan(const string &table_name, unique_ptr<TableRef> replacement);
 	const unordered_set<string> &GetTableNames();
 	case_insensitive_map_t<unique_ptr<TableRef>> &GetReplacementScans();
+	optional_ptr<const case_insensitive_map_t<unique_ptr<TableRef>>> GetReplacementScanBindings() {
+		return global_binder_state->replacement_scan_bindings;
+	}
+	void SetReplacementScanBindings(optional_ptr<const case_insensitive_map_t<unique_ptr<TableRef>>> bindings) {
+		global_binder_state->replacement_scan_bindings = bindings;
+	}
 	CatalogEntryRetriever &EntryRetriever() {
 		return entry_retriever;
 	}

--- a/external/duckdb/src/main/relation/insert_relation.cpp
+++ b/external/duckdb/src/main/relation/insert_relation.cpp
@@ -7,8 +7,10 @@
 #include "duckdb/main/relation/insert_relation.hpp"
 #include "duckdb/parser/statement/insert_statement.hpp"
 #include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/parser/tableref.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/planner/binder.hpp"
+#include "duckdb/planner/bound_parameter_map.hpp"
 #include "duckdb/main/client_context.hpp"
 
 namespace duckdb {
@@ -25,7 +27,50 @@ InsertRelation::InsertRelation(shared_ptr<Relation> child_p, string catalog_name
 	TryBindRelation(columns);
 }
 
+InsertRelation::InsertRelation(const shared_ptr<ClientContext> &context, unique_ptr<InsertStatement> statement_p,
+                               case_insensitive_map_t<BoundParameterData> parameters_p)
+    : Relation(context, RelationType::INSERT_RELATION), statement(std::move(statement_p)),
+      parameters(std::move(parameters_p)) {
+	if (!statement) {
+		throw InvalidInputException("InsertRelation requires an INSERT statement");
+	}
+	TryBindRelation(columns);
+}
+
+InsertRelation::~InsertRelation() = default;
+
 BoundStatement InsertRelation::Bind(Binder &binder) {
+	if (statement) {
+		// Bind the complete INSERT so target-column inference, DEFAULT values,
+		// BY NAME and CTE scopes retain DuckDB's statement semantics.
+		BoundParameterMap parameter_map(parameters);
+		struct ParameterScope {
+			Binder &binder;
+			optional_ptr<BoundParameterMap> previous;
+			BindingMode previous_mode;
+			optional_ptr<const case_insensitive_map_t<unique_ptr<TableRef>>> previous_scans;
+			~ParameterScope() {
+				binder.SetParameters(previous);
+				binder.SetBindingMode(previous_mode);
+				binder.SetReplacementScanBindings(previous_scans);
+			}
+		} scope {binder, binder.GetParameters(), binder.GetBindingMode(), binder.GetReplacementScanBindings()};
+		binder.SetParameters(parameter_map);
+		binder.SetReplacementScanBindings(replacement_scans);
+		binder.SetBindingMode(BindingMode::EXTRACT_REPLACEMENT_SCANS);
+		auto copy = statement->Copy();
+		auto result = binder.Bind(*copy);
+		if (columns.empty()) {
+			// Preserve Python sources from the caller's frame. Keep the complete
+			// INSERT AST: wrapping VALUES in a SELECT would lose DEFAULT inference.
+			for (auto &entry : binder.GetReplacementScans()) {
+				if (entry.second->external_dependency) {
+					replacement_scans.emplace(entry.first, entry.second->Copy());
+				}
+			}
+		}
+		return result;
+	}
 	auto query_node = TryGetSerializableChildQueryNode(*child, binder);
 	if (!query_node) {
 		throw NotImplementedException("Cannot insert from a relation that cannot be faithfully represented as a SQL "
@@ -55,6 +100,9 @@ const vector<ColumnDefinition> &InsertRelation::Columns() {
 }
 
 string InsertRelation::ToString(idx_t depth) {
+	if (statement) {
+		return RenderWhitespace(depth) + "Insert From SQL\n";
+	}
 	string str = RenderWhitespace(depth) + "Insert\n";
 	return str + child->ToString(depth + 1);
 }

--- a/external/duckdb/src/planner/binder/tableref/bind_basetableref.cpp
+++ b/external/duckdb/src/planner/binder/tableref/bind_basetableref.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -45,49 +51,61 @@ static bool TryLoadExtensionForReplacementScan(ClientContext &context, const str
 }
 
 BoundStatement Binder::BindWithReplacementScan(ClientContext &context, BaseTableRef &ref) {
-	auto &config = DBConfig::GetConfig(context);
-	if (!context.config.use_replacement_scans) {
+	unique_ptr<TableRef> replacement_function;
+	auto captured = GetReplacementScanBindings();
+	if (captured) {
+		auto entry = captured->find(ref.table_name);
+		if (entry != captured->end()) {
+			replacement_function = entry->second->Copy();
+		}
+	}
+	if (!replacement_function) {
+		if (!context.config.use_replacement_scans) {
+			return BoundStatement();
+		}
+		auto &config = DBConfig::GetConfig(context);
+		for (auto &scan : config.replacement_scans) {
+			ReplacementScanInput input(ref.catalog_name, ref.schema_name, ref.table_name);
+			replacement_function = scan.function(context, input, scan.data.get());
+			if (replacement_function) {
+				break;
+			}
+		}
+	}
+	if (!replacement_function) {
 		return BoundStatement();
 	}
-	for (auto &scan : config.replacement_scans) {
-		ReplacementScanInput input(ref.catalog_name, ref.schema_name, ref.table_name);
-		auto replacement_function = scan.function(context, input, scan.data.get());
-		if (!replacement_function) {
-			continue;
-		}
-		if (!ref.alias.empty()) {
-			// user-provided alias overrides the default alias
-			replacement_function->alias = ref.alias;
-		} else if (replacement_function->alias.empty()) {
-			// if the replacement scan itself did not provide an alias we use the table name
-			replacement_function->alias = ref.table_name;
-		}
-		if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
-			auto &table_function = replacement_function->Cast<TableFunctionRef>();
-			table_function.column_name_alias = ref.column_name_alias;
-		} else if (replacement_function->type == TableReferenceType::SUBQUERY) {
-			auto &subquery = replacement_function->Cast<SubqueryRef>();
-			subquery.column_name_alias = ref.column_name_alias;
-		} else {
-			// carry the alias to the wrapping SubqueryRef so qualified references
-			// like `SELECT d.x FROM _ AS d` can resolve against the outer ref
-			auto inner_alias = replacement_function->alias;
-			auto select_node = make_uniq<SelectNode>();
-			select_node->select_list.push_back(make_uniq<StarExpression>());
-			select_node->from_table = std::move(replacement_function);
-			auto select_stmt = make_uniq<SelectStatement>();
-			select_stmt->node = std::move(select_node);
-			auto subquery = make_uniq<SubqueryRef>(std::move(select_stmt));
-			subquery->alias = std::move(inner_alias);
-			subquery->column_name_alias = ref.column_name_alias;
-			replacement_function = std::move(subquery);
-		}
-		if (GetBindingMode() == BindingMode::EXTRACT_REPLACEMENT_SCANS) {
-			AddReplacementScan(ref.table_name, replacement_function->Copy());
-		}
-		return Bind(*replacement_function);
+	if (!ref.alias.empty()) {
+		// user-provided alias overrides the default alias
+		replacement_function->alias = ref.alias;
+	} else if (replacement_function->alias.empty()) {
+		// if the replacement scan itself did not provide an alias we use the table name
+		replacement_function->alias = ref.table_name;
 	}
-	return BoundStatement();
+	if (replacement_function->type == TableReferenceType::TABLE_FUNCTION) {
+		auto &table_function = replacement_function->Cast<TableFunctionRef>();
+		table_function.column_name_alias = ref.column_name_alias;
+	} else if (replacement_function->type == TableReferenceType::SUBQUERY) {
+		auto &subquery = replacement_function->Cast<SubqueryRef>();
+		subquery.column_name_alias = ref.column_name_alias;
+	} else {
+		// carry the alias to the wrapping SubqueryRef so qualified references
+		// like `SELECT d.x FROM _ AS d` can resolve against the outer ref
+		auto inner_alias = replacement_function->alias;
+		auto select_node = make_uniq<SelectNode>();
+		select_node->select_list.push_back(make_uniq<StarExpression>());
+		select_node->from_table = std::move(replacement_function);
+		auto select_stmt = make_uniq<SelectStatement>();
+		select_stmt->node = std::move(select_node);
+		auto subquery = make_uniq<SubqueryRef>(std::move(select_stmt));
+		subquery->alias = std::move(inner_alias);
+		subquery->column_name_alias = ref.column_name_alias;
+		replacement_function = std::move(subquery);
+	}
+	if (GetBindingMode() == BindingMode::EXTRACT_REPLACEMENT_SCANS) {
+		AddReplacementScan(ref.table_name, replacement_function->Copy());
+	}
+	return Bind(*replacement_function);
 }
 
 unique_ptr<BoundAtClause> Binder::BindAtClause(optional_ptr<AtClause> at_clause) {

--- a/src/vane_py/include/vane_python/pyrelation.hpp
+++ b/src/vane_py/include/vane_python/pyrelation.hpp
@@ -314,7 +314,8 @@ public:
 	py::object GetConnectionOwnerReference() const;
 	string GetRunnerType() const;
 	shared_ptr<DuckDBPyResult> ExecuteForConnection(const py::object &interrupt_check);
-	shared_ptr<DuckDBPyResult> ExecuteCopyForConnection(const py::object &interrupt_check);
+	shared_ptr<DuckDBPyResult> ExecuteWriteForConnection(StatementType statement_type,
+	                                                     const py::object &interrupt_check);
 	unique_ptr<DuckDBPyRelation> DeriveRelation(shared_ptr<Relation> new_rel);
 	unique_ptr<DuckDBPyRelation> DeriveRelation(shared_ptr<DuckDBPyResult> result);
 

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -6,7 +6,9 @@
 
 #include "vane_python/pyconnection/pyconnection.hpp"
 #include "duckdb/main/relation/write_file_relation.hpp"
+#include "duckdb/main/relation/insert_relation.hpp"
 #include "duckdb/parser/statement/copy_statement.hpp"
+#include "duckdb/parser/statement/insert_statement.hpp"
 #include "vane_python/audio_file_functions.hpp"
 #include "vane_python/image_file_functions.hpp"
 #include "vane_python/image_functions.hpp"
@@ -711,10 +713,10 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	      py::arg("key").none(false), py::arg("value").none(false));
 	m.def("duplicate", &DuckDBPyConnection::Cursor, "Create a duplicate of the current connection");
 	m.def("execute", &DuckDBPyConnection::Execute,
-	      "Execute SQL with optional parameters. SELECT and COPY TO use the runner selected when connecting; "
+	      "Execute SQL with optional parameters. SELECT, COPY TO and INSERT use the runner selected when connecting; "
 	      "VANE_RUNNER=local-fast uses native DuckDB; ray (the default) uses Ray. Other statements execute on the "
 	      "client. "
-	      "Ray SELECT and runner COPY TO require auto-commit mode. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
+	      "Ray SELECT and runner writes require auto-commit mode. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
 	      "local-fast.",
 	      py::arg("query"), py::arg("parameters") = py::none());
 	m.def("executemany", &DuckDBPyConnection::ExecuteMany,
@@ -795,17 +797,17 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	      "Parse the query string and extract the Statement object(s) produced", py::arg("query"));
 	m.def("sql", &DuckDBPyConnection::RunQuery,
 	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	      "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
+	      "connection runner when consumed. COPY TO and INSERT use the write runner and execute immediately; other "
 	      "statements execute on the client connection. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require local-fast.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("query", &DuckDBPyConnection::RunQuery,
 	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	      "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
+	      "connection runner when consumed. COPY TO and INSERT use the write runner and execute immediately; other "
 	      "statements execute on the client connection. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require local-fast.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("from_query", &DuckDBPyConnection::RunQuery,
 	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	      "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
+	      "connection runner when consumed. COPY TO and INSERT use the write runner and execute immediately; other "
 	      "statements execute on the client connection. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require local-fast.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("read_csv", &DuckDBPyConnection::ReadCSV, "Create a relation object from the CSV file in 'name'",
@@ -2430,14 +2432,27 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 		throw NotImplementedException("Runner execution does not support SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE; "
 		                              "use direct SQL with bound parameters or a local-fast connection");
 	}
-	if (statement->type == StatementType::COPY_STATEMENT && GetRunnerType() != "local-fast") {
-		if (statement->Cast<CopyStatement>().info->is_from) {
+	const auto statement_type = statement->type;
+	const bool is_copy = statement_type == StatementType::COPY_STATEMENT;
+	const bool is_insert = statement_type == StatementType::INSERT_STATEMENT;
+	if ((is_copy || is_insert) && GetRunnerType() != "local-fast") {
+		if (is_copy && statement->Cast<CopyStatement>().info->is_from) {
 			throw NotImplementedException("Runner execution does not support SQL COPY FROM");
 		}
+		if (is_insert) {
+			auto &insert = statement->Cast<InsertStatement>();
+			if (!insert.returning_list.empty() || insert.on_conflict_info) {
+				throw NotImplementedException("Runner SQL INSERT does not support RETURNING or ON CONFLICT");
+			}
+		}
 		auto ensure_auto_commit = [&]() {
+			if (is_insert && GetRunnerType() != "ray") {
+				throw InvalidInputException("INSERT requires a ray or local-fast connection");
+			}
 			if (!con.GetConnection().context->transaction.IsAutoCommit()) {
-				throw InvalidInputException("Runner COPY TO requires DuckDB auto-commit mode and cannot participate "
-				                            "in an explicit transaction");
+				throw InvalidInputException("Runner %s requires DuckDB auto-commit mode and cannot participate "
+				                            "in an explicit transaction",
+				                            is_copy ? "COPY TO" : "INSERT");
 			}
 		};
 		ensure_auto_commit();
@@ -2450,8 +2465,14 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 		try {
 			py::gil_scoped_release release;
 			unique_lock<mutex> lock(py_connection_lock);
-			relation = make_shared_ptr<WriteFileRelation>(
-			    context, unique_ptr_cast<SQLStatement, CopyStatement>(std::move(statement)), std::move(parameters));
+			if (is_copy) {
+				relation = make_shared_ptr<WriteFileRelation>(
+				    context, unique_ptr_cast<SQLStatement, CopyStatement>(std::move(statement)), std::move(parameters));
+			} else {
+				relation = make_shared_ptr<InsertRelation>(
+				    context, unique_ptr_cast<SQLStatement, InsertStatement>(std::move(statement)),
+				    std::move(parameters));
+			}
 		} catch (const Exception &exception) {
 			ErrorData error(exception);
 			context->ProcessError(error, query);
@@ -2459,7 +2480,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 		}
 		auto write_relation = make_uniq<DuckDBPyRelation>(std::move(relation));
 		write_relation->SetConnectionOwner(CreateWeakOwner(shared_from_this()));
-		auto result = write_relation->ExecuteCopyForConnection(interrupt_check);
+		auto result = write_relation->ExecuteWriteForConnection(statement_type, interrupt_check);
 		return for_connection ? make_uniq<DuckDBPyRelation>(std::move(result)) : nullptr;
 	}
 	if (statement->type == StatementType::SELECT_STATEMENT) {

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -1281,23 +1281,29 @@ static bool TryDispatchToRunner(const shared_ptr<Relation> &write_rel, const py:
 	return true;
 }
 
-shared_ptr<DuckDBPyResult> DuckDBPyRelation::ExecuteCopyForConnection(const py::object &interrupt_check) {
+shared_ptr<DuckDBPyResult> DuckDBPyRelation::ExecuteWriteForConnection(StatementType statement_type,
+                                                                       const py::object &interrupt_check) {
 	AssertRelation();
 	auto context = rel->context->GetContext();
+	if (statement_type != StatementType::INSERT_STATEMENT && statement_type != StatementType::COPY_STATEMENT) {
+		throw InternalException("Unsupported SQL write result statement type");
+	}
+	const char *mutation_name = statement_type == StatementType::INSERT_STATEMENT ? "INSERT" : nullptr;
+	auto operation = mutation_name ? string(mutation_name) : string("COPY");
 	if (GetRunnerType() == "local-fast") {
-		throw InternalException("Runner SQL COPY requires a configured write runner");
+		throw InternalException("Runner SQL write requires a configured write runner");
 	}
 	if (!context->transaction.IsAutoCommit()) {
-		throw InvalidInputException("Runner COPY TO requires DuckDB auto-commit mode and cannot participate "
-		                            "in an explicit transaction");
+		throw InvalidInputException("Runner %s requires DuckDB auto-commit mode and cannot participate "
+		                            "in an explicit transaction",
+		                            operation);
 	}
 	if (types != vector<LogicalType> {LogicalType::BIGINT} || names != vector<string> {"Count"}) {
-		throw NotImplementedException("Runner SQL COPY currently supports its default Count result; "
-		                              "RETURN_FILES and RETURN_STATS are not supported");
+		throw NotImplementedException("Runner SQL %s only supports its default Count result", operation);
 	}
 	auto error_type = py::module_::import("vane.runners.copy_outcome").attr("CopyResultUnavailableError");
 	py::object outcome;
-	TryDispatchToRunner(rel, connection_owner, nullptr, &outcome, interrupt_check);
+	TryDispatchToRunner(rel, connection_owner, mutation_name, &outcome, interrupt_check);
 	string operation_id;
 	py::tuple cleanup_warnings;
 	try {
@@ -1308,7 +1314,7 @@ shared_ptr<DuckDBPyResult> DuckDBPyRelation::ExecuteCopyForConnection(const py::
 		}
 		auto rows_copied = result["rows_copied"].cast<int64_t>();
 		if (rows_copied < 0) {
-			throw InternalException("COPY returned a negative row count");
+			throw InternalException("%s returned a negative row count", operation);
 		}
 		auto collection = make_uniq<ColumnDataCollection>(Allocator::Get(*context), types);
 		DataChunk chunk;
@@ -1318,11 +1324,12 @@ shared_ptr<DuckDBPyResult> DuckDBPyRelation::ExecuteCopyForConnection(const py::
 		collection->Append(chunk);
 		StatementProperties properties;
 		properties.return_type = StatementReturnType::CHANGED_ROWS;
-		auto result_set = make_uniq<MaterializedQueryResult>(StatementType::COPY_STATEMENT, properties, names,
-		                                                     std::move(collection), context->GetClientProperties());
+		auto result_set = make_uniq<MaterializedQueryResult>(statement_type, properties, names, std::move(collection),
+		                                                     context->GetClientProperties());
 		return make_shared_ptr<DuckDBPyResult>(std::move(result_set));
 	} catch (const std::exception &error) {
-		auto value = error_type(operation_id, "SQL COPY result handling failed after commit: " + string(error.what()),
+		auto value = error_type(operation_id,
+		                        "SQL " + operation + " result handling failed after commit: " + string(error.what()),
 		                        cleanup_warnings);
 		PyErr_SetObject(error_type.ptr(), value.ptr());
 		throw py::error_already_set();

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -536,14 +536,20 @@ def test_parameterized_sql_ray_failure_does_not_execute_locally(monkeypatch):
             relation.fetchall()
 
 
-def test_connection_execute_ray_keeps_control_and_write_statements_on_connection(monkeypatch):
+def test_connection_execute_ray_keeps_control_and_remaining_dml_on_connection(monkeypatch, tmp_path):
+
+    database = str(tmp_path / "control.db")
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(database) as connection:
+            connection.execute("CREATE TABLE items(value BIGINT)")
+            connection.execute("INSERT INTO items VALUES (11)")
     runner = _FakeRayRunner([])
     factory_calls = _install_fake_ray_runner(monkeypatch, runner)
-    with vane.connect() as connection:
-        connection.execute("SET threads=2; CREATE TABLE items(value BIGINT)")
-        assert connection.execute("INSERT INTO items VALUES (?)", [11]).fetchall() == [(1,)]
+    with vane.connect(database) as connection:
+        connection.execute("SET threads=2; CREATE TABLE other(value BIGINT)")
         connection.begin()
-        connection.execute("INSERT INTO items VALUES (12)")
+        connection.execute("UPDATE items SET value=12")
         connection.rollback()
         assert factory_calls == []
         assert connection.execute("UPDATE items SET value=value RETURNING value").fetchall() == [(11,)]

--- a/tests/fast/test_merge_relation.py
+++ b/tests/fast/test_merge_relation.py
@@ -25,13 +25,15 @@ def _require_ray_cxx():
     return ray_cxx
 
 
-def _merge_connection(database=None):
-    connection = vane.connect() if database is None else vane.connect(str(database))
-    connection.execute("CREATE TABLE merge_target (id INTEGER PRIMARY KEY, value VARCHAR)")
-    connection.execute("INSERT INTO merge_target VALUES (1, 'old'), (3, 'keep')")
-    connection.execute("CREATE TABLE merge_source (id INTEGER, value VARCHAR)")
-    connection.execute("INSERT INTO merge_source VALUES (1, 'new'), (2, 'inserted')")
-    return connection
+def _merge_connection(monkeypatch, database):
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(str(database)) as connection:
+            connection.execute("CREATE TABLE merge_target (id INTEGER PRIMARY KEY, value VARCHAR)")
+            connection.execute("INSERT INTO merge_target VALUES (1, 'old'), (3, 'keep')")
+            connection.execute("CREATE TABLE merge_source (id INTEGER, value VARCHAR)")
+            connection.execute("INSERT INTO merge_source VALUES (1, 'new'), (2, 'inserted')")
+    return vane.connect(str(database))
 
 
 def _merge(source, **kwargs):
@@ -62,9 +64,9 @@ def _local_target_rows(monkeypatch, connection):
     return [tuple(row.values()) for table in result.partition_payloads for row in table.to_pylist()]
 
 
-def test_merge_relation_runs_with_explicit_local_fast(monkeypatch):
+def test_merge_relation_runs_with_explicit_local_fast(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         assert _merge(connection.table("merge_source")) is None
         assert connection.execute("SELECT * FROM merge_target ORDER BY id").fetchall() == [
@@ -76,9 +78,9 @@ def test_merge_relation_runs_with_explicit_local_fast(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_supports_using_columns(monkeypatch):
+def test_merge_relation_supports_using_columns(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -94,9 +96,9 @@ def test_merge_relation_supports_using_columns(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_supports_expression_condition_and_custom_aliases(monkeypatch):
+def test_merge_relation_supports_expression_condition_and_custom_aliases(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         condition = vane.ColumnExpression("destination.id") == vane.ColumnExpression("changes.id")
         connection.table("merge_source").merge_into(
@@ -118,9 +120,9 @@ def test_merge_relation_supports_expression_condition_and_custom_aliases(monkeyp
         connection.close()
 
 
-def test_merge_relation_separates_line_comment_clauses(monkeypatch):
+def test_merge_relation_separates_line_comment_clauses(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -139,9 +141,9 @@ def test_merge_relation_separates_line_comment_clauses(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_accepts_sql_whitespace_after_when(monkeypatch):
+def test_merge_relation_accepts_sql_whitespace_after_when(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -160,9 +162,9 @@ def test_merge_relation_accepts_sql_whitespace_after_when(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_accepts_sql_comments_after_when(monkeypatch):
+def test_merge_relation_accepts_sql_comments_after_when(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -181,7 +183,7 @@ def test_merge_relation_accepts_sql_comments_after_when(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch):
+def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     ray_cxx = _require_ray_cxx()
     relation_types = []
@@ -193,7 +195,7 @@ def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch)
         return {"ok": True}
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         assert _merge(connection.table("merge_source")) is None
         assert relation_types == ["MERGE_RELATION"]
@@ -206,7 +208,7 @@ def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch)
         connection.close()
 
 
-def test_merge_relation_preserves_non_sql_source_operators(monkeypatch):
+def test_merge_relation_preserves_non_sql_source_operators(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     ray_cxx = _require_ray_cxx()
     logical_plans = []
@@ -216,7 +218,7 @@ def test_merge_relation_preserves_non_sql_source_operators(monkeypatch):
         return {"ok": True}
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         source = connection.table("merge_source").repartition(2, "id")
         _merge(source)
@@ -229,14 +231,14 @@ def test_merge_relation_preserves_non_sql_source_operators(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_failure_never_executes_locally(monkeypatch):
+def test_merge_relation_failure_never_executes_locally(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
 
     def run_write(_relation):
         raise RuntimeError("injected distributed merge failure")
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         with pytest.raises(RuntimeError, match="injected distributed merge failure"):
             _merge(connection.table("merge_source"))
@@ -248,11 +250,11 @@ def test_merge_relation_failure_never_executes_locally(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch):
+def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     calls = []
     _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     connection.execute("BEGIN")
     try:
         with pytest.raises(vane.InvalidInputException, match="Ray MERGE INTO requires DuckDB auto-commit mode"):
@@ -267,9 +269,9 @@ def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch
         connection.close()
 
 
-def test_merge_relation_rejects_local_fte_runner(monkeypatch):
+def test_merge_relation_rejects_local_fte_runner(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         with pytest.raises(
             vane.InvalidInputException,
@@ -297,9 +299,9 @@ def test_merge_relation_rejects_local_fte_runner(monkeypatch):
         ("target.id = source.id", _WHEN_CLAUSES, {"source_alias": "target"}, "must be different"),
     ],
 )
-def test_merge_relation_validates_api_inputs(monkeypatch, condition, when_clauses, kwargs, message):
+def test_merge_relation_validates_api_inputs(monkeypatch, condition, when_clauses, kwargs, message, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         with pytest.raises(vane.InvalidInputException, match=message):
             connection.table("merge_source").merge_into(
@@ -312,11 +314,11 @@ def test_merge_relation_validates_api_inputs(monkeypatch, condition, when_clause
         connection.close()
 
 
-def test_merge_relation_rejects_parameters_before_dispatch(monkeypatch):
+def test_merge_relation_rejects_parameters_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     calls = []
     _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         with pytest.raises(vane.InvalidInputException, match="does not accept prepared parameters"):
             connection.table("merge_source").merge_into(
@@ -329,11 +331,11 @@ def test_merge_relation_rejects_parameters_before_dispatch(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_propagates_parser_and_binding_errors_before_dispatch(monkeypatch):
+def test_merge_relation_propagates_parser_and_binding_errors_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     calls = []
     _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         with pytest.raises(vane.ParserException):
             connection.table("merge_source").merge_into(
@@ -356,7 +358,7 @@ def test_merge_relation_propagates_parser_and_binding_errors_before_dispatch(mon
         connection.close()
 
 
-def test_merge_relation_is_only_accepted_by_write_factory(monkeypatch):
+def test_merge_relation_is_only_accepted_by_write_factory(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     ray_cxx = _require_ray_cxx()
     checks = []
@@ -368,7 +370,7 @@ def test_merge_relation_is_only_accepted_by_write_factory(monkeypatch):
         return {"ok": True}
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.db")
     try:
         _merge(connection.table("merge_source"))
         assert len(checks) == 1
@@ -387,7 +389,7 @@ def test_merge_relation_logical_plan_round_trip_does_not_execute_locally(tmp_pat
 
     _install_fake_ray_runner(monkeypatch, run_write)
     database_path = tmp_path / "merge-round-trip.duckdb"
-    connection = _merge_connection(database_path)
+    connection = _merge_connection(monkeypatch, database_path)
     try:
         _merge(connection.table("merge_source"))
         logical_plan = logical_plans[0]
@@ -437,7 +439,7 @@ def test_merge_relation_rejects_ordinary_duckdb_target_before_backend_mutation(t
 
     _install_fake_ray_runner(monkeypatch, run_write)
     database_path = tmp_path / "native-merge-rejection.duckdb"
-    connection = _merge_connection(database_path)
+    connection = _merge_connection(monkeypatch, database_path)
     try:
         source = connection.sql("SELECT i::INTEGER AS id, 'new' AS value FROM range(2, 3) rows(i)")
         _merge(source)

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -156,14 +156,17 @@ def test_distributed_write_snapshot_covers_write_owned_file_io_expressions(
 
     monkeypatch.setenv("VANE_RUNNER", "ray")
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(str(database_path)) as seed:
+            if write_expression == "check":
+                seed.execute("CREATE TABLE file_target (value FILE, CHECK (file_exists(value)))")
+            else:
+                seed.execute(f"CREATE TABLE file_target (value FILE DEFAULT try_to_file({path_sql}))")
+                seed.execute(f"INSERT INTO file_target VALUES (file({path_sql}, NULL, NULL, NULL, NULL))")
+
     connection = vane.connect(str(database_path))
     try:
-        if write_expression == "check":
-            connection.execute("CREATE TABLE file_target (value FILE, CHECK (file_exists(value)))")
-        else:
-            connection.execute(f"CREATE TABLE file_target (value FILE DEFAULT try_to_file({path_sql}))")
-            connection.execute(f"INSERT INTO file_target VALUES (file({path_sql}, NULL, NULL, NULL, NULL))")
-
         monkeypatch.setenv("VANE_RUNNER", "ray")
         if write_expression == "check":
             connection.sql(f"SELECT file({path_sql}, NULL, NULL, NULL, NULL) AS value").insert_into("file_target")

--- a/tests/fast/test_sql_insert_runner.py
+++ b/tests/fast/test_sql_insert_runner.py
@@ -178,6 +178,8 @@ def test_insert_replacement_scan_survives_logical_serialization(monkeypatch, tmp
         connection.execute(queries[source_kind])
         assert connection.fetchall() == [(3,)]
         expected = source_frame[["id"]] if source_kind == "values-default" else source_frame
+        if source_kind == "aliases":
+            expected = expected.rename(columns={"id": "x", "value": "y"})
         assert snapshots == [expected.to_dict("records")]
         assert runner.plans[0]._memory_source_ref_count_for_test() == 1
         assert inspector.execute(f"SELECT * FROM {_TARGET}").fetchall() == []

--- a/tests/fast/test_sql_insert_runner.py
+++ b/tests/fast/test_sql_insert_runner.py
@@ -1,0 +1,331 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+import vane
+from tests.fast.test_distributed_result_consumers import _install_fake_ray_runner
+from vane.runners.copy_outcome import CopyOutcomeUnknownError, CopyResultUnavailableError
+
+
+class _InsertRunner:
+    def __init__(self, database=None):
+        self.database = database
+        self.plans = []
+        self.outcome = {"copy_operation_id": "insert-test", "rows_copied": 3}
+        self.error = None
+
+    def run_write(self, relation):
+        assert relation.type == "INSERT_RELATION"
+        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, f"insert-{len(self.plans)}")
+        restored = pickle.loads(pickle.dumps(plan))
+        self.plans.append(restored)
+        if self.error is not None:
+            raise self.error
+        if self.database is not None:
+            # This test runner checks bound SQL semantics in the shared native
+            # database. execute_native assumes read-only statement properties,
+            # so explicitly establish its write transaction on a separate
+            # connection. Distributed target rejection is tested separately.
+            with vane.connect(self.database) as worker:
+                physical = plan.to_physical_plan(worker)
+                worker.begin()
+                worker.execute(f"UPDATE {_TARGET} SET id = id WHERE false")
+                result = vane.ray_cxx.DistributedPhysicalPlanRunner().execute_native(worker, physical)
+                worker.commit()
+                rows = [row for table in result.partition_payloads for row in table.to_pylist()]
+                return {"copy_operation_id": "transported-insert", "rows_copied": next(iter(rows[0].values()))}
+        return self.outcome
+
+
+def _database(monkeypatch, tmp_path):
+    path = str(tmp_path / "insert.db")
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        inspector = vane.connect(path)
+    inspector.execute('CREATE SCHEMA "target schema"')
+    inspector.execute('CREATE TABLE "target schema"."target table" (id BIGINT DEFAULT 7, value VARCHAR DEFAULT \'d\')')
+    return path, inspector
+
+
+def _invoke(connection, method, query, parameters=None):
+    if method in {"execute", "executemany"}:
+        return getattr(connection, method)(query, [parameters or []] if method == "executemany" else parameters)
+    return getattr(connection, method)(query, params=parameters)
+
+
+_TARGET = '"target schema"."target table"'
+
+
+@pytest.mark.parametrize("method", ["execute", "sql", "query", "from_query", "executemany"])
+@pytest.mark.parametrize("selected", ["ray", "", None])
+def test_sql_insert_uses_fixed_runner_without_local_mutation(monkeypatch, tmp_path, method, selected):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    calls = _install_fake_ray_runner(monkeypatch, runner)
+    if selected is None:
+        monkeypatch.delenv("VANE_RUNNER")
+    else:
+        monkeypatch.setenv("VANE_RUNNER", selected)
+    with inspector, vane.connect(path) as connection:
+        assert calls == []
+        monkeypatch.setenv("VANE_RUNNER", "local-fast")
+        result = _invoke(connection, method, f"INSERT INTO {_TARGET} VALUES ($id, $value)", {"id": 4, "value": "v"})
+        if method in {"execute", "executemany"}:
+            assert result is connection
+            assert [column[0] for column in connection.description] == ["Count"]
+            assert connection.fetchall() == [(3,)]
+            assert connection.fetchall() == []
+        else:
+            assert result is None
+        assert len(runner.plans) == len(calls) == 1
+        assert inspector.execute(f"SELECT count(*) FROM {_TARGET}").fetchone() == (0,)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "parameters", "expected"),
+    [
+        ("VALUES (?, ?)", [2, "q'; INSERT is data"], [(2, "q'; INSERT is data")]),
+        ("(value, id) VALUES ($v, $i)", {"v": "v", "i": 4}, [(4, "v")]),
+        ("BY NAME SELECT $v AS value, $i AS id", {"v": "n", "i": 5}, [(5, "n")]),
+        ("(id) VALUES (?), (DEFAULT)", [9], [(7, "d"), (9, "d")]),
+        ("DEFAULT VALUES", None, [(7, "d")]),
+        ("SELECT i, 'r' FROM range(?) t(i) WHERE i > 0", [3], [(1, "r"), (2, "r")]),
+        ("VALUES (?, ?)", [None, None], [(None, None)]),
+        ("SELECT 1, 'empty' WHERE false", None, []),
+    ],
+)
+def test_serialized_insert_preserves_sql_binding(monkeypatch, tmp_path, suffix, parameters, expected):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner(path)
+    _install_fake_ray_runner(monkeypatch, runner)
+    with inspector, vane.connect(path) as connection:
+        connection.execute(f"INSERT INTO {_TARGET} {suffix}", parameters)
+        assert connection.fetchall() == [(len(expected),)]
+        assert inspector.execute(f"SELECT * FROM {_TARGET} ORDER BY id").fetchall() == expected
+        assert len(runner.plans) == 1
+
+
+def test_insert_cte_and_executemany_share_transport(monkeypatch, tmp_path):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner(path)
+    _install_fake_ray_runner(monkeypatch, runner)
+    with inspector, vane.connect(path) as connection:
+        connection.executemany(
+            f"WITH source AS (SELECT $id::BIGINT AS id) INSERT INTO {_TARGET} SELECT id, $v FROM source",
+            [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}],
+        )
+        assert connection.fetchall() == [(1,)]
+        assert inspector.execute(f"SELECT * FROM {_TARGET} ORDER BY id").fetchall() == [(1, "a"), (2, "b")]
+        assert len(runner.plans) == 2
+
+
+def test_insert_statement_object_keeps_catalog_qualification(monkeypatch, tmp_path):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner(path)
+    _install_fake_ray_runner(monkeypatch, runner)
+    with inspector, vane.connect(path) as connection:
+        statement = connection.extract_statements(f'INSERT INTO "insert".{_TARGET} VALUES (?, ?)')[0]
+        connection.execute(statement, [11, "qualified"])
+        assert connection.fetchall() == [(1,)]
+        assert inspector.execute(f"SELECT * FROM {_TARGET}").fetchall() == [(11, "qualified")]
+
+
+@pytest.mark.parametrize("parameters", [[], [1], [1, "v", 3], {"missing": 1}])
+def test_insert_rejects_invalid_parameters_before_runner(monkeypatch, tmp_path, parameters):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    calls = _install_fake_ray_runner(monkeypatch, runner)
+    with inspector, vane.connect(path) as connection:
+        with pytest.raises(vane.InvalidInputException):
+            connection.execute(f"INSERT INTO {_TARGET} VALUES (?, ?)", parameters)
+        assert calls == runner.plans == []
+        assert inspector.execute(f"SELECT count(*) FROM {_TARGET}").fetchone() == (0,)
+
+
+@pytest.mark.real_ray
+@pytest.mark.parametrize("source_kind", ["select", "cte", "values-default", "aliases", "shadow"])
+def test_insert_replacement_scan_survives_logical_serialization(monkeypatch, tmp_path, ray_local, source_kind):
+    import pandas as pd
+
+    from vane import _memory
+
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    source_frame = pd.DataFrame({"id": [3, 4], "value": ["a", "b"]})
+    queries = {
+        "select": f"INSERT INTO {_TARGET} SELECT * FROM source_frame",
+        "cte": f"WITH source AS (SELECT * FROM source_frame) INSERT INTO {_TARGET} SELECT * FROM source",
+        "values-default": f"INSERT INTO {_TARGET} VALUES ((SELECT max(id) FROM source_frame), DEFAULT)",
+        "aliases": f"INSERT INTO {_TARGET} SELECT d.x, d.y FROM source_frame AS d(x, y)",
+        "shadow": f"INSERT INTO {_TARGET} SELECT * FROM source_frame UNION ALL "
+        "SELECT * FROM (WITH source_frame AS (SELECT 9 AS id, 'cte' AS value) SELECT * FROM source_frame)",
+    }
+    snapshots = []
+    put_partition = _memory._put_memory_partition
+
+    def capture_partition(table):
+        snapshots.append(table.to_pylist())
+        return put_partition(table)
+
+    monkeypatch.setattr(_memory, "_put_memory_partition", capture_partition)
+    with inspector, vane.connect(path) as connection:
+        connection.execute(queries[source_kind])
+        assert connection.fetchall() == [(3,)]
+        expected = source_frame[["id"]] if source_kind == "values-default" else source_frame
+        assert snapshots == [expected.to_dict("records")]
+        assert runner.plans[0]._memory_source_ref_count_for_test() == 1
+        assert inspector.execute(f"SELECT * FROM {_TARGET}").fetchall() == []
+
+
+@pytest.mark.parametrize("method", ["execute", "sql"])
+def test_preceding_insert_uses_write_runner(monkeypatch, tmp_path, method):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner(path)
+    _install_fake_ray_runner(monkeypatch, runner)
+    with inspector, vane.connect(path) as connection:
+        _invoke(
+            connection,
+            method,
+            f"INSERT INTO {_TARGET} VALUES (1, 'first'); INSERT INTO {_TARGET} VALUES (?, ?)",
+            [2, "last"],
+        )
+        assert len(runner.plans) == 2
+        assert inspector.execute(f"SELECT * FROM {_TARGET} ORDER BY id").fetchall() == [(1, "first"), (2, "last")]
+
+
+@pytest.mark.parametrize("method", ["execute", "sql", "executemany"])
+@pytest.mark.parametrize("form", ["returning", "ignore", "replace", "conflict"])
+def test_unsupported_insert_forms_fail_before_runner(monkeypatch, tmp_path, method, form):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    calls = _install_fake_ray_runner(monkeypatch, runner)
+    queries = {
+        "returning": f"INSERT INTO {_TARGET} VALUES (1, 'v') RETURNING id",
+        "ignore": f"INSERT OR IGNORE INTO {_TARGET} VALUES (1, 'v')",
+        "replace": f"INSERT OR REPLACE INTO {_TARGET} VALUES (1, 'v')",
+        "conflict": f"INSERT INTO {_TARGET} VALUES (1, 'v') ON CONFLICT DO NOTHING",
+    }
+    with inspector, vane.connect(path) as connection:
+        with pytest.raises(vane.NotImplementedException, match="RETURNING or ON CONFLICT"):
+            _invoke(connection, method, queries[form])
+        assert calls == runner.plans == []
+        assert inspector.execute(f"SELECT count(*) FROM {_TARGET}").fetchone() == (0,)
+
+
+@pytest.mark.parametrize("restriction", ["local", "transaction", "parameter-begin", "parameter-close"])
+def test_insert_revalidates_policy_and_transaction_before_runner(monkeypatch, tmp_path, restriction):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    calls = _install_fake_ray_runner(monkeypatch, runner)
+    if restriction == "local":
+        monkeypatch.setenv("VANE_RUNNER", "local")
+    with inspector, vane.connect(path) as connection:
+        parameters = [1, "v"]
+        if restriction == "transaction":
+            connection.begin()
+        elif restriction.startswith("parameter-"):
+
+            class Parameters(list):
+                triggered = False
+
+                def __len__(self):
+                    if not self.triggered:
+                        self.triggered = True
+                        getattr(connection, restriction.removeprefix("parameter-"))()
+                    return super().__len__()
+
+            parameters = Parameters(parameters)
+        with pytest.raises((vane.InvalidInputException, vane.ConnectionException)):
+            connection.execute(f"INSERT INTO {_TARGET} VALUES (?, ?)", parameters)
+        assert calls == runner.plans == []
+        if restriction in {"transaction", "parameter-begin"}:
+            connection.rollback()
+        assert inspector.execute(f"SELECT count(*) FROM {_TARGET}").fetchone() == (0,)
+
+
+@pytest.mark.parametrize("error_kind", ["execution", "unknown", "committed-result"])
+def test_insert_failure_never_replays_locally(monkeypatch, tmp_path, error_kind):
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    if error_kind == "execution":
+        runner.error = RuntimeError("injected INSERT execution failure")
+    elif error_kind == "unknown":
+        runner.error = CopyOutcomeUnknownError("insert-test")
+    else:
+        runner.outcome["rows_copied"] = "invalid count"
+    with inspector, vane.connect(path) as connection:
+        with pytest.raises((RuntimeError, CopyResultUnavailableError)) as raised:
+            connection.execute(f"INSERT INTO {_TARGET} VALUES (1, 'v')")
+        if error_kind != "execution":
+            assert raised.value.safe_to_retry is False
+        if error_kind == "committed-result":
+            assert raised.value.write_state == "committed"
+        assert len(runner.plans) == 1
+        assert inspector.execute(f"SELECT count(*) FROM {_TARGET}").fetchone() == (0,)
+
+
+def test_local_fast_insert_preserves_native_returning_and_transactions(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE target(id INTEGER PRIMARY KEY, value VARCHAR)")
+        monkeypatch.setenv("VANE_RUNNER", "ray")
+        connection.begin()
+        assert connection.sql("INSERT INTO target VALUES (?, ?) RETURNING *", params=[1, "a"]).fetchall() == [(1, "a")]
+        connection.execute("INSERT OR REPLACE INTO target VALUES (1, 'b')")
+        connection.rollback()
+        assert connection.execute("SELECT * FROM target").fetchall() == []
+
+
+def test_insert_rejects_ordinary_duckdb_target_before_worker_execution(monkeypatch, tmp_path):
+    from vane.runners.fte.backends.native import NativeFteWorkerManagerBackend
+
+    path, inspector = _database(monkeypatch, tmp_path)
+    runner = _InsertRunner()
+    _install_fake_ray_runner(monkeypatch, runner)
+    with inspector, vane.connect(path) as connection:
+        plans = []
+
+        def run_write(relation):
+            plans.append(vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, "unsupported-insert"))
+            return runner.outcome
+
+        monkeypatch.setattr(runner, "run_write", run_write)
+        connection.execute(f"INSERT INTO {_TARGET} VALUES (1, 'v')")
+        physical = plans[0].to_physical_plan(connection)
+        backend_calls = []
+
+        def execute_backend(request):
+            backend_calls.append(request)
+            raise AssertionError("unsupported INSERT must fail before worker execution")
+
+        backend = NativeFteWorkerManagerBackend(execute_fn=execute_backend)
+        try:
+            with pytest.raises(ValueError, match="Distributed pipeline does not support operator type: INSERT"):
+                vane.ray_cxx.DistributedPhysicalPlanRunner(backend).run_copy_plan(physical)
+            assert backend_calls == []
+            assert inspector.execute(f"SELECT count(*) FROM {_TARGET}").fetchone() == (0,)
+        finally:
+            backend.shutdown()
+
+
+@pytest.mark.real_ray
+def test_real_ray_insert_rejects_client_table_without_mutation(monkeypatch, ray_local):
+    from vane import runners
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    runners.set_runner_ray(noop_if_initialized=True)
+    try:
+        with vane.connect() as connection:
+            connection.execute("CREATE TABLE client_target(id BIGINT)")
+            with pytest.raises(Exception, match="Table with name client_target does not exist"):
+                connection.execute("INSERT INTO client_target VALUES (1)")
+            assert connection.execute("UPDATE client_target SET id = id RETURNING id").fetchall() == []
+    finally:
+        vane.teardown_runner()

--- a/tests/fast/test_sql_insert_runner.py
+++ b/tests/fast/test_sql_insert_runner.py
@@ -152,7 +152,7 @@ def test_insert_rejects_invalid_parameters_before_runner(monkeypatch, tmp_path, 
 def test_insert_replacement_scan_survives_logical_serialization(monkeypatch, tmp_path, ray_local, source_kind):
     import pandas as pd
 
-    from vane import _memory
+    from vane.datasource import _memory
 
     path, inspector = _database(monkeypatch, tmp_path)
     runner = _InsertRunner()

--- a/tests/fast/test_write_local_default_runner.py
+++ b/tests/fast/test_write_local_default_runner.py
@@ -38,11 +38,13 @@ def _execute_relation_mutation(vane, connection, operation):
         raise AssertionError(f"unknown relation mutation: {operation}")
 
 
-def _new_mutation_connection(vane, database=":memory:"):
-    connection = vane.connect(database)
-    connection.execute("CREATE TABLE target (value INTEGER)")
-    connection.execute("INSERT INTO target VALUES (1), (2)")
-    return connection
+def _new_mutation_connection(vane, monkeypatch, database):
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(database) as connection:
+            connection.execute("CREATE TABLE target (value INTEGER)")
+            connection.execute("INSERT INTO target VALUES (1), (2)")
+    return vane.connect(database)
 
 
 @pytest.mark.parametrize(
@@ -157,7 +159,7 @@ def test_relation_mutations_dispatch_ray_without_local_execution(tmp_path, monke
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
     database = str(tmp_path / "mutations.db")
-    connection = _new_mutation_connection(vane, database)
+    connection = _new_mutation_connection(vane, monkeypatch, database)
     for operation, _expected_name in _RELATION_MUTATIONS:
         _execute_relation_mutation(vane, connection, operation)
 
@@ -177,11 +179,11 @@ def test_relation_mutations_dispatch_ray_without_local_execution(tmp_path, monke
     ).fetchone() == (0,)
 
 
-def test_relation_mutations_run_with_explicit_local_fast(monkeypatch):
+def test_relation_mutations_run_with_explicit_local_fast(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     import vane
 
-    connection = _new_mutation_connection(vane)
+    connection = _new_mutation_connection(vane, monkeypatch, str(tmp_path / "mutations.db"))
     for operation, _expected_name in _RELATION_MUTATIONS:
         _execute_relation_mutation(vane, connection, operation)
 
@@ -238,7 +240,7 @@ def test_ray_relation_mutations_reject_explicit_transactions(tmp_path, monkeypat
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
     database = str(tmp_path / "mutations.db")
-    connection = _new_mutation_connection(vane, database)
+    connection = _new_mutation_connection(vane, monkeypatch, database)
     connection.execute("BEGIN")
     try:
         with pytest.raises(
@@ -259,11 +261,11 @@ def test_ray_relation_mutations_reject_explicit_transactions(tmp_path, monkeypat
 
 
 @pytest.mark.parametrize(("operation", "expected_name"), _RELATION_MUTATIONS, ids=_RELATION_MUTATION_IDS)
-def test_relation_mutations_reject_local_fte_runner(monkeypatch, operation, expected_name):
+def test_relation_mutations_reject_local_fte_runner(monkeypatch, tmp_path, operation, expected_name):
     monkeypatch.setenv("VANE_RUNNER", "local")
     import vane
 
-    connection = _new_mutation_connection(vane)
+    connection = _new_mutation_connection(vane, monkeypatch, str(tmp_path / "mutations.db"))
     with pytest.raises(
         vane.InvalidInputException,
         match=rf"{expected_name} requires VANE_RUNNER=ray or VANE_RUNNER=local-fast",
@@ -288,7 +290,7 @@ def test_ray_relation_mutation_failures_never_execute_locally(tmp_path, monkeypa
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FailingRayRunner())
 
     database = str(tmp_path / "mutations.db")
-    connection = _new_mutation_connection(vane, database)
+    connection = _new_mutation_connection(vane, monkeypatch, database)
     with pytest.raises(RuntimeError, match=rf"injected distributed {operation} failure"):
         _execute_relation_mutation(vane, connection, operation)
 

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -139,10 +139,11 @@ class DuckDBPyConnection:
     def duplicate(self) -> DuckDBPyConnection: ...
     def enum_type(self, name: str, type: sqltypes.DuckDBPyType, values: lst[typing.Any]) -> sqltypes.DuckDBPyType: ...
     def execute(self, query: Statement | str, parameters: object = None) -> DuckDBPyConnection:
-        """Execute SELECT and COPY TO through the runner fixed when connecting.
+        """Execute SELECT, COPY TO and INSERT through the runner fixed when connecting.
 
         SQL PREPARE, EXECUTE and EXPLAIN ANALYZE require local-fast. Other SQL
-        statements execute on the connection. Ray SELECT requires auto-commit.
+        statements execute on the connection. Ray queries and writes require auto-commit.
+        Ray INSERT requires a distributed target and rejects RETURNING/conflict actions.
         """
         ...
     def executemany(self, query: Statement | str, parameters: object = None) -> DuckDBPyConnection: ...


### PR DESCRIPTION
## Summary

SQL INSERT now uses the same connection-scoped write runner as Relation `insert()` / `insert_into()`. This covers `execute()`, `sql()` and its aliases, preceding statements, `executemany()`, and `append()`. Local-fast executes natively; Ray receives a bound logical plan and returns the committed `Count` (`sql()` returns `None`).

The complete INSERT statement preserves parameters, column lists, BY NAME, defaults, CTEs and qualified targets. Captured Python replacement scans survive the transition into the writer. Writes reuse the existing commit, cancellation and unknown-outcome protocol without fallback or implicit replay.

Ray requires a distributed-write target. RETURNING/conflict actions, explicit transactions and local FTE table mutations fail before execution. This change does not add distributed ownership of ordinary client DuckDB tables (#657); CTAS follows separately in #803.

## Related issue

close: #802

Part of #596; follows #792.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

Updated README and native API documentation.

## Validation

- Two consecutive clean local code reviews before native build/runtime validation; fixes went through the same review loop.
- Incremental, non-editable Release install: `SKBUILD_BUILD_DIR="$PWD/build/python-release" SKBUILD_CMAKE_BUILD_TYPE=Release uv pip install . --no-build-isolation --no-deps`.
- Affected installed-package tests: 723 non-Ray tests and 18 real-Ray tests, including SQL binding/serialization, native controls, target rejection, COPY, Relation mutations and connection snapshots.
- `scripts/run_release_tests.sh`: 1,224 non-Ray tests and 30 real-Ray tests passed.
- `python -m build --sdist --no-isolation` and `python scripts/check_release_artifacts.py dist/vane_ai-0.2.0.dev648.tar.gz`: passed.
- Workspace formatting and commit hooks, including Ruff and mypy.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/astrovela/vane/pull/804" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->