### PR TITLE
[fix](sql) Bind execute SELECT after pending result cleanup

### DIFF
--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -2360,14 +2360,17 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 	// Resolve its live context afterward; execution admission validates the plan.
 	auto context = con.GetConnection().context;
 	interrupt_check();
-	// execute() must enter the pending-query lifecycle before binding, so an
-	// abandoned streaming result cannot lend its transaction to the next SELECT.
-	// sql() still constructs a lazy relation for SELECT statements.
-	if (statement->type == StatementType::SELECT_STATEMENT && !for_connection) {
+	if (statement->type == StatementType::SELECT_STATEMENT) {
 		shared_ptr<Relation> relation;
 		try {
 			py::gil_scoped_release release;
 			unique_lock<std::recursive_mutex> lock(py_connection_lock);
+			if (for_connection) {
+				// QueryRelation binds during construction. Clean up the previous
+				// query first, as PendingQuery does, while retaining the relation's
+				// source dependencies for the lifetime of the result stream.
+				context->CancelTransaction();
+			}
 			auto select = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(statement));
 			relation = make_shared_ptr<QueryRelation>(context, std::move(select), alias, "", std::move(parameters));
 		} catch (const Exception &exception) {
@@ -2375,7 +2378,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 			context->ProcessError(error, query);
 			error.Throw();
 		}
-		return CreateRelation(std::move(relation));
+		if (!for_connection) {
+			return CreateRelation(std::move(relation));
+		}
+		auto query_relation = make_uniq<DuckDBPyRelation>(std::move(relation));
+		query_relation->SetConnectionOwner(CreateWeakOwner(shared_from_this()));
+		return make_uniq<DuckDBPyRelation>(query_relation->ExecuteForConnection(interrupt_check));
 	}
 
 	auto execution = ExecuteWithRunner(context, std::move(statement), nullptr, std::move(parameters),

--- a/src/vane_py/pyconnection.cpp
+++ b/src/vane_py/pyconnection.cpp
@@ -2360,7 +2360,10 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 	// Resolve its live context afterward; execution admission validates the plan.
 	auto context = con.GetConnection().context;
 	interrupt_check();
-	if (statement->type == StatementType::SELECT_STATEMENT) {
+	// execute() must enter the pending-query lifecycle before binding, so an
+	// abandoned streaming result cannot lend its transaction to the next SELECT.
+	// sql() still constructs a lazy relation for SELECT statements.
+	if (statement->type == StatementType::SELECT_STATEMENT && !for_connection) {
 		shared_ptr<Relation> relation;
 		try {
 			py::gil_scoped_release release;
@@ -2372,12 +2375,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunStatement(unique_ptr<SQLStat
 			context->ProcessError(error, query);
 			error.Throw();
 		}
-		if (!for_connection) {
-			return CreateRelation(std::move(relation));
-		}
-		auto query_relation = make_uniq<DuckDBPyRelation>(std::move(relation));
-		query_relation->SetConnectionOwner(CreateWeakOwner(shared_from_this()));
-		return make_uniq<DuckDBPyRelation>(query_relation->ExecuteForConnection(interrupt_check));
+		return CreateRelation(std::move(relation));
 	}
 
 	auto execution = ExecuteWithRunner(context, std::move(statement), nullptr, std::move(parameters),

--- a/tests/fast/test_connection_sql_runner.py
+++ b/tests/fast/test_connection_sql_runner.py
@@ -32,6 +32,26 @@ class _SQLRunner(_TransportedPlanRunner):
         return self.outcome
 
 
+@pytest.mark.parametrize("explicit_transaction", [False, True])
+@pytest.mark.parametrize("parameterized", [False, True])
+def test_execute_select_binds_after_abandoned_result_cleanup(monkeypatch, explicit_transaction, parameterized):
+    monkeypatch.setenv("VANE_RUNNER", "local-fast")
+    with vane.connect() as connection:
+        if explicit_transaction:
+            connection.begin()
+        transaction = connection.execute("SELECT current_transaction_id() FROM range(3)").fetchone()[0]
+        comparison = "=" if explicit_transaction else "<>"
+        previous_transaction = "?" if parameterized else str(transaction)
+        query = (
+            f"SELECT * FROM range(CASE WHEN current_transaction_id() {comparison} {previous_transaction} "
+            "THEN 1 ELSE error('incorrect binding transaction') END)"
+        )
+        parameters = [transaction] if parameterized else None
+        assert connection.execute(query, parameters).fetchall() == [(0,)]
+        if explicit_transaction:
+            connection.rollback()
+
+
 def _install_sql_runner(monkeypatch, runner, runner_type):
     calls = _install_fake_ray_runner(monkeypatch, runner)
     if runner_type == "local":

--- a/tests/fast/test_datasource_distributed_scan.py
+++ b/tests/fast/test_datasource_distributed_scan.py
@@ -273,7 +273,7 @@ def test_datasource_relation_keeps_source_alive_until_relation_is_released(duckd
 
 
 @pytest.mark.parametrize("stream_outcome", ["complete", "close", "error"])
-@pytest.mark.parametrize("entry", ["relation", "sql", "execute"])
+@pytest.mark.parametrize("entry", ["relation", "sql", "sql_params", "execute", "execute_params"])
 def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
     monkeypatch,
     stream_outcome,
@@ -309,6 +309,10 @@ def test_ray_runner_plan_retention_does_not_extend_datasource_lifetime(
         # locals snapshot out of the frame that probes source destruction.
         if entry == "relation":
             return relation.to_arrow_reader()
+        if entry == "sql_params":
+            return connection.sql("SELECT * FROM relation WHERE value = ?", params=[43]).to_arrow_reader()
+        if entry == "execute_params":
+            return connection.execute("SELECT * FROM relation WHERE value = ?", [43]).to_arrow_reader()
         return getattr(connection, entry)("SELECT * FROM relation").to_arrow_reader()
 
     results = open_reader(relation)


### PR DESCRIPTION
## Summary

After `execute(...).fetchone()` left a result unread, the next `execute(SELECT ...)` bound a temporary QueryRelation before cleaning up the previous query. Bind-time table functions could observe the old autocommit transaction; real Iceberg testing exposed this as an immediate read of a newly committed Ray CTAS failing with no reachable table state.

Clean up the previous query through the existing ClientContext lifecycle before constructing the SELECT QueryRelation. This preserves the Relation source dependencies held by distributed result streams, releasing them after exhaustion, close or failure. `sql()` continues to return lazy SELECT Relations. Cover literal and parameterized transaction boundaries and parameterized source lifetimes. No fallback is added.

## Related issue

Closes #809

Found during AstroVela/duckdb-iceberg#24.

## Documentation impact

- [x] No user-facing documentation update is required.
- [ ] Documentation is updated in this PR or in a linked website PR.
- [ ] <!-- docs-follow-up --> A follow-up issue is required in `AstroVela/vane-website`.

This restores the expected transaction boundary of `execute()`.

## Validation

- Two consecutive clean local reviews preceded the incremental Release build and targeted tests.
- `scripts/format root --changed`, pre-commit checks and `git diff --check` passed.
- The original transaction regression failed twice in autocommit and passed twice in explicit transactions on the pre-fix runtime.
- Source-lifetime regression on the previous PR runtime: all 6 execute cases failed (with/without parameters, completion/close/error); the 9 Relation/sql cases passed.
- Corrected non-editable Vane wheel, Python 3.12: 150 targeted tests passed. This includes 133 SQL runner cases, all 15 source-lifetime cases, and both partial-result teardown cases after connection close.
- `scripts/run_installed_pytest.sh tests/fast/test_connection_sql_runner.py -q -m real_ray`: all 6 real-Ray tests passed in a separate pytest process.
- Scope of this review correction: targeted Vane tests only; provider qualification is tracked separately.

## Checklist

- [x] The change is focused and includes tests or a reason tests are unnecessary.
- [x] Public behavior and compatibility impact are documented.
- [x] New dependencies, copied code, model assets, and datasets have compatible licenses and are recorded where required (none added).
- [x] No credentials, private endpoints, personal paths, generated data, model weights, or build artifacts are included.
- [x] Security implications of UDFs, serialization, remote code, network access, and untrusted input have been considered.
- [x] Native changes were compiled; Python-only, documentation, and workflow changes passed relevant checks.
