### PR TITLE
[refactor](execution) Unify SQL and Relation dispatch at bound plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,12 @@ STDOUT/devices/pipes, and explicit transactions. Ray table writes also reject
 `RETURNING`, INSERT conflict handling, and CTAS `TEMPORARY`, `OR REPLACE`, and
 `IF NOT EXISTS`. Read-only targets are checked before runner initialization.
 `ATTACH`, `DETACH`, settings, transaction control, catalog-only DDL, and PRAGMA
-control commands remain client connection operations. Query-style PRAGMAs expand
-to SQL and follow the same bound-plan policy as that SQL. SQL `CALL` has no
+commands remain client connection operations. Query-style PRAGMAs retain their
+client origin through binding and Relation composition, so they inspect the
+client catalog; runner writes cannot include those queries. Database-modifying
+expressions such as `nextval()` are unsupported in distributed plans. Native
+query verification requires local-fast; connection controls can still disable
+verification on Ray/local FTE connections. SQL `CALL` has no
 distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
 `EXECUTE`, and `EXPLAIN ANALYZE`. Plain `EXPLAIN` remains available for client-side planning.
 Pass parameters directly to `execute()` or `sql()` for runner execution.
@@ -256,7 +260,7 @@ final result. The `local` FTE runner supports COPY and DataSink terminals;
 its SELECT result consumption continues to use native DuckDB. Other table
 writes require ray or local-fast. Execution errors never trigger local fallback.
 
-Session configuration, `ATTACH`, transaction control, DDL, and other SQL DML
+Session configuration, `ATTACH`, transaction control, and catalog-only DDL
 continue executing on the client coordinator connection. SQL is bound there;
 Ray receives serialized bound logical plans for both SQL and Relation queries
 and writes. Moving catalog and session operations to the driver is outside

--- a/README.md
+++ b/README.md
@@ -250,15 +250,23 @@ target columns because their runtime expressions are outside the bound write
 plan. Functions that depend on the client's query, transaction, catalog or session
 state are unsupported in distributed expressions, including `current_query()`,
 transaction/connection identifiers, current schema/database/settings, `currval()`,
-`setseed()` and transaction-clock functions such as `now()`, `current_date`,
+`setseed()`, logging functions (`write_log()` and `parse_log_message()`) and
+transaction-clock functions such as `now()`, `current_date`,
 `localtimestamp` and unary `age(timestamp)`. Binary `age(a, b)` remains portable
 because both timestamps are explicit.
 This restriction also applies inside defaults and CHECK constraints. Values
 already bound as constants, such as `getvariable()`, remain portable.
+System table functions that inspect or change client state, such as
+`duckdb_settings()`, `duckdb_tables()` and logging controls, are also rejected
+in distributed reads and writes. Native queries and client PRAGMA queries keep
+access to those functions; static lists such as `duckdb_keywords()` remain portable.
 Native query verification requires local-fast; connection controls can still disable
 verification on Ray/local FTE connections. SQL `CALL` has no
 distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
-`EXECUTE`, and `EXPLAIN ANALYZE`. Plain `EXPLAIN` remains available for client-side planning.
+`EXECUTE`, and `EXPLAIN ANALYZE`. These unsupported wrappers are rejected before
+binding can evaluate their arguments, including inside plain `EXPLAIN`.
+Plain `EXPLAIN` remains available for supported client-side planning. Runner
+admission rejection preserves an existing client transaction and its prior work.
 Pass parameters directly to `execute()` or `sql()` for runner execution.
 
 `connection.interrupt()` cancels active runner writes and waits for their outcome;
@@ -266,7 +274,9 @@ a commit that wins the race retains its successful result. A committed write
 whose result cannot be delivered raises `CopyResultUnavailableError` with
 `safe_to_retry=False`; an uncertain outcome remains `CopyOutcomeUnknownError`.
 `executemany()` uses the shared entry for every parameter set and retains the
-final result. The `local` FTE runner supports COPY and DataSink terminals;
+final result. Local-fast reuses one native prepared statement across the batch;
+runner execution exports a bound plan for each parameter set.
+The `local` FTE runner supports COPY and DataSink terminals;
 its SELECT result consumption continues to use native DuckDB. Other table
 writes require ray or local-fast. Execution errors never trigger local fallback.
 

--- a/README.md
+++ b/README.md
@@ -223,25 +223,36 @@ Ray initializes when a query or write first needs it. Ray queries require auto-c
 planning and execution errors propagate without local fallback. `execute()`
 returns the connection and shares one cursor across row, DataFrame, and Arrow
 consumers. Multiple statements execute in order and retain only the last result.
-SQL `COPY TO` also uses the connection runner and shares the Relation write
-APIs' planning, commit, and failure-cleanup protocol. `execute()` returns its
-`Count` row; `sql()` completes the write and returns `None`. Ray and local FTE
-use the Relation writer's dataset layout: a new target such as `output.parquet`
-is a directory containing worker output files. Both runners reject
-`COPY FROM`, `RETURN_FILES`, `RETURN_STATS`, non-file destinations such as
-STDOUT/devices/pipes, and explicit transactions before writing. Other unsupported
-write capabilities fail explicitly. SQL `PREPARE`, `EXECUTE`, and `EXPLAIN ANALYZE`
-require a local-fast connection; Ray and local FTE reject these commands before
-native execution. Pass parameters directly to `execute()` or `sql()` for runner
-execution. Plain `EXPLAIN` remains available for client-side planning.
-`connection.interrupt()` cancels an active
-SQL COPY and waits for its write outcome; a commit that wins the race retains
-its successful result. A committed
-write whose result cannot be delivered raises `CopyResultUnavailableError`
-with `safe_to_retry=False`; an uncertain outcome remains
-`CopyOutcomeUnknownError`. `executemany()` uses the same query/COPY routing for
-every parameter set and retains the final result. The `local` FTE runner
-supports writes; its SELECT result consumption continues to use native DuckDB.
+SQL and Relation terminals share one execution entry after client-side binding,
+before native optimization. local-fast continues through DuckDB; Ray receives
+that same bound logical plan and builds its physical plan on the driver. Runners
+do not bind the SQL or Relation again. Lazy SELECT relations remain composable.
+SQL `COPY TO`, `INSERT`, `UPDATE`, `DELETE`, `MERGE`, and CTAS use the same write
+protocol as their Relation counterparts. `execute()` returns the runner's `Count`
+row; `sql()` completes the write and returns `None`. A distributed table write
+requires a target catalog with a distributed write provider; routing does not
+make ordinary client DuckDB tables distributed. Unsupported targets fail
+explicitly before backend mutation.
+
+Ray and local FTE COPY use the Relation writer's dataset layout: a new target
+such as `output.parquet` is a directory containing worker output files. Both
+reject `COPY FROM`, `RETURN_FILES`, `RETURN_STATS`, non-file destinations such as
+STDOUT/devices/pipes, and explicit transactions. Ray table writes also reject
+`RETURNING`, INSERT conflict handling, and CTAS `TEMPORARY`, `OR REPLACE`, and
+`IF NOT EXISTS`. Read-only targets are checked before runner initialization.
+`ATTACH`, `DETACH`, settings, transaction control, and catalog-only DDL remain
+client connection operations. SQL `PREPARE`, `EXECUTE`, and `EXPLAIN ANALYZE`
+require local-fast. Plain `EXPLAIN` remains available for client-side planning.
+Pass parameters directly to `execute()` or `sql()` for runner execution.
+
+`connection.interrupt()` cancels active runner writes and waits for their outcome;
+a commit that wins the race retains its successful result. A committed write
+whose result cannot be delivered raises `CopyResultUnavailableError` with
+`safe_to_retry=False`; an uncertain outcome remains `CopyOutcomeUnknownError`.
+`executemany()` uses the shared entry for every parameter set and retains the
+final result. The `local` FTE runner supports COPY and DataSink terminals;
+its SELECT result consumption continues to use native DuckDB. Other table
+writes require ray or local-fast. Execution errors never trigger local fallback.
 
 Session configuration, `ATTACH`, transaction control, DDL, and other SQL DML
 continue executing on the client coordinator connection. SQL is bound there;

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ System table functions that inspect or change client state, such as
 in distributed reads and writes. Native queries and client PRAGMA queries keep
 access to those functions; static lists such as `duckdb_keywords()` remain portable.
 Native query verification requires local-fast; connection controls can still disable
-verification on Ray/local FTE connections. SQL `CALL` has no
+verification on Ray/local FTE connections. `VACUUM` and `ANALYZE` run on the client
+connection for every runner. SQL `CALL` has no
 distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
 `EXECUTE`, and `EXPLAIN ANALYZE`. These unsupported wrappers are rejected before
 binding can evaluate their arguments, including inside plain `EXPLAIN`.

--- a/README.md
+++ b/README.md
@@ -240,9 +240,11 @@ reject `COPY FROM`, `RETURN_FILES`, `RETURN_STATS`, non-file destinations such a
 STDOUT/devices/pipes, and explicit transactions. Ray table writes also reject
 `RETURNING`, INSERT conflict handling, and CTAS `TEMPORARY`, `OR REPLACE`, and
 `IF NOT EXISTS`. Read-only targets are checked before runner initialization.
-`ATTACH`, `DETACH`, settings, transaction control, and catalog-only DDL remain
-client connection operations. SQL `PREPARE`, `EXECUTE`, and `EXPLAIN ANALYZE`
-require local-fast. Plain `EXPLAIN` remains available for client-side planning.
+`ATTACH`, `DETACH`, settings, transaction control, catalog-only DDL, and PRAGMA
+control commands remain client connection operations. Query-style PRAGMAs expand
+to SQL and follow the same bound-plan policy as that SQL. SQL `CALL` has no
+distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
+`EXECUTE`, and `EXPLAIN ANALYZE`. Plain `EXPLAIN` remains available for client-side planning.
 Pass parameters directly to `execute()` or `sql()` for runner execution.
 
 `connection.interrupt()` cancels active runner writes and waits for their outcome;

--- a/README.md
+++ b/README.md
@@ -271,7 +271,11 @@ in distributed reads and writes. Native queries and client PRAGMA queries keep
 access to those functions; static lists such as `duckdb_keywords()` remain portable.
 Native query verification requires local-fast; connection controls can still disable
 verification on Ray/local FTE connections. `VACUUM` and `ANALYZE` run on the client
-connection for every runner. SQL `CALL` has no
+connection for every runner. Catalog commands such as `SHOW TABLES`, `SHOW DATABASES`
+and `SHOW VARIABLES` also use the client connection, including derived relations.
+Distributed plans cannot read or write client temporary tables. Temporary views
+whose definitions expand into transportable data sources remain supported.
+SQL `CALL` has no
 distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
 `EXECUTE`, and `EXPLAIN ANALYZE`. These unsupported wrappers are rejected before
 binding can evaluate their arguments, including inside plain `EXPLAIN`.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,9 @@ target columns because their runtime expressions are outside the bound write
 plan. Functions that depend on the client's query, transaction, catalog or session
 state are unsupported in distributed expressions, including `current_query()`,
 transaction/connection identifiers, current schema/database/settings, `currval()`,
-`setseed()` and transaction-clock functions such as `now()` and `current_date`.
+`setseed()` and transaction-clock functions such as `now()`, `current_date`,
+`localtimestamp` and unary `age(timestamp)`. Binary `age(a, b)` remains portable
+because both timestamps are explicit.
 This restriction also applies inside defaults and CHECK constraints. Values
 already bound as constants, such as `getvariable()`, remain portable.
 Native query verification requires local-fast; connection controls can still disable

--- a/README.md
+++ b/README.md
@@ -272,7 +272,9 @@ access to those functions; static lists such as `duckdb_keywords()` remain porta
 Native query verification requires local-fast; connection controls can still disable
 verification on Ray/local FTE connections. `VACUUM` and `ANALYZE` run on the client
 connection for every runner. Catalog commands such as `SHOW TABLES`, `SHOW DATABASES`
-and `SHOW VARIABLES` also use the client connection, including derived relations.
+and `SHOW VARIABLES` also use the client connection, including derived relations
+and catalog queries revealed during `query()` expansion. Writes and explicit plan
+transports reject that query origin before binding its contents.
 Distributed plans cannot read or write client temporary tables. Temporary views
 whose definitions expand into transportable data sources remain supported.
 SQL `CALL` has no

--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ default connection's policy, or create an explicit connection to choose a new on
 Ray and local FTE runner instances are initialized separately and retain their
 explicit configuration. `get_runner()` and `get_or_create_runner()` select by
 the current environment; `teardown_runner()` closes both initialized runners.
-Ray initializes when a query or write first needs it. Ray queries require auto-commit mode;
+Ray initializes when a query or write first needs it. Ray queries require auto-commit mode,
+including when binding a lazy Relation's schema. Distributed queries and writes
+reject explicit transactions before binding can evaluate table-function arguments;
 planning and execution errors propagate without local fallback. `execute()`
 returns the connection and shares one cursor across row, DataFrame, and Arrow
 consumers. Multiple statements execute in order and retain only the last result.
@@ -254,8 +256,12 @@ transaction/connection identifiers, current schema/database/settings, `currval()
 transaction-clock functions such as `now()`, `current_date`,
 `localtimestamp` and unary `age(timestamp)`. Binary `age(a, b)` remains portable
 because both timestamps are explicit.
-This restriction also applies inside defaults and CHECK constraints. Values
-already bound as constants, such as `getvariable()`, remain portable.
+This restriction also applies inside defaults, CHECK constraints and CTAS
+`WITH`, `PARTITIONED BY` and `SORTED BY` metadata. Metadata SQL expressions
+are checked on the client; macro expansions and values already bound as
+constants, such as `getvariable()`, are captured before transport. Extension
+partition/sort transforms validate their SQL arguments against the created
+table's columns. Metadata subqueries and lambda expressions are unsupported.
 System table functions that inspect or change client state, such as
 `duckdb_settings()`, `duckdb_tables()` and logging controls, are also rejected
 in distributed reads and writes. Native queries and client PRAGMA queries keep

--- a/README.md
+++ b/README.md
@@ -244,8 +244,10 @@ STDOUT/devices/pipes, and explicit transactions. Ray table writes also reject
 commands remain client connection operations. Query-style PRAGMAs retain their
 client origin through binding and Relation composition, so they inspect the
 client catalog; runner writes cannot include those queries. Database-modifying
-expressions such as `nextval()` are unsupported in distributed plans. Native
-query verification requires local-fast; connection controls can still disable
+expressions such as `nextval()` are unsupported in distributed plans, including
+write defaults and CHECK constraints. Ray INSERT/UPDATE/MERGE reject generated
+target columns because their runtime expressions are outside the bound write
+plan. Native query verification requires local-fast; connection controls can still disable
 verification on Ray/local FTE connections. SQL `CALL` has no
 distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
 `EXECUTE`, and `EXPLAIN ANALYZE`. Plain `EXPLAIN` remains available for client-side planning.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ target columns because their runtime expressions are outside the bound write
 plan. Functions that depend on the client's query, transaction, catalog or session
 state are unsupported in distributed expressions, including `current_query()`,
 transaction/connection identifiers, current schema/database/settings, `currval()`,
-`setseed()`, logging functions (`write_log()` and `parse_log_message()`) and
+`setseed()`, logging functions (`write_log()` and `parse_duckdb_log_message()`) and
 transaction-clock functions such as `now()`, `current_date`,
 `localtimestamp` and unary `age(timestamp)`. Binary `age(a, b)` remains portable
 because both timestamps are explicit.

--- a/README.md
+++ b/README.md
@@ -247,7 +247,13 @@ client catalog; runner writes cannot include those queries. Database-modifying
 expressions such as `nextval()` are unsupported in distributed plans, including
 write defaults and CHECK constraints. Ray INSERT/UPDATE/MERGE reject generated
 target columns because their runtime expressions are outside the bound write
-plan. Native query verification requires local-fast; connection controls can still disable
+plan. Functions that depend on the client's query, transaction, catalog or session
+state are unsupported in distributed expressions, including `current_query()`,
+transaction/connection identifiers, current schema/database/settings, `currval()`,
+`setseed()` and transaction-clock functions such as `now()` and `current_date`.
+This restriction also applies inside defaults and CHECK constraints. Values
+already bound as constants, such as `getvariable()`, remain portable.
+Native query verification requires local-fast; connection controls can still disable
 verification on Ray/local FTE connections. SQL `CALL` has no
 distributed side-effect contract and requires local-fast, as do SQL `PREPARE`,
 `EXECUTE`, and `EXPLAIN ANALYZE`. Plain `EXPLAIN` remains available for client-side planning.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,10 @@ the current environment; `teardown_runner()` closes both initialized runners.
 Ray initializes when a query or write first needs it. Ray queries require auto-commit mode,
 including when binding a lazy Relation's schema. Distributed queries and writes
 reject explicit transactions before binding can evaluate table-function arguments;
-planning and execution errors propagate without local fallback. `execute()`
+runner-bound table-function arguments also reject client-context and database-modifying
+expressions before bind-time evaluation in auto-commit mode. Explicit `PyLogicalPlan`
+factories apply the same runner admission regardless of the source connection's runner.
+Planning and execution errors propagate without local fallback. `execute()`
 returns the connection and shares one cursor across row, DataFrame, and Arrow
 consumers. Multiple statements execute in order and retain only the last result.
 SQL and Relation terminals share one execution entry after client-side binding,

--- a/benchmarking/tpch/run_tpch_vane_native_relapi.py
+++ b/benchmarking/tpch/run_tpch_vane_native_relapi.py
@@ -99,7 +99,7 @@ def _run_query_native_in_subprocess(
 
         t0 = time.time()
         row_count = 0
-        for table in runner.run_iter_tables(rel):
+        for table in runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)):
             row_count += table.num_rows
         elapsed = time.time() - t0
 

--- a/benchmarking/tpch/run_tpch_vane_ray_relapi.py
+++ b/benchmarking/tpch/run_tpch_vane_ray_relapi.py
@@ -4,10 +4,9 @@
 
 """Run Vane TPC-H benchmarks with true Ray distributed execution via Relation API.
 
-Unlike run_tpch_vane_ray.py (which exercises execute/fetchall with optional fallback),
-this script uses con.sql(sql).write_parquet(path) which triggers the VANE_RUNNER=ray
-dispatch path: pyrelation.cpp → runner.run_write() → PyLogicalPlan →
-to_physical_plan() → RayQueryDriverClient on Ray.
+SQL and Relation execution share admission after client binding. This script
+exercises explicit bound-plan read transport and Relation write_parquet terminals:
+bound logical plan -> RayQueryDriverClient -> driver physical planning -> workers.
 
 Each query runs in a subprocess (spawn) for isolation. Failures are classified as:
   TIMEOUT_ERROR  — query raised a timeout error
@@ -129,16 +128,16 @@ def _run_query_distributed_in_subprocess(queue, parquet_folder, qnum, threads, r
             import vane.runners
 
             runner = vane.runners.get_or_create_runner()
-            tables = [r.partition() for r in runner.run_iter(con.sql(sql))]
+            tables = [
+                r.partition()
+                for r in runner.run_iter(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(con.sql(sql), None))
+            ]
             elapsed = time.time() - t0
             non_empty = [t for t in tables if t.num_rows > 0]
             row_count = sum(t.num_rows for t in non_empty) if non_empty else 0
         else:
-            # Distributed write via runner.run_write()
-            import vane.runners
-
-            runner = vane.runners.get_or_create_runner()
-            runner.run_write(con.sql(sql))
+            # The terminal builds and dispatches the bound COPY plan.
+            con.sql(sql).write_parquet(output_path)
             elapsed = time.time() - t0
             try:
                 row_count = _read_row_count(output_path)

--- a/benchmarking/tpch/run_tpch_vane_ray_relapi_daft_shuffle.py
+++ b/benchmarking/tpch/run_tpch_vane_ray_relapi_daft_shuffle.py
@@ -4,10 +4,9 @@
 
 """Run Vane TPC-H benchmarks with true Ray distributed execution via Relation API.
 
-Unlike run_tpch_vane_ray.py (which uses con.execute(sql).fetchall() — always local),
-this script uses con.sql(sql).write_parquet(path) which triggers the VANE_RUNNER=ray
-dispatch path: pyrelation.cpp → runner.run_write() → PyLogicalPlan →
-to_physical_plan() → RayQueryDriverClient on Ray.
+SQL and Relation execution share admission after client binding. This script
+exercises explicit bound-plan read transport and Relation write_parquet terminals:
+bound logical plan -> RayQueryDriverClient -> driver physical planning -> workers.
 
 Each query runs in a subprocess (spawn) for isolation. Failures are classified as:
   TIMEOUT_ERROR  — query raised a timeout error
@@ -132,16 +131,16 @@ def _run_query_distributed_in_subprocess(queue, parquet_folder, qnum, threads, r
             import vane.runners
 
             runner = vane.runners.get_or_create_runner()
-            tables = [r.partition() for r in runner.run_iter(con.sql(sql))]
+            tables = [
+                r.partition()
+                for r in runner.run_iter(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(con.sql(sql), None))
+            ]
             elapsed = time.time() - t0
             non_empty = [t for t in tables if t.num_rows > 0]
             row_count = sum(t.num_rows for t in non_empty) if non_empty else 0
         else:
-            # Distributed write via runner.run_write()
-            import vane.runners
-
-            runner = vane.runners.get_or_create_runner()
-            runner.run_write(con.sql(sql))
+            # The terminal builds and dispatches the bound COPY plan.
+            con.sql(sql).write_parquet(output_path)
             elapsed = time.time() - t0
             try:
                 row_count = _read_row_count(output_path)

--- a/benchmarking/vllm/vane_common.py
+++ b/benchmarking/vllm/vane_common.py
@@ -101,7 +101,7 @@ def _run_relation_benchmark(script_name: str, rel, *, distributed: bool = False)
         from vane.runners import get_or_create_runner
 
         runner = get_or_create_runner()
-        tables = list(runner.run_iter_tables(rel))
+        tables = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)))
         combined = pa.concat_tables(tables)
         rows = combined.to_pydict()
         row_count = combined.num_rows

--- a/examples/common_crawl.py
+++ b/examples/common_crawl.py
@@ -135,7 +135,9 @@ def relation_from_rows(
 
 def collect_relation(rel: Any) -> pa.Table:
     """Materialize a relation through the configured default runner."""
-    tables = list(vane.runners.get_or_create_runner().run_iter_tables(rel))
+    tables = list(
+        vane.runners.get_or_create_runner().run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None))
+    )
     if not tables:
         return pa.table({column: pa.array([]) for column in rel.columns})
     table = pa.concat_tables(tables)

--- a/examples/image_generation.py
+++ b/examples/image_generation.py
@@ -82,7 +82,9 @@ def relation_from_rows(
 
 def collect_relation(rel: Any) -> pa.Table:
     """Materialize a relation through the configured default runner."""
-    tables = list(vane.runners.get_or_create_runner().run_iter_tables(rel))
+    tables = list(
+        vane.runners.get_or_create_runner().run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None))
+    )
     if not tables:
         return pa.table({column: pa.array([]) for column in rel.columns})
     table = pa.concat_tables(tables)

--- a/examples/llms_red_pajamas.py
+++ b/examples/llms_red_pajamas.py
@@ -115,7 +115,9 @@ def relation_from_rows(
 
 def collect_relation(rel: Any) -> pa.Table:
     """Materialize a relation through the configured default runner."""
-    tables = list(vane.runners.get_or_create_runner().run_iter_tables(rel))
+    tables = list(
+        vane.runners.get_or_create_runner().run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None))
+    )
     if not tables:
         return pa.table({column: pa.array([]) for column in rel.columns})
     table = pa.concat_tables(tables)

--- a/examples/minhash_dedupe.py
+++ b/examples/minhash_dedupe.py
@@ -149,7 +149,9 @@ def relation_from_rows(
 
 def collect_relation(rel: Any) -> pa.Table:
     """Materialize a relation through the configured default runner."""
-    tables = list(vane.runners.get_or_create_runner().run_iter_tables(rel))
+    tables = list(
+        vane.runners.get_or_create_runner().run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None))
+    )
     if not tables:
         return pa.table({column: pa.array([]) for column in rel.columns})
     table = pa.concat_tables(tables)

--- a/examples/querying_images.py
+++ b/examples/querying_images.py
@@ -152,7 +152,9 @@ def quote_ident(value: str) -> str:
 
 def collect_relation(rel: Any) -> pa.Table:
     """Materialize a relation through the configured default runner."""
-    tables = list(vane.runners.get_or_create_runner().run_iter_tables(rel))
+    tables = list(
+        vane.runners.get_or_create_runner().run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None))
+    )
     if not tables:
         return pa.table({column: pa.array([]) for column in rel.columns})
     table = pa.concat_tables(tables)

--- a/examples/voice_ai_analytics.py
+++ b/examples/voice_ai_analytics.py
@@ -126,7 +126,9 @@ def relation_from_dicts(
 
 def collect_relation(rel: Any) -> pa.Table:
     """Materialize a relation through the configured default runner."""
-    tables = list(vane.runners.get_or_create_runner().run_iter_tables(rel))
+    tables = list(
+        vane.runners.get_or_create_runner().run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None))
+    )
     if not tables:
         return pa.table({column: pa.array([]) for column in rel.columns})
     table = pa.concat_tables(tables)

--- a/external/duckdb/examples/driver_demo.py
+++ b/external/duckdb/examples/driver_demo.py
@@ -2,100 +2,56 @@
 # SPDX-FileCopyrightText: 2026 Vane contributors
 # SPDX-License-Identifier: MIT
 
-"""
-Minimal demo that uses `driver.py` via the Ray runner to execute a small plan.
+"""Run a Relation through Ray, then stream its explicit bound-plan transport.
 
-This demo will:
-- initialize ray (or rely on an existing Ray cluster)
-- set the DuckDB Runner to Ray
-- create a small DataFrame using `duckdb.from_pydict`
-- perform a small transformation (select + expression)
-- collect / show the results which will trigger the DistributedPhysicalPlanRunner used by Driver
-
-Usage:
-  python examples/driver_demo.py
-
-Optional args:
-  --no-ray-init    Don't call ray.init() and expect a Ray cluster to be running
-  --verbose        Enable debug logging
+Use the installed Vane package:
+    python external/duckdb/examples/driver_demo.py
 """
 
 import argparse
 import logging
 import os
-import sys
 
-# Ensure our local repo is discoverable as a module when running the demo from the repository root
-# Not strictly necessary if you installed the package to your venv
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
+import pyarrow as pa
 import ray
-import duckdb
-
-from duckdb import from_pydict, col
+import vane
 
 logger = logging.getLogger("driver_demo")
 
 
 def run_demo(no_ray_init: bool = False, verbose: bool = False) -> None:
-    if verbose:
-        logging.basicConfig(level=logging.DEBUG)
-    else:
-        logging.basicConfig(level=logging.INFO)
-
-    if not no_ray_init:
-        logger.info("Initializing ray (local head)...")
-        ray.init(ignore_reinit_error=True)
-    else:
-        logger.info("Not initializing ray; using existing cluster")
-
-    # Use the Ray runner. Ray is the default when `VANE_RUNNER` is unset or empty, but we call it
-    # explicitly to ensure it uses the Ray runner.
-    duckdb.set_runner_ray()
-    logger.info("Current runner type: %s", duckdb.get_or_create_runner().name)
-
-    # Small data set
-    data = {"a": [1, 2, 3, 4], "b": [10, 20, 30, 40]}
-
-    # Create DataFrame from plain dict
-    df = from_pydict(data)
-
-    # Make a simple expression and a projection
-    df = df.select("a", "b", (col("a") + col("b")).alias("sum"))
-
-    logger.info("Running collect() which will execute the plan through the configured runner (Ray/Driver)...")
-    # collect() blocks and materializes the result; as we set the runner to Ray, this should use Driver
-    collected = df.collect()
-
-    logger.info("Result: (Preview)")
-    collected.show()
-
-    # For additional traceability, print raw partition content using run_iter_tables.
-    logger.info("Printing partitions using runner.run_iter_tables for explicit iteration:")
-    runner = duckdb.get_or_create_runner()
-    builder = df._builder
-    for table in runner.run_iter_tables(builder):
-        try:
-            print(table.to_pandas())
-        except Exception:
-            # to keep the demo robust, fallback to printing a string repr
-            print(repr(table))
-    # Show how RayQueryDriverClient can be used directly to stream a DistributedPhysicalPlan
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
+    if no_ray_init and not ray.is_initialized():
+        raise RuntimeError("--no-ray-init requires an initialized Ray runtime")
+    owns_ray = not ray.is_initialized()
+    if owns_ray:
+        ray.init()
+    # Connection policy is fixed when the explicit connection is created.
+    os.environ["VANE_RUNNER"] = "ray"
     try:
-        from duckdb.runners.ray.driver import RayQueryDriverClient
-
-        if duckdb.get_or_create_runner().name == "ray":
-            logger.info("Instantiating RayQueryDriverClient directly to show the remote actor handle.")
-            driver = RayQueryDriverClient()
-            logger.info("Created RayQueryDriverClient actor: %s", driver.runner)
-    except Exception as e:
-        logger.debug("Unable to instantiate RayQueryDriverClient directly: %s", e)
+        runner = vane.set_runner_ray()
+        with vane.connect() as connection:
+            source = pa.table({"a": [1, 2, 3, 4], "b": [10, 20, 30, 40]})
+            relation = connection.from_arrow(source).project("a, b, a + b AS total")
+            logger.info("Rows from the shared Relation execution entry: %s", relation.fetchall())
+            # Low-level runner methods consume a bound plan, with the source
+            # relation retained until its result stream has closed.
+            plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+            partitions = runner.run_iter_tables(plan)
+            try:
+                for table in partitions:
+                    print(table.to_pydict())
+            finally:
+                partitions.close()
+    finally:
+        vane.teardown_runner()
+        if owns_ray:
+            ray.shutdown()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--no-ray-init", action="store_true", help="Don't call ray.init(); assume cluster exists")
-    parser.add_argument("--verbose", action="store_true", help="Verbose logging")
+    parser.add_argument("--no-ray-init", action="store_true", help="Use an already initialized Ray runtime")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
-
     run_demo(no_ray_init=args.no_ray_init, verbose=args.verbose)

--- a/external/duckdb/examples/driver_demo.py
+++ b/external/duckdb/examples/driver_demo.py
@@ -4,8 +4,12 @@
 
 """Run a Relation through Ray, then stream its explicit bound-plan transport.
 
-Use the installed Vane package:
-    python external/duckdb/examples/driver_demo.py
+Run from this directory with the installed Vane package:
+    cd external/duckdb/examples
+    python driver_demo.py
+
+Connect to an existing Ray cluster without starting a local one:
+    python driver_demo.py --ray-address auto
 """
 
 import argparse
@@ -19,13 +23,11 @@ import vane
 logger = logging.getLogger("driver_demo")
 
 
-def run_demo(no_ray_init: bool = False, verbose: bool = False) -> None:
+def run_demo(ray_address: str | None = None, verbose: bool = False) -> None:
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
-    if no_ray_init and not ray.is_initialized():
-        raise RuntimeError("--no-ray-init requires an initialized Ray runtime")
     owns_ray = not ray.is_initialized()
     if owns_ray:
-        ray.init()
+        ray.init(address=ray_address)
     # Connection policy is fixed when the explicit connection is created.
     os.environ["VANE_RUNNER"] = "ray"
     try:
@@ -51,7 +53,7 @@ def run_demo(no_ray_init: bool = False, verbose: bool = False) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--no-ray-init", action="store_true", help="Use an already initialized Ray runtime")
+    parser.add_argument("--ray-address", help="Ray cluster address; use 'auto' to require an existing cluster")
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args()
-    run_demo(no_ray_init=args.no_ray_init, verbose=args.verbose)
+    run_demo(ray_address=args.ray_address, verbose=args.verbose)

--- a/external/duckdb/extension/core_functions/scalar/date/age.cpp
+++ b/external/duckdb/extension/core_functions/scalar/date/age.cpp
@@ -46,7 +46,9 @@ static void AgeFunction(DataChunk &input, ExpressionState &state, Vector &result
 
 ScalarFunctionSet AgeFun::GetFunctions() {
 	ScalarFunctionSet age("age");
-	age.AddFunction(ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunctionStandard));
+	auto unary_age = ScalarFunction({LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunctionStandard);
+	unary_age.SetRequiresClientContext();
+	age.AddFunction(unary_age);
 	age.AddFunction(
 	    ScalarFunction({LogicalType::TIMESTAMP, LogicalType::TIMESTAMP}, LogicalType::INTERVAL, AgeFunction));
 	return age;

--- a/external/duckdb/extension/core_functions/scalar/date/current.cpp
+++ b/external/duckdb/extension/core_functions/scalar/date/current.cpp
@@ -24,6 +24,7 @@ static void CurrentTimestampFunction(DataChunk &input, ExpressionState &state, V
 ScalarFunction GetCurrentTimestampFun::GetFunction() {
 	ScalarFunction current_timestamp({}, LogicalType::TIMESTAMP_TZ, CurrentTimestampFunction);
 	current_timestamp.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	current_timestamp.SetRequiresClientContext();
 	return current_timestamp;
 }
 

--- a/external/duckdb/extension/core_functions/scalar/generic/current_setting.cpp
+++ b/external/duckdb/extension/core_functions/scalar/generic/current_setting.cpp
@@ -66,6 +66,7 @@ unique_ptr<FunctionData> CurrentSettingBind(ClientContext &context, ScalarFuncti
 ScalarFunction CurrentSettingFun::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, CurrentSettingFunction, CurrentSettingBind);
 	fun.SetNullHandling(FunctionNullHandling::SPECIAL_HANDLING);
+	fun.SetRequiresClientContext();
 	return fun;
 }
 

--- a/external/duckdb/extension/core_functions/scalar/generic/system_functions.cpp
+++ b/external/duckdb/extension/core_functions/scalar/generic/system_functions.cpp
@@ -109,18 +109,21 @@ void VersionFunction(DataChunk &input, ExpressionState &state, Vector &result) {
 ScalarFunction CurrentQueryFun::GetFunction() {
 	ScalarFunction current_query({}, LogicalType::VARCHAR, CurrentQueryFunction);
 	current_query.SetStability(FunctionStability::VOLATILE);
+	current_query.SetRequiresClientContext();
 	return current_query;
 }
 
 ScalarFunction CurrentSchemaFun::GetFunction() {
 	ScalarFunction current_schema({}, LogicalType::VARCHAR, CurrentSchemaFunction);
 	current_schema.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	current_schema.SetRequiresClientContext();
 	return current_schema;
 }
 
 ScalarFunction CurrentDatabaseFun::GetFunction() {
 	ScalarFunction current_database({}, LogicalType::VARCHAR, CurrentDatabaseFunction);
 	current_database.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	current_database.SetRequiresClientContext();
 	return current_database;
 }
 
@@ -129,6 +132,7 @@ ScalarFunction CurrentSchemasFun::GetFunction() {
 	ScalarFunction current_schemas({LogicalType::BOOLEAN}, varchar_list_type, CurrentSchemasFunction,
 	                               CurrentSchemasBind);
 	current_schemas.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	current_schemas.SetRequiresClientContext();
 	return current_schemas;
 }
 
@@ -136,12 +140,14 @@ ScalarFunction InSearchPathFun::GetFunction() {
 	ScalarFunction in_search_path({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::BOOLEAN,
 	                              InSearchPathFunction);
 	in_search_path.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	in_search_path.SetRequiresClientContext();
 	return in_search_path;
 }
 
 ScalarFunction CurrentTransactionIdFun::GetFunction() {
 	ScalarFunction txid_current({}, LogicalType::UBIGINT, TransactionIdCurrent);
 	txid_current.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	txid_current.SetRequiresClientContext();
 	return txid_current;
 }
 

--- a/external/duckdb/extension/core_functions/scalar/random/setseed.cpp
+++ b/external/duckdb/extension/core_functions/scalar/random/setseed.cpp
@@ -60,6 +60,7 @@ ScalarFunction SetseedFun::GetFunction() {
 	ScalarFunction setseed("setseed", {LogicalType::DOUBLE}, LogicalType::SQLNULL, SetSeedFunction, SetSeedBind);
 	setseed.SetVolatile();
 	setseed.SetFallible();
+	setseed.SetRequiresClientContext();
 	return setseed;
 }
 

--- a/external/duckdb/extension/icu/icu-current.cpp
+++ b/external/duckdb/extension/icu/icu-current.cpp
@@ -37,12 +37,14 @@ static void CurrentDateFunction(DataChunk &input, ExpressionState &state, Vector
 ScalarFunction GetCurrentTimeFun() {
 	ScalarFunction current_time({}, LogicalType::TIME_TZ, CurrentTimeFunction);
 	current_time.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	current_time.SetRequiresClientContext();
 	return current_time;
 }
 
 ScalarFunction GetCurrentDateFun() {
 	ScalarFunction current_date({}, LogicalType::DATE, CurrentDateFunction);
 	current_date.SetStability(FunctionStability::CONSISTENT_WITHIN_QUERY);
+	current_date.SetRequiresClientContext();
 	return current_date;
 }
 

--- a/external/duckdb/extension/icu/icu-dateadd.cpp
+++ b/external/duckdb/extension/icu/icu-dateadd.cpp
@@ -278,7 +278,9 @@ struct ICUDateAdd : public ICUDateFunc {
 
 	template <typename TA, typename OP>
 	static ScalarFunction GetUnaryAgeFunction(const LogicalTypeId &left_type) {
-		return GetUnaryDateFunction<TA, interval_t, OP>(left_type, LogicalType::INTERVAL);
+		auto function = GetUnaryDateFunction<TA, interval_t, OP>(left_type, LogicalType::INTERVAL);
+		function.SetRequiresClientContext();
+		return function;
 	}
 
 	template <typename TA, typename TB, typename OP>

--- a/external/duckdb/extension/icu/icu-timezone.cpp
+++ b/external/duckdb/extension/icu/icu-timezone.cpp
@@ -349,7 +349,9 @@ struct ICULocalTimestampFunc : public ICUDateFunc {
 
 	static void AddFunction(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
-		set.AddFunction(ScalarFunction({}, LogicalType::TIMESTAMP, Execute, BindNow));
+		auto function = ScalarFunction({}, LogicalType::TIMESTAMP, Execute, BindNow);
+		function.SetRequiresClientContext();
+		set.AddFunction(function);
 		loader.RegisterFunction(set);
 	}
 };
@@ -365,7 +367,9 @@ struct ICULocalTimeFunc : public ICUDateFunc {
 
 	static void AddFunction(const string &name, ExtensionLoader &loader) {
 		ScalarFunctionSet set(name);
-		set.AddFunction(ScalarFunction({}, LogicalType::TIME, Execute, ICULocalTimestampFunc::BindNow));
+		auto function = ScalarFunction({}, LogicalType::TIME, Execute, ICULocalTimestampFunc::BindNow);
+		function.SetRequiresClientContext();
+		set.AddFunction(function);
 		loader.RegisterFunction(set);
 	}
 };

--- a/external/duckdb/extension/json/json_functions/json_serialize_plan.cpp
+++ b/external/duckdb/extension/json/json_functions/json_serialize_plan.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/execution/column_binding_resolver.hpp"
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/connection.hpp"
@@ -217,6 +223,9 @@ ScalarFunctionSet JSONFunctions::GetSerializePlanFunction() {
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
 	    LogicalType::JSON(), JsonSerializePlanFunction, JsonSerializePlanBind, nullptr, nullptr,
 	    JSONFunctionLocalState::Init));
+	for (auto &function : set.functions) {
+		function.SetRequiresClientContext();
+	}
 	return set;
 }
 

--- a/external/duckdb/extension/json/json_functions/json_serialize_sql.cpp
+++ b/external/duckdb/extension/json/json_functions/json_serialize_sql.cpp
@@ -179,6 +179,9 @@ ScalarFunctionSet JSONFunctions::GetSerializeSqlFunction() {
 	    {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN, LogicalType::BOOLEAN},
 	    LogicalType::JSON(), JsonSerializeFunction, JsonSerializeBind, nullptr, nullptr, JSONFunctionLocalState::Init));
 
+	for (auto &function : set.functions) {
+		function.SetRequiresClientContext();
+	}
 	return set;
 }
 

--- a/external/duckdb/extension/json/json_functions/json_serialize_sql.cpp
+++ b/external/duckdb/extension/json/json_functions/json_serialize_sql.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
@@ -7,6 +13,7 @@
 #include "json_functions.hpp"
 #include "json_serializer.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
+#include "duckdb/planner/binder.hpp"
 
 namespace duckdb {
 
@@ -288,6 +295,13 @@ struct ExecuteSqlTableFunction {
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
 	                                     vector<LogicalType> &return_types, vector<string> &names) {
+		// This bind callback creates an independent connection and binds arbitrary
+		// SQL. Reject before that nested binding can evaluate client-side effects.
+		if (input.binder && input.binder->IsBindingForRunner()) {
+			throw NotImplementedException("Runner execution does not support client-context table function %s; "
+			                              "use a local-fast connection",
+			                              input.table_function.name);
+		}
 		JSONFunctionLocalState local_state(context);
 		auto alc = local_state.json_allocator->GetYYAlc();
 
@@ -327,6 +341,7 @@ struct ExecuteSqlTableFunction {
 TableFunctionSet JSONFunctions::GetExecuteJsonSerializedSqlFunction() {
 	TableFunction func("json_execute_serialized_sql", {LogicalType::VARCHAR}, ExecuteSqlTableFunction::Function,
 	                   ExecuteSqlTableFunction::Bind);
+	func.SetRequiresClientContext();
 	return TableFunctionSet(func);
 }
 

--- a/external/duckdb/extension/tpcds/tpcds_extension.cpp
+++ b/external/duckdb/extension/tpcds/tpcds_extension.cpp
@@ -162,6 +162,7 @@ static string PragmaTpcdsQuery(ClientContext &context, const FunctionParameters 
 
 static void LoadInternal(ExtensionLoader &loader) {
 	TableFunction dsdgen_func("dsdgen", {}, DsdgenFunction, DsdgenBind);
+	dsdgen_func.SetRequiresClientContext();
 	dsdgen_func.named_parameters["sf"] = LogicalType::DOUBLE;
 	dsdgen_func.named_parameters["overwrite"] = LogicalType::BOOLEAN;
 	dsdgen_func.named_parameters["keys"] = LogicalType::BOOLEAN;

--- a/external/duckdb/extension/tpch/tpch_extension.cpp
+++ b/external/duckdb/extension/tpch/tpch_extension.cpp
@@ -171,6 +171,7 @@ static string PragmaTpchQuery(ClientContext &context, const FunctionParameters &
 
 static void LoadInternal(ExtensionLoader &loader) {
 	TableFunction dbgen_func("dbgen", {}, DbgenFunction, DbgenBind);
+	dbgen_func.SetRequiresClientContext();
 	dbgen_func.named_parameters["sf"] = LogicalType::DOUBLE;
 	dbgen_func.named_parameters["overwrite"] = LogicalType::BOOLEAN;
 	dbgen_func.named_parameters["catalog"] = LogicalType::VARCHAR;

--- a/external/duckdb/src/function/built_in_functions.cpp
+++ b/external/duckdb/src/function/built_in_functions.cpp
@@ -71,6 +71,18 @@ void BuiltinFunctions::AddFunction(ScalarFunctionSet set) {
 	catalog.CreateFunction(transaction, info);
 }
 
+void BuiltinFunctions::AddClientContextFunction(TableFunction function) {
+	function.SetRequiresClientContext();
+	AddFunction(std::move(function));
+}
+
+void BuiltinFunctions::AddClientContextFunction(TableFunctionSet set) {
+	for (auto &function : set.functions) {
+		function.SetRequiresClientContext();
+	}
+	AddFunction(std::move(set));
+}
+
 void BuiltinFunctions::AddFunction(TableFunction function) {
 	CreateTableFunctionInfo info(std::move(function));
 	info.internal = true;

--- a/external/duckdb/src/function/function_binder.cpp
+++ b/external/duckdb/src/function/function_binder.cpp
@@ -1,3 +1,9 @@
+// SPDX-FileCopyrightText: 2018-2025 Stichting DuckDB Foundation
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: MIT
+//
+// Modified by Vane contributors.
+
 #include "duckdb/function/function_binder.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
@@ -645,6 +651,14 @@ void FunctionBinder::CheckTemplateTypesResolved(const BaseScalarFunction &bound_
 unique_ptr<Expression> FunctionBinder::BindScalarFunction(ScalarFunction bound_function,
                                                           vector<unique_ptr<Expression>> children, bool is_operator,
                                                           optional_ptr<Binder> binder) {
+	// A bind callback can mutate client state (for example by autoloading an
+	// extension). Reject marked functions before invoking any such callback.
+	auto active_binder = binder ? binder : this->binder;
+	if (active_binder && active_binder->IsBindingForRunner() && bound_function.RequiresClientContext() &&
+	    (bound_function.HasBindCallback() || bound_function.HasBindExtendedCallback() ||
+	     bound_function.HasBindExpressionCallback())) {
+		bound_function.VerifyRunnerExecution();
+	}
 	// Attempt to resolve template types, before we call the "Bind" callback.
 	ResolveTemplateTypes(bound_function, children);
 

--- a/external/duckdb/src/function/scalar/sequence/nextval.cpp
+++ b/external/duckdb/src/function/scalar/sequence/nextval.cpp
@@ -159,6 +159,7 @@ ScalarFunction CurrvalFun::GetFunction() {
 	curr_val.SetInitStateCallback(NextValLocalFunction);
 	curr_val.SetVolatile();
 	curr_val.SetFallible();
+	curr_val.SetRequiresClientContext();
 	return curr_val;
 }
 

--- a/external/duckdb/src/function/scalar/system/current_connection_id.cpp
+++ b/external/duckdb/src/function/scalar/system/current_connection_id.cpp
@@ -36,8 +36,11 @@ void CurrentConnectionIdFunction(DataChunk &args, ExpressionState &state, Vector
 } // namespace
 
 ScalarFunction CurrentConnectionId::GetFunction() {
-	return ScalarFunction({}, LogicalType::UBIGINT, CurrentConnectionIdFunction, CurrentConnectionIdBind, nullptr,
-	                      nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	auto function =
+	    ScalarFunction({}, LogicalType::UBIGINT, CurrentConnectionIdFunction, CurrentConnectionIdBind, nullptr, nullptr,
+	                   nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	function.SetRequiresClientContext();
+	return function;
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/scalar/system/current_query_id.cpp
+++ b/external/duckdb/src/function/scalar/system/current_query_id.cpp
@@ -42,8 +42,10 @@ void CurrentQueryIdFunction(DataChunk &args, ExpressionState &state, Vector &res
 } // namespace
 
 ScalarFunction CurrentQueryId::GetFunction() {
-	return ScalarFunction({}, LogicalType::UBIGINT, CurrentQueryIdFunction, CurrentQueryIdBind, nullptr, nullptr,
-	                      nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	auto function = ScalarFunction({}, LogicalType::UBIGINT, CurrentQueryIdFunction, CurrentQueryIdBind, nullptr,
+	                               nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	function.SetRequiresClientContext();
+	return function;
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/scalar/system/current_transaction_id.cpp
+++ b/external/duckdb/src/function/scalar/system/current_transaction_id.cpp
@@ -43,8 +43,11 @@ void CurrentTransactionIdFunction(DataChunk &args, ExpressionState &state, Vecto
 } // namespace
 
 ScalarFunction CurrentTransactionId::GetFunction() {
-	return ScalarFunction({}, LogicalType::UBIGINT, CurrentTransactionIdFunction, CurrentTransactionIdBind, nullptr,
-	                      nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	auto function =
+	    ScalarFunction({}, LogicalType::UBIGINT, CurrentTransactionIdFunction, CurrentTransactionIdBind, nullptr,
+	                   nullptr, nullptr, LogicalType(LogicalTypeId::INVALID), FunctionStability::VOLATILE);
+	function.SetRequiresClientContext();
+	return function;
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/scalar/system/parse_log_message.cpp
+++ b/external/duckdb/src/function/scalar/system/parse_log_message.cpp
@@ -80,6 +80,7 @@ ScalarFunction ParseLogMessage::GetFunction() {
 	auto fun = ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::ANY, ParseLogMessageFunction,
 	                          ParseLogMessageBind, nullptr, nullptr, nullptr, LogicalType(LogicalTypeId::INVALID));
 	fun.errors = FunctionErrors::CAN_THROW_RUNTIME_ERROR;
+	fun.SetRequiresClientContext();
 	return fun;
 }
 

--- a/external/duckdb/src/function/scalar/system/write_log.cpp
+++ b/external/duckdb/src/function/scalar/system/write_log.cpp
@@ -159,8 +159,10 @@ void WriteLogFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 ScalarFunctionSet WriteLogFun::GetFunctions() {
 	ScalarFunctionSet set("write_log");
 
-	set.AddFunction(ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, WriteLogFunction, WriteLogBind, nullptr,
-	                               nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE));
+	auto function = ScalarFunction({LogicalType::VARCHAR}, LogicalType::ANY, WriteLogFunction, WriteLogBind, nullptr,
+	                               nullptr, nullptr, LogicalType::ANY, FunctionStability::VOLATILE);
+	function.SetRequiresClientContext();
+	set.AddFunction(function);
 
 	return set;
 }

--- a/external/duckdb/src/function/scalar_function.cpp
+++ b/external/duckdb/src/function/scalar_function.cpp
@@ -8,6 +8,18 @@ FunctionLocalState::~FunctionLocalState() {
 ScalarFunctionInfo::~ScalarFunctionInfo() {
 }
 
+void ScalarFunction::VerifyRunnerExecution() const {
+	if (RequiresClientContext()) {
+		throw NotImplementedException("Runner execution does not support client-context function %s; "
+		                              "use a local-fast connection",
+		                              name);
+	}
+	if (HasModifiedDatabasesCallback()) {
+		throw NotImplementedException("Runner execution does not support database-modifying expressions such as %s",
+		                              name);
+	}
+}
+
 ScalarFunction::ScalarFunction(string name, vector<LogicalType> arguments, LogicalType return_type,
                                scalar_function_t function, bind_scalar_function_t bind,
                                bind_scalar_function_extended_t bind_extended, function_statistics_t statistics,

--- a/external/duckdb/src/function/table/checkpoint.cpp
+++ b/external/duckdb/src/function/table/checkpoint.cpp
@@ -57,13 +57,13 @@ void CheckpointFunction::RegisterFunction(BuiltinFunctions &set) {
 	TableFunctionSet checkpoint("checkpoint");
 	checkpoint.AddFunction(TableFunction({}, TemplatedCheckpointFunction<false>, CheckpointBind));
 	checkpoint.AddFunction(TableFunction({LogicalType::VARCHAR}, TemplatedCheckpointFunction<false>, CheckpointBind));
-	set.AddFunction(checkpoint);
+	set.AddClientContextFunction(checkpoint);
 
 	TableFunctionSet force_checkpoint("force_checkpoint");
 	force_checkpoint.AddFunction(TableFunction({}, TemplatedCheckpointFunction<true>, CheckpointBind));
 	force_checkpoint.AddFunction(
 	    TableFunction({LogicalType::VARCHAR}, TemplatedCheckpointFunction<true>, CheckpointBind));
-	set.AddFunction(force_checkpoint);
+	set.AddClientContextFunction(force_checkpoint);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_approx_database_count.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_approx_database_count.cpp
@@ -36,8 +36,8 @@ void DuckDBApproxDatabaseCountFunction(ClientContext &context, TableFunctionInpu
 }
 
 void DuckDBApproxDatabaseCountFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_approx_database_count", {}, DuckDBApproxDatabaseCountFunction,
-	                              DuckDBApproxDatabaseCountBind, DuckDBApproxDatabaseCountInit));
+	set.AddClientContextFunction(TableFunction("duckdb_approx_database_count", {}, DuckDBApproxDatabaseCountFunction,
+	                                           DuckDBApproxDatabaseCountBind, DuckDBApproxDatabaseCountInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_columns.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_columns.cpp
@@ -364,7 +364,8 @@ static void DuckDBColumnsFunction(ClientContext &context, TableFunctionInput &da
 }
 
 void DuckDBColumnsFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_columns", {}, DuckDBColumnsFunction, DuckDBColumnsBind, DuckDBColumnsInit));
+	set.AddClientContextFunction(
+	    TableFunction("duckdb_columns", {}, DuckDBColumnsFunction, DuckDBColumnsBind, DuckDBColumnsInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_connection_count.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_connection_count.cpp
@@ -38,8 +38,8 @@ void DuckDBConnectionCountFunction(ClientContext &context, TableFunctionInput &d
 }
 
 void DuckDBConnectionCountFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_connection_count", {}, DuckDBConnectionCountFunction,
-	                              DuckDBConnectionCountBind, DuckDBConnectionCountInit));
+	set.AddClientContextFunction(TableFunction("duckdb_connection_count", {}, DuckDBConnectionCountFunction,
+	                                           DuckDBConnectionCountBind, DuckDBConnectionCountInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_constraints.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_constraints.cpp
@@ -330,8 +330,8 @@ void DuckDBConstraintsFunction(ClientContext &context, TableFunctionInput &data_
 }
 
 void DuckDBConstraintsFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_constraints", {}, DuckDBConstraintsFunction, DuckDBConstraintsBind,
-	                              DuckDBConstraintsInit));
+	set.AddClientContextFunction(TableFunction("duckdb_constraints", {}, DuckDBConstraintsFunction,
+	                                           DuckDBConstraintsBind, DuckDBConstraintsInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_coordinate_systems.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_coordinate_systems.cpp
@@ -117,8 +117,8 @@ static void DuckDBCoordinateSystemsFunction(ClientContext &context, TableFunctio
 }
 
 void DuckDBCoordinateSystemsFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_coordinate_systems", {}, DuckDBCoordinateSystemsFunction,
-	                              DuckDBCoordinateSystemsBind, DuckDBCoordinateSystemsInit));
+	set.AddClientContextFunction(TableFunction("duckdb_coordinate_systems", {}, DuckDBCoordinateSystemsFunction,
+	                                           DuckDBCoordinateSystemsBind, DuckDBCoordinateSystemsInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_databases.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_databases.cpp
@@ -124,7 +124,7 @@ void DuckDBDatabasesFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 void DuckDBDatabasesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("duckdb_databases", {}, DuckDBDatabasesFunction, DuckDBDatabasesBind, DuckDBDatabasesInit));
 }
 

--- a/external/duckdb/src/function/table/system/duckdb_dependencies.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_dependencies.cpp
@@ -109,8 +109,8 @@ void DuckDBDependenciesFunction(ClientContext &context, TableFunctionInput &data
 }
 
 void DuckDBDependenciesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_dependencies", {}, DuckDBDependenciesFunction, DuckDBDependenciesBind,
-	                              DuckDBDependenciesInit));
+	set.AddClientContextFunction(TableFunction("duckdb_dependencies", {}, DuckDBDependenciesFunction,
+	                                           DuckDBDependenciesBind, DuckDBDependenciesInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_extensions.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_extensions.cpp
@@ -226,7 +226,7 @@ void DuckDBExtensionsFunction(ClientContext &context, TableFunctionInput &data_p
 void DuckDBExtensionsFun::RegisterFunction(BuiltinFunctions &set) {
 	TableFunctionSet functions("duckdb_extensions");
 	functions.AddFunction(TableFunction({}, DuckDBExtensionsFunction, DuckDBExtensionsBind, DuckDBExtensionsInit));
-	set.AddFunction(functions);
+	set.AddClientContextFunction(functions);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_external_file_cache.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_external_file_cache.cpp
@@ -62,8 +62,8 @@ void DuckDBExternalFileCacheFunction(ClientContext &context, TableFunctionInput 
 }
 
 void DuckDBExternalFileCacheFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_external_file_cache", {}, DuckDBExternalFileCacheFunction,
-	                              DuckDBExternalFileCacheBind, DuckDBExternalFileCacheInit));
+	set.AddClientContextFunction(TableFunction("duckdb_external_file_cache", {}, DuckDBExternalFileCacheFunction,
+	                                           DuckDBExternalFileCacheBind, DuckDBExternalFileCacheInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_functions.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_functions.cpp
@@ -849,7 +849,7 @@ void DuckDBFunctionsFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 void DuckDBFunctionsFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("duckdb_functions", {}, DuckDBFunctionsFunction, DuckDBFunctionsBind, DuckDBFunctionsInit));
 }
 

--- a/external/duckdb/src/function/table/system/duckdb_indexes.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_indexes.cpp
@@ -144,7 +144,8 @@ void DuckDBIndexesFunction(ClientContext &context, TableFunctionInput &data_p, D
 }
 
 void DuckDBIndexesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_indexes", {}, DuckDBIndexesFunction, DuckDBIndexesBind, DuckDBIndexesInit));
+	set.AddClientContextFunction(
+	    TableFunction("duckdb_indexes", {}, DuckDBIndexesFunction, DuckDBIndexesBind, DuckDBIndexesInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_log.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_log.cpp
@@ -97,7 +97,7 @@ void DuckDBLogFun::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction logs_fun("duckdb_logs", {}, DuckDBLogFunction, DuckDBLogBind, DuckDBLogInit);
 	logs_fun.bind_replace = DuckDBLogBindReplace;
 	logs_fun.named_parameters["denormalized_table"] = LogicalType::BOOLEAN;
-	set.AddFunction(logs_fun);
+	set.AddClientContextFunction(logs_fun);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_log_contexts.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_log_contexts.cpp
@@ -72,7 +72,7 @@ void DuckDBLogContextFun::RegisterFunction(BuiltinFunctions &set) {
 	auto fun =
 	    TableFunction("duckdb_log_contexts", {}, DuckDBLogContextFunction, DuckDBLogContextBind, DuckDBLogContextInit);
 	fun.bind_replace = DuckDBLogContextsBindReplace;
-	set.AddFunction(fun);
+	set.AddClientContextFunction(fun);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_memory.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_memory.cpp
@@ -63,7 +63,8 @@ void DuckDBMemoryFunction(ClientContext &context, TableFunctionInput &data_p, Da
 }
 
 void DuckDBMemoryFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_memory", {}, DuckDBMemoryFunction, DuckDBMemoryBind, DuckDBMemoryInit));
+	set.AddClientContextFunction(
+	    TableFunction("duckdb_memory", {}, DuckDBMemoryFunction, DuckDBMemoryBind, DuckDBMemoryInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_prepared_statements.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_prepared_statements.cpp
@@ -102,8 +102,8 @@ void DuckDBPreparedStatementsFunction(ClientContext &context, TableFunctionInput
 }
 
 void DuckDBPreparedStatementsFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_prepared_statements", {}, DuckDBPreparedStatementsFunction,
-	                              DuckDBPreparedStatementsBind, DuckDBPreparedStatementsInit));
+	set.AddClientContextFunction(TableFunction("duckdb_prepared_statements", {}, DuckDBPreparedStatementsFunction,
+	                                           DuckDBPreparedStatementsBind, DuckDBPreparedStatementsInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_schemas.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_schemas.cpp
@@ -92,7 +92,8 @@ void DuckDBSchemasFunction(ClientContext &context, TableFunctionInput &data_p, D
 }
 
 void DuckDBSchemasFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_schemas", {}, DuckDBSchemasFunction, DuckDBSchemasBind, DuckDBSchemasInit));
+	set.AddClientContextFunction(
+	    TableFunction("duckdb_schemas", {}, DuckDBSchemasFunction, DuckDBSchemasBind, DuckDBSchemasInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_secret_types.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_secret_types.cpp
@@ -64,8 +64,8 @@ void DuckDBSecretTypesFunction(ClientContext &context, TableFunctionInput &data_
 }
 
 void DuckDBSecretTypesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_secret_types", {}, DuckDBSecretTypesFunction, DuckDBSecretTypesBind,
-	                              DuckDBSecretTypesInit));
+	set.AddClientContextFunction(TableFunction("duckdb_secret_types", {}, DuckDBSecretTypesFunction,
+	                                           DuckDBSecretTypesBind, DuckDBSecretTypesInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_secrets.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_secrets.cpp
@@ -132,7 +132,7 @@ void DuckDBSecretsFun::RegisterFunction(BuiltinFunctions &set) {
 	auto fun = TableFunction({}, DuckDBSecretsFunction, DuckDBSecretsBind, DuckDBSecretsInit);
 	fun.named_parameters["redact"] = LogicalType::BOOLEAN;
 	functions.AddFunction(fun);
-	set.AddFunction(functions);
+	set.AddClientContextFunction(functions);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_sequences.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_sequences.cpp
@@ -137,7 +137,7 @@ void DuckDBSequencesFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 void DuckDBSequencesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("duckdb_sequences", {}, DuckDBSequencesFunction, DuckDBSequencesBind, DuckDBSequencesInit));
 }
 

--- a/external/duckdb/src/function/table/system/duckdb_settings.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_settings.cpp
@@ -142,7 +142,7 @@ void DuckDBSettingsFunction(ClientContext &context, TableFunctionInput &data_p, 
 }
 
 void DuckDBSettingsFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("duckdb_settings", {}, DuckDBSettingsFunction, DuckDBSettingsBind, DuckDBSettingsInit));
 }
 

--- a/external/duckdb/src/function/table/system/duckdb_tables.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_tables.cpp
@@ -159,7 +159,8 @@ void DuckDBTablesFunction(ClientContext &context, TableFunctionInput &data_p, Da
 }
 
 void DuckDBTablesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_tables", {}, DuckDBTablesFunction, DuckDBTablesBind, DuckDBTablesInit));
+	set.AddClientContextFunction(
+	    TableFunction("duckdb_tables", {}, DuckDBTablesFunction, DuckDBTablesBind, DuckDBTablesInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_temporary_files.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_temporary_files.cpp
@@ -52,8 +52,8 @@ void DuckDBTemporaryFilesFunction(ClientContext &context, TableFunctionInput &da
 }
 
 void DuckDBTemporaryFilesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_temporary_files", {}, DuckDBTemporaryFilesFunction, DuckDBTemporaryFilesBind,
-	                              DuckDBTemporaryFilesInit));
+	set.AddClientContextFunction(TableFunction("duckdb_temporary_files", {}, DuckDBTemporaryFilesFunction,
+	                                           DuckDBTemporaryFilesBind, DuckDBTemporaryFilesInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_types.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_types.cpp
@@ -200,7 +200,8 @@ void DuckDBTypesFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 }
 
 void DuckDBTypesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_types", {}, DuckDBTypesFunction, DuckDBTypesBind, DuckDBTypesInit));
+	set.AddClientContextFunction(
+	    TableFunction("duckdb_types", {}, DuckDBTypesFunction, DuckDBTypesBind, DuckDBTypesInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_variables.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_variables.cpp
@@ -77,7 +77,7 @@ void DuckDBVariablesFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 void DuckDBVariablesFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("duckdb_variables", {}, DuckDBVariablesFunction, DuckDBVariablesBind, DuckDBVariablesInit));
 }
 

--- a/external/duckdb/src/function/table/system/duckdb_views.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_views.cpp
@@ -168,7 +168,7 @@ void DuckDBViewsFunction(ClientContext &context, TableFunctionInput &data_p, Dat
 void DuckDBViewsFun::RegisterFunction(BuiltinFunctions &set) {
 	TableFunction duckdb_views("duckdb_views", {}, DuckDBViewsFunction, DuckDBViewsBind, DuckDBViewsInit);
 	duckdb_views.projection_pushdown = true;
-	set.AddFunction(std::move(duckdb_views));
+	set.AddClientContextFunction(std::move(duckdb_views));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/duckdb_which_secret.cpp
+++ b/external/duckdb/src/function/table/system/duckdb_which_secret.cpp
@@ -68,8 +68,9 @@ void DuckDBWhichSecretFunction(ClientContext &context, TableFunctionInput &data_
 }
 
 void DuckDBWhichSecretFun::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("which_secret", {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
-	                              DuckDBWhichSecretFunction, DuckDBWhichSecretBind, DuckDBWhichSecretInit));
+	set.AddClientContextFunction(
+	    TableFunction("which_secret", {duckdb::LogicalType::VARCHAR, duckdb::LogicalType::VARCHAR},
+	                  DuckDBWhichSecretFunction, DuckDBWhichSecretBind, DuckDBWhichSecretInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/enable_profiling.cpp
+++ b/external/duckdb/src/function/table/system/enable_profiling.cpp
@@ -137,10 +137,10 @@ void EnableProfilingFun::RegisterFunction(BuiltinFunctions &set) {
 	enable_fun.named_parameters.emplace("metrics", LogicalType::ANY);
 
 	enable_fun.varargs = LogicalType::LIST(LogicalType::VARCHAR);
-	set.AddFunction(enable_fun);
+	set.AddClientContextFunction(enable_fun);
 
 	auto disable_fun = TableFunction("disable_profiling", {}, DisableProfiling, BindDisableProfiling, nullptr, nullptr);
-	set.AddFunction(disable_fun);
+	set.AddClientContextFunction(disable_fun);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/logging_utils.cpp
+++ b/external/duckdb/src/function/table/system/logging_utils.cpp
@@ -168,13 +168,13 @@ void EnableLoggingFun::RegisterFunction(BuiltinFunctions &set) {
 	enable_fun.named_parameters.emplace("storage_buffer_size", LogicalType::UBIGINT);
 
 	enable_fun.varargs = LogicalType::ANY;
-	set.AddFunction(enable_fun);
+	set.AddClientContextFunction(enable_fun);
 
 	auto disable_fun = TableFunction("disable_logging", {}, DisableLogging, BindDisableLogging, nullptr, nullptr);
-	set.AddFunction(disable_fun);
+	set.AddClientContextFunction(disable_fun);
 
 	auto truncate_fun = TableFunction("truncate_duckdb_logs", {}, TruncateLogs, BindTruncateLogs, nullptr, nullptr);
-	set.AddFunction(truncate_fun);
+	set.AddClientContextFunction(truncate_fun);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/pragma_collations.cpp
+++ b/external/duckdb/src/function/table/system/pragma_collations.cpp
@@ -51,7 +51,7 @@ static void PragmaCollateFunction(ClientContext &context, TableFunctionInput &da
 }
 
 void PragmaCollations::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("pragma_collations", {}, PragmaCollateFunction, PragmaCollateBind, PragmaCollateInit));
 }
 

--- a/external/duckdb/src/function/table/system/pragma_database_size.cpp
+++ b/external/duckdb/src/function/table/system/pragma_database_size.cpp
@@ -90,8 +90,8 @@ void PragmaDatabaseSizeFunction(ClientContext &context, TableFunctionInput &data
 }
 
 void PragmaDatabaseSize::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("pragma_database_size", {}, PragmaDatabaseSizeFunction, PragmaDatabaseSizeBind,
-	                              PragmaDatabaseSizeInit));
+	set.AddClientContextFunction(TableFunction("pragma_database_size", {}, PragmaDatabaseSizeFunction,
+	                                           PragmaDatabaseSizeBind, PragmaDatabaseSizeInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/pragma_metadata_info.cpp
+++ b/external/duckdb/src/function/table/system/pragma_metadata_info.cpp
@@ -84,7 +84,7 @@ void PragmaMetadataInfo::RegisterFunction(BuiltinFunctions &set) {
 	    TableFunction({}, PragmaMetadataInfoFunction, PragmaMetadataInfoBind, PragmaMetadataInfoInit));
 	metadata_info.AddFunction(TableFunction({LogicalType::VARCHAR}, PragmaMetadataInfoFunction, PragmaMetadataInfoBind,
 	                                        PragmaMetadataInfoInit));
-	set.AddFunction(metadata_info);
+	set.AddClientContextFunction(metadata_info);
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/pragma_storage_info.cpp
+++ b/external/duckdb/src/function/table/system/pragma_storage_info.cpp
@@ -163,8 +163,8 @@ static void PragmaStorageInfoFunction(ClientContext &context, TableFunctionInput
 }
 
 void PragmaStorageInfo::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("pragma_storage_info", {LogicalType::VARCHAR}, PragmaStorageInfoFunction,
-	                              PragmaStorageInfoBind, PragmaStorageInfoInit));
+	set.AddClientContextFunction(TableFunction("pragma_storage_info", {LogicalType::VARCHAR}, PragmaStorageInfoFunction,
+	                                           PragmaStorageInfoBind, PragmaStorageInfoInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/pragma_table_info.cpp
+++ b/external/duckdb/src/function/table/system/pragma_table_info.cpp
@@ -293,10 +293,10 @@ static void PragmaTableInfoFunction(ClientContext &context, TableFunctionInput &
 }
 
 void PragmaTableInfo::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("pragma_table_info", {LogicalType::VARCHAR}, PragmaTableInfoFunction,
-	                              PragmaTableInfoBind<true>, PragmaTableInfoInit));
-	set.AddFunction(TableFunction("pragma_show", {LogicalType::VARCHAR}, PragmaTableInfoFunction,
-	                              PragmaTableInfoBind<false>, PragmaTableInfoInit));
+	set.AddClientContextFunction(TableFunction("pragma_table_info", {LogicalType::VARCHAR}, PragmaTableInfoFunction,
+	                                           PragmaTableInfoBind<true>, PragmaTableInfoInit));
+	set.AddClientContextFunction(TableFunction("pragma_show", {LogicalType::VARCHAR}, PragmaTableInfoFunction,
+	                                           PragmaTableInfoBind<false>, PragmaTableInfoInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/pragma_table_sample.cpp
+++ b/external/duckdb/src/function/table/system/pragma_table_sample.cpp
@@ -87,8 +87,8 @@ static void DuckDBTableSampleFunction(ClientContext &context, TableFunctionInput
 }
 
 void DuckDBTableSample::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(TableFunction("duckdb_table_sample", {LogicalType::VARCHAR}, DuckDBTableSampleFunction,
-	                              DuckDBTableSampleBind, DuckDBTableSampleInit));
+	set.AddClientContextFunction(TableFunction("duckdb_table_sample", {LogicalType::VARCHAR}, DuckDBTableSampleFunction,
+	                                           DuckDBTableSampleBind, DuckDBTableSampleInit));
 }
 
 } // namespace duckdb

--- a/external/duckdb/src/function/table/system/pragma_user_agent.cpp
+++ b/external/duckdb/src/function/table/system/pragma_user_agent.cpp
@@ -42,7 +42,7 @@ void PragmaUserAgentFunction(ClientContext &context, TableFunctionInput &data_p,
 }
 
 void PragmaUserAgent::RegisterFunction(BuiltinFunctions &set) {
-	set.AddFunction(
+	set.AddClientContextFunction(
 	    TableFunction("pragma_user_agent", {}, PragmaUserAgentFunction, PragmaUserAgentBind, PragmaUserAgentInit));
 }
 

--- a/external/duckdb/src/include/duckdb/common/enums/statement_type.hpp
+++ b/external/duckdb/src/include/duckdb/common/enums/statement_type.hpp
@@ -109,6 +109,8 @@ struct StatementProperties {
 	idx_t parameter_count;
 	//! Whether or not the statement ALWAYS requires a rebind
 	bool always_require_rebind;
+	//! A bound query requires its client context because of its query origin.
+	bool requires_client_context = false;
 
 	bool IsReadOnly() {
 		return modified_databases.empty();

--- a/external/duckdb/src/include/duckdb/function/built_in_functions.hpp
+++ b/external/duckdb/src/include/duckdb/function/built_in_functions.hpp
@@ -31,6 +31,9 @@ public:
 	void AddFunction(const vector<string> &names, ScalarFunction function);
 	void AddFunction(TableFunctionSet set);
 	void AddFunction(TableFunction function);
+	//! Register table functions that inspect or mutate the executing client context.
+	void AddClientContextFunction(TableFunction function);
+	void AddClientContextFunction(TableFunctionSet set);
 	void AddFunction(CopyFunction function);
 
 	void AddCollation(string name, ScalarFunction function, bool combinable = false,

--- a/external/duckdb/src/include/duckdb/function/scalar_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar_function.hpp
@@ -176,6 +176,9 @@ public:
 	get_modified_databases_t GetModifiedDatabasesCallback() const { return get_modified_databases; }
 	void SetModifiedDatabasesCallback(get_modified_databases_t callback) { get_modified_databases = callback; }
 
+	bool RequiresClientContext() const { return requires_client_context; }
+	void SetRequiresClientContext() { requires_client_context = true; }
+
 	bool HasSerializationCallbacks() const { return serialize != nullptr && deserialize != nullptr; }
 	void SetSerializeCallback(function_serialize_t callback) { serialize = callback; }
 	void SetDeserializeCallback(function_deserialize_t callback) { deserialize = callback; }
@@ -215,6 +218,8 @@ public:
 	function_bind_expression_t bind_expression;
 	//! Gets the modified databases (if any)
 	get_modified_databases_t get_modified_databases;
+	//! Uses query, transaction, catalog or session state that bound-plan transport does not preserve
+	bool requires_client_context = false;
 
 	function_serialize_t serialize;
 	function_deserialize_t deserialize;

--- a/external/duckdb/src/include/duckdb/function/scalar_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/scalar_function.hpp
@@ -178,6 +178,8 @@ public:
 
 	bool RequiresClientContext() const { return requires_client_context; }
 	void SetRequiresClientContext() { requires_client_context = true; }
+	//! Reject effects that cannot be transported to a runner.
+	DUCKDB_API void VerifyRunnerExecution() const;
 
 	bool HasSerializationCallbacks() const { return serialize != nullptr && deserialize != nullptr; }
 	void SetSerializeCallback(function_serialize_t callback) { serialize = callback; }

--- a/external/duckdb/src/include/duckdb/function/table_function.hpp
+++ b/external/duckdb/src/include/duckdb/function/table_function.hpp
@@ -403,6 +403,12 @@ public:
 	bool HasBindCallback() const {
 		return bind != nullptr;
 	}
+	bool RequiresClientContext() const {
+		return requires_client_context;
+	}
+	void SetRequiresClientContext() {
+		requires_client_context = true;
+	}
 	table_function_bind_t GetBindCallback() const {
 		return bind;
 	}
@@ -547,6 +553,9 @@ public:
 	DUCKDB_API bool Equal(const TableFunction &rhs) const;
 	DUCKDB_API bool operator==(const TableFunction &rhs) const;
 	DUCKDB_API bool operator!=(const TableFunction &rhs) const;
+
+private:
+	bool requires_client_context = false;
 };
 
 } // namespace duckdb

--- a/external/duckdb/src/include/duckdb/main/client_context.hpp
+++ b/external/duckdb/src/include/duckdb/main/client_context.hpp
@@ -45,6 +45,7 @@ class ColumnDataCollection;
 class DatabaseInstance;
 class FileOpener;
 class LogicalOperator;
+class Planner;
 class PreparedStatementData;
 class Relation;
 class BufferedFileWriter;
@@ -68,6 +69,12 @@ struct PendingQueryParameters {
 	//! Query-local callback used to create a materialized result collector.
 	//! Takes precedence over the connection-level callback without modifying connection state.
 	get_result_collector_t get_result_collector = nullptr;
+	//! Query-local execution admission after binding, before native optimization.
+	//! Return true after taking ownership of the logical plan to suspend this query
+	//! without executing it. PendingQuery then returns nullptr. The caller must
+	//! finish with RunWithBoundPlan or CancelBoundPlan, retaining the binding snapshot.
+	//! Return false to continue the normal DuckDB execution lifecycle unchanged.
+	std::function<bool(Planner &, unique_ptr<LogicalOperator> &, PreparedStatementData &)> bound_plan_handler;
 };
 
 //! The ClientContext holds information relevant to the current client session
@@ -129,6 +136,8 @@ public:
 	//! Issues a query to the database and returns a Pending Query Result
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(unique_ptr<SQLStatement> statement,
 	                                                       QueryParameters query_parameters);
+	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(unique_ptr<SQLStatement> statement,
+	                                                       const PendingQueryParameters &parameters);
 
 	//! Create a pending query with a list of parameters
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(unique_ptr<SQLStatement> statement,
@@ -138,6 +147,11 @@ public:
 	                                                       case_insensitive_map_t<BoundParameterData> &values,
 	                                                       QueryParameters query_parameters);
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const string &query, PendingQueryParameters parameters);
+	//! Serialize an extracted plan while its binding transaction is still active,
+	//! then finish that transaction. Reject a superseded or closed binding query.
+	DUCKDB_API void RunWithBoundPlan(idx_t query_number, const std::function<void()> &callback);
+	//! Cancel an extracted binding query if it has not already been finished/replaced.
+	DUCKDB_API void CancelBoundPlan(idx_t query_number);
 
 	//! Destroy the client context
 	DUCKDB_API void Destroy();
@@ -162,6 +176,8 @@ public:
 	//! Execute a relation
 	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const shared_ptr<Relation> &relation,
 	                                                       QueryParameters query_parameters);
+	DUCKDB_API unique_ptr<PendingQueryResult> PendingQuery(const shared_ptr<Relation> &relation,
+	                                                       const PendingQueryParameters &parameters);
 	DUCKDB_API unique_ptr<QueryResult> Execute(const shared_ptr<Relation> &relation);
 
 	//! Prepare a query
@@ -281,7 +297,7 @@ private:
 	unique_ptr<PendingQueryResult> PendingPreparedStatementInternal(ClientContextLock &lock,
 	                                                                shared_ptr<PreparedStatementData> statement_data_p,
 	                                                                const PendingQueryParameters &parameters);
-	void CheckIfPreparedStatementIsExecutable(PreparedStatementData &statement);
+	void CheckIfPreparedStatementIsExecutable(PreparedStatementData &statement, bool register_write = true);
 
 	//! Internally prepare a SQL statement. Caller must hold the context_lock.
 	shared_ptr<PreparedStatementData>
@@ -319,6 +335,8 @@ private:
 
 	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &, const shared_ptr<Relation> &relation,
 	                                                    QueryParameters query_parameters);
+	unique_ptr<PendingQueryResult> PendingQueryInternal(ClientContextLock &, const shared_ptr<Relation> &relation,
+	                                                    const PendingQueryParameters &parameters);
 
 	void RebindPreparedStatement(ClientContextLock &lock, const string &query,
 	                             shared_ptr<PreparedStatementData> &prepared, const PendingQueryParameters &parameters);

--- a/external/duckdb/src/include/duckdb/main/prepared_statement_data.hpp
+++ b/external/duckdb/src/include/duckdb/main/prepared_statement_data.hpp
@@ -41,6 +41,8 @@ public:
 
 	//! The statement properties
 	StatementProperties properties;
+	//! A query-local handler took ownership of the bound plan before native planning.
+	bool bound_plan_exported = false;
 
 	//! The map of parameter index to the actual value entry
 	bound_parameter_map_t value_map;

--- a/external/duckdb/src/include/duckdb/main/relation/query_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/query_relation.hpp
@@ -26,6 +26,8 @@ public:
 	QueryRelation(const shared_ptr<ClientContext> &context, unique_ptr<SelectStatement> select_stmt, string alias,
 	              const string &query = "", case_insensitive_map_t<BoundParameterData> parameters = {});
 	~QueryRelation() override;
+	static void CaptureParameters(unique_ptr<ParsedExpression> &expression,
+	                              const case_insensitive_map_t<BoundParameterData> &parameters);
 
 	unique_ptr<SelectStatement> select_stmt;
 	string query;

--- a/external/duckdb/src/include/duckdb/main/relation/write_file_relation.hpp
+++ b/external/duckdb/src/include/duckdb/main/relation/write_file_relation.hpp
@@ -11,11 +11,8 @@
 #pragma once
 
 #include "duckdb/main/relation.hpp"
-#include "duckdb/planner/expression/bound_parameter_data.hpp"
 
 namespace duckdb {
-
-class CopyStatement;
 
 //! A format-neutral COPY TO relation. The named CopyFunction owns format
 //! validation, options, bind state, and execution.
@@ -23,17 +20,12 @@ class WriteFileRelation : public Relation {
 public:
 	WriteFileRelation(shared_ptr<Relation> child, string file_path, string format,
 	                  case_insensitive_map_t<vector<Value>> options);
-	WriteFileRelation(const shared_ptr<ClientContext> &context, unique_ptr<CopyStatement> statement,
-	                  case_insensitive_map_t<BoundParameterData> parameters);
-	~WriteFileRelation() override;
 
 	shared_ptr<Relation> child;
 	string file_path;
 	string format;
 	vector<ColumnDefinition> columns;
 	case_insensitive_map_t<vector<Value>> options;
-	unique_ptr<CopyStatement> statement;
-	case_insensitive_map_t<BoundParameterData> parameters;
 
 public:
 	BoundStatement Bind(Binder &binder) override;

--- a/external/duckdb/src/include/duckdb/parser/query_node.hpp
+++ b/external/duckdb/src/include/duckdb/parser/query_node.hpp
@@ -57,6 +57,8 @@ public:
 	vector<unique_ptr<ResultModifier>> modifiers;
 	//! CTEs (used by SelectNode and SetOperationNode)
 	CommonTableExpressionMap cte_map;
+	//! Query origin requires client execution (PRAGMA expansion or a materialized command result).
+	bool requires_client_context = false;
 
 public:
 	//! Convert the query node to a string

--- a/external/duckdb/src/include/duckdb/planner/binder.hpp
+++ b/external/duckdb/src/include/duckdb/planner/binder.hpp
@@ -176,6 +176,8 @@ struct GlobalBinderState {
 	idx_t bound_tables = 0;
 	//! Statement properties
 	StatementProperties prop;
+	//! This tree will be admitted for runner execution; guard bind-time evaluation.
+	bool binding_for_runner = false;
 	//! Binding mode
 	BindingMode mode = BindingMode::STANDARD_BINDING;
 	//! Table names extracted for BindingMode::EXTRACT_NAMES or BindingMode::EXTRACT_QUALIFIED_NAMES.
@@ -340,6 +342,8 @@ public:
 	void SetAlwaysRequireRebind();
 
 	StatementProperties &GetStatementProperties();
+	void SetBindingForRunner(bool enabled);
+	bool IsBindingForRunner() const;
 	static void ReplaceStarExpression(unique_ptr<ParsedExpression> &expr, unique_ptr<ParsedExpression> &replacement);
 	static string ReplaceColumnsAlias(const string &alias, const string &column_name,
 	                                  optional_ptr<duckdb_re2::RE2> regex);

--- a/external/duckdb/src/include/duckdb/planner/binder.hpp
+++ b/external/duckdb/src/include/duckdb/planner/binder.hpp
@@ -178,6 +178,8 @@ struct GlobalBinderState {
 	StatementProperties prop;
 	//! This tree will be admitted for runner execution; guard bind-time evaluation.
 	bool binding_for_runner = false;
+	//! Ordinary reads can discover a native client query during bind replacement.
+	bool allow_client_queries = false;
 	//! Binding mode
 	BindingMode mode = BindingMode::STANDARD_BINDING;
 	//! Table names extracted for BindingMode::EXTRACT_NAMES or BindingMode::EXTRACT_QUALIFIED_NAMES.
@@ -342,7 +344,7 @@ public:
 	void SetAlwaysRequireRebind();
 
 	StatementProperties &GetStatementProperties();
-	void SetBindingForRunner(bool enabled);
+	void SetBindingForRunner(bool enabled, bool allow_client_queries = false);
 	bool IsBindingForRunner() const;
 	static void ReplaceStarExpression(unique_ptr<ParsedExpression> &expr, unique_ptr<ParsedExpression> &replacement);
 	static string ReplaceColumnsAlias(const string &alias, const string &column_name,

--- a/external/duckdb/src/include/duckdb/storage/serialization/query_node.json
+++ b/external/duckdb/src/include/duckdb/storage/serialization/query_node.json
@@ -20,10 +20,17 @@
         "id": 102,
         "name": "cte_map",
         "type": "CommonTableExpressionMap"
+      },
+      {
+        "id": 103,
+        "name": "requires_client_context",
+        "type": "bool",
+        "default": "false"
       }
     ],
     "finalize_deserialization": [
         "if (type == QueryNodeType::CTE_NODE) {",
+        "\tresult->Cast<CTENode>().child->requires_client_context |= result->requires_client_context;",
         "\tresult = std::move(result->Cast<CTENode>().child);",
         "}"
     ]

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -30,14 +30,19 @@
 #include "duckdb/main/query_profiler.hpp"
 #include "duckdb/main/query_result.hpp"
 #include "duckdb/main/relation.hpp"
+#include "duckdb/main/relation/query_relation.hpp"
 #include "duckdb/main/stream_query_result.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
+#include "duckdb/parser/expression/subquery_expression.hpp"
 #include "duckdb/parser/parsed_data/create_function_info.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/query_node/select_node.hpp"
 #include "duckdb/parser/statement/drop_statement.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
 #include "duckdb/parser/statement/execute_statement.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/parser/statement/delete_statement.hpp"
@@ -405,10 +410,101 @@ static bool IsExplainAnalyze(SQLStatement *statement) {
 	return explain.explain_type == ExplainType::EXPLAIN_ANALYZE;
 }
 
+static bool IsClientConnectionQuery(QueryNode &node) {
+	bool requires_client_context = node.requires_client_context;
+	ParsedExpressionIterator::EnumerateQueryNodeChildren(
+	    node,
+	    [&](unique_ptr<ParsedExpression> &expression) {
+		    ParsedExpressionIterator::VisitExpressionMutable<SubqueryExpression>(
+		        *expression, [&](SubqueryExpression &subquery) {
+			        requires_client_context |= IsClientConnectionQuery(*subquery.subquery->node);
+		        });
+	    },
+	    [](TableRef &) {}, [&](QueryNode &child) { requires_client_context |= child.requires_client_context; });
+	return requires_client_context;
+}
+
+static bool RequiresRunnerTransactionCheck(ClientContext &context) {
+	return context.vane_runner_type != "local-fast" && !context.transaction.IsAutoCommit();
+}
+
+static void RejectRunnerTransaction(const string &operation) {
+	throw BinderException(
+	    "Runner %s requires DuckDB auto-commit mode and cannot participate in an explicit transaction", operation);
+}
+
+static void CheckRunnerRelationTransaction(ClientContext &context, Relation &relation) {
+	if (!RequiresRunnerTransactionCheck(context)) {
+		return;
+	}
+	if (relation.type == RelationType::CREATE_VIEW_RELATION || relation.type == RelationType::EXPLAIN_RELATION) {
+		return;
+	}
+	if (!relation.IsReadOnly()) {
+		RejectRunnerTransaction("write");
+	}
+	if (context.vane_runner_type == "ray") {
+		// Inspect only the AST. Binding even a lazy Relation can evaluate table
+		// function arguments, so transaction rejection must happen before it.
+		try {
+			unique_ptr<QueryNode> node;
+			optional_ptr<QueryNode> query;
+			if (relation.type == RelationType::QUERY_RELATION) {
+				query = static_cast<QueryRelation &>(relation).select_stmt->node.get();
+			} else {
+				node = relation.GetQueryNode();
+				query = node.get();
+			}
+			if (IsClientConnectionQuery(*query)) {
+				return;
+			}
+		} catch (const NotImplementedException &) {
+			// Relations without an SQL representation also require auto-commit.
+		}
+		RejectRunnerTransaction("SELECT");
+	}
+}
+
+static void CheckRunnerStatementTransaction(ClientContext &context, SQLStatement &statement) {
+	if (!RequiresRunnerTransactionCheck(context)) {
+		return;
+	}
+	switch (statement.type) {
+	case StatementType::RELATION_STATEMENT:
+		CheckRunnerRelationTransaction(context, *statement.Cast<RelationStatement>().relation);
+		return;
+	case StatementType::SELECT_STATEMENT:
+		if (context.vane_runner_type == "ray" && !IsClientConnectionQuery(*statement.Cast<SelectStatement>().node)) {
+			RejectRunnerTransaction("SELECT");
+		}
+		return;
+	case StatementType::CREATE_STATEMENT: {
+		auto &info = *statement.Cast<CreateStatement>().info;
+		if (info.type == CatalogType::TABLE_ENTRY && info.Cast<CreateTableInfo>().query) {
+			RejectRunnerTransaction("CTAS");
+		}
+		return;
+	}
+	case StatementType::COPY_STATEMENT:
+	case StatementType::INSERT_STATEMENT:
+	case StatementType::UPDATE_STATEMENT:
+	case StatementType::DELETE_STATEMENT:
+	case StatementType::MERGE_INTO_STATEMENT:
+		RejectRunnerTransaction(StatementTypeToString(statement.type));
+		return;
+	default:
+		// Catalog DDL, SET, ATTACH, PRAGMA and transaction control stay native.
+		return;
+	}
+}
+
 shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal(ClientContextLock &lock,
                                                                                  const string &query,
                                                                                  unique_ptr<SQLStatement> statement,
                                                                                  PendingQueryParameters parameters) {
+	if (parameters.bound_plan_handler) {
+		CheckRunnerStatementTransaction(*this, *statement);
+	}
 	StatementType statement_type = statement->type;
 	auto result = make_shared_ptr<PreparedStatementData>(statement_type);
 
@@ -1462,6 +1558,7 @@ void ClientContext::Append(TableDescription &description, ColumnDataCollection &
 }
 
 void ClientContext::InternalTryBindRelation(Relation &relation, vector<ColumnDefinition> &result_columns) {
+	CheckRunnerRelationTransaction(*this, relation);
 	// bind the expressions
 	auto binder = Binder::CreateBinder(*this);
 	auto result = relation.Bind(*binder);

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -437,6 +437,13 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 		// not all parameters were bound - return
 		return result;
 	}
+	if (parameters.bound_plan_handler && parameters.bound_plan_handler(logical_planner, logical_plan, *result)) {
+		if (logical_plan) {
+			throw InternalException("Bound plan handler did not take ownership of the plan");
+		}
+		result->bound_plan_exported = true;
+		return result;
+	}
 #ifdef DEBUG
 	logical_plan->Verify(*this);
 #endif
@@ -504,6 +511,9 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatement(ClientC
 		}
 		if (result) {
 			D_ASSERT(!rebind);
+			if (result->bound_plan_exported) {
+				return result;
+			}
 			for (auto &state : registered_state->States()) {
 				auto info = state->OnFinalizePrepare(*this, *result, mode);
 				if (info == RebindQueryInfo::ATTEMPT_TO_REBIND) {
@@ -550,7 +560,7 @@ void ClientContext::RebindPreparedStatement(ClientContextLock &lock, const strin
 	prepared->properties.bound_all_parameters = false;
 }
 
-void ClientContext::CheckIfPreparedStatementIsExecutable(PreparedStatementData &statement) {
+void ClientContext::CheckIfPreparedStatementIsExecutable(PreparedStatementData &statement, bool register_write) {
 	if (ValidChecker::IsInvalidated(ActiveTransaction()) && statement.properties.requires_valid_transaction) {
 		throw ErrorManager::InvalidatedTransaction(*this);
 	}
@@ -569,7 +579,9 @@ void ClientContext::CheckIfPreparedStatementIsExecutable(PreparedStatementData &
 			    "Cannot execute statement of type \"%s\" on database \"%s\" which is attached in read-only mode!",
 			    StatementTypeToString(statement.statement_type), modified_database));
 		}
-		meta_transaction.ModifyDatabase(*entry, it.second.modifications);
+		if (register_write) {
+			meta_transaction.ModifyDatabase(*entry, it.second.modifications);
+		}
 	}
 }
 
@@ -947,6 +959,11 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementInternal(ClientCon
 	if (!prepared->properties.bound_all_parameters) {
 		return ErrorResult<PendingQueryResult>(InvalidInputException("Not all parameters were bound"), query);
 	}
+	if (prepared->bound_plan_exported) {
+		// Keep read-only and transaction validation without claiming a local write.
+		CheckIfPreparedStatementIsExecutable(*prepared, false);
+		return nullptr;
+	}
 	// execute the prepared statement
 	CheckIfPreparedStatementIsExecutable(*prepared);
 	return PendingPreparedStatementInternal(lock, std::move(prepared), parameters);
@@ -1083,6 +1100,12 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
 		// other types of exceptions do invalidate the current transaction
 		pending = ErrorResult<PendingQueryResult>(std::move(error), query);
 	}
+	if (!pending) {
+		// The caller owns an extracted plan. Retain its binding transaction until
+		// serialization finishes, without registering any local write or executor.
+		D_ASSERT(parameters.bound_plan_handler);
+		return nullptr;
+	}
 	if (pending->HasError()) {
 		// query failed: abort now
 		EndQueryInternal(lock, false, invalidate_query, pending->GetErrorObject());
@@ -1090,6 +1113,37 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
 	}
 	D_ASSERT(active_query->IsOpenResult(*pending));
 	return pending;
+}
+
+void ClientContext::RunWithBoundPlan(idx_t query_number, const std::function<void()> &callback) {
+	auto lock = LockContext();
+	if (!active_query || active_query->executor || transaction.GetActiveQuery() != query_number) {
+		throw InvalidInputException("The bound plan's connection query was closed or replaced before execution");
+	}
+	try {
+		callback();
+	} catch (const std::exception &exception) {
+		ErrorData error(exception);
+		EndQueryInternal(*lock, false, ErrorInvalidatesTransaction(error.Type()), error);
+		throw;
+	} catch (...) {
+		EndQueryInternal(*lock, false, false);
+		throw;
+	}
+	auto error = EndQueryInternal(*lock, true, false);
+	if (error.HasError()) {
+		error.Throw();
+	}
+}
+
+void ClientContext::CancelBoundPlan(idx_t query_number) {
+	auto lock = LockContext();
+	if (active_query && !active_query->executor && transaction.GetActiveQuery() == query_number) {
+		auto error = EndQueryInternal(*lock, false, false);
+		if (error.HasError()) {
+			error.Throw();
+		}
+	}
 }
 
 void ClientContext::LogQueryInternal(ClientContextLock &, const string &query) {
@@ -1239,16 +1293,19 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const string &query, 
 unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStatement> statement,
                                                            case_insensitive_map_t<BoundParameterData> &values,
                                                            QueryParameters parameters) {
+	PendingQueryParameters params;
+	params.query_parameters = parameters;
+	params.parameters = values;
+	return PendingQuery(std::move(statement), params);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQuery(unique_ptr<SQLStatement> statement,
+                                                           const PendingQueryParameters &parameters) {
 	auto lock = LockContext();
 	auto query = statement->query;
 	try {
 		InitialCleanup(*lock);
-
-		PendingQueryParameters params;
-		params.query_parameters = parameters;
-		params.parameters = values;
-
-		return PendingQueryInternal(*lock, std::move(statement), params, true);
+		return PendingQueryInternal(*lock, std::move(statement), parameters, true);
 	} catch (std::exception &ex) {
 		return make_uniq<PendingQueryResult>(ErrorData(ex));
 	}
@@ -1445,6 +1502,14 @@ unordered_set<string> ClientContext::GetTableNames(const string &query, const bo
 unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
                                                                    const shared_ptr<Relation> &relation,
                                                                    QueryParameters query_parameters) {
+	PendingQueryParameters parameters;
+	parameters.query_parameters = query_parameters;
+	return PendingQueryInternal(lock, relation, parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContextLock &lock,
+                                                                   const shared_ptr<Relation> &relation,
+                                                                   const PendingQueryParameters &parameters) {
 	InitialCleanup(lock);
 
 	string query;
@@ -1462,10 +1527,10 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 				// verify read only statements by running a select statement
 				auto select = make_uniq<SelectStatement>();
 				select->node = std::move(query_node);
-				PendingQueryParameters parameters;
-				parameters.query_parameters = query_parameters;
-				parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
-				RunStatementInternal(lock, query, std::move(select), parameters);
+				PendingQueryParameters verification_parameters;
+				verification_parameters.query_parameters = parameters.query_parameters;
+				verification_parameters.query_parameters.output_type = QueryResultOutputType::FORCE_MATERIALIZED;
+				RunStatementInternal(lock, query, std::move(select), verification_parameters);
 			}
 		}
 	}
@@ -1475,8 +1540,6 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 		auto statement_binder = Binder::CreateBinder(*this);
 		relation_stmt = make_uniq<RelationStatement>(relation, *statement_binder);
 	});
-	PendingQueryParameters parameters;
-	parameters.query_parameters = query_parameters;
 	return PendingQueryInternal(lock, std::move(relation_stmt), parameters);
 }
 
@@ -1484,6 +1547,12 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const shared_ptr<Rela
                                                            QueryParameters query_parameters) {
 	auto lock = LockContext();
 	return PendingQueryInternal(*lock, relation, query_parameters);
+}
+
+unique_ptr<PendingQueryResult> ClientContext::PendingQuery(const shared_ptr<Relation> &relation,
+                                                           const PendingQueryParameters &parameters) {
+	auto lock = LockContext();
+	return PendingQueryInternal(*lock, relation, parameters);
 }
 
 unique_ptr<QueryResult> ClientContext::Execute(const shared_ptr<Relation> &relation) {

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -1127,10 +1127,10 @@ void ClientContext::RunWithBoundPlan(idx_t query_number, const std::function<voi
 		EndQueryInternal(*lock, false, ErrorInvalidatesTransaction(error.Type()), error);
 		throw;
 	} catch (...) {
-		EndQueryInternal(*lock, false, false);
+		EndQueryInternal(*lock, false, false, nullptr);
 		throw;
 	}
-	auto error = EndQueryInternal(*lock, true, false);
+	auto error = EndQueryInternal(*lock, true, false, nullptr);
 	if (error.HasError()) {
 		error.Throw();
 	}
@@ -1139,7 +1139,7 @@ void ClientContext::RunWithBoundPlan(idx_t query_number, const std::function<voi
 void ClientContext::CancelBoundPlan(idx_t query_number) {
 	auto lock = LockContext();
 	if (active_query && !active_query->executor && transaction.GetActiveQuery() == query_number) {
-		auto error = EndQueryInternal(*lock, false, false);
+		auto error = EndQueryInternal(*lock, false, false, nullptr);
 		if (error.HasError()) {
 			error.Throw();
 		}

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -994,7 +994,9 @@ unique_ptr<PendingQueryResult> ClientContext::PendingStatementOrPreparedStatemen
 		statement = statement->Copy();
 	}
 #endif
-	if (statement && config.query_verification_enabled) {
+	// An admission callback must run before verification can execute any SQL.
+	// Its caller decides whether native verification is supported for the plan.
+	if (statement && config.query_verification_enabled && !parameters.bound_plan_handler) {
 		// query verification is enabled
 		// create a copy of the statement, and use the copy
 		// this way we verify that the copy correctly copies all properties
@@ -1513,7 +1515,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 	InitialCleanup(lock);
 
 	string query;
-	if (config.query_verification_enabled) {
+	if (config.query_verification_enabled && !parameters.bound_plan_handler) {
 		// run the ToString method of any relation we run, mostly to ensure it doesn't crash
 		relation->ToString();
 		relation->GetAlias();

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -424,24 +424,15 @@ static bool IsClientConnectionQuery(QueryNode &node) {
 	return requires_client_context;
 }
 
-static bool RequiresRunnerTransactionCheck(ClientContext &context) {
-	return context.vane_runner_type != "local-fast" && !context.transaction.IsAutoCommit();
-}
-
-static void RejectRunnerTransaction(const string &operation) {
-	throw BinderException(
-	    "Runner %s requires DuckDB auto-commit mode and cannot participate in an explicit transaction", operation);
-}
-
-static void CheckRunnerRelationTransaction(ClientContext &context, Relation &relation) {
-	if (!RequiresRunnerTransactionCheck(context)) {
-		return;
+static string RunnerRelationOperation(ClientContext &context, Relation &relation) {
+	if (context.vane_runner_type == "local-fast") {
+		return string();
 	}
 	if (relation.type == RelationType::CREATE_VIEW_RELATION || relation.type == RelationType::EXPLAIN_RELATION) {
-		return;
+		return string();
 	}
 	if (!relation.IsReadOnly()) {
-		RejectRunnerTransaction("write");
+		return "write";
 	}
 	if (context.vane_runner_type == "ray") {
 		// Inspect only the AST. Binding even a lazy Relation can evaluate table
@@ -456,45 +447,51 @@ static void CheckRunnerRelationTransaction(ClientContext &context, Relation &rel
 				query = node.get();
 			}
 			if (IsClientConnectionQuery(*query)) {
-				return;
+				return string();
 			}
 		} catch (const NotImplementedException &) {
 			// Relations without an SQL representation also require auto-commit.
 		}
-		RejectRunnerTransaction("SELECT");
+		return "SELECT";
 	}
+	return string();
 }
 
-static void CheckRunnerStatementTransaction(ClientContext &context, SQLStatement &statement) {
-	if (!RequiresRunnerTransactionCheck(context)) {
-		return;
+static string RunnerStatementOperation(ClientContext &context, SQLStatement &statement) {
+	if (context.vane_runner_type == "local-fast") {
+		return string();
 	}
 	switch (statement.type) {
 	case StatementType::RELATION_STATEMENT:
-		CheckRunnerRelationTransaction(context, *statement.Cast<RelationStatement>().relation);
-		return;
+		return RunnerRelationOperation(context, *statement.Cast<RelationStatement>().relation);
 	case StatementType::SELECT_STATEMENT:
 		if (context.vane_runner_type == "ray" && !IsClientConnectionQuery(*statement.Cast<SelectStatement>().node)) {
-			RejectRunnerTransaction("SELECT");
+			return "SELECT";
 		}
-		return;
+		return string();
 	case StatementType::CREATE_STATEMENT: {
 		auto &info = *statement.Cast<CreateStatement>().info;
 		if (info.type == CatalogType::TABLE_ENTRY && info.Cast<CreateTableInfo>().query) {
-			RejectRunnerTransaction("CTAS");
+			return "CTAS";
 		}
-		return;
+		return string();
 	}
 	case StatementType::COPY_STATEMENT:
 	case StatementType::INSERT_STATEMENT:
 	case StatementType::UPDATE_STATEMENT:
 	case StatementType::DELETE_STATEMENT:
 	case StatementType::MERGE_INTO_STATEMENT:
-		RejectRunnerTransaction(StatementTypeToString(statement.type));
-		return;
+		return StatementTypeToString(statement.type);
 	default:
 		// Catalog DDL, SET, ATTACH, PRAGMA and transaction control stay native.
-		return;
+		return string();
+	}
+}
+
+static void CheckRunnerTransaction(ClientContext &context, const string &operation) {
+	if (!operation.empty() && !context.transaction.IsAutoCommit()) {
+		throw BinderException(
+		    "Runner %s requires DuckDB auto-commit mode and cannot participate in an explicit transaction", operation);
 	}
 }
 
@@ -502,9 +499,8 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
                                                                                  const string &query,
                                                                                  unique_ptr<SQLStatement> statement,
                                                                                  PendingQueryParameters parameters) {
-	if (parameters.bound_plan_handler) {
-		CheckRunnerStatementTransaction(*this, *statement);
-	}
+	auto runner_operation = parameters.bound_plan_handler ? RunnerStatementOperation(*this, *statement) : string();
+	CheckRunnerTransaction(*this, runner_operation);
 	StatementType statement_type = statement->type;
 	auto result = make_shared_ptr<PreparedStatementData>(statement_type);
 
@@ -512,6 +508,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 	profiler.StartQuery(query, IsExplainAnalyze(statement.get()), true);
 	profiler.StartPhase(MetricType::PLANNER);
 	Planner logical_planner(*this);
+	logical_planner.binder->SetBindingForRunner(!runner_operation.empty());
 	if (parameters.parameters) {
 		auto &parameter_values = *parameters.parameters;
 		for (auto &value : parameter_values) {
@@ -1558,9 +1555,11 @@ void ClientContext::Append(TableDescription &description, ColumnDataCollection &
 }
 
 void ClientContext::InternalTryBindRelation(Relation &relation, vector<ColumnDefinition> &result_columns) {
-	CheckRunnerRelationTransaction(*this, relation);
+	auto runner_operation = RunnerRelationOperation(*this, relation);
+	CheckRunnerTransaction(*this, runner_operation);
 	// bind the expressions
 	auto binder = Binder::CreateBinder(*this);
+	binder->SetBindingForRunner(!runner_operation.empty());
 	auto result = relation.Bind(*binder);
 	D_ASSERT(result.names.size() == result.types.size());
 
@@ -1634,9 +1633,12 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 		}
 	}
 
+	auto runner_operation = parameters.bound_plan_handler ? RunnerRelationOperation(*this, *relation) : string();
+	CheckRunnerTransaction(*this, runner_operation);
 	unique_ptr<RelationStatement> relation_stmt;
 	RunFunctionInTransactionInternal(lock, [&]() {
 		auto statement_binder = Binder::CreateBinder(*this);
+		statement_binder->SetBindingForRunner(!runner_operation.empty());
 		relation_stmt = make_uniq<RelationStatement>(relation, *statement_binder);
 	});
 	return PendingQueryInternal(lock, std::move(relation_stmt), parameters);

--- a/external/duckdb/src/main/client_context.cpp
+++ b/external/duckdb/src/main/client_context.cpp
@@ -508,7 +508,7 @@ shared_ptr<PreparedStatementData> ClientContext::CreatePreparedStatementInternal
 	profiler.StartQuery(query, IsExplainAnalyze(statement.get()), true);
 	profiler.StartPhase(MetricType::PLANNER);
 	Planner logical_planner(*this);
-	logical_planner.binder->SetBindingForRunner(!runner_operation.empty());
+	logical_planner.binder->SetBindingForRunner(!runner_operation.empty(), runner_operation == "SELECT");
 	if (parameters.parameters) {
 		auto &parameter_values = *parameters.parameters;
 		for (auto &value : parameter_values) {
@@ -1559,7 +1559,7 @@ void ClientContext::InternalTryBindRelation(Relation &relation, vector<ColumnDef
 	CheckRunnerTransaction(*this, runner_operation);
 	// bind the expressions
 	auto binder = Binder::CreateBinder(*this);
-	binder->SetBindingForRunner(!runner_operation.empty());
+	binder->SetBindingForRunner(!runner_operation.empty(), runner_operation == "SELECT");
 	auto result = relation.Bind(*binder);
 	D_ASSERT(result.names.size() == result.types.size());
 
@@ -1638,7 +1638,7 @@ unique_ptr<PendingQueryResult> ClientContext::PendingQueryInternal(ClientContext
 	unique_ptr<RelationStatement> relation_stmt;
 	RunFunctionInTransactionInternal(lock, [&]() {
 		auto statement_binder = Binder::CreateBinder(*this);
-		statement_binder->SetBindingForRunner(!runner_operation.empty());
+		statement_binder->SetBindingForRunner(!runner_operation.empty(), runner_operation == "SELECT");
 		relation_stmt = make_uniq<RelationStatement>(relation, *statement_binder);
 	});
 	return PendingQueryInternal(lock, std::move(relation_stmt), parameters);

--- a/external/duckdb/src/main/relation/materialized_relation.cpp
+++ b/external/duckdb/src/main/relation/materialized_relation.cpp
@@ -29,6 +29,8 @@ MaterializedRelation::MaterializedRelation(const shared_ptr<ClientContext> &cont
 
 unique_ptr<QueryNode> MaterializedRelation::GetQueryNode() {
 	auto result = make_uniq<SelectNode>();
+	// Reading a completed command result must not initialize a runner.
+	result->requires_client_context = true;
 	result->select_list.push_back(make_uniq<StarExpression>());
 	result->from_table = GetTableRefForSerialization(*this);
 	return std::move(result);

--- a/external/duckdb/src/main/relation/query_relation.cpp
+++ b/external/duckdb/src/main/relation/query_relation.cpp
@@ -100,6 +100,11 @@ static void CaptureExpressionParameters(unique_ptr<ParsedExpression> &expression
 	});
 }
 
+void QueryRelation::CaptureParameters(unique_ptr<ParsedExpression> &expression,
+                                      const case_insensitive_map_t<BoundParameterData> &parameters) {
+	CaptureExpressionParameters(expression, parameters, nullptr);
+}
+
 static void CaptureQueryParameters(QueryNode &node, const case_insensitive_map_t<BoundParameterData> &parameters,
                                    optional_ptr<UnpackedColumnNameCaptures> name_captures) {
 	unordered_set<const ParsedExpression *> pivot_aggregates;

--- a/external/duckdb/src/main/relation/write_file_relation.cpp
+++ b/external/duckdb/src/main/relation/write_file_relation.cpp
@@ -2,50 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 #include "duckdb/main/relation/write_file_relation.hpp"
-#include "duckdb/main/client_context.hpp"
-#include "duckdb/main/relation/query_relation.hpp"
-#include "duckdb/parser/expression/columnref_expression.hpp"
-#include "duckdb/parser/expression/star_expression.hpp"
-#include "duckdb/parser/query_node/select_node.hpp"
-#include "duckdb/parser/statement/select_statement.hpp"
-#include "duckdb/parser/tableref/basetableref.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/parser/parsed_data/copy_info.hpp"
 #include "duckdb/parser/statement/copy_statement.hpp"
 #include "duckdb/planner/binder.hpp"
-#include "duckdb/planner/bound_parameter_map.hpp"
-#include "duckdb/planner/operator/logical_copy_to_file.hpp"
-
-#include <filesystem>
 
 namespace duckdb {
-
-static BoundStatement ValidateCopyDestination(const shared_ptr<ClientContext> &context, BoundStatement bound) {
-	if (context->vane_runner_type == "local-fast" || bound.plan->type != LogicalOperatorType::LOGICAL_COPY_TO_FILE) {
-		return bound;
-	}
-	auto &path = bound.plan->Cast<LogicalCopyToFile>().file_path;
-	if (FileSystem::IsRemoteFile(path)) {
-		return bound;
-	}
-	auto expanded = FileSystem::GetFileSystem(*context).ExpandPath(path);
-	auto normalized = std::filesystem::path(expanded).lexically_normal().generic_string();
-	bool non_file = normalized == "/dev/stdout" || normalized == "/dev/stderr" || normalized == "/dev/stdin" ||
-	                StringUtil::StartsWith(normalized, "/dev/fd/") ||
-	                StringUtil::StartsWith(normalized, "/proc/self/fd/");
-	std::error_code error;
-	auto status = std::filesystem::status(expanded, error);
-	if (!error && std::filesystem::exists(status)) {
-		non_file |= !std::filesystem::is_regular_file(status) && !std::filesystem::is_directory(status);
-	}
-	if (non_file) {
-		throw NotImplementedException("Runner COPY TO requires a file dataset destination; STDOUT, devices and pipes "
-		                              "are not supported");
-	}
-	return bound;
-}
 
 WriteFileRelation::WriteFileRelation(shared_ptr<Relation> child_p, string file_path_p, string format_p,
                                      case_insensitive_map_t<vector<Value>> options_p)
@@ -57,55 +21,7 @@ WriteFileRelation::WriteFileRelation(shared_ptr<Relation> child_p, string file_p
 	TryBindRelation(columns);
 }
 
-WriteFileRelation::WriteFileRelation(const shared_ptr<ClientContext> &context, unique_ptr<CopyStatement> statement_p,
-                                     case_insensitive_map_t<BoundParameterData> parameters_p)
-    : Relation(context, RelationType::WRITE_FILE_RELATION), statement(std::move(statement_p)),
-      parameters(std::move(parameters_p)) {
-	if (!statement || statement->info->is_from) {
-		throw InvalidInputException("WriteFileRelation requires a COPY TO statement");
-	}
-	auto &info = *statement->info;
-	auto select = make_uniq<SelectStatement>();
-	if (info.select_statement) {
-		select->node = std::move(info.select_statement);
-	} else {
-		auto table = make_uniq<BaseTableRef>();
-		table->catalog_name = info.catalog;
-		table->schema_name = info.schema;
-		table->table_name = info.table;
-		auto node = make_uniq<SelectNode>();
-		node->from_table = std::move(table);
-		for (auto &column : info.select_list) {
-			node->select_list.push_back(make_uniq<ColumnRefExpression>(column));
-		}
-		if (node->select_list.empty()) {
-			node->select_list.push_back(make_uniq<StarExpression>());
-		}
-		select->node = std::move(node);
-	}
-	// Keep replacement scans and their Python dependencies alive across the
-	// initial bind and the runner's later logical-plan extraction.
-	child = make_shared_ptr<QueryRelation>(context, std::move(select), "copy_source", "", parameters);
-	info.select_relation = child;
-	TryBindRelation(columns);
-}
-
-WriteFileRelation::~WriteFileRelation() = default;
-
 BoundStatement WriteFileRelation::Bind(Binder &binder) {
-	if (statement) {
-		BoundParameterMap parameter_map(parameters);
-		struct ParameterScope {
-			Binder &binder;
-			optional_ptr<BoundParameterMap> previous;
-			~ParameterScope() {
-				binder.SetParameters(previous);
-			}
-		} scope {binder, binder.GetParameters()};
-		binder.SetParameters(parameter_map);
-		auto copy = statement->Copy();
-		return ValidateCopyDestination(context->GetContext(), binder.Bind(*copy));
-	}
 	CopyStatement copy;
 	auto info = make_uniq<CopyInfo>();
 	info->select_relation = child;
@@ -115,7 +31,7 @@ BoundStatement WriteFileRelation::Bind(Binder &binder) {
 	info->is_format_auto_detected = false;
 	info->options = options;
 	copy.info = std::move(info);
-	return ValidateCopyDestination(context->GetContext(), binder.Bind(copy.Cast<SQLStatement>()));
+	return binder.Bind(copy.Cast<SQLStatement>());
 }
 
 unique_ptr<QueryNode> WriteFileRelation::GetQueryNode() {
@@ -131,9 +47,6 @@ const vector<ColumnDefinition> &WriteFileRelation::Columns() {
 }
 
 string WriteFileRelation::ToString(idx_t depth) {
-	if (statement) {
-		return RenderWhitespace(depth) + "Write From SQL\n";
-	}
 	string str = RenderWhitespace(depth) + "Write To " + StringUtil::Upper(format) + " [" + file_path + "]\n";
 	return str + child->ToString(depth + 1);
 }

--- a/external/duckdb/src/parser/query_node.cpp
+++ b/external/duckdb/src/parser/query_node.cpp
@@ -168,6 +168,7 @@ bool QueryNode::Equals(const QueryNode *other) const {
 }
 
 void QueryNode::CopyProperties(QueryNode &other) const {
+	other.requires_client_context = requires_client_context;
 	for (auto &modifier : modifiers) {
 		other.modifiers.push_back(modifier->Copy());
 	}

--- a/external/duckdb/src/parser/transform/statement/transform_show.cpp
+++ b/external/duckdb/src/parser/transform/statement/transform_show.cpp
@@ -56,6 +56,9 @@ unique_ptr<QueryNode> Transformer::TransformShow(duckdb_libpgquery::PGVariableSh
 	if (showref->show_type == ShowType::DESCRIBE) {
 		showref->show_type = stmt.is_summary ? ShowType::SUMMARY : ShowType::DESCRIBE;
 	}
+	// Catalog SHOW commands inspect this connection, including inside derived queries.
+	select_node->requires_client_context =
+	    showref->show_type == ShowType::SHOW_FROM || showref->show_type == ShowType::SHOW_UNQUALIFIED;
 	select_node->from_table = std::move(showref);
 	return std::move(select_node);
 }

--- a/external/duckdb/src/planner/binder.cpp
+++ b/external/duckdb/src/planner/binder.cpp
@@ -235,12 +235,14 @@ StatementProperties &Binder::GetStatementProperties() {
 	return global_binder_state->prop;
 }
 
-void Binder::SetBindingForRunner(bool enabled) {
+void Binder::SetBindingForRunner(bool enabled, bool allow_client_queries) {
 	global_binder_state->binding_for_runner = enabled;
+	global_binder_state->allow_client_queries = allow_client_queries;
 }
 
 bool Binder::IsBindingForRunner() const {
-	return global_binder_state->binding_for_runner;
+	return global_binder_state->binding_for_runner &&
+	       !(global_binder_state->allow_client_queries && global_binder_state->prop.requires_client_context);
 }
 
 optional_ptr<BoundParameterMap> Binder::GetParameters() {

--- a/external/duckdb/src/planner/binder.cpp
+++ b/external/duckdb/src/planner/binder.cpp
@@ -235,6 +235,14 @@ StatementProperties &Binder::GetStatementProperties() {
 	return global_binder_state->prop;
 }
 
+void Binder::SetBindingForRunner(bool enabled) {
+	global_binder_state->binding_for_runner = enabled;
+}
+
+bool Binder::IsBindingForRunner() const {
+	return global_binder_state->binding_for_runner;
+}
+
 optional_ptr<BoundParameterMap> Binder::GetParameters() {
 	return global_binder_state->parameters;
 }

--- a/external/duckdb/src/planner/binder/expression/bind_function_expression.cpp
+++ b/external/duckdb/src/planner/binder/expression/bind_function_expression.cpp
@@ -322,6 +322,10 @@ BindResult ExpressionBinder::BindLambdaFunction(FunctionExpression &function, Sc
 	if (!bind_lambda_function) {
 		return BindResult("This scalar function does not support lambdas!");
 	}
+	// Lambda parameter callbacks run before FunctionBinder's normal callbacks.
+	if (binder.IsBindingForRunner() && scalar_function.RequiresClientContext()) {
+		scalar_function.VerifyRunnerExecution();
+	}
 
 	// the first child is the list, the second child is the lambda expression
 	// constexpr idx_t list_ix = 0;

--- a/external/duckdb/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_cte_node.cpp
@@ -16,6 +16,7 @@ struct BoundCTEData {
 };
 
 BoundStatement Binder::BindNode(QueryNode &node) {
+	GetStatementProperties().requires_client_context |= node.requires_client_context;
 	reference<Binder> current_binder(*this);
 	vector<BoundCTEData> bound_ctes;
 	for (auto &cte : node.cte_map.map) {

--- a/external/duckdb/src/planner/binder/query_node/bind_cte_node.cpp
+++ b/external/duckdb/src/planner/binder/query_node/bind_cte_node.cpp
@@ -17,6 +17,12 @@ struct BoundCTEData {
 
 BoundStatement Binder::BindNode(QueryNode &node) {
 	GetStatementProperties().requires_client_context |= node.requires_client_context;
+	// query() and other replacements may reveal catalog query origin only now.
+	// Reads stay native; writes and explicit transports must reject before binding
+	// the client query or evaluating any of its arguments.
+	if (node.requires_client_context && IsBindingForRunner()) {
+		throw NotImplementedException("Runner plans cannot include client connection queries or command results");
+	}
 	reference<Binder> current_binder(*this);
 	vector<BoundCTEData> bound_ctes;
 	for (auto &cte : node.cte_map.map) {

--- a/external/duckdb/src/planner/binder/tableref/bind_table_function.cpp
+++ b/external/duckdb/src/planner/binder/tableref/bind_table_function.cpp
@@ -201,6 +201,14 @@ BoundStatement Binder::BindTableFunctionInternal(TableFunction &table_function, 
 	string ordinality_column_name = ordinality_name;
 	optional_idx ordinality_column_id;
 	if (table_function.bind || table_function.bind_replace || table_function.bind_operator) {
+		// Replacements can perform client-side work and erase the original function
+		// from the plan. Validate their capability before invoking either callback.
+		if (IsBindingForRunner() && table_function.RequiresClientContext() &&
+		    (table_function.bind_replace || table_function.bind_operator)) {
+			throw NotImplementedException("Runner execution does not support client-context table function %s; "
+			                              "use a local-fast connection",
+			                              table_function.name);
+		}
 		TableFunctionBindInput bind_input(parameters, named_parameters, input_table_types, input_table_names,
 		                                  table_function.function_info.get(), this, table_function, ref);
 		if (table_function.bind_operator) {

--- a/external/duckdb/src/planner/expression_binder/table_function_binder.cpp
+++ b/external/duckdb/src/planner/expression_binder/table_function_binder.cpp
@@ -1,6 +1,8 @@
 #include "duckdb/planner/expression_binder/table_function_binder.hpp"
 #include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/table_binding.hpp"
 #include "duckdb/planner/binder.hpp"
 
@@ -89,8 +91,17 @@ BindResult TableFunctionBinder::BindExpression(unique_ptr<ParsedExpression> &exp
 		return BindResult(clause + " cannot contain DEFAULT clause");
 	case ExpressionClass::WINDOW:
 		return BindResult(clause + " cannot contain window functions!");
-	default:
-		return ExpressionBinder::BindExpression(expr_ptr, depth);
+	default: {
+		auto result = ExpressionBinder::BindExpression(expr_ptr, depth);
+		if (!result.HasError() && binder.IsBindingForRunner()) {
+			// Validate each child before its parent can fold it in a bind callback,
+			// and before BindTableFunctionParameters evaluates the complete argument.
+			ExpressionIterator::VisitExpression<BoundFunctionExpression>(
+			    *result.expression,
+			    [](const BoundFunctionExpression &function) { function.function.VerifyRunnerExecution(); });
+		}
+		return result;
+	}
 	}
 }
 

--- a/external/duckdb/src/planner/statement_preprocessor.cpp
+++ b/external/duckdb/src/planner/statement_preprocessor.cpp
@@ -16,6 +16,7 @@
 #include "duckdb/parser/statement/transaction_statement.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/statement/set_statement.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
 #include "duckdb/common/enums/current_transaction_state.hpp"
 
 namespace duckdb {
@@ -116,6 +117,11 @@ vector<unique_ptr<SQLStatement>> StatementPreprocessor::TryReparsePragma(unique_
 		const auto query_to_reparse = bound_info->function.query(context, parameters);
 		Parser parser(context.GetParserOptions());
 		parser.ParseQuery(query_to_reparse);
+		for (auto &expanded : parser.statements) {
+			if (expanded->type == StatementType::SELECT_STATEMENT) {
+				expanded->Cast<SelectStatement>().node->requires_client_context = true;
+			}
+		}
 		return std::move(parser.statements);
 	}
 	vector<unique_ptr<SQLStatement>> res;

--- a/external/duckdb/src/storage/serialization/serialize_query_node.cpp
+++ b/external/duckdb/src/storage/serialization/serialize_query_node.cpp
@@ -13,12 +13,14 @@ void QueryNode::Serialize(Serializer &serializer) const {
 	serializer.WriteProperty<QueryNodeType>(100, "type", type);
 	serializer.WritePropertyWithDefault<vector<unique_ptr<ResultModifier>>>(101, "modifiers", modifiers);
 	serializer.WriteProperty<CommonTableExpressionMap>(102, "cte_map", cte_map);
+	serializer.WritePropertyWithDefault<bool>(103, "requires_client_context", requires_client_context, false);
 }
 
 unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &deserializer) {
 	auto type = deserializer.ReadProperty<QueryNodeType>(100, "type");
 	auto modifiers = deserializer.ReadPropertyWithDefault<vector<unique_ptr<ResultModifier>>>(101, "modifiers");
 	auto cte_map = deserializer.ReadProperty<CommonTableExpressionMap>(102, "cte_map");
+	auto requires_client_context = deserializer.ReadPropertyWithExplicitDefault<bool>(103, "requires_client_context", false);
 	unique_ptr<QueryNode> result;
 	switch (type) {
 	case QueryNodeType::CTE_NODE:
@@ -38,7 +40,9 @@ unique_ptr<QueryNode> QueryNode::Deserialize(Deserializer &deserializer) {
 	}
 	result->modifiers = std::move(modifiers);
 	result->cte_map = std::move(cte_map);
+	result->requires_client_context = requires_client_context;
 	if (type == QueryNodeType::CTE_NODE) {
+		result->Cast<CTENode>().child->requires_client_context |= result->requires_client_context;
 		result = std::move(result->Cast<CTENode>().child);
 	}
 	return result;

--- a/scripts/benchmark_native_media.py
+++ b/scripts/benchmark_native_media.py
@@ -352,7 +352,7 @@ def main() -> None:
                 return relation.fetchone()
             import pyarrow as pa
 
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             if not parts:
                 raise RuntimeError("Ray benchmark aggregate returned no partitions")
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])

--- a/src/vane_py/CMakeLists.txt
+++ b/src/vane_py/CMakeLists.txt
@@ -24,6 +24,7 @@ add_subdirectory(vane-runners)
 add_library(
   python_src OBJECT
   dataframe.cpp
+  bound_plan.cpp
   dynamic_extension.cpp
   vane_python.cpp
   importer.cpp

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -172,17 +172,7 @@ private:
 	}
 
 	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expression, unique_ptr<Expression> *) override {
-		if (expression.function.RequiresClientContext()) {
-			throw NotImplementedException("Runner execution does not support client-context function %s; "
-			                              "use a local-fast connection",
-			                              expression.function.name);
-		}
-		// Write plans can also contain expression-level database modifications,
-		// which are not covered by the write target's distributed protocol.
-		if (expression.function.GetModifiedDatabasesCallback()) {
-			throw NotImplementedException("Runner execution does not support database-modifying expressions such as %s",
-			                              expression.function.name);
-		}
+		expression.function.VerifyRunnerExecution();
 		return nullptr;
 	}
 };
@@ -297,10 +287,18 @@ static void ValidateRunnerCTASMetadata(ClientContext &context, CreateTableInfo &
 
 static unique_ptr<RunnerBoundPlan>
 AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan, PreparedStatementData &prepared,
-                             const case_insensitive_map_t<BoundParameterData> &parameters) {
+                             const case_insensitive_map_t<BoundParameterData> &parameters,
+                             RunnerPlanAdmission admission) {
 	auto &context = planner.context;
-	const auto &runner_type = context.vane_runner_type;
-	if (runner_type == "local-fast" || IsConnectionPlan(*plan)) {
+	const bool transport = admission == RunnerPlanAdmission::TRANSPORT;
+	const auto runner_type = transport ? "ray" : context.vane_runner_type;
+	if (runner_type == "local-fast") {
+		return nullptr;
+	}
+	if (IsConnectionPlan(*plan)) {
+		if (transport) {
+			throw NotImplementedException("Runner transports cannot include client connection operations");
+		}
 		return nullptr;
 	}
 	if (prepared.statement_type == StatementType::CALL_STATEMENT) {
@@ -324,6 +322,10 @@ AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan
 	if (prepared.properties.requires_client_context) {
 		if (write || dynamic_cast<LogicalDataSink *>(plan.get())) {
 			throw NotImplementedException("Runner writes cannot include client connection queries or command results");
+		}
+		if (transport) {
+			throw NotImplementedException(
+			    "Runner transports cannot include client connection queries or command results");
 		}
 		return nullptr;
 	}
@@ -408,9 +410,10 @@ AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan
 
 unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
                                                  PreparedStatementData &prepared,
-                                                 const case_insensitive_map_t<BoundParameterData> &parameters) {
+                                                 const case_insensitive_map_t<BoundParameterData> &parameters,
+                                                 RunnerPlanAdmission admission) {
 	try {
-		return AdmitRunnerBoundPlanInternal(planner, plan, prepared, parameters);
+		return AdmitRunnerBoundPlanInternal(planner, plan, prepared, parameters, admission);
 	} catch (const Exception &exception) {
 		ErrorData error(exception);
 		if (!planner.context.transaction.IsAutoCommit() &&

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -141,6 +141,11 @@ private:
 	}
 
 	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expression, unique_ptr<Expression> *) override {
+		if (expression.function.RequiresClientContext()) {
+			throw NotImplementedException("Runner execution does not support client-context function %s; "
+			                              "use a local-fast connection",
+			                              expression.function.name);
+		}
 		// Write plans can also contain expression-level database modifications,
 		// which are not covered by the write target's distributed protocol.
 		if (expression.function.GetModifiedDatabasesCallback()) {

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -118,8 +118,8 @@ private:
 	}
 
 	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expression, unique_ptr<Expression> *) override {
-		// Dynamic nextval arguments may not identify a database while binding.
-		// Reject the declared effect even when modified_databases is still empty.
+		// Write plans can also contain expression-level database modifications,
+		// which are not covered by the write target's distributed protocol.
 		if (expression.function.GetModifiedDatabasesCallback()) {
 			throw NotImplementedException("Runner execution does not support database-modifying expressions such as %s",
 			                              expression.function.name);

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -3,12 +3,18 @@
 
 #include "vane_python/bound_plan.hpp"
 
+#include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/parser/expression/constant_expression.hpp"
+#include "duckdb/parser/expression/function_expression.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/planner/constraints/bound_check_constraint.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression_binder.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
@@ -181,6 +187,114 @@ private:
 	}
 };
 
+class RunnerCTASMetadataBinder : public ExpressionBinder {
+public:
+	RunnerCTASMetadataBinder(Binder &binder, ClientContext &context) : ExpressionBinder(binder, context) {
+	}
+
+	void ValidateAndCapture(unique_ptr<ParsedExpression> &expression, bool allow_transform) {
+		RejectUnsupportedExpression(*expression);
+		bool transform = false;
+		if (expression->GetExpressionClass() == ExpressionClass::FUNCTION) {
+			auto &function = expression->Cast<FunctionExpression>();
+			EntryLookupInfo scalar_lookup(CatalogType::SCALAR_FUNCTION_ENTRY, function.function_name);
+			auto entry =
+			    GetCatalogEntry(function.catalog, function.schema, scalar_lookup, OnEntryNotFound::RETURN_NULL);
+			if (entry && entry->type == CatalogType::MACRO_ENTRY) {
+				// Validate the entire expansion first, including recursion limits.
+				// Keep its expansion in the payload: the driver has no client macros.
+				auto copy = expression->Copy();
+				auto bound = Bind(copy);
+				ValidateRunnerExpressionEffects().VisitExpression(&bound);
+				auto alias = expression->GetAlias();
+				auto query_location = expression->GetQueryLocation();
+				UnfoldMacroExpression(function, entry->Cast<ScalarMacroCatalogEntry>(), expression, 0);
+				expression->SetAlias(alias);
+				expression->SetQueryLocation(query_location);
+				ValidateAndCapture(expression, false);
+				return;
+			}
+			// Extension partition/sort transforms (for example bucket) are a
+			// catalog-owned declaration, not necessarily registered SQL functions.
+			// Only an unqualified outer transform may use that syntax. Every
+			// argument still goes through ordinary SQL binding and effect checks.
+			if (allow_transform && !entry && function.catalog.empty() && function.schema.empty() &&
+			    !function.children.empty() && !function.distinct && !function.filter &&
+			    function.order_bys->orders.empty() && !IsUnnestFunction(function.function_name)) {
+				EntryLookupInfo table_lookup(CatalogType::TABLE_FUNCTION_ENTRY, function.function_name);
+				transform =
+				    !GetCatalogEntry(INVALID_CATALOG, INVALID_SCHEMA, table_lookup, OnEntryNotFound::RETURN_NULL);
+			}
+		}
+		ParsedExpressionIterator::EnumerateChildren(
+		    *expression, [&](unique_ptr<ParsedExpression> &child) { ValidateAndCapture(child, false); });
+		if (transform) {
+			return;
+		}
+		auto copy = expression->Copy();
+		auto bound = Bind(copy);
+		ValidateRunnerExpressionEffects().VisitExpression(&bound);
+		if (bound->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+			// Binding can capture client values (for example getvariable).
+			// Preserve those constants instead of looking them up on the driver.
+			auto constant = make_uniq<ConstantExpression>(bound->Cast<BoundConstantExpression>().value);
+			constant->SetAlias(expression->GetAlias());
+			constant->SetQueryLocation(expression->GetQueryLocation());
+			expression = std::move(constant);
+		}
+	}
+
+protected:
+	static void RejectUnsupportedExpression(const ParsedExpression &expression) {
+		if (expression.GetExpressionClass() == ExpressionClass::SUBQUERY) {
+			throw NotImplementedException("Runner CTAS metadata does not support subqueries");
+		}
+		if (expression.GetExpressionClass() == ExpressionClass::LAMBDA) {
+			throw NotImplementedException("Runner CTAS metadata does not support lambda expressions");
+		}
+	}
+
+	BindResult BindExpression(unique_ptr<ParsedExpression> &expression, idx_t depth,
+	                          bool root_expression = false) override {
+		RejectUnsupportedExpression(*expression);
+		auto result = ExpressionBinder::BindExpression(expression, depth, root_expression);
+		if (!result.HasError()) {
+			// Validate children as they bind: a parent's bind callback may fold
+			// them away or evaluate a constant argument before the final visit.
+			ValidateRunnerExpressionEffects().VisitExpression(&result.expression);
+		}
+		return result;
+	}
+};
+
+static void ValidateRunnerCTASMetadata(ClientContext &context, CreateTableInfo &info,
+                                       const case_insensitive_map_t<BoundParameterData> &parameters) {
+	if (info.options.empty() && info.partition_keys.empty() && info.sort_keys.empty()) {
+		return;
+	}
+	auto binder = Binder::CreateBinder(context);
+	// These are expression fragments, not SELECT result columns. Preserve
+	// untyped NULLs so capturing one child does not change its parent's overload.
+	binder->SetCanContainNulls(true);
+	RunnerCTASMetadataBinder metadata_binder(*binder, context);
+	for (auto &option : info.options) {
+		QueryRelation::CaptureParameters(option.second, parameters);
+		metadata_binder.ValidateAndCapture(option.second, false);
+	}
+	// Keys refer to the created table's output columns, not the CTAS query's
+	// input bindings (which can have different names or no table at all).
+	binder->bind_context.AddGenericBinding(binder->GenerateTableIndex(), info.table, info.columns.GetColumnNames(),
+	                                       info.columns.GetColumnTypes());
+	for (auto &key : info.partition_keys) {
+		QueryRelation::CaptureParameters(key, parameters);
+		metadata_binder.ValidateAndCapture(key, true);
+	}
+	for (auto &key : info.sort_keys) {
+		QueryRelation::CaptureParameters(key, parameters);
+		metadata_binder.ValidateAndCapture(key, true);
+	}
+}
+
 static unique_ptr<RunnerBoundPlan>
 AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan, PreparedStatementData &prepared,
                              const case_insensitive_map_t<BoundParameterData> &parameters) {
@@ -272,15 +386,7 @@ AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan
 			if (info.temporary || info.on_conflict != OnCreateConflict::ERROR_ON_CONFLICT) {
 				throw NotImplementedException("Runner CTAS does not support TEMPORARY, OR REPLACE or IF NOT EXISTS");
 			}
-			for (auto &option : info.options) {
-				QueryRelation::CaptureParameters(option.second, parameters);
-			}
-			for (auto &key : info.partition_keys) {
-				QueryRelation::CaptureParameters(key, parameters);
-			}
-			for (auto &key : info.sort_keys) {
-				QueryRelation::CaptureParameters(key, parameters);
-			}
+			ValidateRunnerCTASMetadata(context, info, parameters);
 		}
 	}
 	// Resolve remaining bound parameter expressions before transport. Native

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -68,6 +68,7 @@ static bool IsConnectionPlan(LogicalOperator &plan) {
 	case LogicalOperatorType::LOGICAL_PRAGMA:
 	case LogicalOperatorType::LOGICAL_LOAD:
 	case LogicalOperatorType::LOGICAL_UPDATE_EXTENSIONS:
+	case LogicalOperatorType::LOGICAL_VACUUM:
 		return true;
 	default:
 		return false;
@@ -322,8 +323,7 @@ AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan
 		throw NotImplementedException("Runner execution does not support SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE; "
 		                              "use direct SQL with bound parameters or a local-fast connection");
 	}
-	if (plan->type == LogicalOperatorType::LOGICAL_EXPORT || plan->type == LogicalOperatorType::LOGICAL_COPY_DATABASE ||
-	    plan->type == LogicalOperatorType::LOGICAL_VACUUM) {
+	if (plan->type == LogicalOperatorType::LOGICAL_EXPORT || plan->type == LogicalOperatorType::LOGICAL_COPY_DATABASE) {
 		throw NotImplementedException("Runner execution does not support logical operator %s", plan->GetName());
 	}
 	auto kind = RunnerPlanKind::READ;

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -35,6 +35,7 @@ static bool IsConnectionPlan(LogicalOperator &plan) {
 	case LogicalOperatorType::LOGICAL_DETACH:
 	case LogicalOperatorType::LOGICAL_SET:
 	case LogicalOperatorType::LOGICAL_RESET:
+	case LogicalOperatorType::LOGICAL_PRAGMA:
 	case LogicalOperatorType::LOGICAL_LOAD:
 	case LogicalOperatorType::LOGICAL_UPDATE_EXTENSIONS:
 		return true;
@@ -91,13 +92,19 @@ unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<Lo
 	if (runner_type == "local-fast" || IsConnectionPlan(*plan)) {
 		return nullptr;
 	}
+	if (prepared.statement_type == StatementType::CALL_STATEMENT) {
+		// CALL is lowered to a SELECT-like GET, but its function can mutate a
+		// catalog (for example dbgen/checkpoint). No distributed effect contract
+		// exists for these calls, so never admit them as ordinary reads.
+		throw NotImplementedException("Runner execution does not support SQL CALL; use a local-fast connection");
+	}
 	if (plan->type == LogicalOperatorType::LOGICAL_PREPARE || plan->type == LogicalOperatorType::LOGICAL_EXECUTE ||
 	    plan->type == LogicalOperatorType::LOGICAL_EXPLAIN) {
 		throw NotImplementedException("Runner execution does not support SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE; "
 		                              "use direct SQL with bound parameters or a local-fast connection");
 	}
 	if (plan->type == LogicalOperatorType::LOGICAL_EXPORT || plan->type == LogicalOperatorType::LOGICAL_COPY_DATABASE ||
-	    plan->type == LogicalOperatorType::LOGICAL_VACUUM || plan->type == LogicalOperatorType::LOGICAL_PRAGMA) {
+	    plan->type == LogicalOperatorType::LOGICAL_VACUUM) {
 		throw NotImplementedException("Runner execution does not support logical operator %s", plan->GetName());
 	}
 	auto kind = RunnerPlanKind::READ;

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -5,11 +5,15 @@
 
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/operator/logical_data_sink.hpp"
 #include "duckdb/planner/operator/logical_explain.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
+#include "duckdb/planner/operator/logical_merge_into.hpp"
+#include "duckdb/planner/operator/logical_update.hpp"
 
 #include <filesystem>
 
@@ -84,6 +88,46 @@ static void ValidateCopyDestination(ClientContext &context, LogicalCopyToFile &c
 	}
 }
 
+class ValidateRunnerExpressionEffects : public LogicalOperatorVisitor {
+public:
+	void VisitOperator(LogicalOperator &op) override {
+		// This is validation only; avoid the rewriting visitor's projection-map
+		// repair and cover defaults stored outside the usual expression lists.
+		for (auto &child : op.children) {
+			VisitOperator(*child);
+		}
+		VisitOperatorExpressions(op);
+		if (op.type == LogicalOperatorType::LOGICAL_INSERT) {
+			auto &insert = op.Cast<LogicalInsert>();
+			VisitDefaults(insert.bound_defaults);
+			for (auto &row : insert.insert_values) {
+				VisitDefaults(row);
+			}
+		} else if (op.type == LogicalOperatorType::LOGICAL_UPDATE) {
+			VisitDefaults(op.Cast<LogicalUpdate>().bound_defaults);
+		} else if (op.type == LogicalOperatorType::LOGICAL_MERGE_INTO) {
+			VisitDefaults(op.Cast<LogicalMergeInto>().bound_defaults);
+		}
+	}
+
+private:
+	void VisitDefaults(vector<unique_ptr<Expression>> &expressions) {
+		for (auto &expression : expressions) {
+			VisitExpression(&expression);
+		}
+	}
+
+	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expression, unique_ptr<Expression> *) override {
+		// Dynamic nextval arguments may not identify a database while binding.
+		// Reject the declared effect even when modified_databases is still empty.
+		if (expression.function.GetModifiedDatabasesCallback()) {
+			throw NotImplementedException("Runner execution does not support database-modifying expressions such as %s",
+			                              expression.function.name);
+		}
+		return nullptr;
+	}
+};
+
 unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
                                                  PreparedStatementData &prepared,
                                                  const case_insensitive_map_t<BoundParameterData> &parameters) {
@@ -110,6 +154,15 @@ unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<Lo
 	auto kind = RunnerPlanKind::READ;
 	string operation = "SELECT";
 	auto write = FindWrite(*plan);
+	if (prepared.properties.requires_client_context) {
+		if (write || dynamic_cast<LogicalDataSink *>(plan.get())) {
+			throw NotImplementedException("Runner writes cannot include client connection queries or command results");
+		}
+		return nullptr;
+	}
+	if (context.config.query_verification_enabled) {
+		throw NotImplementedException("Native query verification requires a local-fast connection");
+	}
 	if (prepared.statement_type == StatementType::COPY_STATEMENT && write &&
 	    write->type == LogicalOperatorType::LOGICAL_INSERT) {
 		throw NotImplementedException("Runner execution does not support SQL COPY FROM");
@@ -130,6 +183,10 @@ unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<Lo
 		// The local FTE backend only supports terminals; reads use native DuckDB.
 		return nullptr;
 	}
+	if (kind == RunnerPlanKind::READ && !prepared.properties.modified_databases.empty()) {
+		throw NotImplementedException("Runner reads do not support database-modifying expressions");
+	}
+	ValidateRunnerExpressionEffects().VisitOperator(*plan);
 	if (!context.transaction.IsAutoCommit()) {
 		// This is a binding restriction, so rejecting it must not abort the
 		// caller's transaction before any runner has been initialized.

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "vane_python/bound_plan.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/planner/operator/logical_copy_to_file.hpp"
+#include "duckdb/planner/operator/logical_create_table.hpp"
+#include "duckdb/planner/operator/logical_data_sink.hpp"
+#include "duckdb/planner/operator/logical_explain.hpp"
+#include "duckdb/planner/operator/logical_insert.hpp"
+
+#include <filesystem>
+
+namespace duckdb {
+
+static bool IsConnectionPlan(LogicalOperator &plan) {
+	switch (plan.type) {
+	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
+		return plan.children.empty();
+	case LogicalOperatorType::LOGICAL_EXPLAIN:
+		return plan.Cast<LogicalExplain>().explain_type != ExplainType::EXPLAIN_ANALYZE;
+	case LogicalOperatorType::LOGICAL_ALTER:
+	case LogicalOperatorType::LOGICAL_CREATE_INDEX:
+	case LogicalOperatorType::LOGICAL_CREATE_SEQUENCE:
+	case LogicalOperatorType::LOGICAL_CREATE_VIEW:
+	case LogicalOperatorType::LOGICAL_CREATE_SCHEMA:
+	case LogicalOperatorType::LOGICAL_CREATE_MACRO:
+	case LogicalOperatorType::LOGICAL_CREATE_TYPE:
+	case LogicalOperatorType::LOGICAL_CREATE_SECRET:
+	case LogicalOperatorType::LOGICAL_DROP:
+	case LogicalOperatorType::LOGICAL_TRANSACTION:
+	case LogicalOperatorType::LOGICAL_ATTACH:
+	case LogicalOperatorType::LOGICAL_DETACH:
+	case LogicalOperatorType::LOGICAL_SET:
+	case LogicalOperatorType::LOGICAL_RESET:
+	case LogicalOperatorType::LOGICAL_LOAD:
+	case LogicalOperatorType::LOGICAL_UPDATE_EXTENSIONS:
+		return true;
+	default:
+		return false;
+	}
+}
+
+static LogicalOperator *FindWrite(LogicalOperator &plan) {
+	switch (plan.type) {
+	case LogicalOperatorType::LOGICAL_COPY_TO_FILE:
+	case LogicalOperatorType::LOGICAL_INSERT:
+	case LogicalOperatorType::LOGICAL_UPDATE:
+	case LogicalOperatorType::LOGICAL_DELETE:
+	case LogicalOperatorType::LOGICAL_MERGE_INTO:
+	case LogicalOperatorType::LOGICAL_CREATE_TABLE:
+		return &plan;
+	default:
+		break;
+	}
+	for (auto &child : plan.children) {
+		if (auto write = FindWrite(*child)) {
+			return write;
+		}
+	}
+	return nullptr;
+}
+
+static void ValidateCopyDestination(ClientContext &context, LogicalCopyToFile &copy) {
+	if (FileSystem::IsRemoteFile(copy.file_path)) {
+		return;
+	}
+	auto expanded = FileSystem::GetFileSystem(context).ExpandPath(copy.file_path);
+	auto normalized = std::filesystem::path(expanded).lexically_normal().generic_string();
+	bool non_file = normalized == "/dev/stdout" || normalized == "/dev/stderr" || normalized == "/dev/stdin" ||
+	                StringUtil::StartsWith(normalized, "/dev/fd/") ||
+	                StringUtil::StartsWith(normalized, "/proc/self/fd/");
+	std::error_code error;
+	auto status = std::filesystem::status(expanded, error);
+	if (!error && std::filesystem::exists(status)) {
+		non_file |= !std::filesystem::is_regular_file(status) && !std::filesystem::is_directory(status);
+	}
+	if (non_file) {
+		throw NotImplementedException("Runner COPY TO requires a file dataset destination; STDOUT, devices and pipes "
+		                              "are not supported");
+	}
+}
+
+unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
+                                                 PreparedStatementData &prepared,
+                                                 const case_insensitive_map_t<BoundParameterData> &parameters) {
+	auto &context = planner.context;
+	const auto &runner_type = context.vane_runner_type;
+	if (runner_type == "local-fast" || IsConnectionPlan(*plan)) {
+		return nullptr;
+	}
+	if (plan->type == LogicalOperatorType::LOGICAL_PREPARE || plan->type == LogicalOperatorType::LOGICAL_EXECUTE ||
+	    plan->type == LogicalOperatorType::LOGICAL_EXPLAIN) {
+		throw NotImplementedException("Runner execution does not support SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE; "
+		                              "use direct SQL with bound parameters or a local-fast connection");
+	}
+	if (plan->type == LogicalOperatorType::LOGICAL_EXPORT || plan->type == LogicalOperatorType::LOGICAL_COPY_DATABASE ||
+	    plan->type == LogicalOperatorType::LOGICAL_VACUUM || plan->type == LogicalOperatorType::LOGICAL_PRAGMA) {
+		throw NotImplementedException("Runner execution does not support logical operator %s", plan->GetName());
+	}
+	auto kind = RunnerPlanKind::READ;
+	string operation = "SELECT";
+	auto write = FindWrite(*plan);
+	if (prepared.statement_type == StatementType::COPY_STATEMENT && write &&
+	    write->type == LogicalOperatorType::LOGICAL_INSERT) {
+		throw NotImplementedException("Runner execution does not support SQL COPY FROM");
+	}
+	if (dynamic_cast<LogicalDataSink *>(plan.get())) {
+		kind = RunnerPlanKind::DATA_SINK;
+		operation = "DataSink";
+	} else if (write) {
+		kind = write->type == LogicalOperatorType::LOGICAL_COPY_TO_FILE ? RunnerPlanKind::COPY
+		                                                                : RunnerPlanKind::TABLE_WRITE;
+		operation = kind == RunnerPlanKind::COPY                               ? "COPY TO"
+		            : write->type == LogicalOperatorType::LOGICAL_CREATE_TABLE ? "CTAS"
+		                                                                       : write->GetName();
+		if (kind == RunnerPlanKind::TABLE_WRITE && runner_type != "ray") {
+			throw InvalidInputException("%s requires a ray or local-fast connection", operation);
+		}
+	} else if (runner_type == "local") {
+		// The local FTE backend only supports terminals; reads use native DuckDB.
+		return nullptr;
+	}
+	if (!context.transaction.IsAutoCommit()) {
+		throw InvalidInputException("Runner %s requires DuckDB auto-commit mode and cannot participate "
+		                            "in an explicit transaction",
+		                            operation);
+	}
+	if (write) {
+		if (prepared.properties.return_type != StatementReturnType::CHANGED_ROWS ||
+		    prepared.types != vector<LogicalType> {LogicalType::BIGINT} || prepared.names != vector<string> {"Count"}) {
+			throw NotImplementedException("Runner writes only support the default Count result; RETURNING, "
+			                              "RETURN_FILES and RETURN_STATS are not supported");
+		}
+		if (write->type == LogicalOperatorType::LOGICAL_COPY_TO_FILE) {
+			ValidateCopyDestination(context, write->Cast<LogicalCopyToFile>());
+		}
+		if (write->type == LogicalOperatorType::LOGICAL_INSERT &&
+		    write->Cast<LogicalInsert>().on_conflict_info.action_type != OnConflictAction::THROW) {
+			throw NotImplementedException("Runner INSERT does not support ON CONFLICT");
+		}
+		if (write->type == LogicalOperatorType::LOGICAL_CREATE_TABLE) {
+			auto &info = write->Cast<LogicalCreateTable>().info->Base();
+			if (info.temporary || info.on_conflict != OnCreateConflict::ERROR_ON_CONFLICT) {
+				throw NotImplementedException("Runner CTAS does not support TEMPORARY, OR REPLACE or IF NOT EXISTS");
+			}
+			for (auto &option : info.options) {
+				QueryRelation::CaptureParameters(option.second, parameters);
+			}
+			for (auto &key : info.partition_keys) {
+				QueryRelation::CaptureParameters(key, parameters);
+			}
+			for (auto &key : info.sort_keys) {
+				QueryRelation::CaptureParameters(key, parameters);
+			}
+		}
+	}
+	// Resolve remaining bound parameter expressions before transport. Native
+	// execution performs the same assignment when admitting its prepared statement.
+	prepared.Bind(parameters);
+	auto result = make_uniq<RunnerBoundPlan>();
+	result->context = context.shared_from_this();
+	result->binder = planner.binder;
+	result->names = prepared.names;
+	result->types = prepared.types;
+	result->properties = prepared.properties;
+	result->statement_type = prepared.statement_type;
+	result->query_number = context.transaction.GetActiveQuery();
+	result->kind = kind;
+	result->operation = std::move(operation);
+	result->plan = std::move(plan);
+	return result;
+}
+
+shared_ptr<DuckDBPyResult> RunnerExecutionResult::TakeResult() {
+	if (native_result) {
+		return make_shared_ptr<DuckDBPyResult>(std::move(native_result));
+	}
+	return std::move(distributed_result);
+}
+
+} // namespace duckdb

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/parser/statement/explain_statement.hpp"
 #include "duckdb/planner/constraints/bound_check_constraint.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
@@ -13,6 +14,7 @@
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/operator/logical_data_sink.hpp"
 #include "duckdb/planner/operator/logical_explain.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
 #include "duckdb/planner/operator/logical_merge_into.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
@@ -20,6 +22,21 @@
 #include <filesystem>
 
 namespace duckdb {
+
+void ValidateRunnerStatement(SQLStatement &statement) {
+	if (statement.type == StatementType::CALL_STATEMENT) {
+		throw NotImplementedException("Runner execution does not support SQL CALL; use a local-fast connection");
+	}
+	if (statement.type == StatementType::PREPARE_STATEMENT || statement.type == StatementType::EXECUTE_STATEMENT ||
+	    (statement.type == StatementType::EXPLAIN_STATEMENT &&
+	     statement.Cast<ExplainStatement>().explain_type == ExplainType::EXPLAIN_ANALYZE)) {
+		throw NotImplementedException("Runner execution does not support SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE; "
+		                              "use direct SQL with bound parameters or a local-fast connection");
+	}
+	if (statement.type == StatementType::EXPLAIN_STATEMENT) {
+		ValidateRunnerStatement(*statement.Cast<ExplainStatement>().stmt);
+	}
+}
 
 static bool IsConnectionPlan(LogicalOperator &plan) {
 	switch (plan.type) {
@@ -93,6 +110,14 @@ static void ValidateCopyDestination(ClientContext &context, LogicalCopyToFile &c
 class ValidateRunnerExpressionEffects : public LogicalOperatorVisitor {
 public:
 	void VisitOperator(LogicalOperator &op) override {
+		if (op.type == LogicalOperatorType::LOGICAL_GET) {
+			auto &function = op.Cast<LogicalGet>().function;
+			if (function.RequiresClientContext()) {
+				throw NotImplementedException("Runner execution does not support client-context table function %s; "
+				                              "use a local-fast connection",
+				                              function.name);
+			}
+		}
 		// This is validation only; avoid the rewriting visitor's projection-map
 		// repair and cover defaults and constraints outside the usual expression lists.
 		for (auto &child : op.children) {
@@ -156,9 +181,9 @@ private:
 	}
 };
 
-unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
-                                                 PreparedStatementData &prepared,
-                                                 const case_insensitive_map_t<BoundParameterData> &parameters) {
+static unique_ptr<RunnerBoundPlan>
+AdmitRunnerBoundPlanInternal(Planner &planner, unique_ptr<LogicalOperator> &plan, PreparedStatementData &prepared,
+                             const case_insensitive_map_t<BoundParameterData> &parameters) {
 	auto &context = planner.context;
 	const auto &runner_type = context.vane_runner_type;
 	if (runner_type == "local-fast" || IsConnectionPlan(*plan)) {
@@ -273,6 +298,23 @@ unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<Lo
 	result->operation = std::move(operation);
 	result->plan = std::move(plan);
 	return result;
+}
+
+unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
+                                                 PreparedStatementData &prepared,
+                                                 const case_insensitive_map_t<BoundParameterData> &parameters) {
+	try {
+		return AdmitRunnerBoundPlanInternal(planner, plan, prepared, parameters);
+	} catch (const Exception &exception) {
+		ErrorData error(exception);
+		if (!planner.context.transaction.IsAutoCommit() &&
+		    (error.Type() == ExceptionType::NOT_IMPLEMENTED || error.Type() == ExceptionType::INVALID_INPUT)) {
+			// Capability rejection is a binding restriction, not an execution
+			// failure. Preserve existing transactional work for the caller.
+			throw BinderException(error.RawMessage());
+		}
+		throw;
+	}
 }
 
 shared_ptr<DuckDBPyResult> RunnerExecutionResult::TakeResult() {

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -270,6 +270,9 @@ static void ValidateRunnerCTASMetadata(ClientContext &context, CreateTableInfo &
 		return;
 	}
 	auto binder = Binder::CreateBinder(context);
+	// Metadata binds independently of the query, but its callbacks must obey
+	// the same runner policy before they can evaluate or change client state.
+	binder->SetBindingForRunner(true);
 	// These are expression fragments, not SELECT result columns. Preserve
 	// untyped NULLs so capturing one child does not change its parent's overload.
 	binder->SetCanContainNulls(true);

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/function/lambda_functions.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
@@ -173,6 +174,12 @@ private:
 
 	unique_ptr<Expression> VisitReplace(BoundFunctionExpression &expression, unique_ptr<Expression> *) override {
 		expression.function.VerifyRunnerExecution();
+		// Bound list functions store their executable lambda body in bind data,
+		// outside the ordinary children visited by LogicalOperatorVisitor.
+		auto lambda = dynamic_cast<ListLambdaBindData *>(expression.bind_info.get());
+		if (lambda && lambda->lambda_expr) {
+			VisitExpression(&lambda->lambda_expr);
+		}
 		return nullptr;
 	}
 };

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -3,8 +3,10 @@
 
 #include "vane_python/bound_plan.hpp"
 
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
+#include "duckdb/planner/constraints/bound_check_constraint.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/logical_operator_visitor.hpp"
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
@@ -92,25 +94,46 @@ class ValidateRunnerExpressionEffects : public LogicalOperatorVisitor {
 public:
 	void VisitOperator(LogicalOperator &op) override {
 		// This is validation only; avoid the rewriting visitor's projection-map
-		// repair and cover defaults stored outside the usual expression lists.
+		// repair and cover defaults and constraints outside the usual expression lists.
 		for (auto &child : op.children) {
 			VisitOperator(*child);
 		}
 		VisitOperatorExpressions(op);
 		if (op.type == LogicalOperatorType::LOGICAL_INSERT) {
 			auto &insert = op.Cast<LogicalInsert>();
-			VisitDefaults(insert.bound_defaults);
+			VisitWriteExpressions(insert.table, insert.bound_defaults, insert.bound_constraints);
 			for (auto &row : insert.insert_values) {
 				VisitDefaults(row);
 			}
 		} else if (op.type == LogicalOperatorType::LOGICAL_UPDATE) {
-			VisitDefaults(op.Cast<LogicalUpdate>().bound_defaults);
+			auto &update = op.Cast<LogicalUpdate>();
+			VisitWriteExpressions(update.table, update.bound_defaults, update.bound_constraints);
 		} else if (op.type == LogicalOperatorType::LOGICAL_MERGE_INTO) {
-			VisitDefaults(op.Cast<LogicalMergeInto>().bound_defaults);
+			auto &merge = op.Cast<LogicalMergeInto>();
+			VisitWriteExpressions(merge.table, merge.bound_defaults, merge.bound_constraints);
 		}
 	}
 
 private:
+	void VisitWriteExpressions(TableCatalogEntry &table, vector<unique_ptr<Expression>> &defaults,
+	                           vector<unique_ptr<BoundConstraint>> &constraints) {
+		// Generated columns are rebound and evaluated by append verification,
+		// outside the bound write plan. They need an explicit effect contract.
+		if (table.HasGeneratedColumns()) {
+			throw NotImplementedException("Runner writes do not support generated target columns");
+		}
+		VisitDefaults(defaults);
+		VisitConstraints(constraints);
+	}
+
+	void VisitConstraints(vector<unique_ptr<BoundConstraint>> &constraints) {
+		for (auto &constraint : constraints) {
+			if (constraint->type == ConstraintType::CHECK) {
+				VisitExpression(&constraint->Cast<BoundCheckConstraint>().expression);
+			}
+		}
+	}
+
 	void VisitDefaults(vector<unique_ptr<Expression>> &expressions) {
 		for (auto &expression : expressions) {
 			VisitExpression(&expression);

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -124,21 +124,30 @@ unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<Lo
 		return nullptr;
 	}
 	if (!context.transaction.IsAutoCommit()) {
-		throw InvalidInputException("Runner %s requires DuckDB auto-commit mode and cannot participate "
-		                            "in an explicit transaction",
-		                            operation);
+		// This is a binding restriction, so rejecting it must not abort the
+		// caller's transaction before any runner has been initialized.
+		throw BinderException("Runner %s requires DuckDB auto-commit mode and cannot participate "
+		                      "in an explicit transaction",
+		                      operation);
 	}
 	if (write) {
-		if (prepared.properties.return_type != StatementReturnType::CHANGED_ROWS ||
-		    prepared.types != vector<LogicalType> {LogicalType::BIGINT} || prepared.names != vector<string> {"Count"}) {
+		// DuckDB marks CTAS as NOTHING even though its result is a Count row.
+		bool count_result = prepared.properties.return_type == StatementReturnType::CHANGED_ROWS ||
+		                    (write->type == LogicalOperatorType::LOGICAL_CREATE_TABLE &&
+		                     prepared.properties.return_type == StatementReturnType::NOTHING);
+		if (!count_result || prepared.types != vector<LogicalType> {LogicalType::BIGINT} ||
+		    prepared.names != vector<string> {"Count"}) {
 			throw NotImplementedException("Runner writes only support the default Count result; RETURNING, "
 			                              "RETURN_FILES and RETURN_STATS are not supported");
 		}
 		if (write->type == LogicalOperatorType::LOGICAL_COPY_TO_FILE) {
 			ValidateCopyDestination(context, write->Cast<LogicalCopyToFile>());
 		}
-		if (write->type == LogicalOperatorType::LOGICAL_INSERT &&
-		    write->Cast<LogicalInsert>().on_conflict_info.action_type != OnConflictAction::THROW) {
+		// The SQL binder rewrites INSERT conflict handling into MERGE INTO.
+		if ((prepared.statement_type == StatementType::INSERT_STATEMENT &&
+		     write->type == LogicalOperatorType::LOGICAL_MERGE_INTO) ||
+		    (write->type == LogicalOperatorType::LOGICAL_INSERT &&
+		     write->Cast<LogicalInsert>().on_conflict_info.action_type != OnConflictAction::THROW)) {
 			throw NotImplementedException("Runner INSERT does not support ON CONFLICT");
 		}
 		if (write->type == LogicalOperatorType::LOGICAL_CREATE_TABLE) {

--- a/src/vane_py/bound_plan.cpp
+++ b/src/vane_py/bound_plan.cpp
@@ -3,6 +3,7 @@
 
 #include "vane_python/bound_plan.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_macro_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -20,6 +21,7 @@
 #include "duckdb/planner/operator/logical_copy_to_file.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/operator/logical_data_sink.hpp"
+#include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/planner/operator/logical_explain.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
@@ -119,7 +121,11 @@ class ValidateRunnerExpressionEffects : public LogicalOperatorVisitor {
 public:
 	void VisitOperator(LogicalOperator &op) override {
 		if (op.type == LogicalOperatorType::LOGICAL_GET) {
-			auto &function = op.Cast<LogicalGet>().function;
+			auto &get = op.Cast<LogicalGet>();
+			if (auto table = get.GetTable()) {
+				ValidateTable(*table);
+			}
+			auto &function = get.function;
 			if (function.RequiresClientContext()) {
 				throw NotImplementedException("Runner execution does not support client-context table function %s; "
 				                              "use a local-fast connection",
@@ -144,12 +150,21 @@ public:
 		} else if (op.type == LogicalOperatorType::LOGICAL_MERGE_INTO) {
 			auto &merge = op.Cast<LogicalMergeInto>();
 			VisitWriteExpressions(merge.table, merge.bound_defaults, merge.bound_constraints);
+		} else if (op.type == LogicalOperatorType::LOGICAL_DELETE) {
+			ValidateTable(op.Cast<LogicalDelete>().table);
 		}
 	}
 
 private:
+	static void ValidateTable(const TableCatalogEntry &table) {
+		if (table.temporary || table.catalog.IsTemporaryCatalog()) {
+			throw NotImplementedException("Runner plans cannot read or write temporary table %s", table.name);
+		}
+	}
+
 	void VisitWriteExpressions(TableCatalogEntry &table, vector<unique_ptr<Expression>> &defaults,
 	                           vector<unique_ptr<BoundConstraint>> &constraints) {
+		ValidateTable(table);
 		// Generated columns are rebound and evaluated by append verification,
 		// outside the bound write plan. They need an explicit effect contract.
 		if (table.HasGeneratedColumns()) {

--- a/src/vane_py/include/vane_python/bound_plan.hpp
+++ b/src/vane_py/include/vane_python/bound_plan.hpp
@@ -12,6 +12,7 @@
 namespace duckdb {
 
 enum class RunnerPlanKind : uint8_t { READ, COPY, TABLE_WRITE, DATA_SINK };
+enum class RunnerPlanAdmission : uint8_t { CONNECTION, TRANSPORT };
 
 //! The executor owns the bound tree and its statement semantics together.
 //! A runner only receives the serialized transport produced from this object.
@@ -31,10 +32,12 @@ struct RunnerBoundPlan {
 //! Reject unsupported SQL wrappers before binding can evaluate their arguments.
 void ValidateRunnerStatement(SQLStatement &statement);
 
-//! Return nullptr for native execution; otherwise take the already-bound tree.
+//! Connection admission may return nullptr for native execution. Explicit
+//! transports must pass runner validation independently of the source runner.
 unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
                                                  PreparedStatementData &prepared,
-                                                 const case_insensitive_map_t<BoundParameterData> &parameters);
+                                                 const case_insensitive_map_t<BoundParameterData> &parameters,
+                                                 RunnerPlanAdmission admission = RunnerPlanAdmission::CONNECTION);
 
 //! Serialize without binding, choosing a runner, or starting query execution.
 py::object SerializeRunnerBoundPlan(RunnerBoundPlan &plan, const py::object &connection_owner);

--- a/src/vane_py/include/vane_python/bound_plan.hpp
+++ b/src/vane_py/include/vane_python/bound_plan.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Vane contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/prepared_statement_data.hpp"
+#include "duckdb/planner/planner.hpp"
+#include "vane_python/pybind11/pybind_wrapper.hpp"
+#include "vane_python/pyresult.hpp"
+
+namespace duckdb {
+
+enum class RunnerPlanKind : uint8_t { READ, COPY, TABLE_WRITE, DATA_SINK };
+
+//! The executor owns the bound tree and its statement semantics together.
+//! A runner only receives the serialized transport produced from this object.
+struct RunnerBoundPlan {
+	shared_ptr<ClientContext> context;
+	shared_ptr<Binder> binder;
+	unique_ptr<LogicalOperator> plan;
+	vector<string> names;
+	vector<LogicalType> types;
+	StatementProperties properties;
+	StatementType statement_type = StatementType::INVALID_STATEMENT;
+	idx_t query_number = 0;
+	RunnerPlanKind kind = RunnerPlanKind::READ;
+	string operation;
+};
+
+//! Return nullptr for native execution; otherwise take the already-bound tree.
+unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
+                                                 PreparedStatementData &prepared,
+                                                 const case_insensitive_map_t<BoundParameterData> &parameters);
+
+//! Serialize without binding, choosing a runner, or starting query execution.
+py::object SerializeRunnerBoundPlan(RunnerBoundPlan &plan, const py::object &connection_owner);
+
+struct RunnerExecutionResult {
+	unique_ptr<QueryResult> native_result;
+	shared_ptr<DuckDBPyResult> distributed_result;
+	py::object write_outcome = py::none();
+	StatementReturnType return_type = StatementReturnType::NOTHING;
+
+	shared_ptr<DuckDBPyResult> TakeResult();
+};
+
+//! Both SQL statements and Relation terminals enter here. Exactly one input is set.
+RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context, unique_ptr<SQLStatement> statement,
+                                        const shared_ptr<Relation> &relation,
+                                        case_insensitive_map_t<BoundParameterData> parameters,
+                                        const py::object &connection_owner, const py::object &interrupt_check,
+                                        bool stream_result = false, vector<string> *cleanup_warnings = nullptr);
+
+} // namespace duckdb

--- a/src/vane_py/include/vane_python/bound_plan.hpp
+++ b/src/vane_py/include/vane_python/bound_plan.hpp
@@ -28,6 +28,9 @@ struct RunnerBoundPlan {
 	string operation;
 };
 
+//! Reject unsupported SQL wrappers before binding can evaluate their arguments.
+void ValidateRunnerStatement(SQLStatement &statement);
+
 //! Return nullptr for native execution; otherwise take the already-bound tree.
 unique_ptr<RunnerBoundPlan> AdmitRunnerBoundPlan(Planner &planner, unique_ptr<LogicalOperator> &plan,
                                                  PreparedStatementData &prepared,
@@ -50,6 +53,7 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
                                         const shared_ptr<Relation> &relation,
                                         case_insensitive_map_t<BoundParameterData> parameters,
                                         const py::object &connection_owner, const py::object &interrupt_check,
-                                        bool stream_result = false, vector<string> *cleanup_warnings = nullptr);
+                                        bool stream_result = false, vector<string> *cleanup_warnings = nullptr,
+                                        optional_ptr<unique_ptr<PreparedStatement>> native_prepared_cache = nullptr);
 
 } // namespace duckdb

--- a/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
+++ b/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
@@ -33,6 +33,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 
 #include <atomic>
+#include <mutex>
 
 namespace duckdb {
 struct BoundParameterData;
@@ -192,7 +193,8 @@ private:
 public:
 	ConnectionGuard con;
 	Cursors cursors;
-	std::mutex py_connection_lock;
+	//! Runner initialization may reenter this connection on its owning thread.
+	std::recursive_mutex py_connection_lock;
 	string connection_database = ":memory:";
 	bool connection_read_only = false;
 	py::dict connection_config = py::dict();

--- a/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
+++ b/src/vane_py/include/vane_python/pyconnection/pyconnection.hpp
@@ -293,10 +293,6 @@ public:
 
 	void ExecuteImmediately(vector<unique_ptr<SQLStatement>> statements);
 	void ExecutePrecedingStatements(vector<unique_ptr<SQLStatement>> statements, const py::object &interrupt_check);
-	unique_ptr<PreparedStatement> PrepareQuery(unique_ptr<SQLStatement> statement);
-	unique_ptr<QueryResult> ExecuteInternal(PreparedStatement &prep, py::object params = py::list());
-	unique_ptr<QueryResult> PrepareAndExecuteInternal(unique_ptr<SQLStatement> statement,
-	                                                  py::object params = py::list());
 
 	shared_ptr<DuckDBPyConnection> Execute(const py::object &query, py::object params = py::list());
 	shared_ptr<DuckDBPyConnection> ExecuteFromString(const string &query);

--- a/src/vane_py/include/vane_python/pyrelation.hpp
+++ b/src/vane_py/include/vane_python/pyrelation.hpp
@@ -314,7 +314,6 @@ public:
 	py::object GetConnectionOwnerReference() const;
 	string GetRunnerType() const;
 	shared_ptr<DuckDBPyResult> ExecuteForConnection(const py::object &interrupt_check);
-	shared_ptr<DuckDBPyResult> ExecuteCopyForConnection(const py::object &interrupt_check);
 	unique_ptr<DuckDBPyRelation> DeriveRelation(shared_ptr<Relation> new_rel);
 	unique_ptr<DuckDBPyRelation> DeriveRelation(shared_ptr<DuckDBPyResult> result);
 
@@ -337,8 +336,7 @@ private:
 	void AssertResult() const;
 	void AssertResultOpen() const;
 	void AssertRelation() const;
-	void ExecuteOrThrow(bool stream_result = false, const string &runner_type = "",
-	                    const py::object &interrupt_check = py::object());
+	void ExecuteOrThrow(bool stream_result = false, const py::object &interrupt_check = py::object());
 	unique_ptr<QueryResult> ExecuteInternal(bool stream_result = false);
 
 private:

--- a/src/vane_py/native/file.cpp
+++ b/src/vane_py/native/file.cpp
@@ -306,7 +306,7 @@ static py::object ExecuteFileScalar(const PythonFile &file, shared_ptr<DuckDBPyC
 	{
 		D_ASSERT(py::gil_check());
 		py::gil_scoped_release release;
-		unique_lock<mutex> lock(connection->py_connection_lock);
+		unique_lock<std::recursive_mutex> lock(connection->py_connection_lock);
 		auto &native_connection = connection->con.GetConnection();
 		auto pending = native_connection.PendingQuery(query, parameters);
 		if (pending->HasError()) {

--- a/src/vane_py/native/file_reader.cpp
+++ b/src/vane_py/native/file_reader.cpp
@@ -122,7 +122,7 @@ shared_ptr<PythonFileReaderHandle> PythonFileReaderHandle::Open(const PythonFile
 	{
 		D_ASSERT(py::gil_check());
 		py::gil_scoped_release release;
-		unique_lock<mutex> connection_guard(connection->py_connection_lock);
+		unique_lock<std::recursive_mutex> connection_guard(connection->py_connection_lock);
 		RunReaderContextOperation(*context, *connection, interrupt_generation,
 		                          [&](ReaderContextScope &) { resolved = ResolvedFile::Open(*context, reference); });
 	}
@@ -263,7 +263,7 @@ py::bytes PythonFileReaderHandle::ReadInternal(int64_t size, bool check_retained
 					}
 				};
 				if (connection) {
-					unique_lock<mutex> connection_guard(connection->py_connection_lock);
+					unique_lock<std::recursive_mutex> connection_guard(connection->py_connection_lock);
 					RunReaderContextOperation(*context, *connection, operation_generation,
 					                          [&](ReaderContextScope &) { read(); });
 				} else {
@@ -355,7 +355,7 @@ void PythonFileReaderHandle::CheckInterrupted() {
 	auto datasource_context_guard = LockDataSourceContext();
 	RequireOpen();
 	if (connection) {
-		unique_lock<mutex> connection_guard(connection->py_connection_lock);
+		unique_lock<std::recursive_mutex> connection_guard(connection->py_connection_lock);
 		ReaderContextScope(*context, *connection, interrupt_generation).CheckInterrupted();
 	} else if (context->IsInterrupted()) {
 		throw InterruptException();
@@ -370,7 +370,7 @@ py::bytes PythonFileReaderHandle::SourceIdentity() {
 		auto datasource_context_guard = LockDataSourceContext();
 		RequireOpen();
 		if (connection) {
-			unique_lock<mutex> connection_guard(connection->py_connection_lock);
+			unique_lock<std::recursive_mutex> connection_guard(connection->py_connection_lock);
 			RunReaderContextOperation(*context, *connection, interrupt_generation,
 			                          [&](ReaderContextScope &) { result = resolved->SourceIdentity(); });
 		} else {
@@ -399,7 +399,7 @@ py::object PythonFileReaderHandle::GuessMimeType() {
 		auto datasource_context_guard = LockDataSourceContext();
 		RequireOpen();
 		if (connection) {
-			unique_lock<mutex> connection_guard(connection->py_connection_lock);
+			unique_lock<std::recursive_mutex> connection_guard(connection->py_connection_lock);
 			RunReaderContextOperation(*context, *connection, interrupt_generation,
 			                          [&](ReaderContextScope &) { found = resolved->GuessMimeType(result); });
 		} else {

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -2364,7 +2364,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 		shared_ptr<Relation> relation;
 		try {
 			py::gil_scoped_release release;
-			unique_lock<mutex> lock(py_connection_lock);
+			unique_lock<std::recursive_mutex> lock(py_connection_lock);
 			auto select = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(statement));
 			relation = make_shared_ptr<QueryRelation>(context, std::move(select), alias, "", std::move(parameters));
 		} catch (const Exception &exception) {
@@ -3243,7 +3243,7 @@ static shared_ptr<DuckDBPyConnection> FetchOrCreateInstance(const string &databa
 	{
 		D_ASSERT(py::gil_check());
 		py::gil_scoped_release release;
-		unique_lock<mutex> lock(res->py_connection_lock);
+		unique_lock<std::recursive_mutex> lock(res->py_connection_lock);
 		auto database =
 		    instance_cache.GetOrCreateInstance(database_path, config, cache_instance, InstantiateNewInstance);
 		res->con.SetDatabase(std::move(database));

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -2655,18 +2655,43 @@ int DuckDBPyConnection::GetRowcount() {
 }
 
 void DuckDBPyConnection::Close() {
-	con.SetResult(nullptr);
 	D_ASSERT(py::gil_check());
-	{
+	case_insensitive_map_t<unique_ptr<ExternalDependency>> closing_functions;
+	try {
+		{
+			unique_lock<std::recursive_mutex> lock;
+			{
+				py::gil_scoped_release release;
+				lock = unique_lock<std::recursive_mutex>(py_connection_lock);
+			}
+			con.SetResult(nullptr);
+			{
+				py::gil_scoped_release release;
+				con.SetConnection(nullptr);
+				con.SetDatabase(nullptr);
+				registered_function_catalog_types.clear();
+			}
+			// Children retain their session references until their own close completes.
+			ReleaseVaneSession();
+			// Keep registered callables alive while children finish, including when
+			// a child's initializer reenters Close on this parent.
+			closing_functions.swap(registered_functions);
+		}
+		// Child connections acquire their own execution locks. Do not hold this
+		// connection's lock while waiting for a child's initializer to finish.
 		py::gil_scoped_release release;
-		con.SetConnection(nullptr);
-		con.SetDatabase(nullptr);
 		// https://peps.python.org/pep-0249/#Connection.close
 		cursors.ClearCursors();
-		registered_functions.clear();
-		registered_function_catalog_types.clear();
+		closing_functions.clear();
+	} catch (...) {
+		// A later Close must retain the dependencies of children still awaiting cleanup.
+		py::gil_scoped_release release;
+		unique_lock<std::recursive_mutex> lock(py_connection_lock);
+		for (auto &entry : closing_functions) {
+			registered_functions.emplace(entry.first, std::move(entry.second));
+		}
+		throw;
 	}
-	ReleaseVaneSession();
 }
 
 void DuckDBPyConnection::Interrupt() {
@@ -2820,23 +2845,33 @@ void DuckDBPyConnection::Cursors::AddCursor(shared_ptr<DuckDBPyConnection> conn)
 }
 
 void DuckDBPyConnection::Cursors::ClearCursors() {
-	lock_guard<mutex> l(lock);
-
-	for (auto &cur : cursors) {
-		auto cursor = cur.lock();
-		if (!cursor) {
-			// The cursor has already been closed
-			continue;
-		}
-		// This is *only* needed because we have a py::gil_scoped_release in Close, so it *needs* the GIL in order to
-		// release it don't ask me why it can't just realize there is no GIL and move on
-		PythonGILWrapper gil;
-		cursor->Close();
-		// Ensure destructor runs with gil if triggered.
-		cursor.reset();
+	vector<weak_ptr<DuckDBPyConnection>> closing_cursors;
+	{
+		lock_guard<mutex> l(lock);
+		closing_cursors.swap(cursors);
 	}
 
-	cursors.clear();
+	// A child's initializer may reenter Close on its parent. Detach the list
+	// before waiting for children so that reentry does not wait on this list.
+	try {
+		for (auto &cur : closing_cursors) {
+			auto cursor = cur.lock();
+			if (!cursor) {
+				// The cursor has already been closed
+				continue;
+			}
+			// Close releases the GIL while waiting for the child's connection lock.
+			PythonGILWrapper gil;
+			cursor->Close();
+			// Ensure destructor runs with gil if triggered.
+			cursor.reset();
+		}
+	} catch (...) {
+		// Preserve the parent's ability to retry a child's failed session cleanup.
+		lock_guard<mutex> l(lock);
+		cursors.insert(cursors.end(), closing_cursors.begin(), closing_cursors.end());
+		throw;
+	}
 }
 
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::Cursor() {

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -55,6 +55,7 @@
 #include "duckdb/function/scalar/udf_functions.hpp"
 #include "duckdb/main/config.hpp"
 #include "vane_python/pyrelation.hpp"
+#include "vane_python/bound_plan.hpp"
 #include "vane_python/pystatement.hpp"
 #include "vane_python/pyresult.hpp"
 #include "vane_python/python_conversion.hpp"
@@ -711,10 +712,12 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	      py::arg("key").none(false), py::arg("value").none(false));
 	m.def("duplicate", &DuckDBPyConnection::Cursor, "Create a duplicate of the current connection");
 	m.def("execute", &DuckDBPyConnection::Execute,
-	      "Execute SQL with optional parameters. SELECT and COPY TO use the runner selected when connecting; "
-	      "VANE_RUNNER=local-fast uses native DuckDB; ray (the default) uses Ray. Other statements execute on the "
+	      "Execute SQL with optional parameters. Queries and writes share bound-plan dispatch with the runner selected "
+	      "when connecting; "
+	      "VANE_RUNNER=local-fast uses native DuckDB; ray (the default) uses Ray. Connection and catalog operations "
+	      "execute on the "
 	      "client. "
-	      "Ray SELECT and runner COPY TO require auto-commit mode. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
+	      "Distributed execution requires auto-commit mode. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
 	      "local-fast.",
 	      py::arg("query"), py::arg("parameters") = py::none());
 	m.def("executemany", &DuckDBPyConnection::ExecuteMany,
@@ -795,18 +798,21 @@ static void InitializeConnectionMethods(py::class_<DuckDBPyConnection, shared_pt
 	      "Parse the query string and extract the Statement object(s) produced", py::arg("query"));
 	m.def("sql", &DuckDBPyConnection::RunQuery,
 	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	      "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
-	      "statements execute on the client connection. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require local-fast.",
+	      "connection runner when consumed. Writes execute immediately through the same bound-plan entry; "
+	      "connection and catalog operations execute on the client. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
+	      "local-fast.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("query", &DuckDBPyConnection::RunQuery,
 	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	      "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
-	      "statements execute on the client connection. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require local-fast.",
+	      "connection runner when consumed. Writes execute immediately through the same bound-plan entry; "
+	      "connection and catalog operations execute on the client. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
+	      "local-fast.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("from_query", &DuckDBPyConnection::RunQuery,
 	      "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	      "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
-	      "statements execute on the client connection. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require local-fast.",
+	      "connection runner when consumed. Writes execute immediately through the same bound-plan entry; "
+	      "connection and catalog operations execute on the client. SQL PREPARE/EXECUTE and EXPLAIN ANALYZE require "
+	      "local-fast.",
 	      py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none());
 	m.def("read_csv", &DuckDBPyConnection::ReadCSV, "Create a relation object from the CSV file in 'name'",
 	      py::arg("path_or_buffer"), py::kw_only());
@@ -1327,31 +1333,14 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object 
 	if (outer_list.empty()) {
 		throw InvalidInputException("executemany requires a non-empty list of parameter sets to be provided");
 	}
-	if (GetRunnerType() != "local-fast") {
-		auto interrupt_check = CreateQueryInterruptCheck();
-		for (idx_t index = 0; index < outer_list.size(); index++) {
-			auto result = RunStatement(last_statement->Copy(), "", outer_list[index], true, interrupt_check);
-			if (result && index + 1 < outer_list.size()) {
-				while (py::len(result->FetchMany(STANDARD_VECTOR_SIZE)) != 0) {
-				}
+	auto interrupt_check = CreateQueryInterruptCheck();
+	for (idx_t index = 0; index < outer_list.size(); index++) {
+		auto result = RunStatement(last_statement->Copy(), "", outer_list[index], true, interrupt_check);
+		if (result && index + 1 < outer_list.size()) {
+			while (py::len(result->FetchMany(STANDARD_VECTOR_SIZE)) != 0) {
 			}
-			con.SetResult(std::move(result));
 		}
-		return shared_from_this();
-	}
-	auto prep = PrepareQuery(std::move(last_statement));
-
-	unique_ptr<QueryResult> query_result;
-	// Execute once for every set of parameters that are provided
-	for (auto &parameters : outer_list) {
-		auto params = py::reinterpret_borrow<py::object>(parameters);
-		query_result = ExecuteInternal(*prep, std::move(params));
-	}
-	// Set the internal 'result' object
-	if (query_result) {
-		// Don't use CreateRelation here — the result is stored inside the connection,
-		// so setting connection_owner would create a ref cycle (connection → result → connection).
-		con.SetResult(make_uniq<DuckDBPyRelation>(make_shared_ptr<DuckDBPyResult>(std::move(query_result))));
+		con.SetResult(std::move(result));
 	}
 
 	return shared_from_this();
@@ -1437,79 +1426,6 @@ case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(const py:
 		throw InvalidInputException("Prepared parameters can only be passed as a list or a dictionary");
 	}
 	return named_values;
-}
-
-unique_ptr<PreparedStatement> DuckDBPyConnection::PrepareQuery(unique_ptr<SQLStatement> statement) {
-	auto &connection = con.GetConnection();
-	unique_ptr<PreparedStatement> prep;
-	{
-		D_ASSERT(py::gil_check());
-		py::gil_scoped_release release;
-		unique_lock<mutex> lock(py_connection_lock);
-
-		prep = connection.Prepare(std::move(statement));
-		if (prep->HasError()) {
-			prep->error.Throw();
-		}
-	}
-	return prep;
-}
-
-unique_ptr<QueryResult> DuckDBPyConnection::ExecuteInternal(PreparedStatement &prep, py::object params) {
-	if (params.is_none()) {
-		params = py::list();
-	}
-
-	// Execute the prepared statement with the prepared parameters
-	auto named_values = TransformPreparedParameters(params, prep);
-	unique_ptr<QueryResult> res;
-	{
-		D_ASSERT(py::gil_check());
-		ScopedPythonUDFActorResourcePreparation udf_actor_resources(*con.GetConnection().context);
-		py::gil_scoped_release release;
-		unique_lock<std::mutex> lock(py_connection_lock);
-
-		auto pending_query = prep.PendingQuery(named_values);
-		if (pending_query->HasError()) {
-			pending_query->ThrowError();
-		}
-		res = CompletePendingQuery(*pending_query);
-
-		if (res->HasError()) {
-			res->ThrowError();
-		}
-	}
-	return res;
-}
-
-unique_ptr<QueryResult> DuckDBPyConnection::PrepareAndExecuteInternal(unique_ptr<SQLStatement> statement,
-                                                                      py::object params) {
-	if (params.is_none()) {
-		params = py::list();
-	}
-
-	auto named_values = TransformPreparedParameters(params);
-
-	unique_ptr<QueryResult> res;
-	{
-		D_ASSERT(py::gil_check());
-		ScopedPythonUDFActorResourcePreparation udf_actor_resources(*con.GetConnection().context);
-		py::gil_scoped_release release;
-		unique_lock<std::mutex> lock(py_connection_lock);
-
-		auto pending_query = con.GetConnection().PendingQuery(std::move(statement), named_values, true);
-
-		if (pending_query->HasError()) {
-			pending_query->ThrowError();
-		}
-
-		res = CompletePendingQuery(*pending_query);
-
-		if (res->HasError()) {
-			res->ThrowError();
-		}
-	}
-	return res;
 }
 
 vector<unique_ptr<SQLStatement>> DuckDBPyConnection::GetStatements(const py::object &query) {
@@ -2421,68 +2337,19 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 	if (alias.empty()) {
 		alias = "unnamed_relation_" + StringUtil::GenerateRandomName(16);
 	}
-	// These wrappers would execute their inner statements directly in DuckDB,
-	// bypassing query/write routing and the runner's capability checks.
-	if (GetRunnerType() != "local-fast" &&
-	    (statement->type == StatementType::PREPARE_STATEMENT || statement->type == StatementType::EXECUTE_STATEMENT ||
-	     (statement->type == StatementType::EXPLAIN_STATEMENT &&
-	      statement->Cast<ExplainStatement>().explain_type == ExplainType::EXPLAIN_ANALYZE))) {
-		throw NotImplementedException("Runner execution does not support SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE; "
-		                              "use direct SQL with bound parameters or a local-fast connection");
-	}
-	if (statement->type == StatementType::COPY_STATEMENT && GetRunnerType() != "local-fast") {
-		if (statement->Cast<CopyStatement>().info->is_from) {
-			throw NotImplementedException("Runner execution does not support SQL COPY FROM");
-		}
-		auto ensure_auto_commit = [&]() {
-			if (!con.GetConnection().context->transaction.IsAutoCommit()) {
-				throw InvalidInputException("Runner COPY TO requires DuckDB auto-commit mode and cannot participate "
-				                            "in an explicit transaction");
-			}
-		};
-		ensure_auto_commit();
-		auto parameters = TransformPreparedParameters(params.is_none() ? py::object(py::list()) : params);
-		PreparedStatement::VerifyParameters(parameters, statement->named_param_map);
-		auto context = con.GetConnection().context;
-		ensure_auto_commit();
-		interrupt_check();
-		shared_ptr<Relation> relation;
-		try {
-			py::gil_scoped_release release;
-			unique_lock<mutex> lock(py_connection_lock);
-			relation = make_shared_ptr<WriteFileRelation>(
-			    context, unique_ptr_cast<SQLStatement, CopyStatement>(std::move(statement)), std::move(parameters));
-		} catch (const Exception &exception) {
-			ErrorData error(exception);
-			context->ProcessError(error, query);
-			error.Throw();
-		}
-		auto write_relation = make_uniq<DuckDBPyRelation>(std::move(relation));
-		write_relation->SetConnectionOwner(CreateWeakOwner(shared_from_this()));
-		auto result = write_relation->ExecuteCopyForConnection(interrupt_check);
-		return for_connection ? make_uniq<DuckDBPyRelation>(std::move(result)) : nullptr;
-	}
+	auto parameters = TransformPreparedParameters(params.is_none() ? py::object(py::list()) : params);
+	PreparedStatement::VerifyParameters(parameters, statement->named_param_map);
+	// Parameter conversion can close the connection or begin a transaction.
+	// Resolve its live context afterward; execution admission validates the plan.
+	auto context = con.GetConnection().context;
+	interrupt_check();
 	if (statement->type == StatementType::SELECT_STATEMENT) {
-		auto ensure_auto_commit = [&]() {
-			if (for_connection && GetRunnerType() == "ray" &&
-			    !con.GetConnection().context->transaction.IsAutoCommit()) {
-				throw InvalidInputException("Ray SELECT requires DuckDB auto-commit mode because distributed execution "
-				                            "cannot participate in the caller's explicit transaction");
-			}
-		};
-		ensure_auto_commit();
-		auto named_values = TransformPreparedParameters(params.is_none() ? py::object(py::list()) : params);
-		PreparedStatement::VerifyParameters(named_values, statement->named_param_map);
-		// Conversion can close the connection, begin a transaction, or change
-		// process configuration. Revalidate the connection and use its policy.
-		auto context = con.GetConnection().context;
-		ensure_auto_commit();
 		shared_ptr<Relation> relation;
 		try {
 			py::gil_scoped_release release;
 			unique_lock<mutex> lock(py_connection_lock);
 			auto select = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(statement));
-			relation = make_shared_ptr<QueryRelation>(context, std::move(select), alias, "", std::move(named_values));
+			relation = make_shared_ptr<QueryRelation>(context, std::move(select), alias, "", std::move(parameters));
 		} catch (const Exception &exception) {
 			ErrorData error(exception);
 			context->ProcessError(error, query);
@@ -2492,29 +2359,42 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 			return CreateRelation(std::move(relation));
 		}
 		auto query_relation = make_uniq<DuckDBPyRelation>(std::move(relation));
-		// A cursor is owned by its connection; retain only a weak owner on the
-		// query/runner side so an abandoned stream cannot keep itself alive.
 		query_relation->SetConnectionOwner(CreateWeakOwner(shared_from_this()));
 		return make_uniq<DuckDBPyRelation>(query_relation->ExecuteForConnection(interrupt_check));
 	}
 
-	auto res = PrepareAndExecuteInternal(std::move(statement), std::move(params));
-	if (!res) {
-		return nullptr;
-	}
+	auto execution = ExecuteWithRunner(context, std::move(statement), nullptr, std::move(parameters),
+	                                   CreateWeakOwner(shared_from_this()), interrupt_check, true);
 	if (for_connection) {
-		return make_uniq<DuckDBPyRelation>(make_shared_ptr<DuckDBPyResult>(std::move(res)));
+		return make_uniq<DuckDBPyRelation>(execution.TakeResult());
 	}
-	if (res->properties.return_type != StatementReturnType::QUERY_RESULT) {
+	if (execution.return_type != StatementReturnType::QUERY_RESULT) {
 		return nullptr;
 	}
-	if (res->type == QueryResultType::STREAM_RESULT) {
-		auto &stream_result = res->Cast<StreamQueryResult>();
-		res = stream_result.Materialize();
+	if (execution.native_result) {
+		auto res = std::move(execution.native_result);
+		if (res->type == QueryResultType::STREAM_RESULT) {
+			res = res->Cast<StreamQueryResult>().Materialize();
+		}
+		auto &materialized = res->Cast<MaterializedQueryResult>();
+		return CreateRelation(
+		    make_shared_ptr<MaterializedRelation>(context, materialized.TakeCollection(), res->names, alias));
 	}
-	auto &materialized_result = res->Cast<MaterializedQueryResult>();
-	return CreateRelation(make_shared_ptr<MaterializedRelation>(
-	    con.GetConnection().context, materialized_result.TakeCollection(), res->names, alias));
+	auto result = execution.TakeResult();
+	auto collection = make_uniq<ColumnDataCollection>(*context, result->GetTypes());
+	while (true) {
+		unique_ptr<DataChunk> chunk;
+		{
+			py::gil_scoped_release release;
+			chunk = result->FetchChunk();
+		}
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+		collection->Append(*chunk);
+	}
+	return CreateRelation(
+	    make_shared_ptr<MaterializedRelation>(context, std::move(collection), result->GetNames(), alias));
 }
 
 unique_ptr<DuckDBPyRelation> DuckDBPyConnection::Table(const string &tname) {

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -1307,6 +1307,9 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	DuckDBPyConnection::ImportCache();
 }
 
+case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(const py::object &params,
+                                                                       optional_ptr<PreparedStatement> prep = {});
+
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object &query, py::object params_p) {
 	PythonGILWrapper gil;
 	con.SetResult(nullptr);
@@ -1334,8 +1337,22 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::ExecuteMany(const py::object 
 		throw InvalidInputException("executemany requires a non-empty list of parameter sets to be provided");
 	}
 	auto interrupt_check = CreateQueryInterruptCheck();
+	unique_ptr<PreparedStatement> native_prepared;
+	const bool local_fast = GetRunnerType() == "local-fast";
 	for (idx_t index = 0; index < outer_list.size(); index++) {
-		auto result = RunStatement(last_statement->Copy(), "", outer_list[index], true, interrupt_check);
+		unique_ptr<DuckDBPyRelation> result;
+		if (local_fast) {
+			auto params = py::reinterpret_borrow<py::object>(outer_list[index]);
+			auto parameters =
+			    TransformPreparedParameters(params.is_none() ? py::object(py::list()) : params, native_prepared.get());
+			auto context = con.GetConnection().context;
+			auto execution = ExecuteWithRunner(context, last_statement->Copy(), nullptr, std::move(parameters),
+			                                   CreateWeakOwner(shared_from_this()), interrupt_check, true, nullptr,
+			                                   &native_prepared);
+			result = make_uniq<DuckDBPyRelation>(execution.TakeResult());
+		} else {
+			result = RunStatement(last_statement->Copy(), "", outer_list[index], true, interrupt_check);
+		}
 		if (result && index + 1 < outer_list.size()) {
 			while (py::len(result->FetchMany(STANDARD_VECTOR_SIZE)) != 0) {
 			}
@@ -1402,7 +1419,7 @@ py::list TransformNamedParameters(const case_insensitive_map_t<idx_t> &named_par
 }
 
 case_insensitive_map_t<BoundParameterData> TransformPreparedParameters(const py::object &params,
-                                                                       optional_ptr<PreparedStatement> prep = {}) {
+                                                                       optional_ptr<PreparedStatement> prep) {
 	case_insensitive_map_t<BoundParameterData> named_values;
 	if (py::is_list_like(params)) {
 		if (prep && prep->named_param_map.size() != py::len(params)) {

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -6,6 +6,7 @@
 
 #include "vane_python/pybind11/pybind_wrapper.hpp"
 #include "vane_python/pyrelation.hpp"
+#include "vane_python/bound_plan.hpp"
 #include "vane_python/merge_relation.hpp"
 #include "vane_python/pyconnection/pyconnection.hpp"
 #include "vane_python/pytype.hpp"
@@ -1150,14 +1151,6 @@ struct CachedRunnerForDatabase {
 
 static unordered_map<DatabaseInstance *, CachedRunnerForDatabase> per_db_runners;
 
-static DatabaseInstance *GetRelationDatabasePtr(const shared_ptr<Relation> &rel) {
-	if (!rel || !rel->context) {
-		return nullptr;
-	}
-	auto context = rel->context->GetContext();
-	return context->db.get();
-}
-
 static void ForgetRunnerForDB(DatabaseInstance *db_ptr) noexcept {
 	if (!db_ptr) {
 		return;
@@ -1191,11 +1184,8 @@ struct RunnerForDatabase {
 	py::object runner;
 };
 
-static RunnerForDatabase GetOrCreateRunnerForDB(const shared_ptr<Relation> &rel, const string &runner_type) {
-	if (!rel || !rel->context) {
-		throw InternalException("Cannot resolve runner: relation has no context");
-	}
-	auto *db_ptr = GetRelationDatabasePtr(rel);
+static RunnerForDatabase GetOrCreateRunnerForDB(const shared_ptr<ClientContext> &context, const string &runner_type) {
+	auto *db_ptr = context ? context->db.get() : nullptr;
 	if (!db_ptr) {
 		throw InternalException("Cannot resolve runner: relation has no database");
 	}
@@ -1235,125 +1225,174 @@ static RunnerForDatabase GetOrCreateRunnerForDB(const shared_ptr<Relation> &rel,
 
 py::object DuckDBPyRelation::RunDataSink() {
 	AssertRelation();
-	auto runner_for_db = GetOrCreateRunnerForDB(rel, GetRunnerType());
-	PerDBRunnerCleanupGuard cleanup_guard(runner_for_db.db_ptr);
-	auto terminal = DeriveRelation(rel);
-	return runner_for_db.runner.attr("run_datasink")(py::cast(std::move(terminal)));
+	auto execution = ExecuteWithRunner(rel->context->GetContext(), nullptr, rel, {}, connection_owner, py::object());
+	return std::move(execution.write_outcome);
 }
 
-// Try to dispatch a write relation to the connection's Python runner.
-// Returns false only when its policy explicitly selects native DuckDB execution.
-static bool TryDispatchToRunner(const shared_ptr<Relation> &write_rel, const py::object &connection_owner,
-                                const char *ray_mutation_name = nullptr, py::object *outcome = nullptr,
-                                const py::object &interrupt_check = py::none()) {
-	if (!write_rel || !write_rel->context) {
-		throw InternalException("Cannot resolve write runner: relation has no context");
-	}
-	auto runner_type = write_rel->context->GetContext()->vane_runner_type;
-	if (runner_type == "local-fast") {
-		return false;
-	}
-	if (ray_mutation_name && runner_type != "ray") {
-		throw InvalidInputException("%s requires VANE_RUNNER=ray or VANE_RUNNER=local-fast; configured runner is '%s'",
-		                            ray_mutation_name, runner_type);
-	}
-	if (ray_mutation_name) {
-		if (!write_rel || !write_rel->context) {
-			throw InternalException("Cannot validate Ray write transaction: relation has no context");
-		}
-		auto context = write_rel->context->GetContext();
-		if (!context->transaction.IsAutoCommit()) {
-			throw InvalidInputException("Ray %s requires DuckDB auto-commit mode because distributed execution cannot "
-			                            "participate in the caller's explicit transaction",
-			                            ray_mutation_name);
-		}
-	}
-	auto runner_for_db = GetOrCreateRunnerForDB(write_rel, runner_type);
-	PerDBRunnerCleanupGuard cleanup_guard(runner_for_db.db_ptr);
-	auto py_write_rel = DuckDBPyRelation(write_rel);
-	py_write_rel.SetConnectionOwner(connection_owner);
-	auto py_write_rel_obj = py::cast(std::move(py_write_rel));
-	auto result = py::module_::import("vane._query_interrupt")
-	                  .attr("run_write_with_interrupt_check")(runner_for_db.runner, py_write_rel_obj, interrupt_check);
-	if (outcome) {
-		*outcome = std::move(result);
-	}
-	return true;
-}
-
-shared_ptr<DuckDBPyResult> DuckDBPyRelation::ExecuteCopyForConnection(const py::object &interrupt_check) {
-	AssertRelation();
-	auto context = rel->context->GetContext();
-	if (GetRunnerType() == "local-fast") {
-		throw InternalException("Runner SQL COPY requires a configured write runner");
-	}
-	if (!context->transaction.IsAutoCommit()) {
-		throw InvalidInputException("Runner COPY TO requires DuckDB auto-commit mode and cannot participate "
-		                            "in an explicit transaction");
-	}
-	if (types != vector<LogicalType> {LogicalType::BIGINT} || names != vector<string> {"Count"}) {
-		throw NotImplementedException("Runner SQL COPY currently supports its default Count result; "
-		                              "RETURN_FILES and RETURN_STATS are not supported");
-	}
+static unique_ptr<QueryResult> MakeRunnerWriteResult(const RunnerBoundPlan &plan, const py::object &outcome) {
 	auto error_type = py::module_::import("vane.runners.copy_outcome").attr("CopyResultUnavailableError");
-	py::object outcome;
-	TryDispatchToRunner(rel, connection_owner, nullptr, &outcome, interrupt_check);
 	string operation_id;
 	py::tuple cleanup_warnings;
 	try {
-		auto result = outcome.cast<py::dict>();
-		operation_id = result["copy_operation_id"].cast<string>();
-		if (result.contains("copy_cleanup_warnings")) {
-			cleanup_warnings = py::tuple(result["copy_cleanup_warnings"]);
+		auto receipt = outcome.cast<py::dict>();
+		operation_id = receipt["copy_operation_id"].cast<string>();
+		if (receipt.contains("copy_cleanup_warnings")) {
+			cleanup_warnings = py::tuple(receipt["copy_cleanup_warnings"]);
 		}
-		auto rows_copied = result["rows_copied"].cast<int64_t>();
-		if (rows_copied < 0) {
-			throw InternalException("COPY returned a negative row count");
+		auto rows = receipt["rows_copied"].cast<int64_t>();
+		if (rows < 0) {
+			throw InternalException("Runner write returned a negative row count");
 		}
-		auto collection = make_uniq<ColumnDataCollection>(Allocator::Get(*context), types);
+		auto collection = make_uniq<ColumnDataCollection>(Allocator::Get(*plan.context), plan.types);
 		DataChunk chunk;
-		chunk.Initialize(Allocator::Get(*context), types);
+		chunk.Initialize(Allocator::Get(*plan.context), plan.types);
 		chunk.SetCardinality(1);
-		chunk.SetValue(0, 0, Value::BIGINT(rows_copied));
+		chunk.SetValue(0, 0, Value::BIGINT(rows));
 		collection->Append(chunk);
-		StatementProperties properties;
-		properties.return_type = StatementReturnType::CHANGED_ROWS;
-		auto result_set = make_uniq<MaterializedQueryResult>(StatementType::COPY_STATEMENT, properties, names,
-		                                                     std::move(collection), context->GetClientProperties());
-		return make_shared_ptr<DuckDBPyResult>(std::move(result_set));
+		return make_uniq<MaterializedQueryResult>(plan.statement_type, plan.properties, plan.names,
+		                                          std::move(collection), plan.context->GetClientProperties());
 	} catch (const std::exception &error) {
-		auto value = error_type(operation_id, "SQL COPY result handling failed after commit: " + string(error.what()),
+		auto value = error_type(operation_id, plan.operation + " result handling failed after commit: " + error.what(),
 		                        cleanup_warnings);
 		PyErr_SetObject(error_type.ptr(), value.ptr());
 		throw py::error_already_set();
 	}
 }
 
-static unique_ptr<QueryResult> PyExecuteRelation(const shared_ptr<Relation> &rel, bool stream_result = false,
-                                                 vector<string> *cleanup_warnings = nullptr) {
+RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context, unique_ptr<SQLStatement> statement,
+                                        const shared_ptr<Relation> &relation,
+                                        case_insensitive_map_t<BoundParameterData> parameters,
+                                        const py::object &connection_owner, const py::object &interrupt_check,
+                                        bool stream_result, vector<string> *cleanup_warnings) {
+	if (!context || bool(statement) == bool(relation)) {
+		throw InternalException("Runner execution requires one SQL statement or relation and its connection");
+	}
 	if (cleanup_warnings) {
 		cleanup_warnings->clear();
 	}
-	if (!rel) {
-		return nullptr;
+	auto check = interrupt_check;
+	if (!check) {
+		auto owner = DuckDBPyConnection::ResolveOwner(connection_owner);
+		check =
+		    owner.is_none() ? py::none() : py::cast<shared_ptr<DuckDBPyConnection>>(owner)->CreateQueryInterruptCheck();
 	}
-	auto context = rel->context->GetContext();
-	D_ASSERT(py::gil_check());
-	ScopedPythonUDFActorResourcePreparation udf_actor_resources(*context);
+	if (!check.is_none()) {
+		check();
+	}
+	if (context->vane_runner_type != "local-fast" && context->config.query_verification_enabled) {
+		throw NotImplementedException("Runner execution does not support native query verification");
+	}
+	RunnerExecutionResult execution;
+	unique_ptr<RunnerBoundPlan> bound;
+	struct BindingQueryGuard {
+		const shared_ptr<ClientContext> &context;
+		const unique_ptr<RunnerBoundPlan> &bound;
+		~BindingQueryGuard() {
+			if (bound) {
+				py::gil_scoped_release release;
+				try {
+					context->CancelBoundPlan(bound->query_number);
+				} catch (...) {
+					// Preserve the execution failure; cancellation has already
+					// released the binding transaction before reporting cleanup errors.
+				}
+			}
+		}
+	} binding_guard {context, bound};
+	PendingQueryParameters pending_parameters;
+	pending_parameters.parameters = parameters;
+	pending_parameters.query_parameters = stream_result;
+	pending_parameters.bound_plan_handler = [&](Planner &planner, unique_ptr<LogicalOperator> &plan,
+	                                            PreparedStatementData &prepared) {
+		bound = AdmitRunnerBoundPlan(planner, plan, prepared, parameters);
+		return bool(bound);
+	};
+	{
+		ScopedPythonUDFActorResourcePreparation udf_actor_resources(*context);
+		try {
+			{
+				py::gil_scoped_release release;
+				auto pending = statement ? context->PendingQuery(std::move(statement), pending_parameters)
+				                         : context->PendingQuery(relation, pending_parameters);
+				if (pending) {
+					execution.native_result = DuckDBPyConnection::CompletePendingQuery(*pending);
+					if (execution.native_result->HasError()) {
+						execution.native_result->ThrowError();
+					}
+				}
+			}
+			if (cleanup_warnings) {
+				*cleanup_warnings = udf_actor_resources.TakeCleanupWarnings();
+			}
+		} catch (...) {
+			if (cleanup_warnings) {
+				*cleanup_warnings = udf_actor_resources.TakeCleanupWarnings();
+			}
+			throw;
+		}
+	}
+	if (execution.native_result) {
+		execution.return_type = execution.native_result->properties.return_type;
+		return execution;
+	}
+	if (!bound) {
+		throw InternalException("Execution produced neither a native result nor a bound runner plan");
+	}
+	execution.return_type = bound->properties.return_type;
+	if (!check.is_none()) {
+		check();
+	}
+	if (bound->kind == RunnerPlanKind::READ) {
+		ValidateDistributedResultTypes(bound->types, *context);
+	}
+	auto &client_config = ClientConfig::GetConfig(*context);
+	auto result_collector = client_config.get_result_collector;
+	ScopedConfigSetting collector_scope(
+	    client_config, [](ClientConfig &config) { config.get_result_collector = nullptr; },
+	    [&result_collector](ClientConfig &config) { config.get_result_collector = std::move(result_collector); });
+	auto runner_for_db = GetOrCreateRunnerForDB(context, context->vane_runner_type);
+	PerDBRunnerCleanupGuard cleanup_guard(runner_for_db.db_ptr);
+	auto transport = SerializeRunnerBoundPlan(*bound, connection_owner);
+	if (!check.is_none()) {
+		check();
+	}
+	if (bound->kind == RunnerPlanKind::DATA_SINK) {
+		execution.write_outcome = runner_for_db.runner.attr("run_datasink")(transport);
+		return execution;
+	}
+	if (bound->kind != RunnerPlanKind::READ) {
+		execution.write_outcome = py::module_::import("vane._query_interrupt")
+		                              .attr("run_write_with_interrupt_check")(runner_for_db.runner, transport, check);
+		execution.native_result = MakeRunnerWriteResult(*bound, execution.write_outcome);
+		return execution;
+	}
+	py::object iterator;
 	try {
-		unique_ptr<QueryResult> result;
-		{
-			py::gil_scoped_release release;
-			auto pending_query = context->PendingQuery(rel, stream_result);
-			result = DuckDBPyConnection::CompletePendingQuery(*pending_query);
+		iterator = py::iter(runner_for_db.runner.attr("run_iter_tables")(transport));
+		iterator = py::module_::import("vane._query_interrupt").attr("QueryResultIterator")(iterator, check);
+		py::object first_partition;
+		bool has_first_partition = false;
+		bool exhausted = false;
+		PyObject *next = PyIter_Next(iterator.ptr());
+		if (next) {
+			first_partition = py::reinterpret_steal<py::object>(next);
+			has_first_partition = true;
+		} else if (PyErr_Occurred()) {
+			throw py::error_already_set();
+		} else {
+			exhausted = true;
 		}
-		if (cleanup_warnings) {
-			*cleanup_warnings = udf_actor_resources.TakeCleanupWarnings();
-		}
-		return result;
+		execution.distributed_result = make_shared_ptr<DuckDBPyResult>(
+		    MakeDistributedArrowPyResultSource(std::move(iterator), std::move(first_partition), has_first_partition,
+		                                       exhausted, bound->names, bound->types, context, connection_owner));
+		return execution;
 	} catch (...) {
-		if (cleanup_warnings) {
-			*cleanup_warnings = udf_actor_resources.TakeCleanupWarnings();
+		if (iterator && py::hasattr(iterator, "close")) {
+			try {
+				iterator.attr("close")();
+			} catch (py::error_already_set &error) {
+				error.discard_as_unraisable("closing distributed result iterator after startup failure");
+			}
 		}
 		throw;
 	}
@@ -1361,7 +1400,12 @@ static unique_ptr<QueryResult> PyExecuteRelation(const shared_ptr<Relation> &rel
 
 unique_ptr<QueryResult> DuckDBPyRelation::ExecuteInternal(bool stream_result) {
 	this->executed = true;
-	return PyExecuteRelation(rel, stream_result, &udf_actor_cleanup_warnings);
+	auto execution = ExecuteWithRunner(rel->context->GetContext(), nullptr, rel, {}, connection_owner, py::object(),
+	                                   stream_result, &udf_actor_cleanup_warnings);
+	if (!execution.native_result) {
+		throw InternalException("Native result consumer received a distributed stream");
+	}
+	return std::move(execution.native_result);
 }
 
 vector<string> DuckDBPyRelation::TakeUDFActorCleanupWarnings() {
@@ -1370,78 +1414,14 @@ vector<string> DuckDBPyRelation::TakeUDFActorCleanupWarnings() {
 	return result;
 }
 
-void DuckDBPyRelation::ExecuteOrThrow(bool stream_result, const string &runner_type,
-                                      const py::object &interrupt_check) {
-	auto selected_runner = runner_type.empty() ? GetRunnerType() : runner_type;
-	if (selected_runner == "ray") {
-		auto check = interrupt_check;
-		if (!check) {
-			auto owner = GetConnectionOwner();
-			check = owner.is_none() ? py::none()
-			                        : py::cast<shared_ptr<DuckDBPyConnection>>(owner)->CreateQueryInterruptCheck();
-		}
-		if (!check.is_none()) {
-			check();
-		}
-		auto context = rel->context->GetContext();
-		if (!context->transaction.IsAutoCommit()) {
-			throw InvalidInputException("Ray SELECT requires DuckDB auto-commit mode because distributed execution "
-			                            "cannot participate in the caller's explicit transaction");
-		}
-		ValidateDistributedResultTypes(types, *context);
-		auto &client_config = ClientConfig::GetConfig(*context);
-		auto result_collector = client_config.get_result_collector;
-		ScopedConfigSetting result_collector_scope(
-		    client_config, [](ClientConfig &config) { config.get_result_collector = nullptr; },
-		    [&result_collector](ClientConfig &config) { config.get_result_collector = std::move(result_collector); });
-
-		this->executed = true;
-		py::object table_iterator;
-		try {
-			auto runner_for_db = GetOrCreateRunnerForDB(rel, "ray");
-			PerDBRunnerCleanupGuard cleanup_guard(runner_for_db.db_ptr);
-			auto py_relation = DuckDBPyRelation(rel);
-			py_relation.SetConnectionOwner(connection_owner);
-			auto py_relation_obj = py::cast(std::move(py_relation));
-			table_iterator = py::iter(runner_for_db.runner.attr("run_iter_tables")(py_relation_obj));
-			table_iterator =
-			    py::module_::import("vane._query_interrupt").attr("QueryResultIterator")(table_iterator, check);
-			py::object prefetched_partition;
-			bool has_prefetched_partition = false;
-			bool iterator_exhausted = false;
-			PyObject *next_ptr = PyIter_Next(table_iterator.ptr());
-			if (next_ptr) {
-				prefetched_partition = py::reinterpret_steal<py::object>(next_ptr);
-				has_prefetched_partition = true;
-			} else if (PyErr_Occurred()) {
-				throw py::error_already_set();
-			} else {
-				iterator_exhausted = true;
-			}
-			result = make_uniq<DuckDBPyResult>(MakeDistributedArrowPyResultSource(
-			    std::move(table_iterator), std::move(prefetched_partition), has_prefetched_partition,
-			    iterator_exhausted, names, types, context, connection_owner));
-			return;
-		} catch (...) {
-			if (table_iterator && py::hasattr(table_iterator, "close")) {
-				try {
-					table_iterator.attr("close")();
-				} catch (py::error_already_set &ex) {
-					ex.discard_as_unraisable("closing distributed result iterator after startup failure");
-				}
-			}
-			throw;
-		}
-	}
-
-	auto query_result = ExecuteInternal(stream_result);
-	if (!query_result) {
+void DuckDBPyRelation::ExecuteOrThrow(bool stream_result, const py::object &interrupt_check) {
+	this->executed = true;
+	auto execution = ExecuteWithRunner(rel->context->GetContext(), nullptr, rel, {}, connection_owner, interrupt_check,
+	                                   stream_result, &udf_actor_cleanup_warnings);
+	result = execution.TakeResult();
+	if (!result) {
 		throw InternalException("ExecuteOrThrow - no query available to execute");
 	}
-	if (query_result->HasError()) {
-		query_result->ThrowError();
-	}
-	result = make_uniq<DuckDBPyResult>(std::move(query_result));
 }
 
 PandasDataFrame DuckDBPyRelation::FetchDF(bool date_as_object) {
@@ -1725,7 +1705,7 @@ py::object DuckDBPyRelation::GetConnectionOwnerReference() const {
 
 shared_ptr<DuckDBPyResult> DuckDBPyRelation::ExecuteForConnection(const py::object &interrupt_check) {
 	AssertRelation();
-	ExecuteOrThrow(true, GetRunnerType(), interrupt_check);
+	ExecuteOrThrow(true, interrupt_check);
 	return std::move(result);
 }
 
@@ -2029,10 +2009,7 @@ void DuckDBPyRelation::ToParquet(const string &filename, const py::object &compr
 	}
 
 	auto write_parquet = rel->WriteParquetRel(filename, std::move(options));
-	if (TryDispatchToRunner(write_parquet, connection_owner)) {
-		return;
-	}
-	PyExecuteRelation(write_parquet);
+	ExecuteWithRunner(write_parquet->context->GetContext(), nullptr, write_parquet, {}, connection_owner, py::object());
 }
 
 void DuckDBPyRelation::ToCSV(const string &filename, const py::object &sep, const py::object &na_rep,
@@ -2176,10 +2153,7 @@ void DuckDBPyRelation::ToCSV(const string &filename, const py::object &sep, cons
 	}
 
 	auto write_csv = rel->WriteCSVRel(filename, std::move(options));
-	if (TryDispatchToRunner(write_csv, connection_owner)) {
-		return;
-	}
-	PyExecuteRelation(write_csv);
+	ExecuteWithRunner(write_csv->context->GetContext(), nullptr, write_csv, {}, connection_owner, py::object());
 }
 
 void DuckDBPyRelation::ToFile(const string &filename, const string &format) {
@@ -2187,10 +2161,7 @@ void DuckDBPyRelation::ToFile(const string &filename, const string &format) {
 		throw InvalidInputException("write_file requires a non-empty format");
 	}
 	auto write_file = rel->WriteFileRel(filename, format);
-	if (TryDispatchToRunner(write_file, connection_owner)) {
-		return;
-	}
-	PyExecuteRelation(write_file);
+	ExecuteWithRunner(write_file->context->GetContext(), nullptr, write_file, {}, connection_owner, py::object());
 }
 
 // should this return a rel with the new view?
@@ -2229,16 +2200,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, co
 		auto query = PragmaShow(view_name);
 		return Query(view_name, query);
 	}
-	{
-		D_ASSERT(py::gil_check());
-		py::gil_scoped_release release;
-		auto query_result = rel->context->GetContext()->Query(std::move(parser.statements[0]), false);
-		// Execute it anyways, for creation/altering statements
-		// We only care that it succeeds, we can't store the result
-		D_ASSERT(query_result);
-		if (query_result->HasError()) {
-			query_result->ThrowError();
-		}
+	auto execution = ExecuteWithRunner(rel->context->GetContext(), std::move(parser.statements[0]), nullptr, {},
+	                                   connection_owner, py::object());
+	// query() exposes a Relation only for SELECT. Finish any immediate result
+	// before discarding it, including a distributed table-function result.
+	auto result = execution.TakeResult();
+	while (result && py::len(result->Fetchmany(STANDARD_VECTOR_SIZE)) != 0) {
 	}
 	return nullptr;
 }
@@ -2261,10 +2228,7 @@ void DuckDBPyRelation::InsertInto(const string &table) {
 	AssertRelation();
 	auto parsed_info = QualifiedName::Parse(table);
 	auto insert = rel->InsertRel(parsed_info.catalog, parsed_info.schema, parsed_info.name);
-	if (TryDispatchToRunner(insert, connection_owner, "INSERT INTO")) {
-		return;
-	}
-	PyExecuteRelation(insert);
+	ExecuteWithRunner(insert->context->GetContext(), nullptr, insert, {}, connection_owner, py::object());
 }
 
 void DuckDBPyRelation::Update(const py::object &set_p, const py::object &where) {
@@ -2315,10 +2279,7 @@ void DuckDBPyRelation::Update(const py::object &set_p, const py::object &where) 
 	auto update = make_shared_ptr<UpdateRelation>(rel->context, std::move(condition), table.description->database,
 	                                              table.description->schema, table.description->table, std::move(names),
 	                                              std::move(expressions));
-	if (TryDispatchToRunner(update, connection_owner, "UPDATE")) {
-		return;
-	}
-	PyExecuteRelation(update);
+	ExecuteWithRunner(update->context->GetContext(), nullptr, update, {}, connection_owner, py::object());
 }
 
 void DuckDBPyRelation::Delete(const py::object &where) {
@@ -2338,10 +2299,8 @@ void DuckDBPyRelation::Delete(const py::object &where) {
 	auto delete_relation =
 	    make_shared_ptr<DeleteRelation>(rel->context, std::move(condition), table.description->database,
 	                                    table.description->schema, table.description->table);
-	if (TryDispatchToRunner(delete_relation, connection_owner, "DELETE")) {
-		return;
-	}
-	PyExecuteRelation(delete_relation);
+	ExecuteWithRunner(delete_relation->context->GetContext(), nullptr, delete_relation, {}, connection_owner,
+	                  py::object());
 }
 
 static string MergeConditionToSQL(const py::object &condition) {
@@ -2439,10 +2398,7 @@ void DuckDBPyRelation::MergeInto(const string &target_table, const py::object &c
 	auto statement = unique_ptr_cast<SQLStatement, MergeIntoStatement>(std::move(statements[0]));
 	auto source = rel->Alias(source_alias);
 	auto merge = make_shared_ptr<MergeRelation>(std::move(source), std::move(statement));
-	if (TryDispatchToRunner(merge, connection_owner, "MERGE INTO")) {
-		return;
-	}
-	PyExecuteRelation(merge);
+	ExecuteWithRunner(merge->context->GetContext(), nullptr, merge, {}, connection_owner, py::object());
 }
 
 void DuckDBPyRelation::Insert(const py::object &params) const {
@@ -2457,10 +2413,7 @@ void DuckDBPyRelation::Insert(const py::object &params) const {
 	auto &table = rel->Cast<TableRelation>();
 	auto insert =
 	    values_relation->InsertRel(table.description->database, table.description->schema, table.description->table);
-	if (TryDispatchToRunner(insert, connection_owner, "INSERT")) {
-		return;
-	}
-	PyExecuteRelation(insert);
+	ExecuteWithRunner(insert->context->GetContext(), nullptr, insert, {}, connection_owner, py::object());
 }
 
 static unique_ptr<ParsedExpression> TransformCreateTablePropertyValue(const py::handle &value) {
@@ -2535,10 +2488,7 @@ void DuckDBPyRelation::Create(const string &table, const py::object &properties,
 	auto create =
 	    rel->CreateRel(parsed_info.catalog, parsed_info.schema, parsed_info.name, false,
 	                   OnCreateConflict::ERROR_ON_CONFLICT, std::move(table_options), std::move(partition_keys));
-	if (TryDispatchToRunner(create, connection_owner, "CTAS")) {
-		return;
-	}
-	PyExecuteRelation(create);
+	ExecuteWithRunner(create->context->GetContext(), nullptr, create, {}, connection_owner, py::object());
 }
 
 static bool IsPythonClassCallable(const py::object &fun) {

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -13,6 +13,7 @@
 #include "vane_python/pyresult.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/prepared_statement.hpp"
 #include "vane_python/numpy/numpy_type.hpp"
 #include "duckdb/main/relation/query_relation.hpp"
 #include "duckdb/main/relation/join_relation.hpp"
@@ -1263,9 +1264,13 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
                                         const shared_ptr<Relation> &relation,
                                         case_insensitive_map_t<BoundParameterData> parameters,
                                         const py::object &connection_owner, const py::object &interrupt_check,
-                                        bool stream_result, vector<string> *cleanup_warnings) {
+                                        bool stream_result, vector<string> *cleanup_warnings,
+                                        optional_ptr<unique_ptr<PreparedStatement>> native_prepared_cache) {
 	if (!context || bool(statement) == bool(relation)) {
 		throw InternalException("Runner execution requires one SQL statement or relation and its connection");
+	}
+	if (native_prepared_cache && (!statement || context->vane_runner_type != "local-fast")) {
+		throw InternalException("Native prepared execution requires a local-fast SQL statement");
 	}
 	if (cleanup_warnings) {
 		cleanup_warnings->clear();
@@ -1326,12 +1331,29 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 		if (!check.is_none()) {
 			check();
 		}
+		if (statement && context->vane_runner_type != "local-fast") {
+			// Even binding can execute scalar table-function arguments. Reject
+			// unsupported wrappers before starting the native query lifecycle.
+			ValidateRunnerStatement(*statement);
+		}
 		ScopedPythonUDFActorResourcePreparation udf_actor_resources(*context);
 		try {
 			{
 				py::gil_scoped_release release;
-				auto pending = statement ? context->PendingQuery(std::move(statement), pending_parameters)
-				                         : context->PendingQuery(relation, pending_parameters);
+				unique_ptr<PendingQueryResult> pending;
+				if (native_prepared_cache) {
+					auto &prepared = *native_prepared_cache;
+					if (!prepared) {
+						prepared = context->Prepare(std::move(statement));
+						if (prepared->HasError()) {
+							prepared->error.Throw();
+						}
+					}
+					pending = prepared->PendingQuery(parameters, stream_result);
+				} else {
+					pending = statement ? context->PendingQuery(std::move(statement), pending_parameters)
+					                    : context->PendingQuery(relation, pending_parameters);
+				}
 				if (pending) {
 					execution.native_result = DuckDBPyConnection::CompletePendingQuery(*pending);
 					if (execution.native_result->HasError()) {

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -1287,6 +1287,14 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 	if (!check.is_none()) {
 		check();
 	}
+	// Serialize the call, including its live binding query and temporary
+	// settings across runner initialization and plan capture. Callbacks may
+	// reenter on this thread; query checks still reject an invalidated plan.
+	unique_lock<std::recursive_mutex> execution_lock;
+	if (source_connection) {
+		py::gil_scoped_release release;
+		execution_lock = unique_lock<std::recursive_mutex>(source_connection->py_connection_lock);
+	}
 	RunnerExecutionResult execution;
 	unique_ptr<RunnerBoundPlan> bound;
 	struct BindingQueryGuard {
@@ -1315,15 +1323,7 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 		};
 	}
 	{
-		// A native pending query releases the context lock between execution
-		// steps. Serialize its entire lifetime on the Python connection so a
-		// competing statement cannot cancel it through InitialCleanup.
-		unique_lock<mutex> execution_lock;
 		if (source_connection) {
-			{
-				py::gil_scoped_release release;
-				execution_lock = unique_lock<mutex>(source_connection->py_connection_lock);
-			}
 			if (source_connection->con.GetConnection().context != context) {
 				throw ConnectionException("The bound plan's connection was replaced before binding");
 			}
@@ -1370,8 +1370,6 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 			}
 			throw;
 		}
-		// Exported plans leave this scope before runner initialization, so
-		// initialization callbacks may still close or reenter the connection.
 	}
 	if (execution.native_result) {
 		execution.return_type = execution.native_result->properties.return_type;

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -1369,7 +1369,18 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 	py::object iterator;
 	try {
 		iterator = py::iter(runner_for_db.runner.attr("run_iter_tables")(transport));
-		iterator = py::module_::import("vane._query_interrupt").attr("QueryResultIterator")(iterator, check);
+		py::object source_owner = py::none();
+		if (relation) {
+			// DataSource dependencies belong to the active stream, not the
+			// transport retained by the driver. Keep only the native Relation;
+			// retaining its Python wrapper could cycle through a connection cursor.
+			auto retained_source = make_uniq<shared_ptr<Relation>>(relation);
+			source_owner = py::capsule(retained_source.get(),
+			                           [](void *source) { delete static_cast<shared_ptr<Relation> *>(source); });
+			retained_source.release();
+		}
+		iterator = py::module_::import("vane._query_interrupt")
+		               .attr("QueryResultIterator")(iterator, check, std::move(source_owner));
 		py::object first_partition;
 		bool has_first_partition = false;
 		bool exhausted = false;

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -1270,11 +1270,14 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 	if (cleanup_warnings) {
 		cleanup_warnings->clear();
 	}
+	auto owner = DuckDBPyConnection::ResolveOwner(connection_owner);
+	shared_ptr<DuckDBPyConnection> source_connection;
+	if (!owner.is_none()) {
+		source_connection = owner.cast<shared_ptr<DuckDBPyConnection>>();
+	}
 	auto check = interrupt_check;
 	if (!check) {
-		auto owner = DuckDBPyConnection::ResolveOwner(connection_owner);
-		check =
-		    owner.is_none() ? py::none() : py::cast<shared_ptr<DuckDBPyConnection>>(owner)->CreateQueryInterruptCheck();
+		check = source_connection ? source_connection->CreateQueryInterruptCheck() : py::none();
 	}
 	if (!check.is_none()) {
 		check();
@@ -1308,6 +1311,22 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 		return bool(bound);
 	};
 	{
+		// A native pending query releases the context lock between execution
+		// steps. Serialize its entire lifetime on the Python connection so a
+		// competing statement cannot cancel it through InitialCleanup.
+		unique_lock<mutex> execution_lock;
+		if (source_connection) {
+			{
+				py::gil_scoped_release release;
+				execution_lock = unique_lock<mutex>(source_connection->py_connection_lock);
+			}
+			if (source_connection->con.GetConnection().context != context) {
+				throw ConnectionException("The bound plan's connection was replaced before binding");
+			}
+		}
+		if (!check.is_none()) {
+			check();
+		}
 		ScopedPythonUDFActorResourcePreparation udf_actor_resources(*context);
 		try {
 			{
@@ -1330,6 +1349,8 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 			}
 			throw;
 		}
+		// Exported plans leave this scope before runner initialization, so
+		// initialization callbacks may still close or reenter the connection.
 	}
 	if (execution.native_result) {
 		execution.return_type = execution.native_result->properties.return_type;

--- a/src/vane_py/pyrelation.cpp
+++ b/src/vane_py/pyrelation.cpp
@@ -1282,9 +1282,6 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 	if (!check.is_none()) {
 		check();
 	}
-	if (context->vane_runner_type != "local-fast" && context->config.query_verification_enabled) {
-		throw NotImplementedException("Runner execution does not support native query verification");
-	}
 	RunnerExecutionResult execution;
 	unique_ptr<RunnerBoundPlan> bound;
 	struct BindingQueryGuard {
@@ -1305,11 +1302,13 @@ RunnerExecutionResult ExecuteWithRunner(const shared_ptr<ClientContext> &context
 	PendingQueryParameters pending_parameters;
 	pending_parameters.parameters = parameters;
 	pending_parameters.query_parameters = stream_result;
-	pending_parameters.bound_plan_handler = [&](Planner &planner, unique_ptr<LogicalOperator> &plan,
-	                                            PreparedStatementData &prepared) {
-		bound = AdmitRunnerBoundPlan(planner, plan, prepared, parameters);
-		return bool(bound);
-	};
+	if (context->vane_runner_type != "local-fast") {
+		pending_parameters.bound_plan_handler = [&](Planner &planner, unique_ptr<LogicalOperator> &plan,
+		                                            PreparedStatementData &prepared) {
+			bound = AdmitRunnerBoundPlan(planner, plan, prepared, parameters);
+			return bool(bound);
+		};
+	}
 	{
 		// A native pending query releases the context lock between execution
 		// steps. Serialize its entire lifetime on the Python connection so a

--- a/src/vane_py/pyresult.cpp
+++ b/src/vane_py/pyresult.cpp
@@ -48,8 +48,9 @@ DuckDBPyResult::~DuckDBPyResult() {
 	try {
 		D_ASSERT(py::gil_check());
 		py::gil_scoped_release gil;
-		source.reset();
+		// The source keeps the allocator backing the current chunk alive.
 		current_chunk.reset();
+		source.reset();
 	} catch (...) { // NOLINT
 	}
 }

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -1809,7 +1809,8 @@ static PyLogicalPlan LogicalPlanFromDuckDBRelation(py::object relation_obj, py::
 	}
 
 	PyLogicalPlan plan;
-	plan.query_id_ = query_id_obj.is_none() ? string() : py::cast<string>(query_id_obj);
+	plan.query_id_ =
+	    query_id_obj.is_none() ? UUID::ToString(UUID::GenerateRandomUUID()) : py::cast<string>(query_id_obj);
 	auto serialized = SerializeLogicalPlanFromRelation(rel);
 	plan.serialized_logical_plan_ = std::move(serialized.serialized_plan);
 	plan.memory_source_refs_ = std::move(serialized.memory_source_refs);

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -505,70 +505,75 @@ static void RewritePythonMemoryScans(unique_ptr<LogicalOperator> &op, ClientCont
 	}
 }
 
-static SerializedLogicalPlanResult SerializeLogicalPlanFromRelation(const duckdb::shared_ptr<duckdb::Relation> &rel) {
-	if (!rel) {
-		throw duckdb::InternalException("Relation is null");
-	}
-	auto client_context = rel->context->GetContext();
+static SerializedLogicalPlanResult SerializeBoundLogicalPlan(unique_ptr<LogicalOperator> &logical_plan, Binder &binder,
+                                                             const shared_ptr<ClientContext> &client_context) {
 	SerializedLogicalPlanResult result;
-	client_context->RunFunctionInTransaction([&]() {
-		auto statement_binder = duckdb::Binder::CreateBinder(*client_context);
-		auto relation_stmt = make_uniq<duckdb::RelationStatement>(rel, *statement_binder);
-		duckdb::Planner planner(*client_context);
-		planner.CreatePlan(std::move(relation_stmt));
-		auto logical_plan = std::move(planner.plan);
-
-		py::dict memory_source_refs;
-		if (PreparePythonMemoryScansForPruning(*logical_plan)) {
-			if (!py::module_::import("ray").attr("is_initialized")().cast<bool>()) {
-				throw InvalidInputException("Ray must be initialized before planning a Python in-memory relation");
-			}
-			// Snapshot only columns referenced by the bound plan. Running this
-			// standard pruning pass before replacing the scans avoids converting
-			// unused Pandas object columns while leaving all other optimizer passes
-			// for the distributed planning connection.
-			Optimizer column_pruner(*planner.binder, *client_context);
-			RemoveUnusedColumns unused_columns(column_pruner);
-			unused_columns.VisitOperator(*logical_plan);
-			logical_plan->ResolveOperatorTypes();
-
-			auto memory_module = py::module_::import("vane.datasource._memory");
-			vector<PendingPythonMemoryScan> scans;
-			PythonMemoryScanRequirements requirements;
-			PythonMemorySourceGroups source_groups;
-			PythonMemoryScanGroups scan_groups;
-			CollectPythonMemoryScans(*logical_plan, memory_module, scans, requirements);
-			GroupPythonMemoryScans(scans, requirements, memory_module, source_groups, scan_groups);
-			RewritePythonMemoryScans(logical_plan, *client_context, memory_module, memory_source_refs, scan_groups);
-			logical_plan->ResolveOperatorTypes();
+	py::dict memory_source_refs;
+	if (PreparePythonMemoryScansForPruning(*logical_plan)) {
+		if (!py::module_::import("ray").attr("is_initialized")().cast<bool>()) {
+			throw InvalidInputException("Ray must be initialized before planning a Python in-memory relation");
 		}
-		if (py::len(memory_source_refs) > 0) {
-			result.memory_source_refs = std::move(memory_source_refs);
-		}
+		// Snapshot only columns referenced by the bound plan. Running this
+		// standard pruning pass before replacing the scans avoids converting
+		// unused Pandas object columns while leaving all other optimizer passes
+		// for the distributed planning connection.
+		Optimizer column_pruner(binder, *client_context);
+		RemoveUnusedColumns unused_columns(column_pruner);
+		unused_columns.VisitOperator(*logical_plan);
+		logical_plan->ResolveOperatorTypes();
 
-		// NOTE: We intentionally do NOT run the Optimizer here.
-		// The unoptimized (bound) logical plan is serialized and sent to the Driver,
-		// where the Optimizer runs. This avoids needing serialization support for
-		// custom LogicalOperator types created by optimizer passes
-		// (e.g., LogicalUDFProject, LogicalLocalExchange).
+		auto memory_module = py::module_::import("vane.datasource._memory");
+		vector<PendingPythonMemoryScan> scans;
+		PythonMemoryScanRequirements requirements;
+		PythonMemorySourceGroups source_groups;
+		PythonMemoryScanGroups scan_groups;
+		CollectPythonMemoryScans(*logical_plan, memory_module, scans, requirements);
+		GroupPythonMemoryScans(scans, requirements, memory_module, source_groups, scan_groups);
+		RewritePythonMemoryScans(logical_plan, *client_context, memory_module, memory_source_refs, scan_groups);
+		logical_plan->ResolveOperatorTypes();
+	}
+	if (py::len(memory_source_refs) > 0) {
+		result.memory_source_refs = std::move(memory_source_refs);
+	}
 
-		duckdb::MemoryStream stream(duckdb::Allocator::Get(*client_context));
-		duckdb::SerializationOptions options;
-		options.serialization_compatibility = duckdb::SerializationCompatibility::Latest();
-		options.serialize_default_values = true;
-		duckdb::BinarySerializer serializer(stream, options);
-		serializer.GetSerializationData().Set<duckdb::ClientContext &>(*client_context);
-		serializer.Begin();
-		logical_plan->Serialize(serializer);
-		serializer.End();
+	// NOTE: We intentionally do NOT run the Optimizer here.
+	// The unoptimized (bound) logical plan is serialized and sent to the Driver,
+	// where the Optimizer runs. This avoids needing serialization support for
+	// custom LogicalOperator types created by optimizer passes
+	// (e.g., LogicalUDFProject, LogicalLocalExchange).
 
-		auto data_ptr = stream.GetData();
-		auto data_size = stream.GetPosition();
-		if (data_size == 0) {
-			throw duckdb::InternalException("Logical plan serialization returned empty payload");
-		}
-		auto logical_payload = string(reinterpret_cast<const char *>(data_ptr), data_size);
-		result.serialized_plan = EncodeLogicalPlanEnvelope(logical_payload);
+	duckdb::MemoryStream stream(duckdb::Allocator::Get(*client_context));
+	duckdb::SerializationOptions options;
+	options.serialization_compatibility = duckdb::SerializationCompatibility::Latest();
+	options.serialize_default_values = true;
+	duckdb::BinarySerializer serializer(stream, options);
+	serializer.GetSerializationData().Set<duckdb::ClientContext &>(*client_context);
+	serializer.Begin();
+	logical_plan->Serialize(serializer);
+	serializer.End();
+
+	auto data_ptr = stream.GetData();
+	auto data_size = stream.GetPosition();
+	if (data_size == 0) {
+		throw duckdb::InternalException("Logical plan serialization returned empty payload");
+	}
+	auto logical_payload = string(reinterpret_cast<const char *>(data_ptr), data_size);
+	result.serialized_plan = EncodeLogicalPlanEnvelope(logical_payload);
+	return result;
+}
+
+static SerializedLogicalPlanResult SerializeLogicalPlanFromRelation(const shared_ptr<Relation> &rel) {
+	if (!rel) {
+		throw InternalException("Relation is null");
+	}
+	auto context = rel->context->GetContext();
+	SerializedLogicalPlanResult result;
+	context->RunFunctionInTransaction([&]() {
+		auto statement_binder = Binder::CreateBinder(*context);
+		auto statement = make_uniq<RelationStatement>(rel, *statement_binder);
+		Planner planner(*context);
+		planner.CreatePlan(std::move(statement));
+		result = SerializeBoundLogicalPlan(planner.plan, *planner.binder, context);
 	});
 	return result;
 }
@@ -1726,6 +1731,39 @@ static py::object CaptureConnectionSnapshot(DuckDBPyConnection &conn_wrapper, co
 		conn_wrapper.MarkVaneRaySessionOpened();
 	}
 	return snapshot_obj;
+}
+
+py::object SerializeRunnerBoundPlan(RunnerBoundPlan &bound, const py::object &connection_owner) {
+	auto owner = DuckDBPyConnection::ResolveOwner(connection_owner);
+	if (connection_owner && !connection_owner.is_none() && owner.is_none()) {
+		throw ConnectionException("The bound plan's connection was closed before serialization");
+	}
+	if (!owner.is_none()) {
+		// Closing the Python connection need not destroy a ClientContext retained
+		// by this plan. Check the live wrapper before touching the bound tree.
+		auto &connection = owner.cast<DuckDBPyConnection &>();
+		if (connection.con.GetConnection().context != bound.context) {
+			throw ConnectionException("The bound plan's connection was replaced before serialization");
+		}
+	}
+	PyLogicalPlan plan;
+	plan.query_id_ = UUID::ToString(UUID::GenerateRandomUUID());
+	SerializedLogicalPlanResult serialized;
+	bound.context->RunWithBoundPlan(bound.query_number, [&]() {
+		serialized = SerializeBoundLogicalPlan(bound.plan, *bound.binder, bound.context);
+	});
+	plan.serialized_logical_plan_ = std::move(serialized.serialized_plan);
+	plan.memory_source_refs_ = std::move(serialized.memory_source_refs);
+	if (!owner.is_none()) {
+		auto &connection = owner.cast<DuckDBPyConnection &>();
+		plan.source_connection_ = connection_owner;
+		auto registrations = connection.ExportDistributedPythonUDFRegistrations();
+		if (py::len(registrations) > 0) {
+			plan.udf_registrations_ = std::move(registrations);
+		}
+		plan.connection_snapshot_ = CaptureConnectionSnapshot(connection, owner);
+	}
+	return py::cast(std::move(plan));
 }
 
 enum class DuckDBRelationPlanKind : uint8_t { READ, WRITE, DATA_SINK };

--- a/src/vane_py/ray/logical_plan_bindings.cpp
+++ b/src/vane_py/ray/logical_plan_bindings.cpp
@@ -567,13 +567,28 @@ static SerializedLogicalPlanResult SerializeLogicalPlanFromRelation(const shared
 		throw InternalException("Relation is null");
 	}
 	auto context = rel->context->GetContext();
+	if (!context->transaction.IsAutoCommit()) {
+		throw InvalidInputException("Runner transports require DuckDB auto-commit mode and cannot participate in an "
+		                            "explicit transaction");
+	}
 	SerializedLogicalPlanResult result;
 	context->RunFunctionInTransaction([&]() {
 		auto statement_binder = Binder::CreateBinder(*context);
+		statement_binder->SetBindingForRunner(true);
 		auto statement = make_uniq<RelationStatement>(rel, *statement_binder);
 		Planner planner(*context);
+		planner.binder->SetBindingForRunner(true);
 		planner.CreatePlan(std::move(statement));
-		result = SerializeBoundLogicalPlan(planner.plan, *planner.binder, context);
+		if (!planner.plan || !planner.properties.bound_all_parameters) {
+			throw InvalidInputException("Runner transports require a fully bound logical plan");
+		}
+		PreparedStatementData prepared(StatementType::RELATION_STATEMENT);
+		prepared.properties = planner.properties;
+		prepared.names = planner.names;
+		prepared.types = planner.types;
+		prepared.value_map = std::move(planner.value_map);
+		auto bound = AdmitRunnerBoundPlan(planner, planner.plan, prepared, {}, RunnerPlanAdmission::TRANSPORT);
+		result = SerializeBoundLogicalPlan(bound->plan, *bound->binder, context);
 	});
 	return result;
 }

--- a/src/vane_py/ray/ray_module.cpp
+++ b/src/vane_py/ray/ray_module.cpp
@@ -76,6 +76,7 @@ static inline int DuckdbGetEnvIntMs(const char *name) {
 #include <duckdb/common/serializer/binary_serializer.hpp>
 #include <duckdb/common/serializer/binary_deserializer.hpp>
 #include <duckdb/main/client_context.hpp>
+#include "vane_python/bound_plan.hpp"
 #include <duckdb/main/client_data.hpp>
 #include <duckdb/main/config.hpp>
 #include <duckdb/main/database.hpp>

--- a/src/vane_py/vane_python.cpp
+++ b/src/vane_py/vane_python.cpp
@@ -718,8 +718,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 		    return conn->RunQuery(query, alias, params);
 	    },
 	    "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	    "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
-	    "statements execute on the client connection.",
+	    "connection runner when consumed. Writes execute immediately through the same bound-plan entry; "
+	    "connection and catalog operations execute on the client.",
 	    py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none(),
 	    py::arg("connection") = py::none());
 	m.def(
@@ -732,8 +732,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 		    return conn->RunQuery(query, alias, params);
 	    },
 	    "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	    "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
-	    "statements execute on the client connection.",
+	    "connection runner when consumed. Writes execute immediately through the same bound-plan entry; "
+	    "connection and catalog operations execute on the client.",
 	    py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none(),
 	    py::arg("connection") = py::none());
 	m.def(
@@ -746,8 +746,8 @@ static void InitializeConnectionMethods(py::module_ &m) {
 		    return conn->RunQuery(query, alias, params);
 	    },
 	    "Create a lazy relation for SELECT, capturing positional or named params for execution with the configured "
-	    "connection runner when consumed. COPY TO uses the same runner and executes immediately; other non-SELECT "
-	    "statements execute on the client connection.",
+	    "connection runner when consumed. Writes execute immediately through the same bound-plan entry; "
+	    "connection and catalog operations execute on the client.",
 	    py::arg("query"), py::kw_only(), py::arg("alias") = "", py::arg("params") = py::none(),
 	    py::arg("connection") = py::none());
 	m.def(

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -69,11 +69,13 @@ def test_sql_call_is_not_dispatched_as_a_distributed_read(monkeypatch, runner_ty
                 getattr(connection, entry)(query)
 
 
-def _run_sql_entry(connection, entry, query):
+def _run_sql_entry(connection, entry, query, query_relation=None):
     if entry == "executemany":
         return connection.executemany(query, [[]])
     if entry == "relation_query":
-        return connection.sql("SELECT 1").query("input", query)
+        if query_relation is None:
+            query_relation = connection.sql("SELECT 1")
+        return query_relation.query("input", query)
     return getattr(connection, entry)(query)
 
 
@@ -103,11 +105,12 @@ def test_rejected_wrappers_do_not_bind_effectful_arguments(
     database = str(tmp_path / "wrappers.duckdb")
     with vane.connect(database) as connection:
         connection.execute("CREATE SEQUENCE seq")
+        query_relation = connection.sql("SELECT 1") if entry == "relation_query" else None
         if transactional:
             connection.begin()
             connection.execute("CREATE TABLE marker(value INTEGER)")
         with pytest.raises(vane.NotImplementedException, match="SQL CALL|SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE"):
-            _run_sql_entry(connection, entry, query)
+            _run_sql_entry(connection, entry, query, query_relation)
         if transactional:
             connection.execute("CREATE TABLE followup(value INTEGER)")
             connection.commit()
@@ -138,17 +141,13 @@ def test_bound_admission_errors_preserve_transactional_work(monkeypatch, tmp_pat
         "client_context": f"COPY (SELECT current_query()) TO '{destination}' (FORMAT PARQUET)",
         "insert": "INSERT INTO marker VALUES (1)",
     }[operation]
-    message = {
-        "copy_from": "SQL COPY FROM",
-        "client_context": "client-context function",
-        "insert": "requires a ray|cannot participate.*explicit transaction",
-    }[operation]
     database = str(tmp_path / "admission.duckdb")
     with vane.connect(database) as connection:
+        query_relation = connection.sql("SELECT 1") if entry == "relation_query" else None
         connection.begin()
         connection.execute("CREATE TABLE marker(value INTEGER)")
-        with pytest.raises(vane.BinderException, match=message):
-            _run_sql_entry(connection, entry, query)
+        with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
+            _run_sql_entry(connection, entry, query, query_relation)
         connection.execute("CREATE TABLE followup(value INTEGER)")
         connection.commit()
     assert not destination.exists()
@@ -156,6 +155,102 @@ def test_bound_admission_errors_preserve_transactional_work(monkeypatch, tmp_pat
     with vane.connect(database) as inspector:
         assert inspector.table("marker").fetchall() == []
         assert inspector.table("followup").fetchall() == []
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+@pytest.mark.parametrize(
+    ("runner_type", "operation"),
+    [
+        ("ray", "select"),
+        *[(runner, operation) for runner in ["local", "ray"] for operation in ["copy", "insert", "ctas"]],
+    ],
+)
+def test_transaction_rejection_precedes_table_function_argument_evaluation(
+    monkeypatch, tmp_path, entry, runner_type, operation
+):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("transaction admission must precede runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    database = str(tmp_path / "transaction-effects.duckdb")
+    destination = tmp_path / "rejected.parquet"
+    source = "SELECT * FROM range(nextval('seq'))"
+    query = {
+        "select": source,
+        "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
+        "insert": f"INSERT INTO marker {source}",
+        "ctas": f"CREATE TABLE created AS {source}",
+    }[operation]
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        query_relation = connection.sql("SELECT 1") if entry == "relation_query" else None
+        connection.begin()
+        connection.execute("CREATE TABLE marker(value INTEGER)")
+        with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
+            _run_sql_entry(connection, entry, query, query_relation)
+        connection.execute("CREATE TABLE followup(value INTEGER)")
+        connection.commit()
+    assert not destination.exists()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.table("marker").fetchall() == []
+        assert inspector.table("followup").fetchall() == []
+        with pytest.raises(vane.CatalogException, match="created"):
+            inspector.table("created")
+
+
+@pytest.mark.parametrize("entry", ["sql", "relation_query", "project"])
+def test_ray_relation_schema_binding_checks_transactions_before_effects(monkeypatch, tmp_path, entry):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    database = str(tmp_path / "relation-effects.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        source = connection.sql("SELECT 1 AS value")
+        connection.begin()
+        connection.execute("CREATE TABLE marker(value INTEGER)")
+        with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
+            if entry == "sql":
+                connection.sql("SELECT * FROM range(nextval($sequence))", params={"sequence": "seq"})
+            elif entry == "relation_query":
+                source.query("input", "SELECT * FROM range(nextval('seq'))")
+            else:
+                source.project("(SELECT count(*) FROM range(nextval('seq'))) AS value")
+        connection.commit()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.table("marker").fetchall() == []
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+def test_transaction_precheck_keeps_client_pragma_composition_native(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client PRAGMA queries must stay native")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    with vane.connect() as connection:
+        connection.begin()
+        connection.execute("CREATE TABLE marker(value INTEGER)")
+        assert connection.sql("PRAGMA table_info('marker')").project("name").fetchall() == [("value",)]
+        assert connection.execute("PRAGMA show_tables").fetchall() == [("marker",)]
+        connection.commit()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_transaction_precheck_keeps_native_read_effects(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.begin()
+        connection.execute("CREATE SEQUENCE seq")
+        assert connection.execute("SELECT nextval('seq')").fetchone() == (1,)
+        connection.commit()
 
 
 @pytest.mark.parametrize("runner_type", ["local", "ray"])
@@ -960,8 +1055,97 @@ def test_read_only_write_target_fails_before_runner_initialization(monkeypatch, 
                 connection.sql("SELECT 3 AS value").insert_into("target")
 
 
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+@pytest.mark.parametrize("clause", ["WITH (location={})", "PARTITIONED BY ({})", "SORTED BY ({})"])
 @pytest.mark.parametrize(
-    "metadata", ["WITH (location=$setting)", "PARTITIONED BY (bucket($setting, value))", "SORTED BY (value + $setting)"]
+    ("expression", "message"),
+    [
+        ("current_query()", "client-context function"),
+        ("current_date", "client-context function"),
+        ("concat('prefix:', current_query())", "client-context function"),
+        ("getvariable(current_query())", "client-context function"),
+        ("CASE WHEN TRUE THEN 'static' ELSE current_query() END", "client-context function"),
+        ("hidden_context('prefix:')", "client-context function"),
+        ("nextval('seq')", "database-modifying expressions"),
+        ("hidden_sequence()", "database-modifying expressions"),
+        ("(SELECT nextval('seq'))", "metadata does not support subqueries"),
+        ("hidden_subquery()", "metadata does not support subqueries"),
+    ],
+)
+def test_ctas_metadata_rejects_effects_before_runner_initialization(
+    monkeypatch, tmp_path, entry, clause, expression, message
+):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("CTAS metadata effects must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    database = str(tmp_path / "metadata.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO hidden_context(x) AS concat(x, current_query())")
+        connection.execute("CREATE MACRO hidden_sequence() AS nextval('seq')")
+        connection.execute("CREATE MACRO hidden_subquery() AS (SELECT nextval('seq'))")
+        query = f"CREATE TABLE created {clause.format(expression)} AS SELECT 7 AS value"
+        with pytest.raises(vane.NotImplementedException, match=message):
+            _run_sql_entry(connection, entry, query)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.execute("SELECT table_name FROM duckdb_tables()").fetchall() == []
+
+
+@pytest.mark.parametrize("clause", ["PARTITIONED BY ({})", "SORTED BY ({})"])
+@pytest.mark.parametrize(
+    ("expression", "message"),
+    [
+        ("bucket(nextval('seq'), value)", "database-modifying expressions"),
+        ("bucket(current_query(), value)", "client-context function"),
+        ("bucket(hidden_context(value), value)", "client-context function"),
+        ("bucket((SELECT nextval('seq')), value)", "metadata does not support subqueries"),
+        ("bucket(unregistered(value), value)", "unregistered.*does not exist"),
+        ("list_transform([value], lambda x: x + 1)", "metadata does not support lambda expressions"),
+    ],
+)
+def test_ctas_transform_arguments_require_validated_sql_expressions(monkeypatch, clause, expression, message):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("invalid CTAS transform arguments must not reach the runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO hidden_context(x) AS concat(x, current_query())")
+        query = f"CREATE TABLE created {clause.format(expression)} AS SELECT 7 AS value"
+        with pytest.raises((vane.NotImplementedException, vane.CatalogException), match=message):
+            connection.execute(query)
+
+
+@pytest.mark.parametrize("metadata", ["properties", "partition_by"])
+@pytest.mark.parametrize("expression", ["current_query()", "nextval('seq')", "hidden_context()"])
+def test_relation_create_metadata_uses_the_same_effect_checks(monkeypatch, metadata, expression):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("Relation CTAS metadata must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO hidden_context() AS current_query()")
+        expression = vane.SQLExpression(expression)
+        arguments = {metadata: {"location": expression} if metadata == "properties" else [expression]}
+        with pytest.raises(
+            vane.NotImplementedException, match="client-context function|database-modifying expressions"
+        ):
+            connection.sql("SELECT 7 AS value").create("created", **arguments)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    ["WITH (location=$setting)", "PARTITIONED BY (bucket($setting, value))", "SORTED BY (value + $setting)"],
 )
 def test_ctas_metadata_captures_parameters_in_transported_plan(monkeypatch, metadata):
     runner = RecordingRunner()
@@ -975,6 +1159,35 @@ def test_ctas_metadata_captures_parameters_in_transported_plan(monkeypatch, meta
         # must contain typed constants instead of unbound parameter identifiers.
         assert b"setting" not in payload.replace(query.encode(), b"")
         assert runner.writes[0].to_physical_plan(connection) is not None
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        "WITH (location=concat('s3://warehouse/', getvariable('setting')))",
+        "WITH (location=metadata_value('table'))",
+        "WITH (location=coalesce(NULL, 's3://warehouse/table'))",
+        "PARTITIONED BY (bucket(getvariable('setting'), value))",
+        "PARTITIONED BY (metadata_value(value))",
+        "SORTED BY (value + getvariable('setting'))",
+        "SORTED BY (metadata_value(value))",
+        "SORTED BY (age(TIMESTAMP '2025-01-01', TIMESTAMP '2020-01-01'))",
+    ],
+)
+def test_ctas_metadata_captures_client_bindings_and_keeps_pure_expressions(monkeypatch, metadata):
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    query = f"CREATE TABLE created(value) {metadata} AS SELECT 7 AS source_name"
+    with vane.connect() as connection:
+        connection.execute("SET VARIABLE setting=29")
+        connection.execute("CREATE MACRO metadata_value(x) AS x || getvariable('setting')")
+        connection.execute(query)
+        payload = runner.writes[0].__getstate__()[1].replace(query.encode(), b"")
+        assert b"getvariable" not in payload
+        assert b"metadata_value" not in payload
+        # The planning connection has neither the client's macro nor variable.
+        with vane.connect() as driver:
+            assert runner.writes[0].to_physical_plan(driver) is not None
 
 
 def test_local_fast_sql_writes_keep_native_transactions(monkeypatch, tmp_path):

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""SQL and Relation execution share admission of an already-bound plan."""
+
+import pickle
+
+import pyarrow as pa
+import pytest
+
+import vane
+from tests.fast.test_distributed_result_consumers import _TransportedPlanRunner
+
+
+class RecordingRunner:
+    def __init__(self):
+        self.reads = []
+        self.writes = []
+
+    def run_iter_tables(self, plan):
+        assert isinstance(plan, vane.ray_cxx.PyLogicalPlan)
+        self.reads.append(plan)
+        yield pa.table({"value": pa.array([42], pa.int64())})
+
+    def run_write(self, plan):
+        assert isinstance(plan, vane.ray_cxx.PyLogicalPlan)
+        self.writes.append(pickle.loads(pickle.dumps(plan)))
+        return {"copy_operation_id": plan.idx(), "rows_copied": 3}
+
+
+def install_runner(monkeypatch, runner):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: runner)
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "query", "from_query", "relation"])
+def test_read_runner_receives_bound_parameters_without_rebinding(monkeypatch, entry):
+    runner = _TransportedPlanRunner()
+    install_runner(monkeypatch, runner)
+    with vane.connect() as connection:
+
+        def forbid_rebinding(*_args, **_kwargs):
+            raise AssertionError("a runner must receive a plan that is already bound")
+
+        monkeypatch.setattr(vane.ray_cxx.PyLogicalPlan, "from_duckdb_relation", forbid_rebinding)
+        if entry == "relation":
+            result = connection.sql("SELECT $value::BIGINT AS value", params={"value": 7}).filter("value > 1")
+        elif entry == "execute":
+            result = connection.execute("SELECT $value::BIGINT AS value", {"value": 7})
+        else:
+            result = getattr(connection, entry)("SELECT $value::BIGINT AS value", params={"value": 7})
+        assert result.fetchall() == [(7,)]
+        assert len(runner.plans) == 1
+
+
+_WRITES = [
+    ("insert_values", "INSERT INTO target VALUES ($value)", {"value": 7}),
+    ("insert_select", "INSERT INTO target SELECT $value::INTEGER", {"value": 8}),
+    ("update", "UPDATE target SET value=$value", {"value": 9}),
+    ("delete", "DELETE FROM target WHERE value=$value", {"value": 10}),
+    (
+        "merge",
+        "MERGE INTO target t USING (SELECT $value::INTEGER AS value) s ON t.value=s.value "
+        "WHEN NOT MATCHED THEN INSERT VALUES (s.value)",
+        {"value": 11},
+    ),
+    ("ctas", "CREATE TABLE created AS SELECT $value::INTEGER AS value", {"value": 12}),
+    ("copy", "COPY (SELECT $value::INTEGER AS value) TO $path (FORMAT PARQUET)", {"value": 13}),
+]
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation", "relation_query"])
+@pytest.mark.parametrize("operation, query, values", _WRITES, ids=[write[0] for write in _WRITES])
+def test_write_entrypoints_dispatch_bound_plans_without_local_mutation(
+    monkeypatch, tmp_path, entry, operation, query, values
+):
+    database = str(tmp_path / "source.duckdb")
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as native:
+        native.execute("CREATE TABLE target(value INTEGER); INSERT INTO target VALUES (1), (2)")
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    values = dict(values)
+    path = tmp_path / "result.parquet"
+    if operation == "copy":
+        values["path"] = str(path)
+
+    def forbid_rebinding(*_args, **_kwargs):
+        raise AssertionError("write runner must not bind a Relation again")
+
+    monkeypatch.setattr(vane.ray_cxx.PyLogicalPlan, "from_duckdb_write_relation", forbid_rebinding)
+    with vane.connect(database) as connection:
+        if entry == "execute":
+            assert connection.execute(query, values).fetchall() == [(3,)]
+            assert connection.description[0][0] == "Count"
+        elif entry == "sql":
+            assert connection.sql(query, params=values) is None
+        elif entry == "executemany":
+            assert connection.executemany(query, [values, values]).fetchall() == [(3,)]
+        elif entry == "relation_query":
+            for key, value in values.items():
+                query = query.replace(f"${key}", str(vane.ConstantExpression(value)))
+            assert connection.sql("SELECT 1 AS unused").query("source_view", query) is None
+        else:
+            source = connection.sql("SELECT $value::INTEGER AS value", params={"value": values["value"]})
+            if operation == "insert_values":
+                connection.table("target").insert([values["value"]])
+            elif operation == "insert_select":
+                source.insert_into("target")
+            elif operation == "update":
+                connection.table("target").update({"value": vane.ConstantExpression(values["value"])})
+            elif operation == "delete":
+                connection.table("target").delete(condition=vane.ColumnExpression("value") == values["value"])
+            elif operation == "merge":
+                source.merge_into(
+                    "target", "target.value = source.value", ["WHEN NOT MATCHED THEN INSERT VALUES (source.value)"]
+                )
+            elif operation == "ctas":
+                source.create("created")
+            else:
+                source.write_parquet(str(path))
+        assert len(runner.writes) == (2 if entry == "executemany" else 1)
+        assert runner.reads == []
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as native:
+        assert native.execute("SELECT * FROM target ORDER BY value").fetchall() == [(1,), (2,)]
+        assert native.execute("SELECT count(*) FROM duckdb_tables() WHERE table_name='created'").fetchone() == (0,)
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "relation"])
+@pytest.mark.parametrize("hook", ["failure", "close", "replace", "begin", "interrupt"])
+def test_runner_initialization_cannot_execute_an_abandoned_bound_query(monkeypatch, tmp_path, entry, hook):
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    connection = vane.connect()
+    path = tmp_path / "abandoned.parquet"
+
+    def initialize(*_args, **_kwargs):
+        if hook == "failure":
+            raise RuntimeError("runner initialization failed")
+        if hook == "replace":
+            connection.execute("SET threads=2")
+        else:
+            getattr(connection, hook)()
+        return runner
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", initialize)
+    try:
+        with pytest.raises(
+            (RuntimeError, vane.InvalidInputException, vane.ConnectionException, vane.InterruptException)
+        ):
+            if entry == "execute":
+                connection.execute("SELECT 7::BIGINT AS value")
+            elif entry == "sql":
+                connection.sql(f"COPY (SELECT 7 AS value) TO '{path}' (FORMAT PARQUET)")
+            else:
+                connection.sql("SELECT 7 AS value").write_parquet(str(path))
+        assert runner.reads == runner.writes == []
+        assert not path.exists()
+        if hook != "close":
+            if hook == "begin":
+                connection.rollback()
+            install_runner(monkeypatch, runner)
+            # Recovery must start a new query; the abandoned binding transaction
+            # must not retain catalog locks or erase this result during cleanup.
+            connection.execute("CREATE TABLE recovered(value INTEGER)")
+            assert connection.execute("SELECT 1::BIGINT AS value").fetchall() == [(42,)]
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize(
+    "query, message",
+    [
+        ("INSERT INTO target VALUES (3) RETURNING value", "default Count"),
+        ("UPDATE target SET value=3 RETURNING value", "default Count"),
+        ("DELETE FROM target RETURNING value", "default Count"),
+        ("INSERT INTO target VALUES (3) ON CONFLICT DO NOTHING", "ON CONFLICT"),
+        ("CREATE TEMP TABLE created AS SELECT 3 AS value", "TEMPORARY"),
+        ("CREATE OR REPLACE TABLE created AS SELECT 3 AS value", "OR REPLACE"),
+        ("CREATE TABLE IF NOT EXISTS created AS SELECT 3 AS value", "IF NOT EXISTS"),
+    ],
+)
+def test_unsupported_write_semantics_fail_before_runner_initialization(monkeypatch, query, message):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("unsupported plans must fail admission before initializing a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE target(value INTEGER PRIMARY KEY)")
+        with pytest.raises(vane.NotImplementedException, match=message):
+            connection.execute(query)
+        with pytest.raises(vane.CatalogException, match="created"):
+            connection.table("created")
+
+
+@pytest.mark.parametrize("entry", ["execute", "relation"])
+def test_read_only_write_target_fails_before_runner_initialization(monkeypatch, tmp_path, entry):
+    database = str(tmp_path / "readonly.duckdb")
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE TABLE target(value INTEGER)")
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("read-only writes must fail before initializing Ray")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect(database, read_only=True) as connection:
+        with pytest.raises(vane.InvalidInputException, match="read-only"):
+            if entry == "execute":
+                connection.execute("INSERT INTO target VALUES (3)")
+            else:
+                connection.sql("SELECT 3 AS value").insert_into("target")
+
+
+@pytest.mark.parametrize(
+    "metadata", ["WITH (location=$setting)", "PARTITIONED BY (bucket($setting, value))", "SORTED BY (value + $setting)"]
+)
+def test_ctas_metadata_captures_parameters_in_transported_plan(monkeypatch, metadata):
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    value = "s3://warehouse/captured" if metadata.startswith("WITH") else 29
+    query = f"CREATE TABLE created {metadata} AS SELECT $value::INTEGER AS value"
+    with vane.connect() as connection:
+        connection.execute(query, {"setting": value, "value": 7})
+        payload = runner.writes[0].__getstate__()[1]
+        # CreateInfo retains the original SQL for diagnostics; executable metadata
+        # must contain typed constants instead of unbound parameter identifiers.
+        assert b"setting" not in payload.replace(query.encode(), b"")
+        assert runner.writes[0].to_physical_plan(connection) is not None
+
+
+def test_local_fast_sql_writes_keep_native_transactions(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("native execution must not initialize Ray")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE target(value INTEGER DEFAULT 7)")
+        connection.begin()
+        assert connection.execute("INSERT INTO target DEFAULT VALUES").fetchall() == [(1,)]
+        assert connection.execute("UPDATE target SET value=? RETURNING value", [8]).fetchall() == [(8,)]
+        connection.rollback()
+        assert connection.execute("SELECT count(*) FROM target").fetchone() == (0,)
+        connection.sql("INSERT INTO target VALUES (?)", params=[9])
+        assert connection.execute("CREATE TABLE created AS SELECT * FROM target").fetchall() == [(1,)]
+        path = tmp_path / "native.parquet"
+        assert connection.execute("COPY created TO ? (FORMAT PARQUET)", [str(path)]).fetchall() == [(1,)]
+        assert connection.execute("SELECT * FROM read_parquet(?)", [str(path)]).fetchall() == [(9,)]

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -383,6 +383,12 @@ _CLIENT_CONTEXT_EXPRESSIONS = [
     "CURRENT_DATE",
     "today()",
     "CURRENT_TIME",
+    "LOCALTIME",
+    "LOCALTIMESTAMP",
+    "current_localtime()",
+    "current_localtimestamp()",
+    "age(TIMESTAMP '2026-09-10 11:00:00')",
+    "age(TIMESTAMPTZ '2026-09-10 11:00:00+00')",
 ]
 
 
@@ -470,6 +476,21 @@ def test_local_fast_writes_keep_client_query_text(monkeypatch, operation):
             query = "CREATE TABLE target AS SELECT current_query() AS value"
         assert connection.execute(query).fetchone() == (1,)
         assert connection.execute("SELECT value FROM target").fetchone() == (query,)
+
+
+@pytest.mark.parametrize("entry", ["execute", "relation"])
+@pytest.mark.parametrize("timestamp_type", ["TIMESTAMP", "TIMESTAMPTZ"])
+def test_runner_reads_keep_binary_age_with_explicit_operands(monkeypatch, entry, timestamp_type):
+    runner = _TransportedPlanRunner()
+    install_runner(monkeypatch, runner)
+    with vane.connect() as connection:
+        query = f"SELECT epoch(age({timestamp_type} '2026-09-10 12:00:00+00', "
+        query += f"{timestamp_type} '2026-09-08 12:00:00+00')) AS value"
+        if entry == "execute":
+            result = connection.execute(query)
+        else:
+            result = connection.sql(query).project("value")
+        assert result.fetchall() == [(172800.0,)]
 
 
 def test_runner_reads_keep_bound_variable_values_and_pure_functions(monkeypatch):

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -1391,7 +1391,13 @@ def test_runner_initialization_serializes_competing_connection_calls(monkeypatch
             def parent_udf(value: int) -> int:
                 return value + 1
 
-            parent.create_function("parent_udf", parent_udf)
+            vane.attach_function(
+                parent_udf,
+                connection=parent,
+                alias="parent_udf",
+                parameters=["BIGINT"],
+                return_dtype="BIGINT",
+            )
             parent_udf_ref = weakref.ref(parent_udf)
             del parent_udf
         connection = parent.cursor() if "parent_close" in competing_operation else parent

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -82,8 +82,188 @@ def test_pragma_control_commands_stay_on_the_client(monkeypatch, runner_type, en
     with vane.connect() as connection:
         for query in ["PRAGMA threads=1", "PRAGMA enable_profiling", "PRAGMA disable_profiling"]:
             result = getattr(connection, entry)(query)
-            if entry == "execute":
+            if result is not None:
                 assert result.fetchall() == []
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "PRAGMA database_size", "PRAGMA table_info('client_table')"])
+def test_query_pragmas_observe_the_client_catalog(monkeypatch, runner_type, entry, query):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client catalog inspection must not initialize a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE client_table(value INTEGER)")
+        connection.execute("ATTACH ':memory:' AS client_catalog")
+        result = connection.executemany(query, [[]]) if entry == "executemany" else getattr(connection, entry)(query)
+        rows = result.fetchall()
+        if "show_tables" in query:
+            assert rows == [("client_table",)]
+        elif "database_size" in query:
+            assert "client_catalog" in {row[0] for row in rows}
+        else:
+            assert rows == [(0, "value", "INTEGER", False, None, False)]
+
+
+@pytest.mark.parametrize("derive", ["filter", "project", "order", "persisted_view"])
+def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path, derive):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("a derived PRAGMA query must still inspect its client catalog")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    database = str(tmp_path / "catalog.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE TABLE client_table(value INTEGER)")
+        relation = connection.sql("PRAGMA show_tables")
+        if derive == "filter":
+            result = relation.filter("name = 'client_table'")
+        elif derive == "project":
+            result = relation.project("name")
+        elif derive == "order":
+            result = relation.order("name")
+        else:
+            relation.filter("name = 'client_table'").create_view("catalog_view")
+            result = connection.sql("SELECT name FROM catalog_view")
+        assert result.fetchall() == [("client_table",)]
+    if derive == "persisted_view":
+        # Reopening exercises the stored query node's serialization, not only Copy().
+        with vane.connect(database) as connection:
+            assert connection.sql("SELECT name FROM catalog_view").fetchall() == [("client_table",)]
+
+
+@pytest.mark.parametrize("entry", ["sql", "relation"])
+def test_runner_write_cannot_make_client_pragma_queries_run_remotely(monkeypatch, tmp_path, entry):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("a client catalog query cannot be embedded in a runner write")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    destination = tmp_path / "catalog.parquet"
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE client_table(value INTEGER)")
+        relation = connection.sql("PRAGMA show_tables")
+        with pytest.raises(vane.NotImplementedException, match="client connection quer"):
+            if entry == "sql":
+                relation.create_view("catalog_view")
+                connection.sql(f"COPY catalog_view TO '{destination}' (FORMAT PARQUET)")
+            else:
+                relation.write_parquet(str(destination))
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql"])
+def test_native_controls_can_disable_query_verification(monkeypatch, tmp_path, runner_type, entry):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("verification rejection and native controls must precede runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    database = str(tmp_path / "verification.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        result = getattr(connection, entry)("PRAGMA enable_verification")
+        if result is not None:
+            assert result.fetchall() == []
+        connection.execute("SET threads=1")
+        connection.execute("CREATE TABLE client_table(value INTEGER)")
+        assert connection.sql("PRAGMA show_tables").fetchall() == [("client_table",)]
+        # Native verification must not execute this SELECT before admission rejects it.
+        with pytest.raises(vane.NotImplementedException, match="query verification"):
+            getattr(connection, entry)("SELECT nextval('seq')").fetchall()
+        destination = tmp_path / "verified.parquet"
+        with pytest.raises(vane.NotImplementedException, match="query verification"):
+            getattr(connection, entry)(f"COPY (SELECT 1) TO '{destination}' (FORMAT PARQUET)")
+        assert not destination.exists()
+        result = getattr(connection, entry)("PRAGMA disable_verification")
+        if result is not None:
+            assert result.fetchall() == []
+        runner = RecordingRunner()
+        monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: runner)
+        assert connection.execute("SELECT 42::BIGINT AS value").fetchall() == [(42,)]
+        assert len(runner.reads) == (1 if runner_type == "ray" else 0)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation"])
+@pytest.mark.parametrize("sequence", ["'seq'", "seq_name", "$sequence"])
+def test_ray_rejects_database_modifying_reads_before_execution(monkeypatch, tmp_path, entry, sequence):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("a database-modifying read must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    database = str(tmp_path / "sequence.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        query = f"SELECT nextval({sequence}) AS value FROM (VALUES ('seq')) t(seq_name)"
+        params = {"sequence": "seq"} if sequence == "$sequence" else {}
+        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+            if entry == "execute":
+                connection.execute(query, params).fetchall()
+            elif entry == "executemany":
+                connection.executemany(query, [params]).fetchall()
+            else:
+                result = connection.sql(query, params=params)
+                if entry == "relation":
+                    result = result.filter("value > 0")
+                result.fetchall()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+
+
+@pytest.mark.parametrize("operation", ["copy", "insert_default", "ctas"])
+def test_ray_writes_reject_untransportable_expression_effects(monkeypatch, tmp_path, operation):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("a write must not transport database-modifying expressions")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE TABLE target(value BIGINT DEFAULT nextval('seq'))")
+        query = {
+            "copy": f"COPY (SELECT nextval('seq')) TO '{tmp_path / 'sequence.parquet'}' (FORMAT PARQUET)",
+            "insert_default": "INSERT INTO target DEFAULT VALUES",
+            "ctas": "CREATE TABLE created AS SELECT nextval('seq') AS value",
+        }[operation]
+        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+            connection.execute(query)
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_native_read_policy_keeps_sequence_effects(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        assert connection.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert connection.sql("SELECT nextval(name) FROM (VALUES ('seq')) t(name)").fetchone() == (2,)
+
+
+def test_local_fast_native_verification_still_executes(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        connection.execute("PRAGMA enable_verification")
+        try:
+            assert connection.execute("SELECT sum(i) FROM range(5) t(i)").fetchall() == [(10,)]
+            assert connection.sql("PRAGMA show_tables").fetchall() == []
+        finally:
+            connection.execute("PRAGMA disable_verification")
 
 
 def test_local_fast_call_keeps_native_results(monkeypatch):

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -4,6 +4,7 @@
 """SQL and Relation execution share admission of an already-bound plan."""
 
 import pickle
+import uuid
 
 import pyarrow as pa
 import pytest
@@ -31,6 +32,18 @@ class RecordingRunner:
 def install_runner(monkeypatch, runner):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: runner)
+
+
+def test_explicit_plan_factory_allocates_stable_unique_query_ids():
+    with vane.connect() as connection:
+        relation = connection.sql("SELECT 7::BIGINT AS value")
+        first = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+        second = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+        assert uuid.UUID(first.idx()) != uuid.UUID(second.idx())
+        assert pickle.loads(pickle.dumps(first)).idx() == first.idx()
+        assert (
+            vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "explicit-query-id").idx() == "explicit-query-id"
+        )
 
 
 @pytest.mark.parametrize("entry", ["execute", "sql", "query", "from_query", "relation"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -77,10 +77,11 @@ def test_explicit_plan_factories_apply_runner_admission(monkeypatch, runner_type
 
 
 @pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
-def test_explicit_plan_factory_rejects_client_query_origin(monkeypatch, runner_type):
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES"])
+def test_explicit_plan_factory_rejects_client_query_origin(monkeypatch, runner_type, query):
     monkeypatch.setenv("VANE_RUNNER", runner_type)
     with vane.connect() as connection:
-        relation = connection.sql("PRAGMA show_tables").project("name")
+        relation = connection.sql(query).project("name")
         with pytest.raises(ValueError, match="client connection queries|client-context table function"):
             vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
 
@@ -569,7 +570,8 @@ def test_maintenance_commands_update_client_statistics_without_a_runner(monkeypa
 
 
 @pytest.mark.parametrize("derive", ["filter", "project", "order", "persisted_view"])
-def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path, derive):
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES"])
+def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path, derive, query):
     monkeypatch.setenv("VANE_RUNNER", "ray")
 
     def forbid_initialization(*_args, **_kwargs):
@@ -579,7 +581,7 @@ def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path
     database = str(tmp_path / "catalog.duckdb")
     with vane.connect(database) as connection:
         connection.execute("CREATE TABLE client_table(value INTEGER)")
-        relation = connection.sql("PRAGMA show_tables")
+        relation = connection.sql(query)
         if derive == "filter":
             result = relation.filter("name = 'client_table'")
         elif derive == "project":
@@ -597,7 +599,8 @@ def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path
 
 
 @pytest.mark.parametrize("entry", ["sql", "relation"])
-def test_runner_write_cannot_make_client_pragma_queries_run_remotely(monkeypatch, tmp_path, entry):
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES"])
+def test_runner_write_cannot_make_client_pragma_queries_run_remotely(monkeypatch, tmp_path, entry, query):
     monkeypatch.setenv("VANE_RUNNER", "ray")
 
     def forbid_initialization(*_args, **_kwargs):
@@ -607,7 +610,7 @@ def test_runner_write_cannot_make_client_pragma_queries_run_remotely(monkeypatch
     destination = tmp_path / "catalog.parquet"
     with vane.connect() as connection:
         connection.execute("CREATE TABLE client_table(value INTEGER)")
-        relation = connection.sql("PRAGMA show_tables")
+        relation = connection.sql(query)
         with pytest.raises(vane.NotImplementedException, match="client connection quer"):
             if entry == "sql":
                 relation.create_view("catalog_view")

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -77,7 +77,7 @@ def test_explicit_plan_factories_apply_runner_admission(monkeypatch, runner_type
 
 
 @pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
-@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES"])
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES", "SELECT * FROM query('SHOW TABLES')"])
 def test_explicit_plan_factory_rejects_client_query_origin(monkeypatch, runner_type, query):
     monkeypatch.setenv("VANE_RUNNER", runner_type)
     with vane.connect() as connection:
@@ -570,7 +570,7 @@ def test_maintenance_commands_update_client_statistics_without_a_runner(monkeypa
 
 
 @pytest.mark.parametrize("derive", ["filter", "project", "order", "persisted_view"])
-@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES"])
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES", "SELECT * FROM query('SHOW TABLES')"])
 def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path, derive, query):
     monkeypatch.setenv("VANE_RUNNER", "ray")
 
@@ -599,7 +599,7 @@ def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path
 
 
 @pytest.mark.parametrize("entry", ["sql", "relation"])
-@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES"])
+@pytest.mark.parametrize("query", ["PRAGMA show_tables", "SHOW TABLES", "SELECT * FROM query('SHOW TABLES')"])
 def test_runner_write_cannot_make_client_pragma_queries_run_remotely(monkeypatch, tmp_path, entry, query):
     monkeypatch.setenv("VANE_RUNNER", "ray")
 

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -363,6 +363,125 @@ def test_local_fast_keeps_native_generated_target_writes(monkeypatch):
         assert connection.execute("SELECT * FROM target").fetchall() == [(2, 3)]
 
 
+_CLIENT_CONTEXT_EXPRESSIONS = [
+    "current_query()",
+    "txid_current()",
+    "current_query_id()",
+    "current_transaction_id()",
+    "current_connection_id()",
+    "currval('seq')",
+    "setseed(0.25)",
+    "current_schema()",
+    "current_database()",
+    "current_catalog()",
+    "current_schemas(true)",
+    "in_search_path('memory', 'main')",
+    "current_setting('threads')",
+    "now()",
+    "CURRENT_TIMESTAMP",
+    "transaction_timestamp()",
+    "CURRENT_DATE",
+    "today()",
+    "CURRENT_TIME",
+]
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation"])
+@pytest.mark.parametrize("expression", _CLIENT_CONTEXT_EXPRESSIONS)
+def test_runner_reads_reject_client_context_functions_before_initialization(monkeypatch, entry, expression):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client-context functions must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        query = f"SELECT {expression} AS value"
+        with pytest.raises(vane.NotImplementedException, match="client-context function"):
+            if entry == "executemany":
+                connection.executemany(query, [[]])
+            elif entry == "relation":
+                connection.sql(query).project("CAST(value AS VARCHAR) AS value").fetchall()
+            else:
+                getattr(connection, entry)(query).fetchall()
+
+
+@pytest.mark.parametrize("expression", ["current_query()", "txid_current()"])
+@pytest.mark.parametrize("operation", ["copy", "insert", "update", "merge", "ctas", "default", "check"])
+def test_runner_writes_reject_client_context_functions(monkeypatch, tmp_path, expression, operation):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client-context functions must not reach the write runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        value = f"CAST({expression} AS VARCHAR)"
+        definition = "value VARCHAR"
+        if operation == "default":
+            definition += f" DEFAULT {value}"
+        elif operation == "check":
+            definition += f" CHECK(length({value}) > 0)"
+        connection.execute(f"CREATE TABLE target({definition})")
+        query = {
+            "copy": f"COPY (SELECT {value}) TO '{tmp_path / 'context.parquet'}' (FORMAT PARQUET)",
+            "insert": f"INSERT INTO target SELECT {value}",
+            "update": f"UPDATE target SET value={value}",
+            "merge": "MERGE INTO target t USING (SELECT 'value' AS value) s ON t.value=s.value "
+            f"WHEN NOT MATCHED THEN INSERT VALUES ({value})",
+            "ctas": f"CREATE TABLE created AS SELECT {value} AS value",
+            "default": "INSERT INTO target DEFAULT VALUES",
+            "check": "INSERT INTO target VALUES ('value')",
+        }[operation]
+        with pytest.raises(vane.NotImplementedException, match="client-context function"):
+            connection.execute(query)
+    assert not (tmp_path / "context.parquet").exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_native_reads_keep_client_context_functions(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        query = "SELECT current_query()"
+        assert connection.execute(query).fetchone() == (query,)
+        for function in ["txid_current", "current_query_id", "current_transaction_id", "current_connection_id"]:
+            assert isinstance(connection.execute(f"SELECT {function}()").fetchone()[0], int)
+        connection.execute("CREATE SEQUENCE seq")
+        assert connection.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert connection.execute("SELECT currval('seq')").fetchone() == (1,)
+        assert connection.execute("SELECT setseed(0.25)").fetchone() == (None,)
+        assert connection.execute(
+            "SELECT CURRENT_TIMESTAMP IS NOT NULL, current_setting('threads') > 0"
+        ).fetchone() == (
+            True,
+            True,
+        )
+
+
+@pytest.mark.parametrize("operation", ["insert", "ctas"])
+def test_local_fast_writes_keep_client_query_text(monkeypatch, operation):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        if operation == "insert":
+            connection.execute("CREATE TABLE target(value VARCHAR)")
+            query = "INSERT INTO target SELECT current_query()"
+        else:
+            query = "CREATE TABLE target AS SELECT current_query() AS value"
+        assert connection.execute(query).fetchone() == (1,)
+        assert connection.execute("SELECT value FROM target").fetchone() == (query,)
+
+
+def test_runner_reads_keep_bound_variable_values_and_pure_functions(monkeypatch):
+    runner = _TransportedPlanRunner()
+    install_runner(monkeypatch, runner)
+    with vane.connect() as connection:
+        connection.execute("SET VARIABLE answer=41")
+        assert connection.execute("SELECT getvariable('answer') + 1, upper('portable')").fetchall() == [
+            (42, "PORTABLE")
+        ]
+
+
 @pytest.mark.parametrize("runner_type", ["local-fast", "local"])
 def test_native_read_policy_keeps_sequence_effects(monkeypatch, runner_type):
     monkeypatch.setenv("VANE_RUNNER", runner_type)

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -1524,6 +1524,55 @@ def test_ctas_metadata_rejects_effects_before_runner_initialization(
         assert inspector.execute("SELECT table_name FROM duckdb_tables()").fetchall() == []
 
 
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query", "parameterized_sql"])
+@pytest.mark.parametrize(
+    "clause",
+    ["WITH (location={})", "PARTITIONED BY (bucket({}, value))", "SORTED BY (concat({}, value::VARCHAR))"],
+)
+@pytest.mark.parametrize("function", ["current_setting", "metadata_setting"])
+def test_ctas_metadata_rejects_bind_callbacks_before_extension_autoload(
+    monkeypatch, client_extension_state, entry, clause, function
+):
+    database, config = client_extension_state
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("CTAS metadata bind callbacks must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect(database, config=config) as connection:
+        connection.execute("CREATE MACRO metadata_setting(key) AS current_setting(key)")
+        setting = "azure_storage_connection_string"
+        argument = "$setting" if entry == "parameterized_sql" else f"'{setting}'"
+        expression = f"{function}({argument})"
+        query = f"CREATE TABLE created {clause.format(expression)} AS SELECT 7 AS value"
+        with pytest.raises(vane.NotImplementedException, match="client-context function current_setting"):
+            if entry == "parameterized_sql":
+                connection.sql(query, params={"setting": setting})
+            else:
+                _run_sql_entry(connection, entry, query)
+
+
+@pytest.mark.parametrize("metadata", ["properties", "partition_by"])
+@pytest.mark.parametrize("function", ["current_setting", "metadata_setting"])
+def test_relation_metadata_rejects_bind_callbacks_before_extension_autoload(
+    monkeypatch, client_extension_state, metadata, function
+):
+    database, config = client_extension_state
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("Relation metadata bind callbacks must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect(database, config=config) as connection:
+        connection.execute("CREATE MACRO metadata_setting(key) AS current_setting(key)")
+        expression = vane.SQLExpression(f"{function}('azure_storage_connection_string')")
+        arguments = {metadata: {"location": expression} if metadata == "properties" else [expression]}
+        with pytest.raises(vane.NotImplementedException, match="client-context function current_setting"):
+            connection.sql("SELECT 7 AS value").create("created", **arguments)
+
+
 @pytest.mark.parametrize("clause", ["PARTITIONED BY ({})", "SORTED BY ({})"])
 @pytest.mark.parametrize(
     ("expression", "message"),

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -248,6 +248,121 @@ def test_ray_writes_reject_untransportable_expression_effects(monkeypatch, tmp_p
             connection.execute(query)
 
 
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation", "relation_query"])
+@pytest.mark.parametrize("operation", ["insert", "update", "merge"])
+@pytest.mark.parametrize("modifies_database", [False, True])
+def test_write_constraint_effects_are_checked_before_runner_initialization(
+    monkeypatch, tmp_path, entry, operation, modifies_database
+):
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    if modifies_database:
+
+        def forbid_initialization(*_args, **_kwargs):
+            raise AssertionError("a database-modifying CHECK must fail before runner initialization")
+
+        monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    database = str(tmp_path / "constraints.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        expression = "value > 0 AND nextval('seq') > 0" if modifies_database else "value > 0"
+        connection.execute(f"CREATE TABLE target(value BIGINT NOT NULL CHECK({expression}))")
+        query = {
+            "insert": "INSERT INTO target VALUES (1)",
+            "update": "UPDATE target SET value=1",
+            "merge": "MERGE INTO target t USING (SELECT 1::BIGINT AS value) s ON t.value=s.value "
+            "WHEN MATCHED THEN UPDATE SET value=s.value WHEN NOT MATCHED THEN INSERT VALUES (s.value)",
+        }[operation]
+
+        def write():
+            if entry == "execute":
+                connection.execute(query)
+            elif entry == "sql":
+                connection.sql(query)
+            elif entry == "executemany":
+                connection.executemany(query, [[]])
+            elif entry == "relation_query":
+                connection.sql("SELECT 1 AS unused").query("source_view", query)
+            elif operation == "insert":
+                connection.sql("SELECT 1::BIGINT AS value").insert_into("target")
+            elif operation == "update":
+                connection.table("target").update({"value": vane.ConstantExpression(1)})
+            else:
+                connection.sql("SELECT 1::BIGINT AS value").merge_into(
+                    "target",
+                    "target.value = source.value",
+                    [
+                        "WHEN MATCHED THEN UPDATE SET value=source.value",
+                        "WHEN NOT MATCHED THEN INSERT VALUES (source.value)",
+                    ],
+                )
+
+        if modifies_database:
+            with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+                write()
+            assert runner.writes == []
+        else:
+            write()
+            assert len(runner.writes) == 1
+        assert runner.reads == []
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.execute("SELECT * FROM target").fetchall() == []
+
+
+@pytest.mark.parametrize("entry", ["execute", "relation"])
+@pytest.mark.parametrize("operation", ["insert", "update", "merge"])
+@pytest.mark.parametrize("expression", ["value + 1", "nextval('seq')"])
+def test_runner_writes_reject_generated_target_columns(monkeypatch, tmp_path, entry, operation, expression):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("generated target columns must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    database = str(tmp_path / "generated.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute(f"CREATE TABLE target(value BIGINT, derived BIGINT GENERATED ALWAYS AS ({expression}))")
+        with pytest.raises(vane.NotImplementedException, match="generated target columns"):
+            if entry == "execute":
+                connection.execute(
+                    {
+                        "insert": "INSERT INTO target VALUES (1)",
+                        "update": "UPDATE target SET value=1",
+                        "merge": "MERGE INTO target t USING (SELECT 1::BIGINT AS value) s ON t.value=s.value "
+                        "WHEN MATCHED THEN UPDATE SET value=s.value WHEN NOT MATCHED THEN INSERT VALUES (s.value)",
+                    }[operation]
+                )
+            elif operation == "insert":
+                connection.sql("SELECT 1::BIGINT AS value").insert_into("target")
+            elif operation == "update":
+                connection.table("target").update({"value": vane.ConstantExpression(1)})
+            else:
+                connection.sql("SELECT 1::BIGINT AS value").merge_into(
+                    "target",
+                    "target.value = source.value",
+                    [
+                        "WHEN MATCHED THEN UPDATE SET value=source.value",
+                        "WHEN NOT MATCHED THEN INSERT VALUES (source.value)",
+                    ],
+                )
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.execute("SELECT value FROM target").fetchall() == []
+
+
+def test_local_fast_keeps_native_generated_target_writes(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE target(value BIGINT, derived BIGINT GENERATED ALWAYS AS (value + 1))")
+        connection.sql("SELECT 1::BIGINT AS value").insert_into("target")
+        connection.execute("UPDATE target SET value=2")
+        assert connection.execute("SELECT * FROM target").fetchall() == [(2, 3)]
+
+
 @pytest.mark.parametrize("runner_type", ["local-fast", "local"])
 def test_native_read_policy_keeps_sequence_effects(monkeypatch, runner_type):
     monkeypatch.setenv("VANE_RUNNER", runner_type)

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -6,6 +6,7 @@
 import pickle
 import threading
 import uuid
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 
 import pyarrow as pa
@@ -1361,7 +1362,10 @@ def test_write_entrypoints_dispatch_bound_plans_without_local_mutation(
 
 
 @pytest.mark.parametrize("entry", ["execute", "sql", "relation"])
-@pytest.mark.parametrize("competing_operation", ["native_control", "lazy_relation", "runner_read"])
+@pytest.mark.parametrize(
+    "competing_operation",
+    ["native_control", "lazy_relation", "runner_read", "close", "parent_close", "reentrant_parent_close"],
+)
 def test_runner_initialization_serializes_competing_connection_calls(monkeypatch, tmp_path, entry, competing_operation):
     runner = RecordingRunner()
     install_runner(monkeypatch, runner)
@@ -1373,10 +1377,24 @@ def test_runner_initialization_serializes_competing_connection_calls(monkeypatch
     def initialize(*_args, **_kwargs):
         initializing.set()
         assert resume_initialization.wait(timeout=10)
+        if competing_operation == "reentrant_parent_close":
+            parent.close()
+        if parent_udf_ref is not None:
+            assert parent_udf_ref() is not None, "parent released its UDF before the active cursor finished"
         return runner
 
     monkeypatch.setattr(vane._native, "set_runner_ray", initialize)
-    with vane.connect() as connection:
+    with vane.connect() as parent:
+        parent_udf_ref = None
+        if "parent_close" in competing_operation:
+
+            def parent_udf(value: int) -> int:
+                return value + 1
+
+            parent.create_function("parent_udf", parent_udf)
+            parent_udf_ref = weakref.ref(parent_udf)
+            del parent_udf
+        connection = parent.cursor() if "parent_close" in competing_operation else parent
         source = connection.sql("SELECT 7::BIGINT AS value")
         target = tmp_path / "output.parquet"
 
@@ -1395,6 +1413,8 @@ def test_runner_initialization_serializes_competing_connection_calls(monkeypatch
                     connection.execute("SET threads=2")
                 elif competing_operation == "lazy_relation":
                     connection.sql("SELECT 8::BIGINT AS value")
+                elif "close" in competing_operation:
+                    parent.close()
                 else:
                     connection.execute("SELECT 8::BIGINT AS value")
             finally:
@@ -1414,6 +1434,11 @@ def test_runner_initialization_serializes_competing_connection_calls(monkeypatch
 
         assert len(runner.reads) == int(entry == "execute") + int(competing_operation == "runner_read")
         assert len(runner.writes) == int(entry != "execute")
+        if "close" in competing_operation:
+            for closed in (parent, connection):
+                with pytest.raises(vane.ConnectionException, match="already closed"):
+                    closed.execute("SELECT 1")
+                closed.close()
 
 
 @pytest.mark.parametrize("entry", ["execute", "sql", "relation"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -4,7 +4,9 @@
 """SQL and Relation execution share admission of an already-bound plan."""
 
 import pickle
+import threading
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import pyarrow as pa
 import pytest
@@ -44,6 +46,50 @@ def test_explicit_plan_factory_allocates_stable_unique_query_ids():
         assert (
             vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "explicit-query-id").idx() == "explicit-query-id"
         )
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+@pytest.mark.parametrize("query", ["CALL checkpoint()", "CALL range(3)"])
+def test_sql_call_is_not_dispatched_as_a_distributed_read(monkeypatch, runner_type, entry, query):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("SQL CALL must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    with vane.connect() as connection:
+        with pytest.raises(vane.NotImplementedException, match="SQL CALL"):
+            if entry == "executemany":
+                connection.executemany(query, [[]])
+            elif entry == "relation_query":
+                connection.sql("SELECT 1").query("input", query)
+            else:
+                getattr(connection, entry)(query)
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql"])
+def test_pragma_control_commands_stay_on_the_client(monkeypatch, runner_type, entry):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("PRAGMA control commands must not initialize a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    with vane.connect() as connection:
+        for query in ["PRAGMA threads=1", "PRAGMA enable_profiling", "PRAGMA disable_profiling"]:
+            result = getattr(connection, entry)(query)
+            if entry == "execute":
+                assert result.fetchall() == []
+
+
+def test_local_fast_call_keeps_native_results(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        assert connection.execute("CALL range(3)").fetchall() == [(0,), (1,), (2,)]
 
 
 @pytest.mark.parametrize("entry", ["execute", "sql", "query", "from_query", "relation"])
@@ -300,3 +346,32 @@ def test_local_fast_sql_writes_keep_native_transactions(monkeypatch, tmp_path):
         path = tmp_path / "native.parquet"
         assert connection.execute("COPY created TO ? (FORMAT PARQUET)", [str(path)]).fetchall() == [(1,)]
         assert connection.execute("SELECT * FROM read_parquet(?)", [str(path)]).fetchall() == [(9,)]
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+def test_local_fast_concurrent_writes_on_one_connection_are_serialized(monkeypatch, entry):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    workers, rounds, rows_per_statement = 4, 8, 32768
+    start = threading.Barrier(workers)
+    query = "INSERT INTO target SELECT ?::INTEGER, i FROM range(?) t(i)"
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE target(worker INTEGER, value BIGINT)")
+
+        def insert(worker):
+            start.wait(timeout=10)
+            for _ in range(rounds):
+                params = [worker, rows_per_statement]
+                if entry == "sql":
+                    connection.sql(query, params=params)
+                elif entry == "executemany":
+                    connection.executemany(query, [params])
+                else:
+                    connection.execute(query, params)
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(insert, worker) for worker in range(workers)]
+            for future in futures:
+                future.result(timeout=30)
+        assert connection.execute("SELECT worker, count(*) FROM target GROUP BY worker ORDER BY worker").fetchall() == [
+            (worker, rounds * rows_per_statement) for worker in range(workers)
+        ]

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -211,7 +211,9 @@ def test_ray_rejects_database_modifying_reads_before_execution(monkeypatch, tmp_
         connection.execute("CREATE SEQUENCE seq")
         query = f"SELECT nextval({sequence}) AS value FROM (VALUES ('seq')) t(seq_name)"
         params = {"sequence": "seq"} if sequence == "$sequence" else {}
-        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+        # Nonconstant sequence names are rejected by the binder itself.
+        error = "requires a constant sequence" if sequence == "seq_name" else "database-modifying expressions"
+        with pytest.raises(vane.NotImplementedException, match=error):
             if entry == "execute":
                 connection.execute(query, params).fetchall()
             elif entry == "executemany":
@@ -252,7 +254,7 @@ def test_native_read_policy_keeps_sequence_effects(monkeypatch, runner_type):
     with vane.connect() as connection:
         connection.execute("CREATE SEQUENCE seq")
         assert connection.execute("SELECT nextval('seq')").fetchone() == (1,)
-        assert connection.sql("SELECT nextval(name) FROM (VALUES ('seq')) t(name)").fetchone() == (2,)
+        assert connection.sql("SELECT nextval($sequence)", params={"sequence": "seq"}).fetchone() == (2,)
 
 
 def test_local_fast_native_verification_still_executes(monkeypatch):

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -461,7 +461,7 @@ _CLIENT_CONTEXT_EXPRESSIONS = [
     "currval('seq')",
     "setseed(0.25)",
     "write_log('runner guard')",
-    "parse_log_message('QueryLog', 'runner guard')",
+    "parse_duckdb_log_message('QueryLog', 'runner guard')",
     "current_schema()",
     "current_database()",
     "current_catalog()",
@@ -506,7 +506,12 @@ def test_runner_reads_reject_client_context_functions_before_initialization(monk
 
 @pytest.mark.parametrize(
     "expression",
-    ["current_query()", "txid_current()", "write_log('runner guard')", "parse_log_message('QueryLog', 'runner guard')"],
+    [
+        "current_query()",
+        "txid_current()",
+        "write_log('runner guard')",
+        "parse_duckdb_log_message('QueryLog', 'runner guard')",
+    ],
 )
 @pytest.mark.parametrize("operation", ["copy", "insert", "update", "merge", "ctas", "default", "check"])
 def test_runner_writes_reject_client_context_functions(monkeypatch, tmp_path, expression, operation):
@@ -554,7 +559,7 @@ def test_native_reads_keep_client_context_functions(monkeypatch, runner_type):
         assert connection.execute(
             "SELECT write_log('native guard', return_value := 42, disable_logging := true)"
         ).fetchone() == (42,)
-        assert connection.execute("SELECT parse_log_message('QueryLog', 'native guard')").fetchone() == (
+        assert connection.execute("SELECT parse_duckdb_log_message('QueryLog', 'native guard')").fetchone() == (
             {"message": "native guard"},
         )
         assert connection.execute(

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -69,6 +69,95 @@ def test_sql_call_is_not_dispatched_as_a_distributed_read(monkeypatch, runner_ty
                 getattr(connection, entry)(query)
 
 
+def _run_sql_entry(connection, entry, query):
+    if entry == "executemany":
+        return connection.executemany(query, [[]])
+    if entry == "relation_query":
+        return connection.sql("SELECT 1").query("input", query)
+    return getattr(connection, entry)(query)
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+@pytest.mark.parametrize("transactional", [False, True])
+@pytest.mark.parametrize(
+    "query",
+    [
+        "PREPARE p AS SELECT * FROM range(nextval('seq'))",
+        "EXPLAIN ANALYZE SELECT * FROM range(nextval('seq'))",
+        "CALL range(nextval('seq'))",
+        "EXPLAIN PREPARE p AS SELECT * FROM range(nextval('seq'))",
+        "EXPLAIN CALL range(nextval('seq'))",
+    ],
+)
+def test_rejected_wrappers_do_not_bind_effectful_arguments(
+    monkeypatch, tmp_path, runner_type, entry, transactional, query
+):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("unsupported wrappers must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    database = str(tmp_path / "wrappers.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        if transactional:
+            connection.begin()
+            connection.execute("CREATE TABLE marker(value INTEGER)")
+        with pytest.raises(vane.NotImplementedException, match="SQL CALL|SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE"):
+            _run_sql_entry(connection, entry, query)
+        if transactional:
+            connection.execute("CREATE TABLE followup(value INTEGER)")
+            connection.commit()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        if transactional:
+            assert inspector.table("marker").fetchall() == []
+            assert inspector.table("followup").fetchall() == []
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+@pytest.mark.parametrize("operation", ["copy_from", "client_context", "insert"])
+def test_bound_admission_errors_preserve_transactional_work(monkeypatch, tmp_path, runner_type, entry, operation):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("admission rejection must precede runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    source = tmp_path / "input.csv"
+    source.write_text("value\n1\n")
+    destination = tmp_path / "rejected.parquet"
+    query = {
+        "copy_from": f"COPY marker FROM '{source}' (FORMAT CSV, HEADER)",
+        "client_context": f"COPY (SELECT current_query()) TO '{destination}' (FORMAT PARQUET)",
+        "insert": "INSERT INTO marker VALUES (1)",
+    }[operation]
+    message = {
+        "copy_from": "SQL COPY FROM",
+        "client_context": "client-context function",
+        "insert": "requires a ray|cannot participate.*explicit transaction",
+    }[operation]
+    database = str(tmp_path / "admission.duckdb")
+    with vane.connect(database) as connection:
+        connection.begin()
+        connection.execute("CREATE TABLE marker(value INTEGER)")
+        with pytest.raises(vane.BinderException, match=message):
+            _run_sql_entry(connection, entry, query)
+        connection.execute("CREATE TABLE followup(value INTEGER)")
+        connection.commit()
+    assert not destination.exists()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.table("marker").fetchall() == []
+        assert inspector.table("followup").fetchall() == []
+
+
 @pytest.mark.parametrize("runner_type", ["local", "ray"])
 @pytest.mark.parametrize("entry", ["execute", "sql"])
 def test_pragma_control_commands_stay_on_the_client(monkeypatch, runner_type, entry):
@@ -371,6 +460,8 @@ _CLIENT_CONTEXT_EXPRESSIONS = [
     "current_connection_id()",
     "currval('seq')",
     "setseed(0.25)",
+    "write_log('runner guard')",
+    "parse_log_message('QueryLog', 'runner guard')",
     "current_schema()",
     "current_database()",
     "current_catalog()",
@@ -413,7 +504,10 @@ def test_runner_reads_reject_client_context_functions_before_initialization(monk
                 getattr(connection, entry)(query).fetchall()
 
 
-@pytest.mark.parametrize("expression", ["current_query()", "txid_current()"])
+@pytest.mark.parametrize(
+    "expression",
+    ["current_query()", "txid_current()", "write_log('runner guard')", "parse_log_message('QueryLog', 'runner guard')"],
+)
 @pytest.mark.parametrize("operation", ["copy", "insert", "update", "merge", "ctas", "default", "check"])
 def test_runner_writes_reject_client_context_functions(monkeypatch, tmp_path, expression, operation):
     monkeypatch.setenv("VANE_RUNNER", "ray")
@@ -458,11 +552,121 @@ def test_native_reads_keep_client_context_functions(monkeypatch, runner_type):
         assert connection.execute("SELECT currval('seq')").fetchone() == (1,)
         assert connection.execute("SELECT setseed(0.25)").fetchone() == (None,)
         assert connection.execute(
+            "SELECT write_log('native guard', return_value := 42, disable_logging := true)"
+        ).fetchone() == (42,)
+        assert connection.execute("SELECT parse_log_message('QueryLog', 'native guard')").fetchone() == (
+            {"message": "native guard"},
+        )
+        assert connection.execute(
             "SELECT CURRENT_TIMESTAMP IS NOT NULL, current_setting('threads') > 0"
         ).fetchone() == (
             True,
             True,
         )
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation"])
+@pytest.mark.parametrize(
+    "function",
+    [
+        "duckdb_settings()",
+        "duckdb_variables()",
+        "duckdb_prepared_statements()",
+        "duckdb_tables()",
+        "duckdb_views()",
+        "duckdb_columns()",
+        "duckdb_schemas()",
+        "duckdb_databases()",
+        "duckdb_memory()",
+        "duckdb_logs()",
+        "enable_logging()",
+        "checkpoint()",
+    ],
+)
+def test_runner_reads_reject_client_context_table_functions(monkeypatch, entry, function):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client-context table functions must fail before runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        query = f"SELECT count(*) AS value FROM {function}"
+        with pytest.raises(vane.NotImplementedException, match="client-context table function"):
+            if entry == "relation":
+                connection.sql(query).project("value").fetchall()
+            else:
+                _run_sql_entry(connection, entry, query).fetchall()
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation"])
+@pytest.mark.parametrize("operation", ["copy", "insert", "ctas"])
+@pytest.mark.parametrize(
+    "source",
+    [
+        "SELECT value FROM duckdb_settings() WHERE name = 'threads'",
+        "SELECT table_name AS value FROM duckdb_tables()",
+    ],
+)
+def test_runner_writes_reject_client_context_table_functions(monkeypatch, tmp_path, entry, operation, source):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("writes must not substitute worker settings or catalog state")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    destination = tmp_path / "context.parquet"
+    with vane.connect() as connection:
+        connection.execute("SET threads=1")
+        connection.execute("CREATE TABLE target(value VARCHAR)")
+        with pytest.raises(vane.NotImplementedException, match="client-context table function"):
+            if entry == "relation":
+                relation = connection.sql(source)
+                if operation == "copy":
+                    relation.write_parquet(str(destination))
+                elif operation == "insert":
+                    relation.insert_into("target")
+                else:
+                    relation.create("created")
+            else:
+                query = {
+                    "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
+                    "insert": f"INSERT INTO target {source}",
+                    "ctas": f"CREATE TABLE created AS {source}",
+                }[operation]
+                _run_sql_entry(connection, entry, query)
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_native_reads_keep_client_context_table_functions(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("SET threads=1")
+        connection.execute("CREATE TABLE client_marker(value INTEGER)")
+        assert connection.sql("SELECT value FROM duckdb_settings() WHERE name='threads'").fetchone() == ("1",)
+        assert connection.execute(
+            "SELECT table_name FROM duckdb_tables() WHERE table_name='client_marker'"
+        ).fetchall() == [("client_marker",)]
+
+
+@pytest.mark.parametrize("function", ["duckdb_keywords()", "duckdb_optimizers()"])
+def test_runner_reads_keep_static_table_functions(monkeypatch, function):
+    install_runner(monkeypatch, _TransportedPlanRunner())
+    with vane.connect() as connection:
+        assert connection.execute(f"SELECT count(*) > 0 AS value FROM {function}").fetchone() == (True,)
+
+
+def test_local_fast_executemany_reuses_the_bound_native_plan(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE TABLE target(value BIGINT)")
+        # Native table-function arguments are evaluated at bind time. Rebinding
+        # each parameter set would advance the sequence and insert 1+2+3 rows.
+        connection.executemany("INSERT INTO target SELECT range FROM range(nextval('seq'))", [[], [], []])
+        assert connection.execute("SELECT value FROM target").fetchall() == [(0,), (0,), (0,)]
+        assert connection.execute("SELECT nextval('seq')").fetchone() == (2,)
 
 
 @pytest.mark.parametrize("operation", ["insert", "ctas"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -876,6 +876,94 @@ def test_runner_writes_reject_client_context_functions(monkeypatch, tmp_path, ex
     assert not (tmp_path / "context.parquet").exists()
 
 
+@pytest.fixture
+def client_extension_state(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    database = str(tmp_path / "extension_state.duckdb")
+    extension_directory = tmp_path / "extensions"
+    config = {
+        "autoload_known_extensions": "true",
+        "autoinstall_known_extensions": "true",
+        "custom_extension_repository": "http://127.0.0.1:9",
+        "extension_directory": str(extension_directory),
+    }
+    with vane.connect(database, config=config) as inspector:
+        query = "SELECT extension_name, loaded FROM duckdb_extensions() ORDER BY extension_name"
+        before = inspector.execute(query).fetchall()
+        # httpfs is statically loaded in the default build; Azure exercises
+        # a setting whose bind callback would actually enter the autoloader.
+        assert not dict(before).get("azure", False)
+        yield database, config
+        assert inspector.execute(query).fetchall() == before
+        assert not extension_directory.exists()
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "parameterized_sql", "executemany", "relation_query"])
+@pytest.mark.parametrize(
+    "runner_type, operation",
+    [("ray", "select"), *[(runner, op) for runner in ["local", "ray"] for op in ["copy", "insert", "ctas"]]],
+)
+@pytest.mark.parametrize(
+    "expression, setting",
+    [
+        ("current_setting({key})", "s3_region"),
+        ("current_setting({key})", "azure_storage_connection_string"),
+        ("upper(current_setting({key}))", "azure_storage_connection_string"),
+        ("list_transform([1], lambda x: current_setting({key}))", "azure_storage_connection_string"),
+    ],
+)
+def test_runner_rejects_scalar_bind_callbacks_before_extension_autoload(
+    monkeypatch, tmp_path, client_extension_state, entry, runner_type, operation, expression, setting
+):
+    database, config = client_extension_state
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("scalar bind callbacks must be rejected before initializing a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    destination = tmp_path / "rejected.parquet"
+    with vane.connect(database, config=config) as connection:
+        connection.execute("CREATE TABLE target(value VARCHAR)")
+        expression = expression.format(key="$setting" if entry == "parameterized_sql" else f"'{setting}'")
+        source = f"SELECT {expression} AS value"
+        query = {
+            "select": source,
+            "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
+            "insert": f"INSERT INTO target {source}",
+            "ctas": f"CREATE TABLE created AS {source}",
+        }[operation]
+        with pytest.raises(vane.NotImplementedException, match="client-context function current_setting"):
+            if entry == "parameterized_sql":
+                result = connection.sql(query, params={"setting": setting})
+            else:
+                result = _run_sql_entry(connection, entry, query)
+            if result is not None:
+                result.fetchall()
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+@pytest.mark.parametrize("factory", ["read", "datasink"])
+def test_explicit_plan_factory_rejects_scalar_bind_callbacks_after_macro_replacement(
+    monkeypatch, client_extension_state, runner_type, factory
+):
+    database, config = client_extension_state
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect(database, config=config) as connection:
+        connection.execute("CREATE MACRO source_setting(key) AS 'initial'")
+        relation = connection.sql("SELECT source_setting('azure_storage_connection_string') AS value")
+        if factory == "datasink":
+            relation = relation._mark_datasink("scalar-bind-admission")
+        connection.execute("CREATE OR REPLACE MACRO source_setting(key) AS current_setting(key)")
+        make_plan = getattr(
+            vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
+        )
+        with pytest.raises(ValueError, match="client-context function current_setting"):
+            make_plan(relation, None)
+
+
 @pytest.mark.parametrize("runner_type", ["local-fast", "local"])
 def test_native_reads_keep_client_context_functions(monkeypatch, runner_type):
     monkeypatch.setenv("VANE_RUNNER", runner_type)

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -665,6 +665,9 @@ def test_runner_reads_keep_static_table_functions(monkeypatch, function):
 def test_local_fast_executemany_reuses_the_bound_native_plan(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     with vane.connect() as connection:
+        # Native Prepare uses a read-only transaction in auto-commit mode.
+        # Bind-time sequence changes require an existing write transaction.
+        connection.begin()
         connection.execute("CREATE SEQUENCE seq")
         connection.execute("CREATE TABLE target(value BIGINT)")
         # Native table-function arguments are evaluated at bind time. Rebinding
@@ -672,6 +675,7 @@ def test_local_fast_executemany_reuses_the_bound_native_plan(monkeypatch):
         connection.executemany("INSERT INTO target SELECT range FROM range(nextval('seq'))", [[], [], []])
         assert connection.execute("SELECT value FROM target").fetchall() == [(0,), (0,), (0,)]
         assert connection.execute("SELECT nextval('seq')").fetchone() == (2,)
+        connection.commit()
 
 
 @pytest.mark.parametrize("operation", ["insert", "ctas"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -196,7 +196,14 @@ def test_runner_rejects_bind_time_effects_in_autocommit(
             "insert": f"INSERT INTO target {source}",
             "ctas": f"CREATE TABLE created AS {source}",
         }[operation]
-        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+        message = "database-modifying expressions"
+        errors = (vane.NotImplementedException,)
+        if runner_type == "local" and operation in {"insert", "ctas"}:
+            # Local FTE can reject the terminal itself before inspecting a
+            # runtime lambda body; it does not support these table writes.
+            message += "|requires a ray or local-fast connection"
+            errors += (vane.InvalidInputException,)
+        with pytest.raises(errors, match=message):
             result = _run_sql_entry(connection, entry, query)
             # Lambda arguments can select range's table-in/table-out overload,
             # whose argument is evaluated at execution rather than binding.
@@ -269,8 +276,10 @@ def test_native_read_binding_keeps_table_argument_effects(monkeypatch, runner_ty
     with vane.connect() as connection:
         connection.begin()
         connection.execute("CREATE SEQUENCE seq")
-        assert connection.execute("SELECT * FROM range(nextval('seq'))").fetchall() == [(0,)]
-        assert connection.execute("SELECT nextval('seq')").fetchone() == (2,)
+        # Native preparation/rebinding evaluates this argument twice, as it did
+        # before runner bind-time admission was introduced.
+        assert connection.execute("SELECT * FROM range(nextval('seq'))").fetchall() == [(0,), (1,)]
+        assert connection.execute("SELECT nextval('seq')").fetchone() == (3,)
         connection.commit()
 
 

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -936,6 +936,109 @@ def test_runner_reads_reject_client_context_table_functions(monkeypatch, entry, 
                 _run_sql_entry(connection, entry, query).fetchall()
 
 
+@pytest.fixture
+def client_file_logs(monkeypatch, tmp_path):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    database = str(tmp_path / "logs.duckdb")
+    log_directory = tmp_path / "logs"
+    with vane.connect(database) as connection:
+        connection.execute(f"CALL enable_logging(['QueryLog'], storage_path='{log_directory}', storage_normalize=true)")
+        connection.execute("SELECT 'client log marker'").fetchall()
+        connection.execute("CALL disable_logging()")
+        yield database, connection, log_directory
+
+
+_FILE_LOG_FUNCTIONS = ["duckdb_logs()", "duckdb_logs(denormalized_table=true)", "duckdb_log_contexts()"]
+
+
+@pytest.mark.parametrize("function", _FILE_LOG_FUNCTIONS)
+@pytest.mark.parametrize("runner_type, operation", [("ray", "select"), ("ray", "copy"), ("local", "copy")])
+@pytest.mark.parametrize("entry", ["execute", "sql", "parameterized_sql", "relation_query", "relation"])
+def test_runner_rejects_file_log_bind_replacement(
+    monkeypatch, tmp_path, client_file_logs, function, runner_type, operation, entry
+):
+    database, _, log_directory = client_file_logs
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("file log functions must fail before initializing a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    destination = tmp_path / "rejected.parquet"
+    with vane.connect(database) as connection:
+        source = f"SELECT count(*) AS value FROM {function}"
+        # A local read may bind and flush natively before becoming a write.
+        relation = connection.sql(source).project("value") if entry == "relation" and runner_type == "local" else None
+        # Disabling logging leaves the buffered storage available for scans.
+        # Admission must reject before bind replacement flushes those buffers.
+        before = {path.name: path.read_bytes() for path in log_directory.glob("*")}
+        query = source if operation == "select" else f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)"
+        with pytest.raises(vane.NotImplementedException, match="client-context table function duckdb_log"):
+            if entry == "parameterized_sql":
+                parameterized = source + " WHERE context_id >= $minimum"
+                if operation == "copy":
+                    parameterized = f"COPY ({parameterized}) TO '{destination}' (FORMAT PARQUET)"
+                result = connection.sql(parameterized, params={"minimum": 0})
+            elif entry == "relation":
+                if relation is None:
+                    relation = connection.sql(source).project("value")
+                result = relation if operation == "select" else relation.write_parquet(str(destination))
+            else:
+                result = _run_sql_entry(connection, entry, query)
+            if result is not None:
+                result.fetchall()
+        assert {path.name: path.read_bytes() for path in log_directory.glob("*")} == before
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("function", _FILE_LOG_FUNCTIONS)
+@pytest.mark.parametrize(
+    "runner_type, factory", [("local-fast", "read"), ("local", "read"), ("local-fast", "datasink")]
+)
+def test_explicit_plan_factory_rejects_file_log_bind_replacement(
+    monkeypatch, client_file_logs, function, runner_type, factory
+):
+    database, _, log_directory = client_file_logs
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect(database) as connection:
+        relation = connection.sql(f"SELECT * FROM {function}")
+        if factory == "datasink":
+            relation = relation._mark_datasink("file-log-admission")
+        make_plan = getattr(
+            vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
+        )
+        before = {path.name: path.read_bytes() for path in log_directory.glob("*")}
+        with pytest.raises(ValueError, match="client-context table function duckdb_log"):
+            make_plan(relation, None)
+        assert {path.name: path.read_bytes() for path in log_directory.glob("*")} == before
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+@pytest.mark.parametrize("function", _FILE_LOG_FUNCTIONS)
+def test_native_reads_keep_file_log_bind_replacement(monkeypatch, client_file_logs, runner_type, function):
+    database, _, _ = client_file_logs
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect(database) as connection:
+        assert connection.execute(f"SELECT count(*) > 0 FROM {function}").fetchone() == (True,)
+        assert connection.sql(
+            "SELECT message FROM duckdb_logs() WHERE message = $message",
+            params={"message": "SELECT 'client log marker'"},
+        ).fetchall() == [("SELECT 'client log marker'",)]
+
+
+@pytest.mark.parametrize("source", ["query('SELECT 42 AS value')", "query_table('portable')"])
+def test_runner_keeps_portable_bind_replacements(monkeypatch, source):
+    runner = _TransportedPlanRunner()
+    install_runner(monkeypatch, runner)
+    try:
+        with vane.connect() as connection:
+            connection.execute("CREATE VIEW portable AS SELECT 42 AS value")
+            assert connection.sql(f"SELECT * FROM {source}").fetchall() == [(42,)]
+    finally:
+        runner.worker.close()
+
+
 @pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation"])
 @pytest.mark.parametrize("operation", ["copy", "insert", "ctas"])
 @pytest.mark.parametrize(

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -48,6 +48,200 @@ def test_explicit_plan_factory_allocates_stable_unique_query_ids():
         )
 
 
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+@pytest.mark.parametrize("factory", ["read", "datasink"])
+@pytest.mark.parametrize(
+    "query, message",
+    [
+        ("SELECT current_query()", "client-context function"),
+        ("SELECT concat('query: ', current_query())", "client-context function"),
+        ("SELECT * FROM duckdb_settings()", "client-context table function"),
+        ("SELECT nextval('seq')", "database-modifying expressions"),
+    ],
+)
+def test_explicit_plan_factories_apply_runner_admission(monkeypatch, runner_type, factory, query, message):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        relation = connection.sql(query)
+        if factory == "datasink":
+            relation = relation._mark_datasink("factory-admission")
+        make_plan = getattr(
+            vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
+        )
+        with pytest.raises(vane.NotImplementedException, match=message):
+            make_plan(relation, None)
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+def test_explicit_plan_factory_rejects_client_query_origin(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        relation = connection.sql("PRAGMA show_tables").project("name")
+        with pytest.raises(
+            vane.NotImplementedException, match="client connection queries|client-context table function"
+        ):
+            vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+def test_explicit_read_factory_rechecks_transaction_before_binding(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO row_count() AS 2")
+        relation = connection.sql("SELECT * FROM range(row_count())")
+        connection.begin()
+        connection.execute("CREATE OR REPLACE MACRO row_count() AS nextval('seq')")
+        with pytest.raises(vane.InvalidInputException, match="cannot participate.*explicit transaction"):
+            vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+        connection.execute("CREATE TABLE still_active(value INTEGER)")
+        connection.rollback()
+        with pytest.raises(vane.CatalogException, match="still_active"):
+            connection.table("still_active")
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+def test_explicit_plan_factory_checks_bind_time_effects_after_macro_replacement(monkeypatch, tmp_path, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    database = str(tmp_path / "factory_effects.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO row_count() AS 2")
+        relation = connection.sql("SELECT * FROM range(row_count())")
+        connection.execute("CREATE OR REPLACE MACRO row_count() AS nextval('seq')")
+        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+            vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+
+
+@pytest.mark.parametrize("derive", ["project", "filter", "order"])
+def test_runner_relation_rebinding_checks_bind_time_effects(monkeypatch, tmp_path, derive):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    database = str(tmp_path / "relation_effects.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO row_count() AS 2")
+        relation = connection.sql("SELECT range AS value FROM range(row_count())")
+        argument = "value > 0" if derive == "filter" else "value"
+        relation = getattr(relation, derive)(argument)
+        connection.execute("CREATE OR REPLACE MACRO row_count() AS nextval('seq')")
+        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+            relation.fetchall()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+def test_explicit_plan_factory_preserves_portable_binding(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("SET VARIABLE row_count=3")
+        relation = connection.sql(
+            "SELECT range + $offset AS value FROM range(getvariable('row_count'))", params={"offset": 5}
+        )
+        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+        runner = _TransportedPlanRunner()
+        try:
+            assert pa.concat_tables(list(runner.run_iter_tables(plan))).to_pydict() == {"value": [5, 6, 7]}
+        finally:
+            runner.worker.close()
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+@pytest.mark.parametrize(
+    "runner_type, operation",
+    [("ray", "select"), *[(runner, op) for runner in ["local", "ray"] for op in ["copy", "insert", "ctas"]]],
+)
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "nextval('seq')",
+        "nextval('seq') + 1",
+        "hidden_sequence()",
+        "getvariable(CAST(nextval('seq') AS VARCHAR))",
+        "CASE WHEN FALSE THEN nextval('seq') ELSE 2 END",
+        "array_length(list_transform([1], x -> nextval('seq')))",
+    ],
+)
+def test_runner_rejects_bind_time_effects_in_autocommit(
+    monkeypatch, tmp_path, entry, runner_type, operation, expression
+):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("bind-time effects must be rejected before initializing a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    database = str(tmp_path / "bind_effects.duckdb")
+    destination = tmp_path / "rejected.parquet"
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE TABLE target(value BIGINT)")
+        connection.execute("CREATE MACRO hidden_sequence() AS nextval('seq')")
+        source = f"SELECT range AS value FROM range({expression})"
+        query = {
+            "select": source,
+            "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
+            "insert": f"INSERT INTO target {source}",
+            "ctas": f"CREATE TABLE created AS {source}",
+        }[operation]
+        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+            _run_sql_entry(connection, entry, query)
+        connection.execute("CREATE TABLE followup(value INTEGER)")
+    assert not destination.exists()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.table("target").fetchall() == []
+        assert inspector.table("followup").fetchall() == []
+        with pytest.raises(vane.CatalogException, match="created"):
+            inspector.table("created")
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+def test_runner_rejects_parameterized_bind_time_effects(monkeypatch, tmp_path, entry):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    database = str(tmp_path / "parameter_effects.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        query = "SELECT * FROM range(nextval($sequence))"
+        params = {"sequence": "seq"}
+        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+            if entry == "sql":
+                connection.sql(query, params=params)
+            elif entry == "executemany":
+                connection.executemany(query, [params])
+            else:
+                connection.execute(query, params)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+
+
+@pytest.mark.parametrize("expression", ["length(current_query())", "length(getvariable(current_query()))"])
+def test_runner_checks_client_context_before_table_argument_folding(monkeypatch, expression):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    with vane.connect() as connection:
+        with pytest.raises(vane.NotImplementedException, match="client-context function"):
+            connection.sql(f"SELECT * FROM range({expression})")
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_native_read_binding_keeps_table_argument_effects(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.begin()
+        connection.execute("CREATE SEQUENCE seq")
+        assert connection.execute("SELECT * FROM range(nextval('seq'))").fetchall() == [(0,)]
+        assert connection.execute("SELECT nextval('seq')").fetchone() == (2,)
+        connection.commit()
+
+
 @pytest.mark.parametrize("runner_type", ["local", "ray"])
 @pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
 @pytest.mark.parametrize("query", ["CALL checkpoint()", "CALL range(3)"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -177,6 +177,9 @@ def test_runner_initialization_cannot_execute_an_abandoned_bound_query(monkeypat
         ("UPDATE target SET value=3 RETURNING value", "default Count"),
         ("DELETE FROM target RETURNING value", "default Count"),
         ("INSERT INTO target VALUES (3) ON CONFLICT DO NOTHING", "ON CONFLICT"),
+        ("INSERT INTO target VALUES (3) ON CONFLICT DO UPDATE SET value=excluded.value", "ON CONFLICT"),
+        ("INSERT OR IGNORE INTO target VALUES (3)", "ON CONFLICT"),
+        ("INSERT OR REPLACE INTO target VALUES (3)", "ON CONFLICT"),
         ("CREATE TEMP TABLE created AS SELECT 3 AS value", "TEMPORARY"),
         ("CREATE OR REPLACE TABLE created AS SELECT 3 AS value", "OR REPLACE"),
         ("CREATE TABLE IF NOT EXISTS created AS SELECT 3 AS value", "IF NOT EXISTS"),
@@ -195,6 +198,37 @@ def test_unsupported_write_semantics_fail_before_runner_initialization(monkeypat
             connection.execute(query)
         with pytest.raises(vane.CatalogException, match="created"):
             connection.table("created")
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql"])
+@pytest.mark.parametrize(
+    "operation, query, values", [("select", "SELECT $value::INTEGER AS value", {"value": 7}), *_WRITES]
+)
+def test_runner_transaction_rejection_preserves_the_client_transaction(
+    monkeypatch, tmp_path, entry, operation, query, values
+):
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    values = dict(values)
+    if operation == "copy":
+        values["path"] = str(tmp_path / "rejected.parquet")
+    with vane.connect() as connection:
+        connection.begin()
+        connection.execute("CREATE TABLE target(value INTEGER)")
+        with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
+            if entry == "execute":
+                connection.execute(query, values)
+            else:
+                result = connection.sql(query, params=values)
+                if result is not None:
+                    result.fetchall()
+        # Binding rejection must neither abort nor commit the transaction.
+        connection.execute("CREATE TABLE still_active(value INTEGER)")
+        connection.rollback()
+        for table in ["target", "still_active"]:
+            with pytest.raises(vane.CatalogException, match=table):
+                connection.table(table)
+        assert runner.reads == runner.writes == []
 
 
 @pytest.mark.parametrize("entry", ["execute", "relation"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -57,6 +57,8 @@ def test_explicit_plan_factory_allocates_stable_unique_query_ids():
         ("SELECT concat('query: ', current_query())", "client-context function"),
         ("SELECT * FROM duckdb_settings()", "client-context table function"),
         ("SELECT nextval('seq')", "database-modifying expressions"),
+        ("SELECT list_transform([1], lambda x: current_query())", "client-context function"),
+        ("SELECT list_transform([1], lambda x: nextval('seq'))", "database-modifying expressions"),
     ],
 )
 def test_explicit_plan_factories_apply_runner_admission(monkeypatch, runner_type, factory, query, message):
@@ -134,19 +136,23 @@ def test_runner_relation_rebinding_checks_bind_time_effects(monkeypatch, tmp_pat
 
 
 @pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
-def test_explicit_plan_factory_preserves_portable_binding(monkeypatch, runner_type):
+@pytest.mark.parametrize(
+    "expression, expected",
+    [("range + $offset", [5, 6, 7]), ("list_transform([range], lambda x: x + $offset)", [[5], [6], [7]])],
+)
+def test_explicit_plan_factory_preserves_portable_binding(monkeypatch, runner_type, expression, expected):
     monkeypatch.setenv("VANE_RUNNER", runner_type)
     with vane.connect() as connection:
         connection.execute("SET VARIABLE row_count=3")
         relation = connection.sql(
-            "SELECT range + $offset AS value FROM range(getvariable('row_count'))", params={"offset": 5}
+            f"SELECT {expression} AS value FROM range(getvariable('row_count'))", params={"offset": 5}
         )
         plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
         runner = _TransportedPlanRunner()
         try:
             result = pa.concat_tables(list(runner.run_iter_tables(plan)))
             assert result.num_columns == 1
-            assert result.column(0).to_pylist() == [5, 6, 7]
+            assert result.column(0).to_pylist() == expected
         finally:
             runner.worker.close()
 
@@ -769,6 +775,8 @@ def test_local_fast_keeps_native_generated_target_writes(monkeypatch):
 
 _CLIENT_CONTEXT_EXPRESSIONS = [
     "current_query()",
+    "list_transform([1], lambda x: current_query())",
+    "list_transform([1], lambda x: list_transform([2], lambda y: current_query()))",
     "txid_current()",
     "current_query_id()",
     "current_transaction_id()",

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -1361,6 +1361,62 @@ def test_write_entrypoints_dispatch_bound_plans_without_local_mutation(
 
 
 @pytest.mark.parametrize("entry", ["execute", "sql", "relation"])
+@pytest.mark.parametrize("competing_operation", ["native_control", "lazy_relation", "runner_read"])
+def test_runner_initialization_serializes_competing_connection_calls(monkeypatch, tmp_path, entry, competing_operation):
+    runner = RecordingRunner()
+    install_runner(monkeypatch, runner)
+    initializing = threading.Event()
+    resume_initialization = threading.Event()
+    competing_started = threading.Event()
+    competing_finished = threading.Event()
+
+    def initialize(*_args, **_kwargs):
+        initializing.set()
+        assert resume_initialization.wait(timeout=10)
+        return runner
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", initialize)
+    with vane.connect() as connection:
+        source = connection.sql("SELECT 7::BIGINT AS value")
+        target = tmp_path / "output.parquet"
+
+        def execute_first():
+            if entry == "execute":
+                connection.execute("SELECT 7::BIGINT AS value")
+            elif entry == "sql":
+                connection.sql(f"COPY (SELECT 7 AS value) TO '{target}' (FORMAT PARQUET)")
+            else:
+                source.write_parquet(str(target))
+
+        def execute_competing():
+            competing_started.set()
+            try:
+                if competing_operation == "native_control":
+                    connection.execute("SET threads=2")
+                elif competing_operation == "lazy_relation":
+                    connection.sql("SELECT 8::BIGINT AS value")
+                else:
+                    connection.execute("SELECT 8::BIGINT AS value")
+            finally:
+                competing_finished.set()
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(execute_first)
+            try:
+                assert initializing.wait(timeout=10)
+                competing = pool.submit(execute_competing)
+                assert competing_started.wait(timeout=10)
+                assert not competing_finished.wait(timeout=0.25)
+            finally:
+                resume_initialization.set()
+            first.result(timeout=20)
+            competing.result(timeout=20)
+
+        assert len(runner.reads) == int(entry == "execute") + int(competing_operation == "runner_read")
+        assert len(runner.writes) == int(entry != "execute")
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "relation"])
 @pytest.mark.parametrize("hook", ["failure", "close", "replace", "begin", "interrupt"])
 def test_runner_initialization_cannot_execute_an_abandoned_bound_query(monkeypatch, tmp_path, entry, hook):
     runner = RecordingRunner()

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -69,7 +69,7 @@ def test_explicit_plan_factories_apply_runner_admission(monkeypatch, runner_type
         make_plan = getattr(
             vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
         )
-        with pytest.raises(vane.NotImplementedException, match=message):
+        with pytest.raises(ValueError, match=message):
             make_plan(relation, None)
 
 
@@ -78,9 +78,7 @@ def test_explicit_plan_factory_rejects_client_query_origin(monkeypatch, runner_t
     monkeypatch.setenv("VANE_RUNNER", runner_type)
     with vane.connect() as connection:
         relation = connection.sql("PRAGMA show_tables").project("name")
-        with pytest.raises(
-            vane.NotImplementedException, match="client connection queries|client-context table function"
-        ):
+        with pytest.raises(ValueError, match="client connection queries|client-context table function"):
             vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
 
 
@@ -93,7 +91,7 @@ def test_explicit_read_factory_rechecks_transaction_before_binding(monkeypatch, 
         relation = connection.sql("SELECT * FROM range(row_count())")
         connection.begin()
         connection.execute("CREATE OR REPLACE MACRO row_count() AS nextval('seq')")
-        with pytest.raises(vane.InvalidInputException, match="cannot participate.*explicit transaction"):
+        with pytest.raises(ValueError, match="cannot participate.*explicit transaction"):
             vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
         connection.execute("CREATE TABLE still_active(value INTEGER)")
         connection.rollback()
@@ -110,7 +108,7 @@ def test_explicit_plan_factory_checks_bind_time_effects_after_macro_replacement(
         connection.execute("CREATE MACRO row_count() AS 2")
         relation = connection.sql("SELECT * FROM range(row_count())")
         connection.execute("CREATE OR REPLACE MACRO row_count() AS nextval('seq')")
-        with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
+        with pytest.raises(ValueError, match="database-modifying expressions"):
             vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     with vane.connect(database) as inspector:
@@ -146,7 +144,9 @@ def test_explicit_plan_factory_preserves_portable_binding(monkeypatch, runner_ty
         plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
         runner = _TransportedPlanRunner()
         try:
-            assert pa.concat_tables(list(runner.run_iter_tables(plan))).to_pydict() == {"value": [5, 6, 7]}
+            result = pa.concat_tables(list(runner.run_iter_tables(plan)))
+            assert result.num_columns == 1
+            assert result.column(0).to_pylist() == [5, 6, 7]
         finally:
             runner.worker.close()
 
@@ -191,7 +191,11 @@ def test_runner_rejects_bind_time_effects_in_autocommit(
             "ctas": f"CREATE TABLE created AS {source}",
         }[operation]
         with pytest.raises(vane.NotImplementedException, match="database-modifying expressions"):
-            _run_sql_entry(connection, entry, query)
+            result = _run_sql_entry(connection, entry, query)
+            # Lambda arguments can select range's table-in/table-out overload,
+            # whose argument is evaluated at execution rather than binding.
+            if result is not None:
+                result.fetchall()
         connection.execute("CREATE TABLE followup(value INTEGER)")
     assert not destination.exists()
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
@@ -229,6 +233,28 @@ def test_runner_checks_client_context_before_table_argument_folding(monkeypatch,
     with vane.connect() as connection:
         with pytest.raises(vane.NotImplementedException, match="client-context function"):
             connection.sql(f"SELECT * FROM range({expression})")
+
+
+@pytest.mark.parametrize(
+    "expression, message",
+    [
+        ("CAST(nextval('seq') AS VARCHAR)", "database-modifying expressions"),
+        ("current_query()", "client-context function"),
+        ("getvariable(current_query())", "client-context function"),
+    ],
+)
+def test_runner_checks_lambda_effects_in_bind_time_table_arguments(monkeypatch, tmp_path, expression, message):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    database = str(tmp_path / "lambda_effects.duckdb")
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        # Unlike range, read_csv always evaluates these arguments during binding.
+        query = f"SELECT * FROM read_csv(list_transform(['unused'], lambda path: {expression}))"
+        with pytest.raises(vane.NotImplementedException, match=message):
+            connection.sql(query)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
 
 
 @pytest.mark.parametrize("runner_type", ["local-fast", "local"])

--- a/tests/fast/test_bound_plan_runner.py
+++ b/tests/fast/test_bound_plan_runner.py
@@ -530,6 +530,44 @@ def test_query_pragmas_observe_the_client_catalog(monkeypatch, runner_type, entr
             assert rows == [(0, "value", "INTEGER", False, None, False)]
 
 
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+def test_maintenance_commands_update_client_statistics_without_a_runner(monkeypatch, tmp_path, runner_type, entry):
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("VACUUM and ANALYZE must stay on the client connection")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    database = str(tmp_path / "maintenance.duckdb")
+    with vane.connect(database) as inspector:
+        for table in ("target", "expected"):
+            inspector.execute(f"CREATE TABLE {table} AS SELECT range % 5000 AS value FROM range(10000)")
+        inspector.execute("ANALYZE expected")
+        expected_stats = inspector.execute("SELECT stats(value) FROM expected LIMIT 1").fetchone()
+        monkeypatch.setenv("VANE_RUNNER", runner_type)
+        with vane.connect(database) as connection:
+            connection.begin()
+            connection.execute("CREATE TABLE transaction_marker(value INTEGER)")
+            for query in (
+                "VACUUM",
+                "ANALYZE",
+                "VACUUM target",
+                "VACUUM ANALYZE target(value)",
+                "ANALYZE target",
+            ):
+                result = (
+                    connection.executemany(query, [[]]) if entry == "executemany" else getattr(connection, entry)(query)
+                )
+                if result is not None:
+                    assert result.fetchall() == []
+            connection.rollback()
+            with pytest.raises(vane.CatalogException, match="transaction_marker"):
+                connection.table("transaction_marker")
+        assert inspector.execute("SELECT stats(value) FROM target LIMIT 1").fetchone() == expected_stats
+        assert inspector.execute("SELECT count(*) FROM target").fetchone() == (10000,)
+
+
 @pytest.mark.parametrize("derive", ["filter", "project", "order", "persisted_view"])
 def test_pragma_query_origin_survives_relation_composition(monkeypatch, tmp_path, derive):
     monkeypatch.setenv("VANE_RUNNER", "ray")

--- a/tests/fast/test_connection_sql_runner.py
+++ b/tests/fast/test_connection_sql_runner.py
@@ -325,11 +325,7 @@ def test_sql_execution_wrappers_cannot_bypass_runner(monkeypatch, tmp_path, meth
     else:
         query = "EXPLAIN ANALYZE SELECT 7::BIGINT"
     with vane.connect() as connection:
-        error_type = vane.BinderException if wrapper == "execute" else vane.NotImplementedException
-        message = (
-            "Prepared statement.*does not exist" if wrapper == "execute" else "SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE"
-        )
-        with pytest.raises(error_type, match=message):
+        with pytest.raises(vane.NotImplementedException, match="SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE"):
             if method == "executemany":
                 connection.executemany(query, [[]])
             else:

--- a/tests/fast/test_connection_sql_runner.py
+++ b/tests/fast/test_connection_sql_runner.py
@@ -26,8 +26,8 @@ class _SQLRunner(_TransportedPlanRunner):
             "copy_cleanup_warnings": ["cleanup pending"],
         }
 
-    def run_write(self, relation):
-        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, f"copy-{len(self.writes)}")
+    def run_write(self, plan):
+        assert isinstance(plan, vane.ray_cxx.PyLogicalPlan)
         self.writes.append(pickle.loads(pickle.dumps(plan)))
         return self.outcome
 
@@ -289,6 +289,7 @@ def test_unsupported_runner_copy_fails_before_dispatch(monkeypatch, tmp_path, me
         query = f"COPY (SELECT 1 AS value) TO '{target}' (FORMAT PARQUET"
         if form == "from":
             connection.execute("CREATE TABLE items(value BIGINT)")
+            pq.write_table(pa.table({"value": [1]}), target)
             query = f"COPY items FROM '{target}' (FORMAT PARQUET)"
         else:
             query += (f", {form}" if form.startswith("return_") else "") + ")"
@@ -298,7 +299,7 @@ def test_unsupported_runner_copy_fails_before_dispatch(monkeypatch, tmp_path, me
             with pytest.raises((vane.NotImplementedException, vane.InvalidInputException), match="COPY|RETURN_"):
                 getattr(connection, method)(query)
             assert factory_calls == []
-            assert not target.exists()
+            assert target.exists() is (form == "from")
         finally:
             if form == "transaction":
                 connection.rollback()
@@ -323,7 +324,11 @@ def test_sql_execution_wrappers_cannot_bypass_runner(monkeypatch, tmp_path, meth
     else:
         query = "EXPLAIN ANALYZE SELECT 7::BIGINT"
     with vane.connect() as connection:
-        with pytest.raises(vane.NotImplementedException, match="SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE"):
+        error_type = vane.BinderException if wrapper == "execute" else vane.NotImplementedException
+        message = (
+            "Prepared statement.*does not exist" if wrapper == "execute" else "SQL PREPARE, EXECUTE, or EXPLAIN ANALYZE"
+        )
+        with pytest.raises(error_type, match=message):
             if method == "executemany":
                 connection.executemany(query, [[]])
             else:

--- a/tests/fast/test_connection_sql_runner.py
+++ b/tests/fast/test_connection_sql_runner.py
@@ -296,7 +296,8 @@ def test_unsupported_runner_copy_fails_before_dispatch(monkeypatch, tmp_path, me
         if form == "transaction":
             connection.begin()
         try:
-            with pytest.raises((vane.NotImplementedException, vane.InvalidInputException), match="COPY|RETURN_"):
+            error_type = vane.BinderException if form == "transaction" else vane.NotImplementedException
+            with pytest.raises(error_type, match="COPY|RETURN_"):
                 getattr(connection, method)(query)
             assert factory_calls == []
             assert target.exists() is (form == "from")
@@ -394,7 +395,12 @@ def test_sql_copy_revalidates_after_parameter_conversion(monkeypatch, tmp_path, 
             return super().__len__()
 
     try:
-        with pytest.raises((vane.InvalidInputException, vane.ConnectionException, vane.InterruptException)):
+        error_type = {
+            "begin": vane.BinderException,
+            "close": vane.ConnectionException,
+            "interrupt": vane.InterruptException,
+        }[hook]
+        with pytest.raises(error_type):
             connection.execute(
                 "COPY (SELECT ? AS value) TO ? (FORMAT PARQUET)",
                 Parameters([str(tmp_path / "reentrant.parquet"), 7]),

--- a/tests/fast/test_datasink.py
+++ b/tests/fast/test_datasink.py
@@ -773,7 +773,8 @@ def test_configured_retry_rejects_potentially_single_use_arrow_scanner():
     assert scanner.to_table().column("id").to_pylist() == [1, 2, 3]
 
 
-def test_configured_retry_accepts_replayable_arrow_table(monkeypatch):
+@pytest.mark.real_ray
+def test_configured_retry_accepts_replayable_arrow_table(monkeypatch, ray_local):
     operation_id = "replayable-arrow-table"
 
     class FakeRunner:
@@ -1070,7 +1071,7 @@ def test_mock_distributed_result_uses_only_selected_results(monkeypatch):
 
     class FakeRunner:
         def run_datasink(self, relation):
-            assert relation.type == "EXTENSION_RELATION"
+            assert isinstance(relation, vane.ray_cxx.PyLogicalPlan)
             return _native_result(operation_id)
 
     _install_datasink_runner(monkeypatch, "ray", FakeRunner())

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -304,10 +304,14 @@ def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
     runner = _RetainingRunner()
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: runner)
 
-    if entry == "relation":
-        results = relation.to_arrow_reader()
-    else:
-        results = getattr(connection, entry)("SELECT * FROM relation").to_arrow_reader()
+    def open_reader(relation):
+        # SQL replacement scans inspect frame locals. Keep their Python 3.12
+        # locals snapshot out of the frame that probes source destruction.
+        if entry == "relation":
+            return relation.to_arrow_reader()
+        return getattr(connection, entry)("SELECT * FROM relation").to_arrow_reader()
+
+    results = open_reader(relation)
     del source
     del relation
     gc.collect()

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -59,7 +59,7 @@ def ray_runner(_vane_shuffle_env, request):
 
 def _collect_tables(runner, relation, timeout_s: float = 60.0) -> pa.Table:
     start = time.time()
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     elapsed = time.time() - start
     assert elapsed < timeout_s
     assert parts
@@ -304,7 +304,7 @@ def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
     runner = object.__new__(RayRunner)
     monkeypatch.setattr(RayRunner, "_client_for_session", lambda _self, _session_id: client)
 
-    results = runner.run_iter(relation)
+    results = runner.run_iter(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None))
     del source
     del relation
     gc.collect()

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -273,26 +273,27 @@ def test_datasource_relation_keeps_source_alive_until_relation_is_released(duckd
 
 
 @pytest.mark.parametrize("stream_outcome", ["complete", "close", "error"])
+@pytest.mark.parametrize("entry", ["relation", "sql", "execute"])
 def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
-    duckdb_conn,
     monkeypatch,
     stream_outcome,
     tmp_path,
+    entry,
 ):
-    from vane.runners.ray.runner import RayRunner
-
     source_path = tmp_path / "runner-plan-retention-source.txt"
     source_path.write_text("43", encoding="utf-8")
     source = SourceKeepaliveProbe(str(source_path))
     source_ref = weakref.ref(source)
-    relation = read_datasource(source, con=duckdb_conn, limit=1)
-    result = object()
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    connection = vane.connect()
+    relation = read_datasource(source, con=connection, limit=1)
+    result = pa.table({"value": pa.array([43], type=pa.int64())})
 
-    class _RetainingClient:
+    class _RetainingRunner:
         def __init__(self):
             self.plan = None
 
-        def stream_plan(self, plan):
+        def run_iter_tables(self, plan):
             self.plan = plan
             assert source_ref() is not None
             yield result
@@ -300,29 +301,33 @@ def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
             if stream_outcome == "error":
                 raise RuntimeError("planned stream failure")
 
-    client = _RetainingClient()
-    runner = object.__new__(RayRunner)
-    monkeypatch.setattr(RayRunner, "_client_for_session", lambda _self, _session_id: client)
+    runner = _RetainingRunner()
+    monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: runner)
 
-    results = runner.run_iter(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None))
+    if entry == "relation":
+        results = relation.to_arrow_reader()
+    else:
+        results = getattr(connection, entry)("SELECT * FROM relation").to_arrow_reader()
     del source
     del relation
     gc.collect()
 
     assert source_ref() is not None
     if stream_outcome == "complete":
-        assert list(results) == [result]
+        assert pa.Table.from_batches(list(results)) == result
     elif stream_outcome == "close":
-        assert next(results) is result
+        assert next(results).column(0).to_pylist() == [43]
         results.close()
     else:
-        with pytest.raises(RuntimeError, match="planned stream failure"):
+        with pytest.raises(Exception, match="planned stream failure"):
             list(results)
-    assert client.plan is not None
+    assert runner.plan is not None
 
     gc.collect()
     assert source_ref() is None
     assert not source_path.exists()
+    results.close()
+    connection.close()
 
 
 def test_ray_runner_keeps_source_alive_until_distributed_scan_finishes(ray_runner, duckdb_conn, tmp_path):

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -517,7 +517,7 @@ def test_parameterized_sql_ray_rejects_explicit_transaction_at_consumption(monke
         if not begin_before_binding:
             connection.begin()
         try:
-            with pytest.raises(vane.InvalidInputException, match="cannot participate.*explicit transaction"):
+            with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
                 relation.fetchall()
             assert factory_calls == []
         finally:
@@ -554,7 +554,7 @@ def test_connection_execute_ray_rejects_select_in_explicit_transaction(monkeypat
     factory_calls = _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
         connection.begin()
-        with pytest.raises(vane.InvalidInputException, match="cannot participate.*explicit transaction"):
+        with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
             connection.execute("SELECT 1")
         connection.rollback()
         assert factory_calls == []
@@ -773,7 +773,7 @@ def test_connection_execute_ray_rechecks_transaction_after_parameter_conversion(
         else:
             query, parameters = "SELECT $value::BIGINT AS value", {ParameterName(): 7}
         try:
-            with pytest.raises(vane.InvalidInputException, match="cannot participate.*explicit transaction"):
+            with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
                 connection.execute(query, parameters)
             assert began_transaction
             assert factory_calls == []

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -25,10 +25,10 @@ from vane._image import image_arrow_type
 class _FakeRayRunner:
     def __init__(self, tables: list[pa.Table]) -> None:
         self.tables = tables
-        self.calls: list[vane.DuckDBPyRelation] = []
+        self.calls: list[object] = []
         self.closed_iterators = 0
 
-    def run_iter_tables(self, relation: vane.DuckDBPyRelation) -> Iterator[pa.Table]:
+    def run_iter_tables(self, relation: object) -> Iterator[pa.Table]:
         self.calls.append(relation)
         try:
             yield from self.tables
@@ -120,8 +120,8 @@ class _TransportedPlanRunner:
         self.closed_iterators = 0
         self.worker = vane.connect()
 
-    def run_iter_tables(self, relation):
-        plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, f"execute-{len(self.plans)}")
+    def run_iter_tables(self, plan):
+        assert isinstance(plan, vane.ray_cxx.PyLogicalPlan)
         self.plans.append(plan)
         restored = pickle.loads(pickle.dumps(plan))
         with self.worker.cursor() as worker:
@@ -536,17 +536,17 @@ def test_parameterized_sql_ray_failure_does_not_execute_locally(monkeypatch):
             relation.fetchall()
 
 
-def test_connection_execute_ray_keeps_control_and_write_statements_on_connection(monkeypatch):
+def test_connection_execute_ray_keeps_connection_operations_native(monkeypatch):
     runner = _FakeRayRunner([])
     factory_calls = _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
         connection.execute("SET threads=2; CREATE TABLE items(value BIGINT)")
-        assert connection.execute("INSERT INTO items VALUES (?)", [11]).fetchall() == [(1,)]
         connection.begin()
-        connection.execute("INSERT INTO items VALUES (12)")
+        connection.execute("ALTER TABLE items ADD COLUMN label VARCHAR")
         connection.rollback()
+        assert connection.table("items").columns == ["value"]
+        connection.execute("ATTACH ':memory:' AS extra; CREATE SCHEMA extra.labels; DETACH extra")
         assert factory_calls == []
-        assert connection.execute("UPDATE items SET value=value RETURNING value").fetchall() == [(11,)]
 
 
 def test_connection_execute_ray_rejects_select_in_explicit_transaction(monkeypatch):
@@ -573,7 +573,7 @@ def test_connection_execute_ray_rejects_coordinator_table_without_fallback(
     runner = _TransportedPlanRunner()
     _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
-        setup = f"CREATE {table_kind} items AS SELECT 11::BIGINT AS value"
+        setup = f"CREATE {table_kind} items(value BIGINT)"
         query = "SELECT value FROM items"
         if combined_statements:
             query = f"{setup}; {query}"
@@ -583,7 +583,7 @@ def test_connection_execute_ray_rejects_coordinator_table_without_fallback(
             connection.execute(query)
         assert len(runner.plans) == 1
         assert connection.description is None
-        assert connection.execute("UPDATE items SET value=value RETURNING value").fetchall() == [(11,)]
+        assert connection.table("items").columns == ["value"]
 
 
 def test_connection_execute_ray_drains_preceding_queries_and_retains_last_result(monkeypatch):
@@ -817,10 +817,14 @@ def test_connection_interrupt_stops_ray_result_wait_and_preserves_other_queries(
             return pending
 
     class Runner:
+        started = False
+
         def run_iter_tables(self, relation):
-            query = relation.sql_query()
+            query = relation.idx()
+            first_query = not self.started
+            self.started = True
             try:
-                if "77" in query:
+                if not first_query:
                     yield pa.table({"value": pa.array([77], pa.int64())})
                     return
                 if phase != "execute":
@@ -1848,4 +1852,4 @@ def test_distributed_repr_uses_common_result_source(monkeypatch):
     assert "42" in output
     assert "999" not in output
     assert len(runner.calls) == 1
-    assert "LIMIT 10000" in runner.calls[0].sql_query().upper()
+    assert isinstance(runner.calls[0], vane.ray_cxx.PyLogicalPlan)

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -507,21 +507,25 @@ def test_parameterized_sql_drains_preceding_ray_selects_and_keeps_final_query_la
 
 
 @pytest.mark.parametrize("begin_before_binding", [False, True])
-def test_parameterized_sql_ray_rejects_explicit_transaction_at_consumption(monkeypatch, begin_before_binding):
+def test_parameterized_sql_ray_rejects_explicit_transaction_before_binding(monkeypatch, begin_before_binding):
     runner = _FakeRayRunner([])
     factory_calls = _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
         if begin_before_binding:
             connection.begin()
-        relation = connection.sql("SELECT ? AS value", params=[7])
-        if not begin_before_binding:
-            connection.begin()
-        try:
             with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
-                relation.fetchall()
-            assert factory_calls == []
-        finally:
+                connection.sql("SELECT ? AS value", params=[7])
             connection.rollback()
+            assert factory_calls == []
+        else:
+            relation = connection.sql("SELECT ? AS value", params=[7])
+            connection.begin()
+            try:
+                with pytest.raises(vane.BinderException, match="cannot participate.*explicit transaction"):
+                    relation.fetchall()
+                assert factory_calls == []
+            finally:
+                connection.rollback()
 
 
 def test_parameterized_sql_ray_failure_does_not_execute_locally(monkeypatch):

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import gc
 import os
 import pickle
+import subprocess
 import sys
 import threading
 import types
@@ -1811,6 +1812,55 @@ def test_distributed_result_close_closes_runner_iterator(monkeypatch):
     assert runner.closed_iterators == 1
     with pytest.raises(vane.InvalidInputException, match="result closed"):
         relation.fetchall()
+
+
+@pytest.mark.parametrize("close_explicitly", [False, True])
+def test_distributed_partial_result_released_after_connection_close(close_explicitly):
+    # Poison freed allocations in a separate process so a dangling allocator
+    # fails reliably without terminating the rest of the test suite.
+    program = """
+import gc
+import sys
+import weakref
+
+import pyarrow as pa
+import vane
+
+class Runner:
+    closed_iterators = 0
+
+    def run_iter_tables(self, plan):
+        # Retaining the plan outside the iterator would also pin its allocator
+        # and mask an incorrect destruction order in the result consumer.
+        try:
+            yield pa.table({'c0': pa.array([1, 2], pa.int64()), 'c1': ['one', 'two']})
+        finally:
+            self.closed_iterators += 1
+
+runner = Runner()
+vane._native.set_runner_ray = lambda *args, **kwargs: runner
+connection = vane.connect()
+connection_ref = weakref.ref(connection)
+relation = connection.sql("SELECT 999::BIGINT AS value, 'local' AS label")
+assert relation.fetchone() == (1, 'one')
+assert runner.closed_iterators == 0
+connection.close()
+del connection
+if sys.argv[1] == 'True':
+    relation.close()
+del relation
+gc.collect()
+assert connection_ref() is None
+assert runner.closed_iterators == 1
+"""
+    completed = subprocess.run(
+        [sys.executable, "-I", "-X", "faulthandler", "-c", program, str(close_explicitly)],
+        env={**os.environ, "VANE_RUNNER": "ray", "MALLOC_PERTURB_": "165"},
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
 def test_distributed_partial_result_lifecycle_stress(monkeypatch):

--- a/tests/fast/test_distributed_result_consumers.py
+++ b/tests/fast/test_distributed_result_consumers.py
@@ -575,7 +575,7 @@ def test_connection_execute_ray_rejects_coordinator_table_without_fallback(
     monkeypatch, table_kind, combined_statements
 ):
     runner = _TransportedPlanRunner()
-    _install_fake_ray_runner(monkeypatch, runner)
+    factory_calls = _install_fake_ray_runner(monkeypatch, runner)
     with vane.connect() as connection:
         setup = f"CREATE {table_kind} items(value BIGINT)"
         query = "SELECT value FROM items"
@@ -583,9 +583,17 @@ def test_connection_execute_ray_rejects_coordinator_table_without_fallback(
             query = f"{setup}; {query}"
         else:
             connection.execute(setup)
-        with pytest.raises((vane.CatalogException, ValueError), match="Table with name items does not exist"):
+        temporary = table_kind == "TEMP TABLE"
+        error = vane.NotImplementedException if temporary else (vane.CatalogException, ValueError)
+        message = (
+            "Runner plans cannot read or write temporary table items"
+            if temporary
+            else "Table with name items does not exist"
+        )
+        with pytest.raises(error, match=message):
             connection.execute(query)
-        assert len(runner.plans) == 1
+        assert len(runner.plans) == (0 if temporary else 1)
+        assert len(factory_calls) == (0 if temporary else 1)
         assert connection.description is None
         assert connection.table("items").columns == ["value"]
 

--- a/tests/fast/test_distributed_show.py
+++ b/tests/fast/test_distributed_show.py
@@ -11,7 +11,7 @@ import vane
 class _FakeRayRunner:
     def __init__(self, tables: list[pa.Table]) -> None:
         self.tables = tables
-        self.calls: list[vane.DuckDBPyRelation] = []
+        self.calls: list[object] = []
 
     def run_iter_tables(self, relation):
         self.calls.append(relation)
@@ -42,8 +42,7 @@ def test_relation_show_materializes_through_ray(monkeypatch, capsys):
     assert "42" in output
     assert "999" not in output
     assert len(runner.calls) == 1
-    limited_relation = runner.calls[0]
-    assert "LIMIT 10000" in limited_relation.sql_query().upper()
+    assert isinstance(runner.calls[0], vane.ray_cxx.PyLogicalPlan)
 
 
 def test_relation_show_uses_local_execution(monkeypatch, capsys):

--- a/tests/fast/test_fixed_shape_image.py
+++ b/tests/fast/test_fixed_shape_image.py
@@ -16,7 +16,9 @@ from vane._image import image_arrow_type
 
 @pytest.mark.skipif(sys.platform != "linux", reason="uses Linux address-space accounting")
 @pytest.mark.parametrize("height,width,channels", [(1080, 1920, 3), (2160, 3840, 4)])
-def test_fixed_image_query_allocates_pixels_for_actual_rows(height, width, channels):
+@pytest.mark.parametrize("input_layout", ["fixed", "generic"])
+def test_fixed_image_query_allocates_pixels_for_actual_rows(height, width, channels, input_layout):
+    # Isolate layouts so retained Arrow/allocator buffers cannot affect the budget.
     program = """
 import resource
 import sys
@@ -24,34 +26,44 @@ from pathlib import Path
 import numpy as np
 import pyarrow as pa
 import vane
-height, width, channels = map(int, sys.argv[1:])
+height, width, channels = map(int, sys.argv[1:4])
+input_layout = sys.argv[4]
 mode = 'RGB' if channels == 3 else 'RGBA'
 dtype = vane.image_type(mode, height, width)
 pixels = np.arange(height * width * channels, dtype=np.uint8).reshape(height, width, channels)
+
+def limit_additional_memory():
+    vm = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
+                  if line.startswith('VmSize:'))) * 1024
+    _, hard = resource.getrlimit(resource.RLIMIT_AS)
+    ceiling = vm + 512 * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (ceiling if hard < 0 else min(ceiling, hard), hard))
+
 with vane.connect(config={'threads': 1}) as con:
     warm = con.sql('SELECT $1 AS image', params=[vane.Value(np.zeros((1, 1, 3), dtype=np.uint8),
                                                          vane.image_type('RGB', 1, 1))]).to_arrow_table()
     # Initialize Arrow's scanner thread pools before limiting image allocations.
     con.from_arrow(warm).fetchone()
     del warm
-    vm = int(next(line.split()[1] for line in Path('/proc/self/status').read_text().splitlines()
-                  if line.startswith('VmSize:'))) * 1024
-    _, hard = resource.getrlimit(resource.RLIMIT_AS)
-    ceiling = vm + 512 * 1024 * 1024
-    resource.setrlimit(resource.RLIMIT_AS, (ceiling if hard < 0 else min(ceiling, hard), hard))
-    for value in (vane.Value(pixels, dtype), vane.Value(pixels, vane.image_type())):
-        table = con.sql('SELECT $1::' + str(dtype) + ' AS image', params=[value]).to_arrow_table()
-        assert table.schema.field('image').type.storage_type == pa.list_(pa.uint8(), pixels.size)
-        restored = con.from_arrow(table).fetchone()[0]
-        assert restored.shape == pixels.shape and restored.dtype == np.uint8
-        for row in range(0, height, 16):
-            np.testing.assert_array_equal(restored[row:row + 16], pixels[row:row + 16])
-        del restored, table
+    limit_additional_memory()
+    value = vane.Value(pixels, dtype if input_layout == 'fixed' else vane.image_type())
+    relation = con.sql('SELECT $1::' + str(dtype) + ' AS image', params=[value])
+    # Binding owns a dense input payload (Float32 for generic IMAGE). Check
+    # execution buffers separately, retaining the same 512 MiB growth limit.
+    limit_additional_memory()
+    table = relation.to_arrow_table()
+    del relation
+    assert table.schema.field('image').type.storage_type == pa.list_(pa.uint8(), pixels.size)
+    restored = con.from_arrow(table).fetchone()[0]
+    assert restored.shape == pixels.shape and restored.dtype == np.uint8
+    for row in range(0, height, 16):
+        np.testing.assert_array_equal(restored[row:row + 16], pixels[row:row + 16])
+    del restored, table
     empty = con.sql('SELECT NULL::' + str(dtype) + ' AS image WHERE FALSE').to_arrow_table()
     assert empty.num_rows == 0
 """
     completed = subprocess.run(
-        [sys.executable, "-I", "-c", program, str(height), str(width), str(channels)],
+        [sys.executable, "-I", "-c", program, str(height), str(width), str(channels), input_layout],
         capture_output=True,
         text=True,
         timeout=60,

--- a/tests/fast/test_fte_native_backend.py
+++ b/tests/fast/test_fte_native_backend.py
@@ -381,7 +381,7 @@ def _captured_native_copy_plan(tmp_path, monkeypatch, *, local_staging: bool, ag
     class _CapturingRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setenv("VANE_RUNNER", "local")
     monkeypatch.setattr(vane._native, "set_runner_local", lambda *_args, **_kwargs: _CapturingRunner())
@@ -392,11 +392,8 @@ def _captured_native_copy_plan(tmp_path, monkeypatch, *, local_staging: bool, ag
     con.sql(f"select {projection} from read_parquet('{src}')").write_parquet(str(dst))
     assert captured, "expected local write relation to be captured"
 
-    query_id = str(uuid.uuid4())
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        query_id,
-    ).to_physical_plan(con)
+    query_id = captured[0].idx()
+    plan = captured[0].to_physical_plan(con)
     assert plan.scan_split_batch_map()
     return con, dst, query_id, plan
 
@@ -418,7 +415,7 @@ def _capture_native_copy_relation(tmp_path, monkeypatch, *, local_staging: bool)
     class _CapturingRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setenv("VANE_RUNNER", "local")
     monkeypatch.setattr(vane._native, "set_runner_local", lambda *_args, **_kwargs: _CapturingRunner())
@@ -4798,11 +4795,8 @@ def test_native_cxx_committed_copy_returns_backend_cleanup_warning(tmp_path, mon
         execute_fn=_InProcessFragmentExecutor(),
         max_running_tasks=2,
     )
-    query_id = f"copy-cleanup-failure-{uuid.uuid4()}"
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        relation,
-        query_id,
-    ).to_physical_plan(con)
+    query_id = relation.idx()
+    plan = relation.to_physical_plan(con)
     original_drop_query = backend.drop_query
     drop_calls = []
 
@@ -4838,10 +4832,11 @@ def test_native_cxx_run_copy_plan_successive_local_staging_runs_use_distinct_pat
     try:
         runner = vane.ray_cxx.DistributedPhysicalPlanRunner(backend)
         for _ in range(2):
-            plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-                relation,
-                str(uuid.uuid4()),
-            ).to_physical_plan(con)
+            state = list(relation.__getstate__())
+            state[0] = str(uuid.uuid4())
+            logical = vane.ray_cxx.PyLogicalPlan.__new__(vane.ray_cxx.PyLogicalPlan)
+            logical.__setstate__(tuple(state))
+            plan = logical.to_physical_plan(con)
             result = runner.run_copy_plan(plan, con)
             results.append(result)
 

--- a/tests/fast/test_local_fte_runner_entrypoint.py
+++ b/tests/fast/test_local_fte_runner_entrypoint.py
@@ -164,28 +164,6 @@ def test_local_runner_records_cleanup_failures_on_copy_outcome(committed):
     assert error.safe_to_retry is False
 
 
-def test_local_runner_uses_write_specific_logical_plan_factory(monkeypatch):
-    from vane.runners.local import runner as runner_module
-
-    relation = object()
-
-    class FakeLogicalPlan:
-        @staticmethod
-        def from_duckdb_write_relation(actual_relation, _query_id):
-            assert actual_relation is relation
-            raise RuntimeError("write transaction validation reached")
-
-    monkeypatch.setattr(runner_module, "_preload_arrow_dataset_imports", lambda: None)
-    monkeypatch.setattr(
-        runner_module,
-        "require_ray_cxx_attr",
-        lambda name: FakeLogicalPlan if name == "PyLogicalPlan" else object,
-    )
-
-    with pytest.raises(RuntimeError, match="write transaction validation reached"):
-        runner_module.LocalRunner().run_write(relation)
-
-
 def test_local_fragment_executor_passes_authoritative_task_attempt_to_native(monkeypatch):
     from vane.runners.fte import FteTaskAttemptId, FteTaskId
     from vane.runners.local import runner as runner_module
@@ -831,10 +809,7 @@ def test_local_copy_interrupt_observes_commit_and_keeps_pending_resources(monkey
                 "copy_output_outcome_unknown": terminal == "unknown",
             }
 
-    class LogicalPlan:
-        @staticmethod
-        def from_duckdb_write_relation(_relation, _query_id):
-            return SimpleNamespace(to_physical_plan=lambda _connection: object())
+    logical_plan = SimpleNamespace(idx=lambda: "interrupt-bound-write", to_physical_plan=lambda _connection: object())
 
     def interrupt_after_start():
         if started.is_set():
@@ -844,9 +819,7 @@ def test_local_copy_interrupt_observes_commit_and_keeps_pending_resources(monkey
     monkeypatch.setattr(local_module, "progress_enabled", lambda _runner: False)
     monkeypatch.setattr(local_module, "_InProcessFragmentExecutor", FragmentExecutor)
     monkeypatch.setattr(local_module, "NativeFteWorkerManagerBackend", Backend)
-    monkeypatch.setattr(
-        local_module, "require_ray_cxx_attr", lambda name: LogicalPlan if name == "PyLogicalPlan" else PlanRunner
-    )
+    monkeypatch.setattr(local_module, "require_ray_cxx_attr", lambda name: PlanRunner)
     monkeypatch.setattr(vane._native, "_connect_with_runner", lambda _runner: Connection())
     monkeypatch.setattr(
         "vane.execution.udf_subprocess.ensure_local_subprocess_actor_pools_for_plan", lambda *_args, **_kwargs: ([], {})
@@ -854,13 +827,13 @@ def test_local_copy_interrupt_observes_commit_and_keeps_pending_resources(monkey
     try:
         runner = local_module.LocalRunner()
         if terminal == "committed":
-            result = run_write_with_interrupt_check(runner, object(), interrupt_after_start)
+            result = run_write_with_interrupt_check(runner, logical_plan, interrupt_after_start)
             assert result["rows_copied"] == 11
             assert result["copy_output_committed"] is True
         else:
             error_type = vane.InterruptException if terminal == "aborted" else CopyOutcomeUnknownError
             with pytest.raises(error_type) as raised:
-                run_write_with_interrupt_check(runner, object(), interrupt_after_start)
+                run_write_with_interrupt_check(runner, logical_plan, interrupt_after_start)
             if terminal != "aborted":
                 assert raised.value.safe_to_retry is False
                 assert raised.value.operation_id

--- a/tests/fast/test_merge_relation.py
+++ b/tests/fast/test_merge_relation.py
@@ -255,7 +255,7 @@ def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch
     connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     connection.execute("BEGIN")
     try:
-        with pytest.raises(vane.InvalidInputException, match="Runner MERGE_INTO requires DuckDB auto-commit mode"):
+        with pytest.raises(vane.BinderException, match="Runner MERGE_INTO requires DuckDB auto-commit mode"):
             _merge(connection.table("merge_source"))
         assert calls == []
         assert _local_target_rows(monkeypatch, connection) == [

--- a/tests/fast/test_merge_relation.py
+++ b/tests/fast/test_merge_relation.py
@@ -25,13 +25,15 @@ def _require_ray_cxx():
     return ray_cxx
 
 
-def _merge_connection(database=None):
-    connection = vane.connect() if database is None else vane.connect(str(database))
-    connection.execute("CREATE TABLE merge_target (id INTEGER PRIMARY KEY, value VARCHAR)")
-    connection.execute("INSERT INTO merge_target VALUES (1, 'old'), (3, 'keep')")
-    connection.execute("CREATE TABLE merge_source (id INTEGER, value VARCHAR)")
-    connection.execute("INSERT INTO merge_source VALUES (1, 'new'), (2, 'inserted')")
-    return connection
+def _merge_connection(monkeypatch, database):
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(str(database)) as connection:
+            connection.execute("CREATE TABLE merge_target (id INTEGER PRIMARY KEY, value VARCHAR)")
+            connection.execute("INSERT INTO merge_target VALUES (1, 'old'), (3, 'keep')")
+            connection.execute("CREATE TABLE merge_source (id INTEGER, value VARCHAR)")
+            connection.execute("INSERT INTO merge_source VALUES (1, 'new'), (2, 'inserted')")
+    return vane.connect(str(database))
 
 
 def _merge(source, **kwargs):
@@ -62,9 +64,9 @@ def _local_target_rows(monkeypatch, connection):
     return [tuple(row.values()) for table in result.partition_payloads for row in table.to_pylist()]
 
 
-def test_merge_relation_runs_with_explicit_local_fast(monkeypatch):
+def test_merge_relation_runs_with_explicit_local_fast(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         assert _merge(connection.table("merge_source")) is None
         assert connection.execute("SELECT * FROM merge_target ORDER BY id").fetchall() == [
@@ -76,9 +78,9 @@ def test_merge_relation_runs_with_explicit_local_fast(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_supports_using_columns(monkeypatch):
+def test_merge_relation_supports_using_columns(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -94,9 +96,9 @@ def test_merge_relation_supports_using_columns(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_supports_expression_condition_and_custom_aliases(monkeypatch):
+def test_merge_relation_supports_expression_condition_and_custom_aliases(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         condition = vane.ColumnExpression("destination.id") == vane.ColumnExpression("changes.id")
         connection.table("merge_source").merge_into(
@@ -118,9 +120,9 @@ def test_merge_relation_supports_expression_condition_and_custom_aliases(monkeyp
         connection.close()
 
 
-def test_merge_relation_separates_line_comment_clauses(monkeypatch):
+def test_merge_relation_separates_line_comment_clauses(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -139,9 +141,9 @@ def test_merge_relation_separates_line_comment_clauses(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_accepts_sql_whitespace_after_when(monkeypatch):
+def test_merge_relation_accepts_sql_whitespace_after_when(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -160,9 +162,9 @@ def test_merge_relation_accepts_sql_whitespace_after_when(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_accepts_sql_comments_after_when(monkeypatch):
+def test_merge_relation_accepts_sql_comments_after_when(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         connection.table("merge_source").merge_into(
             "merge_target",
@@ -181,22 +183,20 @@ def test_merge_relation_accepts_sql_comments_after_when(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch):
+def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     ray_cxx = _require_ray_cxx()
-    relation_types = []
     logical_plans = []
 
     def run_write(relation):
-        relation_types.append(relation.type)
-        logical_plans.append(ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, "merge-relation"))
-        return {"ok": True}
+        logical_plans.append(relation)
+        return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         assert _merge(connection.table("merge_source")) is None
-        assert relation_types == ["MERGE_RELATION"]
+        assert isinstance(logical_plans[0], ray_cxx.PyLogicalPlan)
         assert len(logical_plans) == 1
         assert _local_target_rows(monkeypatch, connection) == [
             (1, "old"),
@@ -206,17 +206,17 @@ def test_merge_relation_dispatches_as_write_without_local_execution(monkeypatch)
         connection.close()
 
 
-def test_merge_relation_preserves_non_sql_source_operators(monkeypatch):
+def test_merge_relation_preserves_non_sql_source_operators(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
-    ray_cxx = _require_ray_cxx()
+    _require_ray_cxx()
     logical_plans = []
 
     def run_write(relation):
-        logical_plans.append(ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, "repartitioned-merge"))
-        return {"ok": True}
+        logical_plans.append(relation)
+        return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         source = connection.table("merge_source").repartition(2, "id")
         _merge(source)
@@ -229,14 +229,14 @@ def test_merge_relation_preserves_non_sql_source_operators(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_failure_never_executes_locally(monkeypatch):
+def test_merge_relation_failure_never_executes_locally(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
 
     def run_write(_relation):
         raise RuntimeError("injected distributed merge failure")
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         with pytest.raises(RuntimeError, match="injected distributed merge failure"):
             _merge(connection.table("merge_source"))
@@ -248,14 +248,14 @@ def test_merge_relation_failure_never_executes_locally(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch):
+def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     calls = []
     _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     connection.execute("BEGIN")
     try:
-        with pytest.raises(vane.InvalidInputException, match="Ray MERGE INTO requires DuckDB auto-commit mode"):
+        with pytest.raises(vane.InvalidInputException, match="Runner MERGE_INTO requires DuckDB auto-commit mode"):
             _merge(connection.table("merge_source"))
         assert calls == []
         assert _local_target_rows(monkeypatch, connection) == [
@@ -267,13 +267,13 @@ def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch
         connection.close()
 
 
-def test_merge_relation_rejects_local_fte_runner(monkeypatch):
+def test_merge_relation_rejects_local_fte_runner(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         with pytest.raises(
             vane.InvalidInputException,
-            match="MERGE INTO requires VANE_RUNNER=ray or VANE_RUNNER=local-fast",
+            match="MERGE_INTO requires a ray or local-fast connection",
         ):
             _merge(connection.table("merge_source"))
         assert connection.execute("SELECT * FROM merge_target ORDER BY id").fetchall() == [
@@ -297,9 +297,9 @@ def test_merge_relation_rejects_local_fte_runner(monkeypatch):
         ("target.id = source.id", _WHEN_CLAUSES, {"source_alias": "target"}, "must be different"),
     ],
 )
-def test_merge_relation_validates_api_inputs(monkeypatch, condition, when_clauses, kwargs, message):
+def test_merge_relation_validates_api_inputs(monkeypatch, condition, when_clauses, kwargs, message, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         with pytest.raises(vane.InvalidInputException, match=message):
             connection.table("merge_source").merge_into(
@@ -312,11 +312,11 @@ def test_merge_relation_validates_api_inputs(monkeypatch, condition, when_clause
         connection.close()
 
 
-def test_merge_relation_rejects_parameters_before_dispatch(monkeypatch):
+def test_merge_relation_rejects_parameters_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     calls = []
     _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         with pytest.raises(vane.InvalidInputException, match="does not accept prepared parameters"):
             connection.table("merge_source").merge_into(
@@ -329,11 +329,11 @@ def test_merge_relation_rejects_parameters_before_dispatch(monkeypatch):
         connection.close()
 
 
-def test_merge_relation_propagates_parser_and_binding_errors_before_dispatch(monkeypatch):
+def test_merge_relation_propagates_parser_and_binding_errors_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     calls = []
     _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         with pytest.raises(vane.ParserException):
             connection.table("merge_source").merge_into(
@@ -356,19 +356,18 @@ def test_merge_relation_propagates_parser_and_binding_errors_before_dispatch(mon
         connection.close()
 
 
-def test_merge_relation_is_only_accepted_by_write_factory(monkeypatch):
+def test_merge_relation_reaches_runner_as_bound_plan(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     ray_cxx = _require_ray_cxx()
     checks = []
 
     def run_write(relation):
-        with pytest.raises(ValueError, match="does not accept terminal write relations"):
-            ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, "merge-read")
-        checks.append(ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, "merge-write"))
-        return {"ok": True}
+        assert isinstance(relation, ray_cxx.PyLogicalPlan)
+        checks.append(relation)
+        return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     _install_fake_ray_runner(monkeypatch, run_write)
-    connection = _merge_connection()
+    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
     try:
         _merge(connection.table("merge_source"))
         assert len(checks) == 1
@@ -378,16 +377,16 @@ def test_merge_relation_is_only_accepted_by_write_factory(monkeypatch):
 
 def test_merge_relation_logical_plan_round_trip_does_not_execute_locally(tmp_path, monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "ray")
-    ray_cxx = _require_ray_cxx()
+    _require_ray_cxx()
     logical_plans = []
 
     def run_write(relation):
-        logical_plans.append(ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, "merge-round-trip"))
-        return {"ok": True}
+        logical_plans.append(relation)
+        return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     _install_fake_ray_runner(monkeypatch, run_write)
     database_path = tmp_path / "merge-round-trip.duckdb"
-    connection = _merge_connection(database_path)
+    connection = _merge_connection(monkeypatch, database_path)
     try:
         _merge(connection.table("merge_source"))
         logical_plan = logical_plans[0]
@@ -432,12 +431,12 @@ def test_merge_relation_rejects_ordinary_duckdb_target_before_backend_mutation(t
     logical_plans = []
 
     def run_write(relation):
-        logical_plans.append(ray_cxx.PyLogicalPlan.from_duckdb_write_relation(relation, "native-merge-rejection"))
-        return {"ok": True}
+        logical_plans.append(relation)
+        return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     _install_fake_ray_runner(monkeypatch, run_write)
     database_path = tmp_path / "native-merge-rejection.duckdb"
-    connection = _merge_connection(database_path)
+    connection = _merge_connection(monkeypatch, database_path)
     try:
         source = connection.sql("SELECT i::INTEGER AS id, 'new' AS value FROM range(2, 3) rows(i)")
         _merge(source)

--- a/tests/fast/test_merge_relation.py
+++ b/tests/fast/test_merge_relation.py
@@ -250,18 +250,24 @@ def test_merge_relation_failure_never_executes_locally(monkeypatch, tmp_path):
 
 def test_merge_relation_rejects_explicit_transaction_before_dispatch(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "ray")
-    calls = []
-    _install_fake_ray_runner(monkeypatch, calls.append)
-    connection = _merge_connection(monkeypatch, tmp_path / "merge.duckdb")
+
+    def unexpected_runner(*_args, **_kwargs):
+        pytest.fail("transaction rejection must happen before Ray initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", unexpected_runner)
+    database = tmp_path / "merge.duckdb"
+    connection = _merge_connection(monkeypatch, database)
+    source = connection.table("merge_source")
     connection.execute("BEGIN")
     try:
-        with pytest.raises(vane.BinderException, match="Runner MERGE_INTO requires DuckDB auto-commit mode"):
-            _merge(connection.table("merge_source"))
-        assert calls == []
-        assert _local_target_rows(monkeypatch, connection) == [
-            (1, "old"),
-            (3, "keep"),
-        ]
+        with pytest.raises(vane.BinderException, match="requires DuckDB auto-commit mode.*explicit transaction"):
+            _merge(source)
+        monkeypatch.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(str(database)) as inspector:
+            assert inspector.execute("SELECT * FROM merge_target ORDER BY id").fetchall() == [
+                (1, "old"),
+                (3, "keep"),
+            ]
     finally:
         connection.execute("ROLLBACK")
         connection.close()

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -389,7 +389,8 @@ def test_cursor_keeps_vane_session_alive_after_root_connection_is_collected(monk
     assert closed_session_ids == [session_id]
 
 
-def test_connection_close_notification_failure_remains_retryable(monkeypatch):
+@pytest.mark.parametrize("cursor_depth", [0, 1, 2])
+def test_connection_close_notification_failure_remains_retryable(monkeypatch, cursor_depth):
     ray_cxx = _require_ray_cxx()
     closed_session_ids = []
     monkeypatch.setenv("VANE_RUNNER", "ray")
@@ -405,13 +406,21 @@ def test_connection_close_notification_failure_remains_retryable(monkeypatch):
     )
 
     connection = vane.connect()
-    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.sql("SELECT 1"), "session-close-retry")
+    connections = [connection]
+    for _ in range(cursor_depth):
+        connections.append(connections[-1].cursor())
+    plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(connections[-1].sql("SELECT 1"), "session-close-retry")
     session_id = plan.session_id()
 
     with pytest.raises(RuntimeError, match="planned session close notification failure"):
         connection.close()
     connection.close()
 
+    assert closed_session_ids == [session_id, session_id]
+    for closed in connections:
+        with pytest.raises(vane.ConnectionException, match="already closed"):
+            closed.execute("SELECT 1")
+        closed.close()
     assert closed_session_ids == [session_id, session_id]
 
 

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -5,6 +5,7 @@ import gc
 import hashlib
 import pickle
 import threading
+from contextlib import contextmanager
 
 import pytest
 
@@ -27,6 +28,23 @@ def _table_from_native_result(result):
     if len(payloads) == 1:
         return payloads[0]
     return pa.concat_tables(payloads)
+
+
+@contextmanager
+def _prepared_snapshot_connection(ray_cxx, plan):
+    """Inspect the worker connection without transporting a client-context query."""
+    query_id = plan.idx()
+    connection = None
+    assert ray_cxx._register_query_python_replay_state(query_id, plan) is True
+    try:
+        connection = ray_cxx._prepare_query_snapshot_connection(query_id)
+        yield connection
+    finally:
+        try:
+            if connection is not None:
+                connection.close()
+        finally:
+            ray_cxx._cleanup_query_python_replay_state(query_id)
 
 
 def _sql_string_literal(value):
@@ -1515,15 +1533,7 @@ def test_snapshot_bootstrap_applies_static_extension_settings_after_connect(tmp_
 
     source_conn = vane.connect()
     logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
-        source_conn.sql(
-            """
-            SELECT
-                CAST(current_setting('http_timeout') AS BIGINT) AS timeout,
-                CAST(current_setting('allow_unsigned_extensions') AS BOOLEAN) AS allow_unsigned,
-                CAST(current_setting('autoinstall_known_extensions') AS BOOLEAN) AS autoinstall,
-                CAST(current_setting('autoload_known_extensions') AS BOOLEAN) AS autoload
-            """
-        ),
+        source_conn.sql("SELECT 1 AS value"),
         "snapshot-bootstrap-static-extension-setting",
     )
     state = list(logical_plan.__getstate__())
@@ -1550,18 +1560,18 @@ def test_snapshot_bootstrap_applies_static_extension_settings_after_connect(tmp_
     replay_logical_plan.__setstate__(tuple(state))
     physical_plan = replay_logical_plan.to_physical_plan(vane.connect())
     restored_plan = pickle.loads(pickle.dumps(physical_plan))
-    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
-        vane.connect().cursor(),
-        restored_plan,
-    )
-
-    table = _table_from_native_result(result)
-    assert [table.column(index).to_pylist() for index in range(4)] == [
-        [41],
-        [False],
-        [False],
-        [False],
-    ]
+    with _prepared_snapshot_connection(ray_cxx, restored_plan) as worker:
+        result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(worker, restored_plan)
+        assert _table_from_native_result(result).column(0).to_pylist() == [1]
+        assert worker.execute(
+            """
+            SELECT
+                CAST(current_setting('http_timeout') AS BIGINT),
+                CAST(current_setting('allow_unsigned_extensions') AS BOOLEAN),
+                CAST(current_setting('autoinstall_known_extensions') AS BOOLEAN),
+                CAST(current_setting('autoload_known_extensions') AS BOOLEAN)
+            """
+        ).fetchone() == (41, False, False, False)
     assert not extension_directory.exists()
 
 
@@ -1618,9 +1628,7 @@ def test_pickled_physical_plan_replays_bootstrap_and_runtime_connection_snapshot
 
     source_conn = vane.connect(config={"custom_user_agent": "snapshot-test"})
     source_conn.execute("SET TimeZone='UTC'")
-    relation = source_conn.sql(
-        "SELECT current_setting('custom_user_agent') AS user_agent, current_setting('TimeZone') AS timezone"
-    )
+    relation = source_conn.sql("SELECT 1 AS value")
 
     target_conn = vane.connect()
     assert target_conn.execute("SELECT current_setting('custom_user_agent')").fetchone()[0] == ""
@@ -1630,12 +1638,13 @@ def test_pickled_physical_plan_replays_bootstrap_and_runtime_connection_snapshot
     physical_plan = plan.to_physical_plan(target_conn)
     restored_plan = pickle.loads(pickle.dumps(physical_plan))
 
-    worker_cursor = vane.connect().cursor()
-    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(worker_cursor, restored_plan)
-    table = _table_from_native_result(result)
-
-    assert table.column(0).to_pylist() == ["snapshot-test"]
-    assert table.column(1).to_pylist() == ["UTC"]
+    with _prepared_snapshot_connection(ray_cxx, restored_plan) as worker:
+        assert worker.execute("SELECT current_setting('TimeZone')").fetchone()[0] != "UTC"
+        result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(worker, restored_plan)
+        assert _table_from_native_result(result).column(0).to_pylist() == [1]
+        assert worker.execute(
+            "SELECT current_setting('custom_user_agent'), current_setting('TimeZone')"
+        ).fetchone() == ("snapshot-test", "UTC")
 
 
 def test_logical_plan_capture_planning_and_execution_preserve_file_database_security_config(tmp_path):
@@ -1716,11 +1725,7 @@ def test_effective_session_config_reaches_nondefault_bootstrap_connection(tmp_pa
     source_conn.execute("SET GLOBAL s3_access_key_id='database-key'")
     source_conn.execute("SET GLOBAL s3_secret_access_key='database-secret'")
     source_conn.execute("SET GLOBAL s3_session_token='database-token'")
-    relation = source_conn.sql(
-        "SELECT current_setting('s3_access_key_id') AS access_key, "
-        "current_setting('s3_secret_access_key') AS secret_key, "
-        "current_setting('s3_session_token') AS session_token"
-    )
+    relation = source_conn.sql("SELECT 1 AS value")
     logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
         relation,
         "snapshot-effective-session-config",
@@ -1745,18 +1750,23 @@ def test_effective_session_config_reaches_nondefault_bootstrap_connection(tmp_pa
         effective_session_config=effective_config,
     )
     restored_plan = pickle.loads(pickle.dumps(physical_plan))
-    result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
-        vane.connect().cursor(),
-        restored_plan,
-        effective_session_config=effective_config,
-    )
-
-    table = _table_from_native_result(result)
-    assert [table.column(index).to_pylist() for index in range(3)] == [
-        ["resolved-profile-key"],
-        ["resolved-profile-secret"],
-        ["resolved-profile-token"],
-    ]
+    # Worker preparation opens an isolated file instance; release coordinator
+    # handles before reopening that file, as a remote worker would.
+    del physical_plan, logical_plan, relation
+    source_conn.close()
+    gc.collect()
+    with _prepared_snapshot_connection(ray_cxx, restored_plan) as worker:
+        worker.execute("SET GLOBAL s3_access_key_id='database-key'")
+        worker.execute("SET GLOBAL s3_secret_access_key='database-secret'")
+        worker.execute("SET GLOBAL s3_session_token='database-token'")
+        result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
+            worker, restored_plan, effective_session_config=effective_config
+        )
+        assert _table_from_native_result(result).column(0).to_pylist() == [1]
+        assert worker.execute(
+            "SELECT current_setting('s3_access_key_id'), current_setting('s3_secret_access_key'), "
+            "current_setting('s3_session_token')"
+        ).fetchone() == ("resolved-profile-key", "resolved-profile-secret", "resolved-profile-token")
 
 
 def test_effective_session_config_does_not_load_undeclared_httpfs():
@@ -1821,11 +1831,7 @@ def test_explicit_connection_s3_settings_override_effective_session_config():
     source_conn.execute("SET s3_access_key_id='explicit-key'")
     source_conn.execute("SET s3_secret_access_key='explicit-secret'")
     source_conn.execute("SET s3_session_token=''")
-    relation = source_conn.sql(
-        "SELECT current_setting('s3_access_key_id') AS access_key, "
-        "current_setting('s3_secret_access_key') AS secret_key, "
-        "current_setting('s3_session_token') AS session_token"
-    )
+    relation = source_conn.sql("SELECT 1 AS value")
     logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
         relation,
         "snapshot-explicit-s3-precedence",
@@ -1852,11 +1858,11 @@ def test_explicit_connection_s3_settings_override_effective_session_config():
         effective_session_config=effective_config,
     )
     direct_table = _table_from_native_result(direct_result)
-    assert direct_table.column(0).to_pylist() == ["explicit-key"]
-    assert direct_table.column(1).to_pylist() == ["explicit-secret"]
-    assert direct_table.column(2).to_pylist() == [""]
-    assert planning_conn.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "explicit-key"
-    assert planning_conn.execute("SELECT current_setting('s3_session_token')").fetchone()[0] == ""
+    assert direct_table.column(0).to_pylist() == [1]
+    assert planning_conn.execute(
+        "SELECT current_setting('s3_access_key_id'), current_setting('s3_secret_access_key'), "
+        "current_setting('s3_session_token')"
+    ).fetchone() == ("explicit-key", "explicit-secret", "")
 
     worker_cursor = vane.connect().cursor()
     result = ray_cxx.DistributedPhysicalPlanRunner().execute_native(
@@ -1866,11 +1872,11 @@ def test_explicit_connection_s3_settings_override_effective_session_config():
     )
 
     table = _table_from_native_result(result)
-    assert table.column(0).to_pylist() == ["explicit-key"]
-    assert table.column(1).to_pylist() == ["explicit-secret"]
-    assert table.column(2).to_pylist() == [""]
-    assert worker_cursor.execute("SELECT current_setting('s3_access_key_id')").fetchone()[0] == "explicit-key"
-    assert worker_cursor.execute("SELECT current_setting('s3_session_token')").fetchone()[0] == ""
+    assert table.column(0).to_pylist() == [1]
+    assert worker_cursor.execute(
+        "SELECT current_setting('s3_access_key_id'), current_setting('s3_secret_access_key'), "
+        "current_setting('s3_session_token')"
+    ).fetchone() == ("explicit-key", "explicit-secret", "")
 
 
 def test_connection_snapshot_requires_both_explicit_s3_credential_settings():
@@ -1961,11 +1967,7 @@ def test_effective_session_config_overrides_stale_captured_environment(monkeypat
 
     source_conn = vane.connect()
     source_conn.execute("LOAD httpfs")
-    relation = source_conn.sql(
-        "SELECT current_setting('s3_access_key_id') AS access_key, "
-        "current_setting('s3_secret_access_key') AS secret_key, "
-        "current_setting('s3_session_token') AS session_token"
-    )
+    relation = source_conn.sql("SELECT 1 AS value")
     logical_plan = ray_cxx.PyLogicalPlan.from_duckdb_relation(
         relation,
         "snapshot-refreshed-s3-precedence",
@@ -1992,6 +1994,8 @@ def test_effective_session_config_overrides_stale_captured_environment(monkeypat
     )
 
     table = _table_from_native_result(result)
-    assert table.column(0).to_pylist() == ["refreshed-key"]
-    assert table.column(1).to_pylist() == ["refreshed-secret"]
-    assert table.column(2).to_pylist() == ["refreshed-token"]
+    assert table.column(0).to_pylist() == [1]
+    assert worker_cursor.execute(
+        "SELECT current_setting('s3_access_key_id'), current_setting('s3_secret_access_key'), "
+        "current_setting('s3_session_token')"
+    ).fetchone() == ("refreshed-key", "refreshed-secret", "refreshed-token")

--- a/tests/fast/test_ray_connection_snapshot.py
+++ b/tests/fast/test_ray_connection_snapshot.py
@@ -137,7 +137,7 @@ def test_distributed_write_snapshot_covers_write_owned_file_io_expressions(
     tmp_path,
     write_expression,
 ):
-    ray_cxx = _require_ray_cxx()
+    _require_ray_cxx()
     payload_path = tmp_path / f"write-{write_expression}.bin"
     payload_path.write_bytes(b"write-owned-file-expression")
     database_path = tmp_path / f"write-{write_expression}.duckdb"
@@ -146,24 +146,22 @@ def test_distributed_write_snapshot_covers_write_owned_file_io_expressions(
 
     class CapturingRunner:
         def run_write(self, relation):
-            captured_plans.append(
-                ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-                    relation,
-                    f"write-owned-file-{write_expression}",
-                )
-            )
-            return {"ok": True}
+            captured_plans.append(relation)
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
-    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
     connection = vane.connect(str(database_path))
-    try:
+    with connection:
         if write_expression == "check":
             connection.execute("CREATE TABLE file_target (value FILE, CHECK (file_exists(value)))")
         else:
             connection.execute(f"CREATE TABLE file_target (value FILE DEFAULT try_to_file({path_sql}))")
             connection.execute(f"INSERT INTO file_target VALUES (file({path_sql}, NULL, NULL, NULL, NULL))")
 
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    connection = vane.connect(str(database_path))
+    try:
         monkeypatch.setenv("VANE_RUNNER", "ray")
         if write_expression == "check":
             connection.sql(f"SELECT file({path_sql}, NULL, NULL, NULL, NULL) AS value").insert_into("file_target")

--- a/tests/fast/test_ray_dynamic_extension_replay.py
+++ b/tests/fast/test_ray_dynamic_extension_replay.py
@@ -176,7 +176,7 @@ def test_real_ray_prepares_and_reuses_explicit_signed_extension_without_driver_p
     try:
         for query_id in range(2):
             relation = connection.sql(f"SELECT hello('worker') AS extension_value, {query_id} AS replay_attempt")
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             result = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
             assert result.column(0).to_pylist() == [11]
             assert result.column(1).to_pylist() == [query_id]

--- a/tests/fast/test_ray_e2e.py
+++ b/tests/fast/test_ray_e2e.py
@@ -270,7 +270,7 @@ def _assert_results_match(con, sql, parts, label, *, ordered=False):
 def _run_iter_tables(runner, builder, label, timeout_s=25.0):
     start = time.time()
     try:
-        parts = list(runner.run_iter_tables(builder))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(builder, None)))
         elapsed = time.time() - start
         _log_partitions(parts)
     except Exception:
@@ -1723,7 +1723,7 @@ def test_ray_task_large_block_stream_reaches_actor_with_bounded_leases(tmp_path,
         )
 
         start = time.time()
-        parts = list(runner.run_iter_tables(rel))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)))
         elapsed = time.time() - start
         ids = []
         lengths = []
@@ -1813,7 +1813,7 @@ def test_ray_lazy_tail_block_submits_without_cross_lease_batching(tmp_path, ray_
         )
 
         total = 0
-        for part in runner.run_iter_tables(rel):
+        for part in runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             total += table.num_rows
         assert total == row_count
@@ -1916,7 +1916,7 @@ def test_ray_actor_compute_batches_span_upstream_block_boundaries(tmp_path, ray_
         runner = _runners.get_or_create_runner()
         total = 0
         observed_batch_rows = set()
-        for part in runner.run_iter_tables(rel):
+        for part in runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             total += table.num_rows
             observed_batch_rows.update(table.column(1).to_pylist())
@@ -2003,7 +2003,7 @@ def test_ray_actor_soft_minimum_task_batch_matches_ray_data_bundling(tmp_path, r
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
         counts = Counter()
-        for part in runner.run_iter_tables(rel):
+        for part in runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             counts.update(table.column(0).to_pylist())
 
@@ -2112,7 +2112,7 @@ def test_ray_actor_lazy_row_backpressure_preserves_non_tail_batch_alignment(tmp_
         runner = _runners.get_or_create_runner()
         total = 0
         observed = Counter()
-        for part in runner.run_iter_tables(rel):
+        for part in runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             total += table.num_rows
             observed.update(table.column(1).to_pylist())
@@ -2204,7 +2204,7 @@ def test_ray_task_block_stream_does_not_deadlock_when_sink_and_source_blocked(tm
         )
 
         start = time.time()
-        parts = list(runner.run_iter_tables(rel))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)))
         elapsed = time.time() - start
         total = 0
         for part in parts:
@@ -2311,7 +2311,7 @@ def test_ray_task_flat_map_ref_stream_preserves_rows_under_actor_backpressure(tm
         ids = set()
         chunk_id_sum = 0
         max_chunk_len = 0
-        for part in runner.run_iter_tables(rel):
+        for part in runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(rel, None)):
             table = part.to_arrow() if hasattr(part, "to_arrow") else part
             count += table.num_rows
             ids.update(table.column(0).to_pylist())
@@ -2417,7 +2417,7 @@ def test_ray_task_flat_map_projected_ref_stream_preserves_column_projection(tmp_
         )
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(aggregate, None)))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2536,7 +2536,7 @@ def test_ray_task_flat_map_ref_stream_preserves_variable_and_empty_outputs(tmp_p
         )
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(aggregate, None)))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2650,7 +2650,7 @@ def test_ray_task_flat_map_ref_stream_preserves_reordered_alias_projection(tmp_p
         )
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(aggregate, None)))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2742,7 +2742,7 @@ def test_ray_task_flat_map_ref_stream_all_empty_output_finishes(tmp_path, ray_su
         aggregate = rel.aggregate("count(*) AS c")
         _runners.set_runner_ray(noop_if_initialized=True)
         runner = _runners.get_or_create_runner()
-        parts = list(runner.run_iter_tables(aggregate))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(aggregate, None)))
         result = pa.concat_tables(
             [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         )
@@ -2884,7 +2884,7 @@ def test_ray_python_udf_terminal_failure_propagates(ray_runner, duckdb_conn, par
     )
 
     with pytest.raises(Exception, match="planned scalar failure|FTE query .* failed"):
-        list(ray_runner.run_iter_tables(relation))
+        list(ray_runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
 
 
 def test_ray_python_udf_map_batches_arrow(ray_runner, duckdb_conn, parquet_path):

--- a/tests/fast/test_ray_e2e_serialization.py
+++ b/tests/fast/test_ray_e2e_serialization.py
@@ -132,7 +132,7 @@ def test_streaming_metadata_and_rows_full_execution(tmp_path):
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     result = pa.concat_tables(tables)
 
@@ -198,7 +198,7 @@ def test_single_csv_file_uses_explicit_byte_ranges_through_real_ray(tmp_path, mo
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     assert len(parts) == 4
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     result = pa.concat_tables(tables)
@@ -250,7 +250,7 @@ def test_multi_file_csv_union_reader_state_survives_worker_serde(tmp_path, monke
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     assert len(parts) == 2
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     result = pa.concat_tables(tables)
@@ -310,7 +310,7 @@ def test_multi_file_json_bind_state_survives_real_ray_serde(tmp_path, monkeypatc
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     assert len(parts) == 2
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     result = pa.concat_tables(tables)
@@ -367,7 +367,7 @@ def test_multi_file_json_preserves_file_index_through_real_ray(tmp_path, monkeyp
         split_batches = next(iter(plan.scan_split_batch_map().values()))
         assert len(split_batches) == 2
         assert all(len(vane.ray_cxx.split_scan_split_batch(batch)) == 1 for batch in split_batches)
-        parts = list(runner.run_iter_tables(relation))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
         tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
         result = pa.concat_tables(tables)
         return sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist()))

--- a/tests/fast/test_ray_image_operators.py
+++ b/tests/fast/test_ray_image_operators.py
@@ -45,7 +45,7 @@ def test_ray_crop_png_and_udf_preserve_image_contract(ray_local, backend, fixed)
         assert relation.types == [vane.sqltypes.BIGINT, result_type, vane.sqltypes.BLOB]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()
@@ -93,7 +93,7 @@ def test_ray_resize_convert_and_arrow_udf_preserve_shapes(ray_local, backend, fi
         assert relation.types == [vane.sqltypes.BIGINT, result_type]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()
@@ -134,7 +134,7 @@ def test_ray_image_to_tensor_udf_and_flight_shuffle_without_extension(ray_local,
         assert relation.types == [vane.sqltypes.BIGINT, tensor_type]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()

--- a/tests/fast/test_ray_image_operators.py
+++ b/tests/fast/test_ray_image_operators.py
@@ -188,7 +188,7 @@ def test_ray_wide_codec_hash_and_udf_keep_logical_types(ray_local, backend, mode
         expected = con.sql("SELECT image_hash($1)", params=[vane.Value(pixels, dtype)]).fetchone()[0]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()

--- a/tests/fast/test_ray_memory_sources.py
+++ b/tests/fast/test_ray_memory_sources.py
@@ -198,7 +198,13 @@ def test_pandas_ignores_unused_converted_buffers(connection, monkeypatch, projec
 
     monkeypatch.setattr(_memory, "_put_memory_partition", capture_snapshot)
     runners.set_runner_ray(noop_if_initialized=True)
-    result = pa.concat_tables(list(runners.get_or_create_runner().run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(
+            runners.get_or_create_runner().run_iter_tables(
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+            )
+        )
+    )
 
     assert sorted(result.column(0).to_pylist()) == expected
     assert len(snapshots) == 1
@@ -231,7 +237,13 @@ def test_rebound_mutated_pandas_source_preserves_each_snapshot(connection, monke
     assert logical._memory_source_ref_count_for_test() == 2
 
     runners.set_runner_ray(noop_if_initialized=True)
-    result = pa.concat_tables(list(runners.get_or_create_runner().run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(
+            runners.get_or_create_runner().run_iter_tables(
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+            )
+        )
+    )
     assert sorted(result.column(0).to_pylist()) == [10, 20, 30, 100, 200, 300]
 
 
@@ -330,7 +342,9 @@ def test_rebound_arrow_views_preserve_distinct_variadic_buffers(connection, monk
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
 
-    result = pa.concat_tables(list(runner.run_iter_tables(left.union(right))))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(left.union(right), None)))
+    )
 
     expected = original_array.to_pylist() + updated_array.to_pylist()
     assert sorted(result.column(0).to_pylist()) == sorted(expected)
@@ -367,7 +381,9 @@ def test_pandas_snapshot_prunes_unreferenced_unconvertible_columns(connection, m
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(left.union(right))))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(left.union(right), None)))
+    )
     assert sorted(result.column(0).to_pylist()) == [1, 2, 3, 10, 20, 30]
 
 
@@ -386,7 +402,9 @@ def test_pandas_row_count_scan_does_not_snapshot_uuid_object_column(connection, 
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == [3]
     assert len(snapshot_columns) == 1
@@ -482,7 +500,13 @@ def test_list_view_partitions_drop_unreferenced_child_ranges(connection, monkeyp
     monkeypatch.setattr(_memory, "_MAX_PARTITION_ROWS", 2)
     monkeypatch.setattr(_memory, "_put_memory_partition", capture_partition)
     runners.set_runner_ray(noop_if_initialized=True)
-    result = pa.concat_tables(list(runners.get_or_create_runner().run_iter_tables(connection.from_arrow(source))))
+    result = pa.concat_tables(
+        list(
+            runners.get_or_create_runner().run_iter_tables(
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.from_arrow(source), None)
+            )
+        )
+    )
 
     assert sorted(result.column(0).to_pylist(), key=str) == sorted(source.column(0).to_pylist(), key=str)
     assert len(partitions) == 4
@@ -685,7 +709,13 @@ def test_ray_nested_views_preserve_shared_storage(connection, monkeypatch, neste
     monkeypatch.setattr(_memory, "_put_memory_partition", capture_partition)
     runners.set_runner_ray(noop_if_initialized=True)
 
-    result = pa.concat_tables(list(runners.get_or_create_runner().run_iter_tables(connection.from_arrow(source))))
+    result = pa.concat_tables(
+        list(
+            runners.get_or_create_runner().run_iter_tables(
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(connection.from_arrow(source), None)
+            )
+        )
+    )
 
     assert result.column(0).to_pylist() == source.column(0).to_pylist()
     assert len(partitions) == 1
@@ -847,7 +877,9 @@ def test_dictionary_memory_scans_preserve_nested_and_view_values(connection, chu
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == expected
 
@@ -906,7 +938,9 @@ def test_pandas_categorical_memory_source_preserves_enum_semantics(connection):
     )
     relation = connection.from_df(source).filter("category != 'unused'").project("category")
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert sorted(value for value in result.column(0).to_pylist() if value is not None) == [
         "blue",
@@ -943,7 +977,9 @@ def test_numpy_memory_source_uses_normalized_dictionary_columns(connection):
     }
     relation = connection.sql("SELECT id, label, metric FROM source")
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
     rows = list(
         zip(
             result.column(0).to_pylist(),
@@ -972,7 +1008,9 @@ def test_pandas_timezone_memory_source_truncates_nanoseconds_like_pandas_scan(co
     )
     relation = connection.from_df(source).project("event_time")
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
     values = result.column(0).combine_chunks().cast(pa.int64()).to_pylist()
 
     assert result.column(0).type == pa.timestamp("us", tz="UTC")
@@ -997,7 +1035,9 @@ def test_pandas_timedelta_memory_source_matches_duckdb_interval_normalization(co
     )
     relation = connection.from_df(source).project("duration")
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == [
         pa.MonthDayNano((0, 0, 0)),
@@ -1013,7 +1053,9 @@ def test_pandas_and_arrow_memory_relations_execute_through_ray(connection):
 
     for source_kind in ("pandas", "arrow"):
         relation = _memory_relation(connection, source_kind, 4).filter("id >= 2").project("id, value * 2")
-        result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+        result = pa.concat_tables(
+            list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+        )
         rows = sorted(zip(result.column(0).to_pylist(), result.column(1).to_pylist(), strict=True))
         assert rows == [(2, 40), (3, 60)]
 
@@ -1024,7 +1066,9 @@ def test_pandas_snapshot_preserves_bound_object_integer_type(connection):
     source = pd.DataFrame({"small_integer": pd.Series([1, 2, None], dtype=object)})
     relation = connection.from_df(source).project("small_integer + 1")
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == [2, 3, None]
 
@@ -1047,7 +1091,9 @@ def test_pandas_varchar_object_memory_source_matches_pandas_scan(connection):
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert expected == ["1", "text", "custom-value", None, None, None, None]
     assert result.column(0).to_pylist() == expected
@@ -1065,7 +1111,9 @@ def test_uuid_object_memory_source_preserves_bound_type(connection, source_kind)
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == [str(values[0]), None, str(values[2])]
 
@@ -1087,7 +1135,9 @@ def test_pandas_map_object_memory_source_preserves_bound_type(connection):
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == [[("a", 1), ("b", 2)], None, []]
 
@@ -1103,7 +1153,9 @@ def test_pandas_file_object_memory_source_preserves_bound_type(connection):
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == ["memory://first", None, "memory://second"]
 
@@ -1134,7 +1186,9 @@ def test_memory_snapshot_matches_native_nested_and_temporal_types(connection, so
 
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
-    result = pa.concat_tables(list(runner.run_iter_tables(relation)))
+    result = pa.concat_tables(
+        list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+    )
 
     assert result.column(0).to_pylist() == expected
 
@@ -1168,7 +1222,13 @@ def test_memory_sources_preserve_empty_inputs_and_count_only_scans(connection, s
     runners.set_runner_ray(noop_if_initialized=True)
     runner = runners.get_or_create_runner()
 
-    result = pa.concat_tables(list(runner.run_iter_tables(relation.aggregate("count(*)"))))
+    result = pa.concat_tables(
+        list(
+            runner.run_iter_tables(
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation.aggregate("count(*)"), None)
+            )
+        )
+    )
 
     assert result.column(0).to_pylist() == [row_count]
 

--- a/tests/fast/test_ray_native_media_extensions.py
+++ b/tests/fast/test_ray_native_media_extensions.py
@@ -51,7 +51,7 @@ def test_ray_executes_native_scalar_with_exact_installed_provider(
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
             for _ in range(2):
-                parts = list(runner.run_iter_tables(relation))
+                parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
                 table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
                 assert table.num_columns == 1
                 assert table.column(0).to_pylist() == [expected] * 8
@@ -75,7 +75,7 @@ def test_ray_native_audio_keeps_tensor_values_through_flight(ray_local, request)
         assert relation.types[1] == vane.tensor_type(vane.sqltypes.DOUBLE, (None, None))
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
             assert table.num_columns == 2
             assert table.column(0).to_pylist() == [0, 1, 2, 3]
@@ -117,7 +117,7 @@ def test_ray_native_video_splits_preserve_files_and_frames(
         assert [len(batches) for batches in plan.scan_split_batch_map().values()] == [expected_splits]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
             assert table.num_columns == 4
             repeats = 1 if frame_limit is not None else 5
@@ -174,7 +174,7 @@ def test_ray_concurrent_connections_keep_independent_media_backends(ray_local, r
 
         def collect(query):
             runner, relation = query
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
             assert table.num_rows == 3 and table.num_columns == 3
             # Raw Worker batches use physical names; the public aliases are
@@ -208,7 +208,7 @@ def test_ray_native_audio_profile_retains_runtime_and_waveform_contract(ray_loca
         relation = con.sql(f"SELECT native_audio_resample_profile({file_sql}, 16000) AS profile FROM range(4)")
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
             profiles = table.column(0).to_pylist()
             assert len(profiles) == 4

--- a/tests/fast/test_ray_read_file.py
+++ b/tests/fast/test_ray_read_file.py
@@ -84,19 +84,15 @@ def test_read_file_functions_allow_empty_glob_through_ray(tmp_path, function_nam
         connection.close()
 
 
-@pytest.mark.skipif(ray is None, reason="ray not installed")
-@pytest.mark.usefixtures("ray_local")
-def test_unsupported_table_function_reports_user_error():
+def test_unsupported_table_function_reports_user_error(monkeypatch):
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client-context table functions must fail before Ray initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
     connection = vane.connect()
     try:
         relation = connection.sql("SELECT name FROM duckdb_settings()")
-        runners.set_runner_ray(noop_if_initialized=True)
-        runner = runners.get_or_create_runner()
-
-        with pytest.raises(
-            vane.InvalidInputException,
-            match=r'Ray runner.*table function "duckdb_settings".*bind data is missing',
-        ):
-            list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
+        with pytest.raises(ValueError, match="client-context table function duckdb_settings"):
+            vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
     finally:
         connection.close()

--- a/tests/fast/test_ray_read_file.py
+++ b/tests/fast/test_ray_read_file.py
@@ -47,7 +47,7 @@ def test_read_file_functions_run_through_ray(tmp_path, function_name, suffix, pa
         runners.set_runner_ray(noop_if_initialized=True)
         runner = runners.get_or_create_runner()
 
-        partitions = list(runner.run_iter_tables(relation))
+        partitions = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
         tables = [partition.to_arrow() if hasattr(partition, "to_arrow") else partition for partition in partitions]
         result = pa.concat_tables(tables)
         actual = list(
@@ -77,7 +77,7 @@ def test_read_file_functions_allow_empty_glob_through_ray(tmp_path, function_nam
         runners.set_runner_ray(noop_if_initialized=True)
         runner = runners.get_or_create_runner()
 
-        partitions = list(runner.run_iter_tables(relation))
+        partitions = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
         tables = [partition.to_arrow() if hasattr(partition, "to_arrow") else partition for partition in partitions]
         assert sum(table.num_rows for table in tables) == 0
     finally:
@@ -97,6 +97,6 @@ def test_unsupported_table_function_reports_user_error():
             vane.InvalidInputException,
             match=r'Ray runner.*table function "duckdb_settings".*bind data is missing',
         ):
-            list(runner.run_iter_tables(relation))
+            list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     finally:
         connection.close()

--- a/tests/fast/test_ray_read_video_frames.py
+++ b/tests/fast/test_ray_read_video_frames.py
@@ -43,7 +43,7 @@ def test_ray_streaming_video_preserves_file_and_fixed_image_through_udf_and_exch
         assert relation.types[-1] == dtype
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()
@@ -80,7 +80,7 @@ def test_ray_nested_explicit_image_cast_retains_validation_mode(ray_local):
         assert relation.types == [vane.struct_type({"images": vane.list_type(vane.image_type("RGB", 1, 1))})]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()

--- a/tests/fast/test_ray_real_integration.py
+++ b/tests/fast/test_ray_real_integration.py
@@ -266,7 +266,7 @@ def test_run_simple_plan_on_ray_local():
     assert getattr(runner, "name", None) == "ray"
 
     relation = vane.sql("SELECT a, b, a + b AS sum FROM (VALUES (1, 10), (2, 20), (3, 30)) AS t(a, b)")
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     assert parts
     rows = sorted(_collect_rows_from_parts(parts))
     assert rows == [(1, 10, 11), (2, 20, 22), (3, 30, 33)]
@@ -297,7 +297,7 @@ def test_run_distributed_plan_end_to_end_on_ray_local(tmp_path):
     runner = _runners.get_or_create_runner()
     assert getattr(runner, "name", None) == "ray"
 
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     assert parts
 
     rows = _collect_rows_from_parts(parts)
@@ -349,8 +349,16 @@ def test_two_connections_share_job_runtime_and_close_independently(monkeypatch, 
         execution_backend="ray_task",
     )
 
-    assert set(_collect_rows_from_parts(runner.run_iter_tables(relation_a))) == {("connection-a",)}
-    assert set(_collect_rows_from_parts(runner.run_iter_tables(relation_b))) == {("connection-b",)}
+    assert set(
+        _collect_rows_from_parts(
+            runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation_a, None))
+        )
+    ) == {("connection-a",)}
+    assert set(
+        _collect_rows_from_parts(
+            runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation_b, None))
+        )
+    ) == {("connection-b",)}
 
     runtime_client = runner.query_driver_client
     assert runtime_client is not None
@@ -366,7 +374,11 @@ def test_two_connections_share_job_runtime_and_close_independently(monkeypatch, 
         schema={"secret": vane.sqltypes.VARCHAR},
         execution_backend="ray_task",
     )
-    assert set(_collect_rows_from_parts(runner.run_iter_tables(relation_b_after_close))) == {("connection-b",)}
+    assert set(
+        _collect_rows_from_parts(
+            runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation_b_after_close, None))
+        )
+    ) == {("connection-b",)}
     connection_b.close()
 
 

--- a/tests/fast/test_ray_result_contract.py
+++ b/tests/fast/test_ray_result_contract.py
@@ -8159,7 +8159,7 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8174,10 +8174,7 @@ def test_run_copy_plan_uses_distributed_worker_path(tmp_path, monkeypatch):
 
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
 
     scan_split_batches = dict(plan.scan_split_batch_map())
     assert scan_split_batches
@@ -8235,7 +8232,7 @@ def test_run_csv_copy_plan_serializes_writer_and_returns_exact_stats(
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8268,10 +8265,7 @@ def test_run_csv_copy_plan_serializes_writer_and_returns_exact_stats(
     )
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
     assert [len(batches) for batches in plan.scan_split_batch_map().values()] == [4]
 
     runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
@@ -8327,7 +8321,7 @@ def test_run_copy_plan_trailing_separator_uses_one_lifecycle_namespace(tmp_path,
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8343,10 +8337,7 @@ def test_run_copy_plan_trailing_separator_uses_one_lifecycle_namespace(tmp_path,
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(raw_dst)
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
     runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
     with _registered_low_level_plan(plan, con):
         result = runner.run_copy_plan(plan, con)
@@ -8379,7 +8370,7 @@ def test_run_copy_plan_existing_file_uses_final_lifecycle_namespace(tmp_path, mo
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8394,10 +8385,7 @@ def test_run_copy_plan_existing_file_uses_final_lifecycle_namespace(tmp_path, mo
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
     runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
     with _registered_low_level_plan(plan, con):
         result = runner.run_copy_plan(plan, con)
@@ -8438,7 +8426,7 @@ def test_run_copy_plan_leaves_stale_direct_write_cleanup_to_explicit_api(tmp_pat
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     from vane.runners.ray import cleanup_copy_direct_write_lifecycle_once
 
@@ -8455,10 +8443,7 @@ def test_run_copy_plan_leaves_stale_direct_write_cleanup_to_explicit_api(tmp_pat
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
 
     stale_run_id = "run-explicit-cleanup"
     stale_lifecycle = vane.ray_cxx.register_copy_direct_write_run_lifecycle(
@@ -8501,7 +8486,7 @@ def test_run_copy_plan_local_staging_env_preserves_rename_path(tmp_path, monkeyp
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8515,10 +8500,7 @@ def test_run_copy_plan_local_staging_env_preserves_rename_path(tmp_path, monkeyp
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
 
     assert captured, "expected write relation to be captured"
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
 
     runner = vane.ray_cxx.DistributedPhysicalPlanRunner()
     with _registered_low_level_plan(plan, con):
@@ -8543,7 +8525,7 @@ def test_run_copy_plan_with_fte_preserves_copy_sink_output_for_existing_dir(tmp_
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8558,10 +8540,7 @@ def test_run_copy_plan_with_fte_preserves_copy_sink_output_for_existing_dir(tmp_
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
 
     assert captured, "expected write relation to be captured"
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
 
     scan_split_batches = dict(plan.scan_split_batch_map())
     assert scan_split_batches
@@ -8587,7 +8566,7 @@ def test_run_copy_plan_local_direct_write_committed_reader(tmp_path, monkeypatch
     class _DummyRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: _DummyRunner())
 
@@ -8601,10 +8580,7 @@ def test_run_copy_plan_local_direct_write_committed_reader(tmp_path, monkeypatch
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
 
     assert captured, "expected write relation to be captured"
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
 
     scan_split_batches = dict(plan.scan_split_batch_map())
     assert scan_split_batches
@@ -8754,7 +8730,7 @@ def test_run_copy_plan_propagates_worker_task_failure_before_finalize(tmp_path, 
     class _CapturingRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", "1")
     failing_worker = _FailingWorkerHandle()
@@ -8778,10 +8754,7 @@ def test_run_copy_plan_propagates_worker_task_failure_before_finalize(tmp_path, 
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
     scan_split_batches = dict(plan.scan_split_batch_map())
     assert scan_split_batches
 
@@ -8896,7 +8869,7 @@ def test_run_copy_plan_direct_write_failure_cleans_uncommitted_run(tmp_path, mon
     class _CapturingRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.delenv("VANE_DISTRIBUTED_COPY_LOCAL_STAGING", raising=False)
     failing_worker = _FailingDirectWriteWorkerHandle()
@@ -8920,10 +8893,7 @@ def test_run_copy_plan_direct_write_failure_cleans_uncommitted_run(tmp_path, mon
     ray_connection.sql(f"select * from read_parquet('{src}')").write_parquet(str(dst))
     assert captured, "expected write relation to be captured"
 
-    plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        str(uuid.uuid4()),
-    ).to_physical_plan(con)
+    plan = captured[0].to_physical_plan(con)
     scan_split_batches = dict(plan.scan_split_batch_map())
     assert scan_split_batches
 
@@ -11484,26 +11454,29 @@ def test_ray_runner_retries_pending_copy_cleanup_by_operation_id():
     assert calls == ["copy-cleanup-runner-retry"]
 
 
-def test_ray_runner_uses_write_specific_logical_plan_factory(monkeypatch):
+@pytest.mark.parametrize(
+    "method, client_method",
+    [("run_write", "run_copy_plan"), ("run_datasink", "run_datasink_plan"), ("run_iter", "stream_plan")],
+)
+def test_ray_runner_forwards_already_bound_plan(monkeypatch, method, client_method):
     from vane.runners.ray import runner as runner_module
 
-    relation = object()
+    plan = SimpleNamespace(session_id=lambda: "bound-plan-session")
+    received = []
+    expected = [{"rows_copied": 3}]
 
-    class _LogicalPlan:
-        @staticmethod
-        def from_duckdb_write_relation(actual_relation, _query_id):
-            assert actual_relation is relation
-            raise RuntimeError("write transaction validation reached")
+    def submit(actual_plan):
+        received.append(actual_plan)
+        return expected
 
+    client = SimpleNamespace(**{client_method: submit})
     ray_runner = object.__new__(runner_module.RayRunner)
     monkeypatch.setattr(
-        runner_module,
-        "require_ray_cxx_attr",
-        lambda name, *, hint: _LogicalPlan,
+        ray_runner, "_client_for_session", lambda session: client if session == "bound-plan-session" else None
     )
-
-    with pytest.raises(RuntimeError, match="write transaction validation reached"):
-        ray_runner.run_write(relation)
+    result = getattr(ray_runner, method)(plan)
+    assert (list(result) if method == "run_iter" else result) == expected
+    assert received == [plan]
 
 
 def test_connection_close_notification_reenters_runner_registry_lock(monkeypatch):

--- a/tests/fast/test_ray_udf_plan_replay.py
+++ b/tests/fast/test_ray_udf_plan_replay.py
@@ -458,7 +458,7 @@ def test_ray_runner_replays_map_batches_udf_via_task_plan_pickle(tmp_path, monke
     )
     _runners.set_runner_ray(noop_if_initialized=True)
     runner = _runners.get_or_create_runner()
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
 
     result = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
     assert result.column(0).to_pylist() == [0, 2, 4, 6]

--- a/tests/fast/test_ray_video_expressions.py
+++ b/tests/fast/test_ray_video_expressions.py
@@ -42,7 +42,7 @@ def test_ray_video_scalars_preserve_nested_images_and_file_windows(ray_local, vi
         assert relation.types[1:] == [dtype, vane.image_type("RGB")]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()
@@ -82,7 +82,7 @@ def test_ray_unnested_video_frames_keep_explicit_image_casts(ray_local, video_pa
         assert relation.types == [vane.image_type("RGB", 6, 8)]
         runner = RayRunner(address=None, max_task_backlog=None)
         try:
-            parts = list(runner.run_iter_tables(relation))
+            parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
             table = pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
         finally:
             runner.close()

--- a/tests/fast/test_ray_video_index.py
+++ b/tests/fast/test_ray_video_index.py
@@ -16,7 +16,7 @@ def _collect(relation):
 
     runner = RayRunner(address=None, max_task_backlog=None)
     try:
-        parts = list(runner.run_iter_tables(relation))
+        parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
         return pa.concat_tables([part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts])
     finally:
         runner.close()

--- a/tests/fast/test_relation_create_options.py
+++ b/tests/fast/test_relation_create_options.py
@@ -106,7 +106,7 @@ def test_ray_create_rejects_explicit_transaction(monkeypatch):
     con.execute("BEGIN")
     try:
         with pytest.raises(
-            vane.InvalidInputException,
+            vane.BinderException,
             match="Runner CTAS requires DuckDB auto-commit mode",
         ):
             con.sql("SELECT 1 AS id").create("transaction_target")

--- a/tests/fast/test_relation_create_options.py
+++ b/tests/fast/test_relation_create_options.py
@@ -58,12 +58,9 @@ def test_create_options_dispatch_to_ray_without_local_execution(monkeypatch, run
     class CapturingRunner:
         def run_write(self, relation):
             captured.append(relation)
-            logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-                relation,
-                "create-options-plan",
-            )
+            logical_plan = relation
             logical_plans.append(pickle.loads(pickle.dumps(logical_plan)))
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
     con = vane.connect()
@@ -73,8 +70,8 @@ def test_create_options_dispatch_to_ray_without_local_execution(monkeypatch, run
         partition_by=["bucket(16, id)"],
     )
 
-    assert [relation.type for relation in captured] == ["CREATE_TABLE_RELATION"]
-    assert logical_plans[0].idx() == "create-options-plan"
+    assert len(captured) == 1 and isinstance(captured[0], vane.ray_cxx.PyLogicalPlan)
+    assert logical_plans[0].idx() == captured[0].idx()
     assert logical_plans[0].to_physical_plan(con) is not None
     with pytest.raises(vane.CatalogException, match="ray_target"):
         con.table("ray_target")
@@ -86,7 +83,7 @@ def test_create_rejects_local_fte_runner(monkeypatch):
 
     with pytest.raises(
         vane.InvalidInputException,
-        match="CTAS requires VANE_RUNNER=ray or VANE_RUNNER=local-fast",
+        match="CTAS requires a ray or local-fast connection",
     ):
         con.sql("SELECT 1 AS id").create("local_fte_target", properties={"format-version": 2})
 
@@ -102,7 +99,7 @@ def test_ray_create_rejects_explicit_transaction(monkeypatch):
     class CapturingRunner:
         def run_write(self, relation):
             calls.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
     con = vane.connect()
@@ -110,7 +107,7 @@ def test_ray_create_rejects_explicit_transaction(monkeypatch):
     try:
         with pytest.raises(
             vane.InvalidInputException,
-            match="Ray CTAS requires DuckDB auto-commit mode",
+            match="Runner CTAS requires DuckDB auto-commit mode",
         ):
             con.sql("SELECT 1 AS id").create("transaction_target")
         assert calls == []
@@ -129,7 +126,7 @@ def test_ray_create_failure_never_executes_locally(monkeypatch):
     class CapturingRunner:
         def run_write(self, relation):
             successful_calls.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FailingRunner())
     con = vane.connect()
@@ -142,7 +139,7 @@ def test_ray_create_failure_never_executes_locally(monkeypatch):
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
     con.sql("SELECT 2 AS id").create("retry_ray_target")
-    assert [relation.type for relation in successful_calls] == ["CREATE_TABLE_RELATION"]
+    assert len(successful_calls) == 1 and isinstance(successful_calls[0], vane.ray_cxx.PyLogicalPlan)
     with pytest.raises(vane.CatalogException, match="retry_ray_target"):
         con.table("retry_ray_target")
 

--- a/tests/fast/test_relation_create_options.py
+++ b/tests/fast/test_relation_create_options.py
@@ -94,25 +94,23 @@ def test_create_rejects_local_fte_runner(monkeypatch):
 
 def test_ray_create_rejects_explicit_transaction(monkeypatch):
     monkeypatch.setenv("VANE_RUNNER", "ray")
-    calls = []
 
-    class CapturingRunner:
-        def run_write(self, relation):
-            calls.append(relation)
-            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
+    def unexpected_runner(*_args, **_kwargs):
+        pytest.fail("transaction rejection must happen before Ray initialization")
 
-    monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: CapturingRunner())
+    monkeypatch.setattr(vane._native, "set_runner_ray", unexpected_runner)
     con = vane.connect()
+    source = con.sql("SELECT 1 AS id")
     con.execute("BEGIN")
     try:
         with pytest.raises(
             vane.BinderException,
-            match="Runner CTAS requires DuckDB auto-commit mode",
+            match="requires DuckDB auto-commit mode.*explicit transaction",
         ):
-            con.sql("SELECT 1 AS id").create("transaction_target")
-        assert calls == []
+            source.create("transaction_target")
     finally:
         con.execute("ROLLBACK")
+        con.close()
 
 
 def test_ray_create_failure_never_executes_locally(monkeypatch):

--- a/tests/fast/test_runner_client_catalog.py
+++ b/tests/fast/test_runner_client_catalog.py
@@ -51,6 +51,76 @@ def test_show_catalog_commands_observe_client_state(monkeypatch, no_runner, runn
             connection.table("client_table")
 
 
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+@pytest.mark.parametrize("argument", ["literal", "parameter", "nested", "macro"])
+@pytest.mark.parametrize("catalog_query", ["SHOW TABLES", "SHOW DATABASES", "SHOW VARIABLES"])
+def test_query_expansion_preserves_client_catalog_origin(monkeypatch, no_runner, entry, argument, catalog_query):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    with vane.connect() as connection:
+        connection.execute("ATTACH ':memory:' AS attached")
+        connection.execute("CREATE TABLE client_table(value INTEGER)")
+        connection.execute("SET VARIABLE client_value=7")
+        expected = connection.execute(catalog_query).fetchall()
+        query = f"SELECT * FROM query('{catalog_query}')"
+        params = {}
+        if argument == "parameter":
+            query = "SELECT * FROM query($catalog_query)"
+            params = {"catalog_query": catalog_query}
+        elif argument == "nested":
+            query = "SELECT * FROM query('" + query.replace("'", "''") + "')"
+        elif argument == "macro":
+            connection.execute(f"CREATE MACRO client_catalog() AS TABLE {query}")
+            query = "SELECT * FROM client_catalog()"
+        if entry == "executemany":
+            result = connection.executemany(query, [params])
+        elif entry == "sql":
+            result = connection.sql(query, params=params)
+        else:
+            result = connection.execute(query, params)
+        assert result.fetchall() == expected
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["sql_copy", "sql_insert", "sql_ctas", "relation_copy", "relation_insert", "relation_create", "read", "datasink"],
+)
+def test_query_catalog_origin_does_not_relax_write_or_transport_guards(monkeypatch, no_runner, tmp_path, operation):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    database = str(tmp_path / "query_catalog.duckdb")
+    destination = tmp_path / "catalog.parquet"
+    with vane.connect(database) as connection:
+        connection.execute("CREATE TABLE target(name VARCHAR)")
+        connection.execute("CREATE SEQUENCE seq")
+        connection.execute("CREATE MACRO row_count() AS 1")
+        query = "SELECT name FROM query('SHOW TABLES'), range(row_count())"
+        relation = connection.sql(query)
+        connection.execute("CREATE OR REPLACE MACRO row_count() AS nextval('seq')")
+        with pytest.raises((vane.NotImplementedException, ValueError), match="client connection queries"):
+            if operation == "sql_copy":
+                connection.execute(f"COPY ({query}) TO '{destination}' (FORMAT PARQUET)")
+            elif operation == "sql_insert":
+                connection.execute(f"INSERT INTO target {query}")
+            elif operation == "sql_ctas":
+                connection.execute(f"CREATE TABLE created AS {query}")
+            elif operation == "relation_copy":
+                relation.write_parquet(str(destination))
+            elif operation == "relation_insert":
+                relation.insert_into("target")
+            elif operation == "relation_create":
+                relation.create("created")
+            elif operation == "datasink":
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_datasink_relation(relation._mark_datasink("catalog"), None)
+            else:
+                vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+        assert inspector.table("target").fetchall() == []
+        with pytest.raises(vane.CatalogException, match="created"):
+            inspector.table("created")
+    assert not destination.exists()
+
+
 _TEMPORARY_QUERIES = [
     "SELECT * FROM temporary_source",
     "SELECT * FROM source_view",

--- a/tests/fast/test_runner_client_catalog.py
+++ b/tests/fast/test_runner_client_catalog.py
@@ -167,7 +167,7 @@ def test_native_temporary_table_reads_remain_available(monkeypatch, no_runner, r
         assert connection.table("source").fetchall() == ([(7,)] if runner_type == "local-fast" else [])
 
 
-def test_temporary_arrow_views_remain_transportable(monkeypatch):
+def test_temporary_arrow_views_remain_transportable(ray_local, monkeypatch):
     runner = _TransportedPlanRunner()
     install_runner(monkeypatch, runner)
     with vane.connect() as connection:

--- a/tests/fast/test_runner_client_catalog.py
+++ b/tests/fast/test_runner_client_catalog.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Client catalog operations and temporary tables must not become remote state."""
+
+import pyarrow as pa
+import pytest
+
+import vane
+from tests.fast.test_bound_plan_runner import install_runner
+from tests.fast.test_distributed_result_consumers import _TransportedPlanRunner
+
+
+@pytest.fixture
+def no_runner(monkeypatch):
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("client catalog handling must precede runner initialization")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+
+
+@pytest.mark.parametrize("runner_type", ["local", "ray"])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+@pytest.mark.parametrize(
+    "query",
+    ["SHOW TABLES", "SHOW DATABASES", "SHOW VARIABLES", "SHOW SCHEMAS", "SHOW ALL TABLES", "SHOW TABLES FROM attached"],
+)
+def test_show_catalog_commands_observe_client_state(monkeypatch, no_runner, runner_type, entry, query):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("ATTACH ':memory:' AS attached")
+        connection.execute("CREATE TABLE attached.attached_table(value INTEGER)")
+        connection.execute("SET VARIABLE client_value=7")
+        connection.begin()
+        connection.execute("CREATE TABLE client_table(value INTEGER)")
+        result = connection.executemany(query, [[]]) if entry == "executemany" else getattr(connection, entry)(query)
+        rows = result.fetchall()
+        if query == "SHOW TABLES":
+            assert ("client_table",) in rows
+        elif query == "SHOW DATABASES":
+            assert ("attached",) in rows
+        elif query == "SHOW VARIABLES":
+            assert ("client_value", "7", "INTEGER") in rows
+        elif query == "SHOW SCHEMAS":
+            assert ("attached", "main") in [row[:2] for row in rows]
+        elif query == "SHOW ALL TABLES":
+            assert ("attached", "main", "attached_table") in [row[:3] for row in rows]
+        else:
+            assert rows == [("attached_table",)]
+        connection.rollback()
+        with pytest.raises(vane.CatalogException, match="client_table"):
+            connection.table("client_table")
+
+
+_TEMPORARY_QUERIES = [
+    "SELECT * FROM temporary_source",
+    "SELECT * FROM source_view",
+    "INSERT INTO temporary_target VALUES (2)",
+    "INSERT INTO temporary_target SELECT 2",
+    "UPDATE temporary_target SET value=2",
+    "DELETE FROM temporary_target",
+    "MERGE INTO temporary_target t USING (SELECT 2 AS value) s ON t.value=s.value "
+    "WHEN NOT MATCHED THEN INSERT VALUES (s.value)",
+    "INSERT INTO target SELECT * FROM temporary_source",
+    "UPDATE target SET value=2 FROM temporary_source s WHERE target.value=s.value",
+    "DELETE FROM target USING temporary_source s WHERE target.value=s.value",
+    "MERGE INTO target t USING temporary_source s ON t.value=s.value WHEN NOT MATCHED THEN INSERT VALUES (s.value)",
+    "CREATE TABLE created AS SELECT * FROM temporary_source",
+    "COPY temporary_source TO $path (FORMAT PARQUET)",
+]
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany"])
+@pytest.mark.parametrize("query", _TEMPORARY_QUERIES)
+def test_ray_sql_rejects_temporary_sources_and_targets_before_dispatch(monkeypatch, no_runner, tmp_path, entry, query):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    path = tmp_path / "temporary.parquet"
+    with vane.connect() as connection:
+        connection.execute("CREATE TABLE target(value INTEGER)")
+        connection.execute("CREATE TEMP TABLE temporary_target(value INTEGER)")
+        connection.execute("CREATE TEMP TABLE temporary_source(value INTEGER)")
+        connection.execute("CREATE TEMP VIEW source_view AS SELECT * FROM temporary_source")
+        params = {"path": str(path)} if "$path" in query else {}
+        with pytest.raises(vane.NotImplementedException, match="temporary table"):
+            if entry == "execute":
+                result = connection.execute(query, params)
+            elif entry == "executemany":
+                result = connection.executemany(query, [params])
+            else:
+                result = connection.sql(query, params=params)
+            if result is not None:
+                result.fetchall()
+        with pytest.raises(vane.CatalogException, match="created"):
+            connection.table("created")
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("operation", ["read", "insert", "update", "delete", "merge", "copy", "create"])
+def test_ray_relations_reject_temporary_tables_before_dispatch(monkeypatch, no_runner, tmp_path, operation):
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    path = tmp_path / "temporary.parquet"
+    with vane.connect() as connection:
+        connection.execute("CREATE TEMP TABLE temporary_target(value INTEGER)")
+        connection.execute("CREATE TEMP TABLE temporary_source(value INTEGER)")
+        source = connection.table("temporary_source")
+        target = connection.table("temporary_target")
+        with pytest.raises(vane.NotImplementedException, match="temporary table"):
+            if operation == "read":
+                source.fetchall()
+            elif operation == "insert":
+                connection.sql("SELECT 2 AS value").insert_into("temporary_target")
+            elif operation == "update":
+                target.update({"value": vane.ConstantExpression(2)})
+            elif operation == "delete":
+                target.delete()
+            elif operation == "merge":
+                source.merge_into(
+                    "temporary_target",
+                    "target.value=source.value",
+                    ["WHEN NOT MATCHED THEN INSERT VALUES (source.value)"],
+                )
+            elif operation == "copy":
+                source.write_parquet(str(path))
+            else:
+                source.create("created")
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+@pytest.mark.parametrize("factory", ["read", "datasink"])
+def test_explicit_plan_factories_reject_temporary_tables(monkeypatch, no_runner, runner_type, factory):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("CREATE TEMP TABLE source(value INTEGER)")
+        relation = connection.table("source")
+        if factory == "datasink":
+            relation = relation._mark_datasink("temporary-source")
+        make_plan = getattr(
+            vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
+        )
+        with pytest.raises(ValueError, match="temporary table"):
+            make_plan(relation, None)
+
+
+@pytest.mark.parametrize("entry", ["execute", "sql", "relation"])
+def test_local_fte_copy_rejects_temporary_sources(monkeypatch, no_runner, tmp_path, entry):
+    monkeypatch.setenv("VANE_RUNNER", "local")
+    path = tmp_path / "temporary.parquet"
+    with vane.connect() as connection:
+        connection.execute("CREATE TEMP TABLE source(value INTEGER)")
+        with pytest.raises(vane.NotImplementedException, match="temporary table"):
+            if entry == "relation":
+                connection.table("source").write_parquet(str(path))
+            else:
+                getattr(connection, entry)(f"COPY source TO '{path}' (FORMAT PARQUET)")
+    assert not path.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_native_temporary_table_reads_remain_available(monkeypatch, no_runner, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("CREATE TEMP TABLE source(value INTEGER)")
+        if runner_type == "local-fast":
+            connection.execute("INSERT INTO source VALUES (7)")
+        assert connection.table("source").fetchall() == ([(7,)] if runner_type == "local-fast" else [])
+
+
+def test_temporary_arrow_views_remain_transportable(monkeypatch):
+    runner = _TransportedPlanRunner()
+    install_runner(monkeypatch, runner)
+    with vane.connect() as connection:
+        connection.register("input", pa.table({"value": [1, 2]}))
+        assert connection.sql("SELECT sum(value)::BIGINT AS value FROM input").fetchall() == [(3,)]
+        assert len(runner.plans) == 1

--- a/tests/fast/test_runner_client_catalog.py
+++ b/tests/fast/test_runner_client_catalog.py
@@ -7,8 +7,6 @@ import pyarrow as pa
 import pytest
 
 import vane
-from tests.fast.test_bound_plan_runner import install_runner
-from tests.fast.test_distributed_result_consumers import _TransportedPlanRunner
 
 
 @pytest.fixture
@@ -168,9 +166,10 @@ def test_native_temporary_table_reads_remain_available(monkeypatch, no_runner, r
 
 
 def test_temporary_arrow_views_remain_transportable(ray_local, monkeypatch):
-    runner = _TransportedPlanRunner()
-    install_runner(monkeypatch, runner)
-    with vane.connect() as connection:
-        connection.register("input", pa.table({"value": [1, 2]}))
-        assert connection.sql("SELECT sum(value)::BIGINT AS value FROM input").fetchall() == [(3,)]
-        assert len(runner.plans) == 1
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    try:
+        with vane.connect() as connection:
+            connection.register("input", pa.table({"value": [1, 2]}))
+            assert connection.sql("SELECT sum(value)::BIGINT AS value FROM input").fetchall() == [(3,)]
+    finally:
+        vane.teardown_runner()

--- a/tests/fast/test_runner_json_sql.py
+++ b/tests/fast/test_runner_json_sql.py
@@ -223,9 +223,13 @@ def test_native_json_sql_serializer_keeps_global_setting(monkeypatch, tmp_path, 
         connection.execute(f"SET GLOBAL storage_compatibility_version='{version}'")
         assert connection.execute("SELECT current_setting('storage_compatibility_version')").fetchone() == (version,)
         serialized = connection.execute(f"SELECT json_serialize_sql('SELECT 42 AS value'{options})").fetchone()[0]
-        assert json.loads(serialized)["error"] is False
-        query = connection.execute("SELECT json_deserialize_sql(?)", [serialized]).fetchone()[0]
-        assert connection.execute(query).fetchone() == (42,)
+        document = json.loads(serialized)
+        assert document["error"] is False
+        # Omission options can remove fields required for deserialization.
+        # Verify the encoder's AST rather than requiring those formats to roundtrip.
+        expression = document["statements"][0]["node"]["select_list"][0]
+        assert expression["alias"] == "value"
+        assert expression["value"]["value"] == 42
 
 
 def test_ray_json_execution_pragma_uses_client_variables(monkeypatch):

--- a/tests/fast/test_runner_json_sql.py
+++ b/tests/fast/test_runner_json_sql.py
@@ -18,21 +18,32 @@ _PLAN_OPTIONS = [
     ", optimize := true, skip_null := true, skip_empty := true",
     ", skip_null := true, skip_empty := true, skip_default := true, format := true",
 ]
+_SQL_OPTIONS = [
+    "",
+    ", skip_null := true",
+    ", skip_null := true, skip_empty := true",
+    ", skip_null := true, skip_empty := true, skip_default := true",
+    ", skip_null := true, skip_empty := true, skip_default := true, format := true",
+]
 _INNER_QUERY = "SELECT getvariable('answer') AS value"
 _INNER_QUERY_LITERAL = "'SELECT getvariable(''answer'') AS value'"
 
 
-@pytest.mark.parametrize("options", _PLAN_OPTIONS)
+@pytest.mark.parametrize(
+    "function, options",
+    [("json_serialize_plan", option) for option in _PLAN_OPTIONS]
+    + [("json_serialize_sql", option) for option in _SQL_OPTIONS],
+)
 @pytest.mark.parametrize("entry", ["execute", "sql", "parameterized_sql", "relation_query", "relation"])
 @pytest.mark.parametrize(
     "runner_type, operation",
     [("ray", "select"), ("ray", "copy"), ("local", "copy"), ("ray", "insert"), ("ray", "ctas")],
 )
-def test_runner_rejects_json_plan_serialization(monkeypatch, tmp_path, options, entry, runner_type, operation):
+def test_runner_rejects_json_serialization(monkeypatch, tmp_path, function, options, entry, runner_type, operation):
     monkeypatch.setenv("VANE_RUNNER", runner_type)
 
     def forbid_initialization(*_args, **_kwargs):
-        raise AssertionError("JSON plan serialization must fail before initializing a runner")
+        raise AssertionError("JSON SQL serialization must fail before initializing a runner")
 
     monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
     monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
@@ -41,14 +52,14 @@ def test_runner_rejects_json_plan_serialization(monkeypatch, tmp_path, options, 
         connection.execute("SET VARIABLE answer=41")
         connection.execute("CREATE TABLE target(value JSON)")
         argument = "$query" if entry == "parameterized_sql" else _INNER_QUERY_LITERAL
-        source = f"SELECT json_serialize_plan({argument}{options}) AS value"
+        source = f"SELECT {function}({argument}{options}) AS value"
         query = {
             "select": source,
             "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
             "insert": f"INSERT INTO target {source}",
             "ctas": f"CREATE TABLE created AS {source}",
         }[operation]
-        with pytest.raises(vane.NotImplementedException, match="client-context function json_serialize_plan"):
+        with pytest.raises(vane.NotImplementedException, match=f"client-context function {function}"):
             if entry == "parameterized_sql":
                 result = connection.sql(query, params={"query": _INNER_QUERY})
             elif entry == "relation":
@@ -70,20 +81,19 @@ def test_runner_rejects_json_plan_serialization(monkeypatch, tmp_path, options, 
 
 @pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
 @pytest.mark.parametrize("factory", ["read", "datasink"])
-def test_plan_factory_rechecks_json_plan_serialization(monkeypatch, runner_type, factory):
+@pytest.mark.parametrize("function", ["json_serialize_plan", "json_serialize_sql"])
+def test_plan_factory_rechecks_json_serialization(monkeypatch, runner_type, factory, function):
     monkeypatch.setenv("VANE_RUNNER", runner_type)
     with vane.connect() as connection:
         connection.execute("CREATE MACRO describe_query(query_text VARCHAR) AS '{}'::JSON")
         relation = connection.sql(f"SELECT describe_query({_INNER_QUERY_LITERAL}) AS value")
         if factory == "datasink":
             relation = relation._mark_datasink("json-plan-admission")
-        connection.execute(
-            "CREATE OR REPLACE MACRO describe_query(query_text VARCHAR) AS json_serialize_plan(query_text)"
-        )
+        connection.execute(f"CREATE OR REPLACE MACRO describe_query(query_text VARCHAR) AS {function}(query_text)")
         make_plan = getattr(
             vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
         )
-        with pytest.raises(ValueError, match="client-context function json_serialize_plan"):
+        with pytest.raises(ValueError, match=f"client-context function {function}"):
             make_plan(relation, None)
 
 
@@ -102,6 +112,11 @@ def test_native_json_plan_serialization_observes_client_variables(monkeypatch, r
 @pytest.mark.parametrize("runner_type, operation", [("ray", "select"), ("ray", "copy"), ("local", "copy")])
 @pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
 def test_runner_rejects_json_execution_before_nested_binding(monkeypatch, tmp_path, runner_type, operation, entry):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as serializer:
+        serialized = serializer.execute(
+            "SELECT json_serialize_sql('SELECT * FROM range(nextval(''seq''))')"
+        ).fetchone()[0]
     monkeypatch.setenv("VANE_RUNNER", runner_type)
 
     def forbid_initialization(*_args, **_kwargs):
@@ -113,9 +128,8 @@ def test_runner_rejects_json_execution_before_nested_binding(monkeypatch, tmp_pa
     destination = tmp_path / "rejected.parquet"
     with vane.connect(database) as connection:
         connection.execute("CREATE SEQUENCE seq")
-        source = (
-            "SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM range(nextval(''seq''))'))"
-        )
+        argument = serialized.replace("'", "''")
+        source = f"SELECT * FROM json_execute_serialized_sql('{argument}')"
         query = source if operation == "select" else f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)"
         with pytest.raises(
             vane.NotImplementedException, match="client-context table function json_execute_serialized_sql"
@@ -135,7 +149,8 @@ def test_runner_rejects_json_execution_before_nested_binding(monkeypatch, tmp_pa
 def test_plan_factory_rejects_json_execution(monkeypatch, runner_type, factory):
     monkeypatch.setenv("VANE_RUNNER", runner_type)
     with vane.connect() as connection:
-        relation = connection.sql("SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT 42 AS value'))")
+        serialized = connection.execute("SELECT json_serialize_sql('SELECT 42 AS value')").fetchone()[0]
+        relation = connection.sql("SELECT * FROM json_execute_serialized_sql(?)", params=[serialized])
         if factory == "datasink":
             relation = relation._mark_datasink("json-execution-admission")
         make_plan = getattr(
@@ -154,19 +169,63 @@ def test_native_json_execution_still_runs(monkeypatch, runner_type):
         ).fetchall() == [(42,)]
 
 
-def test_runner_keeps_pure_json_sql_codecs(monkeypatch):
+def test_runner_keeps_json_sql_deserialization(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as serializer:
+        serialized = serializer.execute("SELECT json_serialize_sql('SELECT 42 AS value')").fetchone()[0]
     runner = _TransportedPlanRunner()
     install_runner(monkeypatch, runner)
     try:
         with vane.connect() as connection:
-            serialized = connection.execute(
-                "SELECT CAST(json_serialize_sql('SELECT 42 AS value') AS VARCHAR)"
-            ).fetchone()[0]
             assert json.loads(serialized)["error"] is False
             query = connection.execute("SELECT json_deserialize_sql(?)", [serialized]).fetchone()[0]
             assert connection.execute(query).fetchall() == [(42,)]
     finally:
         runner.worker.close()
+
+
+@pytest.mark.parametrize("version", ["v1.3.0", "latest"])
+@pytest.mark.parametrize(
+    "runner_type, operation", [("ray", "select"), ("ray", "insert"), ("ray", "ctas"), ("local", "copy")]
+)
+def test_runner_rejects_json_serializer_with_file_database_global_setting(
+    monkeypatch, tmp_path, version, runner_type, operation
+):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("database-global serializer settings cannot be read on a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    destination = tmp_path / "rejected.parquet"
+    with vane.connect(str(tmp_path / "serializer.duckdb")) as connection:
+        connection.execute(f"SET GLOBAL storage_compatibility_version='{version}'")
+        connection.execute("CREATE TABLE target(value VARCHAR)")
+        source = "SELECT CAST(json_serialize_sql('SELECT 42 AS value') AS VARCHAR) AS value"
+        query = {
+            "select": source,
+            "insert": f"INSERT INTO target {source}",
+            "ctas": f"CREATE TABLE created AS {source}",
+            "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
+        }[operation]
+        with pytest.raises(vane.NotImplementedException, match="client-context function json_serialize_sql"):
+            connection.execute(query)
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+@pytest.mark.parametrize("version", ["v1.3.0", "latest"])
+@pytest.mark.parametrize("options", _SQL_OPTIONS)
+def test_native_json_sql_serializer_keeps_global_setting(monkeypatch, tmp_path, runner_type, version, options):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect(str(tmp_path / "native_serializer.duckdb")) as connection:
+        connection.execute(f"SET GLOBAL storage_compatibility_version='{version}'")
+        assert connection.execute("SELECT current_setting('storage_compatibility_version')").fetchone() == (version,)
+        serialized = connection.execute(f"SELECT json_serialize_sql('SELECT 42 AS value'{options})").fetchone()[0]
+        assert json.loads(serialized)["error"] is False
+        query = connection.execute("SELECT json_deserialize_sql(?)", [serialized]).fetchone()[0]
+        assert connection.execute(query).fetchone() == (42,)
 
 
 def test_ray_json_execution_pragma_uses_client_variables(monkeypatch):

--- a/tests/fast/test_runner_json_sql.py
+++ b/tests/fast/test_runner_json_sql.py
@@ -159,7 +159,9 @@ def test_runner_keeps_pure_json_sql_codecs(monkeypatch):
     install_runner(monkeypatch, runner)
     try:
         with vane.connect() as connection:
-            serialized = connection.execute("SELECT json_serialize_sql('SELECT 42 AS value')").fetchone()[0]
+            serialized = connection.execute(
+                "SELECT CAST(json_serialize_sql('SELECT 42 AS value') AS VARCHAR)"
+            ).fetchone()[0]
             assert json.loads(serialized)["error"] is False
             query = connection.execute("SELECT json_deserialize_sql(?)", [serialized]).fetchone()[0]
             assert connection.execute(query).fetchall() == [(42,)]

--- a/tests/fast/test_runner_json_sql.py
+++ b/tests/fast/test_runner_json_sql.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2026 Vane contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""JSON helpers that bind or execute SQL must retain their client context."""
+
+import json
+
+import pytest
+
+import vane
+from tests.fast.test_bound_plan_runner import _run_sql_entry, install_runner
+from tests.fast.test_distributed_result_consumers import _TransportedPlanRunner
+
+_PLAN_OPTIONS = [
+    "",
+    ", optimize := true",
+    ", optimize := true, skip_null := true",
+    ", optimize := true, skip_null := true, skip_empty := true",
+    ", skip_null := true, skip_empty := true, skip_default := true, format := true",
+]
+_INNER_QUERY = "SELECT getvariable('answer') AS value"
+_INNER_QUERY_LITERAL = "'SELECT getvariable(''answer'') AS value'"
+
+
+@pytest.mark.parametrize("options", _PLAN_OPTIONS)
+@pytest.mark.parametrize("entry", ["execute", "sql", "parameterized_sql", "relation_query", "relation"])
+@pytest.mark.parametrize(
+    "runner_type, operation",
+    [("ray", "select"), ("ray", "copy"), ("local", "copy"), ("ray", "insert"), ("ray", "ctas")],
+)
+def test_runner_rejects_json_plan_serialization(monkeypatch, tmp_path, options, entry, runner_type, operation):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("JSON plan serialization must fail before initializing a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    destination = tmp_path / "rejected.parquet"
+    with vane.connect() as connection:
+        connection.execute("SET VARIABLE answer=41")
+        connection.execute("CREATE TABLE target(value JSON)")
+        argument = "$query" if entry == "parameterized_sql" else _INNER_QUERY_LITERAL
+        source = f"SELECT json_serialize_plan({argument}{options}) AS value"
+        query = {
+            "select": source,
+            "copy": f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)",
+            "insert": f"INSERT INTO target {source}",
+            "ctas": f"CREATE TABLE created AS {source}",
+        }[operation]
+        with pytest.raises(vane.NotImplementedException, match="client-context function json_serialize_plan"):
+            if entry == "parameterized_sql":
+                result = connection.sql(query, params={"query": _INNER_QUERY})
+            elif entry == "relation":
+                relation = connection.sql(source)
+                if operation == "copy":
+                    result = relation.write_parquet(str(destination))
+                elif operation == "insert":
+                    result = relation.insert_into("target")
+                elif operation == "ctas":
+                    result = relation.create("created")
+                else:
+                    result = relation
+            else:
+                result = _run_sql_entry(connection, entry, query)
+            if result is not None:
+                result.fetchall()
+    assert not destination.exists()
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local", "ray"])
+@pytest.mark.parametrize("factory", ["read", "datasink"])
+def test_plan_factory_rechecks_json_plan_serialization(monkeypatch, runner_type, factory):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("CREATE MACRO describe_query(query_text VARCHAR) AS '{}'::JSON")
+        relation = connection.sql(f"SELECT describe_query({_INNER_QUERY_LITERAL}) AS value")
+        if factory == "datasink":
+            relation = relation._mark_datasink("json-plan-admission")
+        connection.execute(
+            "CREATE OR REPLACE MACRO describe_query(query_text VARCHAR) AS json_serialize_plan(query_text)"
+        )
+        make_plan = getattr(
+            vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
+        )
+        with pytest.raises(ValueError, match="client-context function json_serialize_plan"):
+            make_plan(relation, None)
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+@pytest.mark.parametrize("options", _PLAN_OPTIONS)
+def test_native_json_plan_serialization_observes_client_variables(monkeypatch, runner_type, options):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        connection.execute("SET VARIABLE answer=41")
+        actual = connection.execute(f"SELECT json_serialize_plan({_INNER_QUERY_LITERAL}{options})").fetchone()[0]
+        expected = connection.execute(f"SELECT json_serialize_plan('SELECT 41 AS value'{options})").fetchone()[0]
+        assert json.loads(actual)["error"] is False
+        assert json.loads(actual) == json.loads(expected)
+
+
+@pytest.mark.parametrize("runner_type, operation", [("ray", "select"), ("ray", "copy"), ("local", "copy")])
+@pytest.mark.parametrize("entry", ["execute", "sql", "executemany", "relation_query"])
+def test_runner_rejects_json_execution_before_nested_binding(monkeypatch, tmp_path, runner_type, operation, entry):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("nested JSON SQL must fail before initializing a runner")
+
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    monkeypatch.setattr(vane._native, "set_runner_local", forbid_initialization)
+    database = str(tmp_path / "json_nested_binding.duckdb")
+    destination = tmp_path / "rejected.parquet"
+    with vane.connect(database) as connection:
+        connection.execute("CREATE SEQUENCE seq")
+        source = (
+            "SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT * FROM range(nextval(''seq''))'))"
+        )
+        query = source if operation == "select" else f"COPY ({source}) TO '{destination}' (FORMAT PARQUET)"
+        with pytest.raises(
+            vane.NotImplementedException, match="client-context table function json_execute_serialized_sql"
+        ):
+            result = _run_sql_entry(connection, entry, query)
+            if result is not None:
+                result.fetchall()
+    assert not destination.exists()
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect(database) as inspector:
+        assert inspector.execute("SELECT nextval('seq')").fetchone() == (1,)
+
+
+@pytest.mark.parametrize(
+    "runner_type, factory", [("local-fast", "read"), ("local", "read"), ("local-fast", "datasink")]
+)
+def test_plan_factory_rejects_json_execution(monkeypatch, runner_type, factory):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        relation = connection.sql("SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT 42 AS value'))")
+        if factory == "datasink":
+            relation = relation._mark_datasink("json-execution-admission")
+        make_plan = getattr(
+            vane.ray_cxx.PyLogicalPlan, f"from_duckdb_{'datasink_' if factory == 'datasink' else ''}relation"
+        )
+        with pytest.raises(ValueError, match="client-context table function json_execute_serialized_sql"):
+            make_plan(relation, None)
+
+
+@pytest.mark.parametrize("runner_type", ["local-fast", "local"])
+def test_native_json_execution_still_runs(monkeypatch, runner_type):
+    monkeypatch.setenv("VANE_RUNNER", runner_type)
+    with vane.connect() as connection:
+        assert connection.execute(
+            "SELECT * FROM json_execute_serialized_sql(json_serialize_sql('SELECT 42 AS value'))"
+        ).fetchall() == [(42,)]
+
+
+def test_runner_keeps_pure_json_sql_codecs(monkeypatch):
+    runner = _TransportedPlanRunner()
+    install_runner(monkeypatch, runner)
+    try:
+        with vane.connect() as connection:
+            serialized = connection.execute("SELECT json_serialize_sql('SELECT 42 AS value')").fetchone()[0]
+            assert json.loads(serialized)["error"] is False
+            query = connection.execute("SELECT json_deserialize_sql(?)", [serialized]).fetchone()[0]
+            assert connection.execute(query).fetchall() == [(42,)]
+    finally:
+        runner.worker.close()
+
+
+def test_ray_json_execution_pragma_uses_client_variables(monkeypatch):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as serializer:
+        serialized = serializer.execute("SELECT json_serialize_sql(?)", [_INNER_QUERY]).fetchone()[0]
+
+    def forbid_initialization(*_args, **_kwargs):
+        raise AssertionError("query PRAGMAs must keep the client connection")
+
+    monkeypatch.setenv("VANE_RUNNER", "ray")
+    monkeypatch.setattr(vane._native, "set_runner_ray", forbid_initialization)
+    with vane.connect() as connection:
+        connection.execute("SET VARIABLE answer=41")
+        argument = serialized.replace("'", "''")
+        assert connection.execute(f"PRAGMA json_execute_serialized_sql('{argument}')").fetchone() == (41,)

--- a/tests/fast/test_vane_config.py
+++ b/tests/fast/test_vane_config.py
@@ -379,9 +379,10 @@ def test_connection_runners_coexist_and_preserve_configuration(monkeypatch, tmp_
             created[name] = self
 
         def run_write(self, relation):
-            assert relation._get_runner_type() == self.name
+            assert isinstance(relation, vane.ray_cxx.PyLogicalPlan)
+            assert relation.__getstate__()[3]["vane_session"]["config"]["VANE_RUNNER"] == self.name
             self.calls += 1
-            return {}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
         def close(self):
             self.closed = True

--- a/tests/fast/test_write_local_default_runner.py
+++ b/tests/fast/test_write_local_default_runner.py
@@ -221,7 +221,7 @@ def test_ray_relation_mutations_reject_explicit_transactions(tmp_path, monkeypat
     connection.execute("BEGIN")
     try:
         with pytest.raises(
-            vane.InvalidInputException,
+            vane.BinderException,
             match=rf"Runner {expected_name} requires DuckDB auto-commit mode",
         ):
             _execute_relation_mutation(vane, connection, operation)

--- a/tests/fast/test_write_local_default_runner.py
+++ b/tests/fast/test_write_local_default_runner.py
@@ -20,20 +20,27 @@ _RELATION_MUTATIONS = [
 _RELATION_MUTATION_IDS = ["insert-into", "insert-values", "update", "delete", "ctas"]
 
 
-def _execute_relation_mutation(vane, connection, operation):
+def _execute_relation_mutation(vane, connection, operation, source=None):
+    if source is None:
+        if operation == "insert_into":
+            source = connection.sql("SELECT 3 AS value")
+        elif operation == "ctas":
+            source = connection.sql("SELECT 7 AS value")
+        else:
+            source = connection.table("target")
     if operation == "insert_into":
-        connection.sql("SELECT 3 AS value").insert_into("target")
+        source.insert_into("target")
     elif operation == "insert_values":
-        connection.table("target").insert([4])
+        source.insert([4])
     elif operation == "update":
-        connection.table("target").update(
+        source.update(
             {"value": vane.ConstantExpression(42)},
             condition=vane.ColumnExpression("value") == 1,
         )
     elif operation == "delete":
-        connection.table("target").delete(condition=vane.ColumnExpression("value") == 2)
+        source.delete(condition=vane.ColumnExpression("value") == 2)
     elif operation == "ctas":
-        connection.sql("SELECT 7 AS value").create("created_target")
+        source.create("created_target")
     else:
         raise AssertionError(f"unknown relation mutation: {operation}")
 
@@ -202,31 +209,34 @@ def test_nested_ray_mutation_does_not_reuse_cached_local_runner(tmp_path, monkey
     assert connection.execute("SELECT count(*) FROM target").fetchone() == (0,)
 
 
-@pytest.mark.parametrize(("operation", "expected_name"), _RELATION_MUTATIONS, ids=_RELATION_MUTATION_IDS)
-def test_ray_relation_mutations_reject_explicit_transactions(tmp_path, monkeypatch, operation, expected_name):
+@pytest.mark.parametrize("prepare_source", [False, True], ids=["inside-transaction", "before-transaction"])
+@pytest.mark.parametrize(("operation", "_expected_name"), _RELATION_MUTATIONS, ids=_RELATION_MUTATION_IDS)
+def test_ray_relation_mutations_reject_explicit_transactions(
+    tmp_path, monkeypatch, operation, _expected_name, prepare_source
+):
     monkeypatch.setenv("VANE_RUNNER", "ray")
     import vane
 
-    calls = []
+    def unexpected_runner(*_args, **_kwargs):
+        pytest.fail("transaction rejection must happen before Ray initialization")
 
-    class FakeRayRunner:
-        def run_write(self, relation, **_kwargs):
-            calls.append(relation)
-            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
-
-    monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
+    monkeypatch.setattr(vane._native, "set_runner_ray", unexpected_runner)
 
     database = str(tmp_path / "mutations.db")
     connection = _new_mutation_connection(vane, database, monkeypatch)
+    source = None
+    if prepare_source:
+        source = (
+            connection.sql("SELECT 3 AS value") if operation in {"insert_into", "ctas"} else connection.table("target")
+        )
     connection.execute("BEGIN")
     try:
         with pytest.raises(
             vane.BinderException,
-            match=rf"Runner {expected_name} requires DuckDB auto-commit mode",
+            match="requires DuckDB auto-commit mode.*cannot participate in an explicit transaction",
         ):
-            _execute_relation_mutation(vane, connection, operation)
+            _execute_relation_mutation(vane, connection, operation, source)
 
-        assert calls == []
         monkeypatch.setenv("VANE_RUNNER", "local-fast")
         inspector = vane.connect(database)
         assert inspector.execute("SELECT * FROM target ORDER BY value").fetchall() == [(1,), (2,)]

--- a/tests/fast/test_write_local_default_runner.py
+++ b/tests/fast/test_write_local_default_runner.py
@@ -11,7 +11,7 @@ import sys
 import pytest
 
 _RELATION_MUTATIONS = [
-    ("insert_into", "INSERT INTO"),
+    ("insert_into", "INSERT"),
     ("insert_values", "INSERT"),
     ("update", "UPDATE"),
     ("delete", "DELETE"),
@@ -38,11 +38,14 @@ def _execute_relation_mutation(vane, connection, operation):
         raise AssertionError(f"unknown relation mutation: {operation}")
 
 
-def _new_mutation_connection(vane, database=":memory:"):
-    connection = vane.connect(database)
-    connection.execute("CREATE TABLE target (value INTEGER)")
-    connection.execute("INSERT INTO target VALUES (1), (2)")
-    return connection
+def _new_mutation_connection(vane, database, monkeypatch):
+    # Seed through an explicitly native connection, then create the tested policy.
+    with monkeypatch.context() as setup:
+        setup.setenv("VANE_RUNNER", "local-fast")
+        with vane.connect(str(database)) as connection:
+            connection.execute("CREATE TABLE target (value INTEGER)")
+            connection.execute("INSERT INTO target VALUES (1), (2)")
+    return vane.connect(str(database))
 
 
 @pytest.mark.parametrize(
@@ -60,7 +63,7 @@ def test_format_convenience_write_with_unset_runner_uses_generic_copy_relation(
     class FakeRayRunner:
         def run_write(self, relation):
             calls.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
@@ -69,11 +72,8 @@ def test_format_convenience_write_with_unset_runner_uses_generic_copy_relation(
     getattr(relation, method_name)(str(target))
 
     assert len(calls) == 1
-    assert calls[0].type == "WRITE_FILE_RELATION"
-    logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        calls[0],
-        f"generic-copy-{extension}-convenience",
-    )
+    assert isinstance(calls[0], vane.ray_cxx.PyLogicalPlan)
+    logical_plan = calls[0]
     assert logical_plan is not None
     assert not target.exists()
 
@@ -87,7 +87,7 @@ def test_write_file_with_unset_runner_dispatches_generic_copy_relation(tmp_path,
     class FakeRayRunner:
         def run_write(self, relation):
             captured.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
@@ -96,11 +96,8 @@ def test_write_file_with_unset_runner_dispatches_generic_copy_relation(tmp_path,
     connection.sql("select 1 as x").write_file(str(target), format="csv")
 
     assert len(captured) == 1
-    assert captured[0].type == "WRITE_FILE_RELATION"
-    logical_plan = vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-        captured[0],
-        "generic-copy-relation",
-    )
+    assert isinstance(captured[0], vane.ray_cxx.PyLogicalPlan)
+    logical_plan = captured[0]
     assert logical_plan is not None
     assert not target.exists()
 
@@ -113,13 +110,8 @@ def test_write_file_json_with_unset_runner_builds_distributed_plan(tmp_path, mon
 
     class FakeRayRunner:
         def run_write(self, relation):
-            logical_plans.append(
-                vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-                    relation,
-                    "generic-json-copy-relation",
-                )
-            )
-            return {"ok": True}
+            logical_plans.append(relation)
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
@@ -140,34 +132,21 @@ def test_relation_mutations_dispatch_ray_without_local_execution(tmp_path, monke
         monkeypatch.setenv("VANE_RUNNER", runner_value)
     import vane
 
-    relation_types = []
     logical_plans = []
 
     class FakeRayRunner:
         def run_write(self, relation, **_kwargs):
-            relation_types.append(relation.type)
-            logical_plans.append(
-                vane.ray_cxx.PyLogicalPlan.from_duckdb_write_relation(
-                    relation,
-                    f"relation-mutation-{len(logical_plans)}",
-                )
-            )
-            return {"ok": True}
+            logical_plans.append(relation)
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
     database = str(tmp_path / "mutations.db")
-    connection = _new_mutation_connection(vane, database)
+    connection = _new_mutation_connection(vane, database, monkeypatch)
     for operation, _expected_name in _RELATION_MUTATIONS:
         _execute_relation_mutation(vane, connection, operation)
 
-    assert relation_types == [
-        "INSERT_RELATION",
-        "INSERT_RELATION",
-        "UPDATE_RELATION",
-        "DELETE_RELATION",
-        "CREATE_TABLE_RELATION",
-    ]
+    assert all(isinstance(plan, vane.ray_cxx.PyLogicalPlan) for plan in logical_plans)
     assert len(logical_plans) == len(_RELATION_MUTATIONS)
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     inspector = vane.connect(database)
@@ -177,11 +156,11 @@ def test_relation_mutations_dispatch_ray_without_local_execution(tmp_path, monke
     ).fetchone() == (0,)
 
 
-def test_relation_mutations_run_with_explicit_local_fast(monkeypatch):
+def test_relation_mutations_run_with_explicit_local_fast(monkeypatch, tmp_path):
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     import vane
 
-    connection = _new_mutation_connection(vane)
+    connection = _new_mutation_connection(vane, tmp_path / "mutations.db", monkeypatch)
     for operation, _expected_name in _RELATION_MUTATIONS:
         _execute_relation_mutation(vane, connection, operation)
 
@@ -198,16 +177,16 @@ def test_nested_ray_mutation_does_not_reuse_cached_local_runner(tmp_path, monkey
 
     class FakeLocalRunner:
         def run_write(self, relation):
-            local_calls.append(relation.type)
+            local_calls.append(relation)
             monkeypatch.setenv("VANE_RUNNER", "ray")
             with vane.connect(database) as ray_connection:
                 ray_connection.sql("SELECT 42 AS value").insert_into("target")
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     class FakeRayRunner:
         def run_write(self, relation, **_kwargs):
-            ray_calls.append(relation.type)
-            return {"ok": True}
+            ray_calls.append(relation)
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_local", lambda *_args, **_kwargs: FakeLocalRunner())
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
@@ -217,8 +196,8 @@ def test_nested_ray_mutation_does_not_reuse_cached_local_runner(tmp_path, monkey
     connection.execute("CREATE TABLE target (value INTEGER)")
     connection.sql("SELECT 1 AS value").write_parquet(str(tmp_path / "nested.parquet"))
 
-    assert local_calls == ["WRITE_FILE_RELATION"]
-    assert ray_calls == ["INSERT_RELATION"]
+    assert len(local_calls) == 1 and isinstance(local_calls[0], vane.ray_cxx.PyLogicalPlan)
+    assert len(ray_calls) == 1 and isinstance(ray_calls[0], vane.ray_cxx.PyLogicalPlan)
     monkeypatch.setenv("VANE_RUNNER", "local-fast")
     assert connection.execute("SELECT count(*) FROM target").fetchone() == (0,)
 
@@ -233,17 +212,17 @@ def test_ray_relation_mutations_reject_explicit_transactions(tmp_path, monkeypat
     class FakeRayRunner:
         def run_write(self, relation, **_kwargs):
             calls.append(relation)
-            return {"ok": True}
+            return {"copy_operation_id": relation.idx(), "rows_copied": 1}
 
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FakeRayRunner())
 
     database = str(tmp_path / "mutations.db")
-    connection = _new_mutation_connection(vane, database)
+    connection = _new_mutation_connection(vane, database, monkeypatch)
     connection.execute("BEGIN")
     try:
         with pytest.raises(
             vane.InvalidInputException,
-            match=rf"Ray {expected_name} requires DuckDB auto-commit mode",
+            match=rf"Runner {expected_name} requires DuckDB auto-commit mode",
         ):
             _execute_relation_mutation(vane, connection, operation)
 
@@ -259,14 +238,14 @@ def test_ray_relation_mutations_reject_explicit_transactions(tmp_path, monkeypat
 
 
 @pytest.mark.parametrize(("operation", "expected_name"), _RELATION_MUTATIONS, ids=_RELATION_MUTATION_IDS)
-def test_relation_mutations_reject_local_fte_runner(monkeypatch, operation, expected_name):
+def test_relation_mutations_reject_local_fte_runner(monkeypatch, tmp_path, operation, expected_name):
     monkeypatch.setenv("VANE_RUNNER", "local")
     import vane
 
-    connection = _new_mutation_connection(vane)
+    connection = _new_mutation_connection(vane, tmp_path / "mutations.db", monkeypatch)
     with pytest.raises(
         vane.InvalidInputException,
-        match=rf"{expected_name} requires VANE_RUNNER=ray or VANE_RUNNER=local-fast",
+        match=rf"{expected_name} requires a ray or local-fast connection",
     ):
         _execute_relation_mutation(vane, connection, operation)
 
@@ -288,7 +267,7 @@ def test_ray_relation_mutation_failures_never_execute_locally(tmp_path, monkeypa
     monkeypatch.setattr(vane._native, "set_runner_ray", lambda *_args, **_kwargs: FailingRayRunner())
 
     database = str(tmp_path / "mutations.db")
-    connection = _new_mutation_connection(vane, database)
+    connection = _new_mutation_connection(vane, database, monkeypatch)
     with pytest.raises(RuntimeError, match=rf"injected distributed {operation} failure"):
         _execute_relation_mutation(vane, connection, operation)
 

--- a/tests/slow/test_expression_udf_ray_chain.py
+++ b/tests/slow/test_expression_udf_ray_chain.py
@@ -45,7 +45,7 @@ try:
         UpperActor()(vane.col("text")).alias("upper_text"),
     )
 
-    parts = list(runner.run_iter_tables(result))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(result, None)))
     table = pa.concat_tables(parts).rename_columns(list(result.columns))
     rows = sorted(table.to_pylist(), key=lambda row: row["id"])
     assert rows == [
@@ -89,7 +89,7 @@ vane.configure(runner="ray")
 
 
 def collect_table(runner, relation):
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     return pa.concat_tables(tables)
 
@@ -254,7 +254,7 @@ class StatefulBatchCounter:
 
 
 def collect_table(runner, relation):
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     return pa.concat_tables(tables)
 
@@ -383,7 +383,7 @@ vane.configure(runner="ray")
 
 
 def collect_table(runner, relation):
-    parts = list(runner.run_iter_tables(relation))
+    parts = list(runner.run_iter_tables(vane.ray_cxx.PyLogicalPlan.from_duckdb_relation(relation, None)))
     tables = [part.to_arrow() if hasattr(part, "to_arrow") else part for part in parts]
     return pa.concat_tables(tables)
 

--- a/vane/_native/__init__.pyi
+++ b/vane/_native/__init__.pyi
@@ -139,10 +139,10 @@ class DuckDBPyConnection:
     def duplicate(self) -> DuckDBPyConnection: ...
     def enum_type(self, name: str, type: sqltypes.DuckDBPyType, values: lst[typing.Any]) -> sqltypes.DuckDBPyType: ...
     def execute(self, query: Statement | str, parameters: object = None) -> DuckDBPyConnection:
-        """Execute SELECT and COPY TO through the runner fixed when connecting.
+        """Execute queries and writes through shared bound-plan runner dispatch.
 
-        SQL PREPARE, EXECUTE and EXPLAIN ANALYZE require local-fast. Other SQL
-        statements execute on the connection. Ray SELECT requires auto-commit.
+        SQL PREPARE, EXECUTE and EXPLAIN ANALYZE require local-fast. Connection
+        and catalog operations remain native. Distributed execution requires auto-commit.
         """
         ...
     def executemany(self, query: Statement | str, parameters: object = None) -> DuckDBPyConnection: ...

--- a/vane/_query_interrupt.py
+++ b/vane/_query_interrupt.py
@@ -23,14 +23,14 @@ def check_query_interrupted() -> None:
     check()
 
 
-def run_write_with_interrupt_check(runner: Any, relation: Any, check: Callable[[], None] | None) -> dict[str, Any]:
+def run_write_with_interrupt_check(runner: Any, logical_plan: Any, check: Callable[[], None] | None) -> dict[str, Any]:
     """Poll one connection operation while preserving a write's terminal outcome."""
     token = _active_interrupt_check.set(check)
     try:
         check_query_interrupted()
         # The runner reconciles cancellation with commit. A check after this
         # return could misreport an already committed write as interrupted.
-        result: dict[str, Any] = runner.run_write(relation)
+        result: dict[str, Any] = runner.run_write(logical_plan)
         return result
     finally:
         _active_interrupt_check.reset(token)

--- a/vane/_query_interrupt.py
+++ b/vane/_query_interrupt.py
@@ -37,9 +37,10 @@ def run_write_with_interrupt_check(runner: Any, logical_plan: Any, check: Callab
 
 
 class QueryResultIterator:
-    def __init__(self, iterator: Iterator[Any], check: Callable[[], None] | None) -> None:
+    def __init__(self, iterator: Iterator[Any], check: Callable[[], None] | None, source_owner: Any = None) -> None:
         self._iterator: Iterator[Any] | None = iterator
         self._check = check
+        self._source_owner = source_owner
 
     def __iter__(self) -> QueryResultIterator:
         return self
@@ -69,4 +70,7 @@ class QueryResultIterator:
             if close is not None:
                 close()
         finally:
+            # Driver teardown can still read source resources. Release their
+            # local owner only after the underlying stream has closed.
+            self._source_owner = None
             _active_interrupt_check.reset(token)

--- a/vane/runners/local/runner.py
+++ b/vane/runners/local/runner.py
@@ -8,7 +8,6 @@ import os
 import sys
 import threading
 import time
-import uuid
 import warnings
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from numbers import Integral
@@ -643,10 +642,10 @@ class LocalRunner(Runner):
         os.environ["VANE_LOCAL_FTE_WORKERS"] = str(self.num_workers)
         os.environ["VANE_LOCAL_FTE_EXECUTION_MODE"] = self.execution_mode
 
-    def run_iter(self, relation: Any) -> Iterator[Any]:
+    def run_iter(self, logical_plan: Any) -> Iterator[Any]:
         raise NotImplementedError("local FTE run_iter is not implemented yet")
 
-    def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
+    def run_iter_tables(self, logical_plan: Any) -> Iterator[pa.Table]:
         raise NotImplementedError("local FTE run_iter_tables is not implemented yet")
 
     @staticmethod
@@ -661,16 +660,14 @@ class LocalRunner(Runner):
             started_at=started_at,
         )
 
-    def run_write(self, relation: Any) -> dict[str, Any]:
+    def run_write(self, logical_plan: Any) -> dict[str, Any]:
         import vane
 
         _preload_arrow_dataset_imports()
 
-        PyLogicalPlan = require_ray_cxx_attr("PyLogicalPlan")
         DistributedPhysicalPlanRunner = require_ray_cxx_attr("DistributedPhysicalPlanRunner")
 
-        query_id = str(uuid.uuid4())
-        logical_plan = PyLogicalPlan.from_duckdb_write_relation(relation, query_id)
+        query_id = str(logical_plan.idx())
         conn = vane._native._connect_with_runner("local")
         fragment_executor = _InProcessFragmentExecutor()
         backend = NativeFteWorkerManagerBackend(
@@ -896,17 +893,15 @@ class LocalRunner(Runner):
                     tuple(result["copy_cleanup_warnings"]),
                 ) from cleanup_errors[0]
 
-    def run_datasink(self, relation: Any) -> dict[str, Any]:
+    def run_datasink(self, logical_plan: Any) -> dict[str, Any]:
         """Execute one DataSink attempt with the local FTE backend."""
 
         import vane
 
         _preload_arrow_dataset_imports()
-        PyLogicalPlan = require_ray_cxx_attr("PyLogicalPlan")
         DistributedPhysicalPlanRunner = require_ray_cxx_attr("DistributedPhysicalPlanRunner")
 
-        query_id = str(uuid.uuid4())
-        logical_plan = PyLogicalPlan.from_duckdb_datasink_relation(relation, query_id)
+        query_id = str(logical_plan.idx())
         conn = vane._native._connect_with_runner("local")
         fragment_executor = _InProcessFragmentExecutor()
         backend = NativeFteWorkerManagerBackend(

--- a/vane/runners/ray/runner.py
+++ b/vane/runners/ray/runner.py
@@ -139,6 +139,7 @@ class RayRunner(Runner):
             return client
 
     def run_iter(self, logical_plan: Any) -> Iterator[RayMaterializedResult]:
+        """Stream a bound plan; low-level callers retain source Relations until close."""
         # The transport owns query data snapshots until stream teardown finishes.
         try:
             client = self._client_for_session(str(logical_plan.session_id()))

--- a/vane/runners/ray/runner.py
+++ b/vane/runners/ray/runner.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 import os
 import threading
-import uuid
 import weakref
 from typing import TYPE_CHECKING, Any
 
-from vane._ray_cxx import require_ray_cxx_attr
 from vane._ray_progress_env import ray_log_to_driver_default
 from vane._vane_session import ensure_vane_session_dir
 from vane.runners.ray.admission_ledger import BoundedReplayMap
@@ -20,8 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     import pyarrow as pa  # type: ignore[import-not-found, import-untyped, unused-ignore]
-
-    import vane
 
 
 _RAY_RUNNERS: weakref.WeakSet[RayRunner] = weakref.WeakSet()
@@ -142,56 +138,22 @@ class RayRunner(Runner):
             self._session_ids.add(session_key)
             return client
 
-    def run_iter(self, relation: vane.DuckDBPyRelation) -> Iterator[RayMaterializedResult]:
-        # PyLogicalPlan is transport-only. This generator owns the source
-        # relation until the client stream and its teardown have finished.
+    def run_iter(self, logical_plan: Any) -> Iterator[RayMaterializedResult]:
+        # The transport owns query data snapshots until stream teardown finishes.
         try:
-            query_id = str(uuid.uuid4())
-
-            PyLogicalPlan = require_ray_cxx_attr(
-                "PyLogicalPlan",
-                hint="Ensure the C++ ray extension is built and importable in worker processes.",
-            )
-
-            logical_plan = PyLogicalPlan.from_duckdb_relation(relation, query_id)
-            session_id = str(logical_plan.session_id())
-
-            client = self._client_for_session(session_id)
-
-            # Send PyLogicalPlan to Driver — Driver will create physical plan
-            yield from client.stream_plan(
-                logical_plan,
-            )
+            client = self._client_for_session(str(logical_plan.session_id()))
+            yield from client.stream_plan(logical_plan)
         finally:
-            del relation
+            del logical_plan
 
-    def run_write(self, relation: vane.DuckDBPyRelation) -> dict[str, Any]:
-        """Execute one distributed write query."""
-        PyLogicalPlan = require_ray_cxx_attr(
-            "PyLogicalPlan",
-            hint="Ensure the C++ ray extension is built and importable in worker processes.",
-        )
-
-        query_id = str(uuid.uuid4())
-        logical_plan = PyLogicalPlan.from_duckdb_write_relation(relation, query_id)
-        session_id = str(logical_plan.session_id())
-
-        client = self._client_for_session(session_id)
-
-        # Send PyLogicalPlan to Driver — Driver will create physical plan
+    def run_write(self, logical_plan: Any) -> dict[str, Any]:
+        """Execute an already-bound logical write plan."""
+        client = self._client_for_session(str(logical_plan.session_id()))
         return client.run_copy_plan(logical_plan)
 
-    def run_datasink(self, relation: vane.DuckDBPyRelation) -> dict[str, Any]:
-        """Execute one distributed Python DataSink query."""
-
-        PyLogicalPlan = require_ray_cxx_attr(
-            "PyLogicalPlan",
-            hint="Ensure the C++ ray extension is built and importable in worker processes.",
-        )
-        query_id = str(uuid.uuid4())
-        logical_plan = PyLogicalPlan.from_duckdb_datasink_relation(relation, query_id)
-        session_id = str(logical_plan.session_id())
-        client = self._client_for_session(session_id)
+    def run_datasink(self, logical_plan: Any) -> dict[str, Any]:
+        """Execute an already-bound Python DataSink plan."""
+        client = self._client_for_session(str(logical_plan.session_id()))
         return client.run_datasink_plan(logical_plan)
 
     def retry_copy_cleanup(self, operation_id: str) -> dict[str, Any]:
@@ -204,9 +166,9 @@ class RayRunner(Runner):
                 raise RuntimeError("RayRunner has no active query runtime client")
         return client.retry_copy_cleanup(operation_id)
 
-    def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
+    def run_iter_tables(self, logical_plan: Any) -> Iterator[pa.Table]:
         try:
-            for result in self.run_iter(relation):
+            for result in self.run_iter(logical_plan):
                 yield result.partition()
         finally:
-            del relation
+            del logical_plan

--- a/vane/runners/runner.py
+++ b/vane/runners/runner.py
@@ -18,29 +18,29 @@ class Runner:
     name: ClassVar[Literal["ray", "local"]]
 
     @abstractmethod
-    def run_iter(self, relation: Any) -> Iterator[MaterializedResult]:
+    def run_iter(self, logical_plan: Any) -> Iterator[MaterializedResult]:
         """Yield individual partitions as they are completed.
 
         Args:
-            relation: a DuckDB relation-like object describing the query to execute
+            logical_plan: an already-bound, serialized query plan
         """
         ...
 
     @abstractmethod
-    def run_iter_tables(self, relation: Any) -> Iterator[pa.Table]:
+    def run_iter_tables(self, logical_plan: Any) -> Iterator[pa.Table]:
         """Similar to run_iter(), but always dereference and yield table objects.
 
         Args:
-            relation: a DuckDB relation-like object describing the query to execute
+            logical_plan: an already-bound, serialized query plan
         """
         ...
 
     @abstractmethod
-    def run_write(self, relation: Any) -> dict[str, Any]:
-        """Execute a write through the selected backend."""
+    def run_write(self, logical_plan: Any) -> dict[str, Any]:
+        """Execute an already-bound write plan through the selected backend."""
         ...
 
     @abstractmethod
-    def run_datasink(self, relation: Any) -> dict[str, Any]:
-        """Execute a Python DataSink terminal through the selected backend."""
+    def run_datasink(self, logical_plan: Any) -> dict[str, Any]:
+        """Execute an already-bound Python DataSink plan through the selected backend."""
         ...


### PR DESCRIPTION
## Summary

SQL and Relation APIs previously selected runners through separate paths. They now share one execution entry immediately after client-side DuckDB binding, before native optimization. `local-fast` continues through native DuckDB execution; Ray receives the bound logical plan for distributed planning and execution. Runners consume `PyLogicalPlan` directly, without a Relation adapter or fallback.

The entry handles parameterized SQL, lazy Relation reads, `executemany`, Relation query/write methods, COPY TO, table writes and DataSink terminals. Connection/catalog commands, VACUUM/ANALYZE maintenance, catalog SHOW statements and PRAGMA controls/queries execute on the client. Catalog query origin survives Relation composition, saved views and deferred query() expansion. Ordinary reads can discover native client-query origin while binding; writes and explicit transports reject that origin before binding its contents. Distributed plans reject temporary table sources and targets before runner initialization; temporary views over transportable sources remain supported. Distributed table writes still require a catalog write provider; ordinary DuckDB tables do not become distributed. Unsupported SQL wrappers, explicit transactions and unsupported write forms fail before runner initialization.

Transport admission validates client-state dependencies and side effects, including write defaults, CHECK constraints, lambda bodies and CTAS metadata. Functions that depend on client catalog, session or transaction state are rejected; binding-time checks run before callbacks can evaluate effects or rewrite away that dependency. Explicit plan factories, subsequent Relation binding and the independent CTAS metadata binder use the same checks. JSON SQL/plan serializers and the JSON execution table function require client context; the standalone SQL AST deserializer remains transportable, and the JSON execution PRAGMA retains native client behavior.

The binding transaction stays alive through serialization, and query identity checks prevent execution after connection reentry or cancellation. Active read streams retain source resources until teardown. Partially consumed results release their data chunks before the source context and allocator, including after the owning connection has been closed. Concurrent calls and connection close stay serialized across runner initialization and plan capture. Parent close waits for active cursors without holding parent or cursor-list locks, retains UDF dependencies until child cleanup finishes, and preserves failed session cleanup for retry. Initialization callbacks can still reenter on the same thread; query identity checks reject plans invalidated by those callbacks. Prepared-statement reuse, native error/transaction behavior, per-connection runner selection and lazy Ray initialization are preserved.

## Related issue

close: #805
close: #802
close: #803

Related: #596, #657. Supersedes #804.

## Documentation impact

- [ ] No user-facing documentation update is required.
- [x] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in
      `AstroVela/vane-website`.

README and API docstrings describe runner routing, native connection commands, catalog write providers and unsupported operations. Examples and benchmarks pass bound plans to runners. The driver demo accepts `--ray-address auto` to require an existing Ray cluster, and documents running from the examples directory with the installed package.

## Validation

Latest head **cd75fc633b** fixes the native use-after-free behind the shared-Ray shard's exit 139 in [CI job 103157558895](https://github.com/AstroVela/vane/actions/runs/34560750934/job/103157558895). Destroying a partially consumed result after closing its connection released the source-owned allocator before the remaining data chunk. The destructor now releases the chunk first, matching explicit result close.

- Two consecutive clean local reviews completed before one non-editable incremental Release build/install (**dev686**).
- The new isolated regression reproduced SIGSEGV on the previous runtime. Both implicit destruction and explicit close now pass, including connection collection and iterator cleanup assertions.
- **31 targeted tests passed** for result/connection lifetimes, Arrow consumers and lossless conversions. The two affected real-Ray result-consumer tests each passed **five repetitions (10 passes)** with `MALLOC_PERTURB_=165` enabled. Changed-file pre-commit and formatting passed.
- CI run **34560750934** confirmed the preceding non-Ray fixes: both non-Ray shards, all native/package gates and the isolated-Ray shard passed. Only the shared-Ray shard failed; the new commit triggers fresh CI.

Rebased onto `main` **364212c49b**. The preceding CI correction **b1d0bb28e4** updates regression tests for early transaction and temporary-table rejection, checks that rejected calls never initialize Ray, and independently bounds image parameter binding and execution memory growth to 512 MiB per stage. Each image input layout runs in its own subprocess. This addresses the two non-Ray shard failures in [CI run 34553582129](https://github.com/AstroVela/vane/actions/runs/34553582129).

- Two consecutive clean local reviews completed before the final targeted tests. **47 targeted tests passed** against the exact CI-built **dev685** wheel in an isolated installed environment: relation writes, transaction rejection, temporary-table admission, and all four HD/4K fixed/generic image memory cases. Changed-file pre-commit and formatting passed. This correction changes tests only, so no native rebuild was needed.
- The preceding CI run passed all native builds, Python 3.10–3.14 package gates, both Ray fast-test shards, and service integrations. The earlier wide-image Ray migration now passes in CI as well.

- Two consecutive clean local reviews covered the rebase, plan-factory contract, source lifetime and runner call-site closure before building and testing.
- Non-editable incremental Release build/install passed on CPython 3.12 as **dev685**. Built and installed a matching test-signed native Image provider for the real-Ray native-backend cases.
- **18 targeted real-Ray tests passed on dc0f353a16**: the four failing RGB16/RGB32F codec/hash/UDF cases across Python and native backends passed first, followed by the other 14 image crop/resize/conversion/tensor cases in the same file. No provider cases were skipped.
- Full branch pre-commit, including mypy and formatting, passed. Runtime validation for this CI correction remained targeted.
- Per the requested exception for this CI fix, new GitHub `@codex review` rounds were not requested. Before this rebase, unchanged head **4988b64d99** passed two consecutive manual rounds with no findings: [round 1](https://github.com/AstroVela/vane/pull/806#issuecomment-5621049799), [round 2](https://github.com/AstroVela/vane/pull/806#issuecomment-5621203525).
- Earlier validation on **4988b64d99** passed 190 targeted cases covering literal, parameterized, nested and macro-expanded `query('SHOW ...')`, composed/persisted catalog queries, early write/transport rejection without sequence effects, portable bind replacements and transaction admission. Its sdist and release-artifact validation also passed.
- Other affected validation groups passed on their implementation commits: 162 SHOW/temporary-table cases (including a real-Ray Arrow view), 50 connection-close cases (including two real-Ray interruption cases), 37 maintenance cases, and four real-Ray demo connection/ownership checks.
- The earlier broad baseline on **d01d4daf6e** passed 1,803 affected non-Ray cases, 12 focused real-Ray regressions, and release tests (1,225 non-Ray + 31 Ray). Subsequent corrections reran only affected runtime tests.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible
      licenses and are recorded where required. No new dependencies.
- [x] No credentials, private endpoints, personal paths, generated data, model
      weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access,
      and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow
      changes passed relevant checks.



